### PR TITLE
chore: fix repository URL in Sprint 0 plan

### DIFF
--- a/docs/superpowers/plans/2026-04-07-sprint-0-scaffolding.md
+++ b/docs/superpowers/plans/2026-04-07-sprint-0-scaffolding.md
@@ -128,7 +128,7 @@ version = "0.0.0"
 edition = "2024"
 rust-version = "1.85.1"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/davidchristensen/rusty-imap-mcp"
+repository = "https://github.com/randomparity/rusty-imap-mcp"
 authors = ["David Christensen"]
 readme = "README.md"
 
@@ -1295,7 +1295,7 @@ Create `SECURITY.md`:
 ## Reporting a vulnerability
 
 Please report security issues by opening a private security advisory on GitHub:
-<https://github.com/davidchristensen/rusty-imap-mcp/security/advisories/new>
+<https://github.com/randomparity/rusty-imap-mcp/security/advisories/new>
 
 Do not report security issues in public issues, discussions, or pull requests.
 


### PR DESCRIPTION
## Summary

Corrects the `repository` URL in the Sprint 0 implementation plan to point at the real origin (`randomparity/rusty-imap-mcp`) instead of a placeholder. Affects two references in `docs/superpowers/plans/2026-04-07-sprint-0-scaffolding.md`:

- Line 131: `Cargo.toml` `[workspace.package] repository = ...`
- Line 1298: `SECURITY.md` advisory URL

Docs-only change. Sprint 0 execution depends on the corrected URL, so this should merge before Sprint 0 work begins.

## Test plan

- [x] No code to test; the change is a string substitution in a plan document