### PR TITLE
Sprint 5 Phase 1: content pipeline remediation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "rimap-audit",
  "rimap-authz",
  "rimap-config",
+ "rimap-content",
  "rimap-core",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1326,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mail-builder"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900998f307338c4013a28ab14d760b784067324b164448c6d98a89e44810473b"
+dependencies = [
+ "gethostname",
+]
 
 [[package]]
 name = "mail-parser"
@@ -2096,6 +2115,7 @@ dependencies = [
  "clap",
  "hex",
  "infer",
+ "mail-builder",
  "mail-parser",
  "predicates",
  "rimap-audit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ dependencies = [
  "clap",
  "hex",
  "infer",
+ "mail-parser",
  "predicates",
  "rimap-audit",
  "rimap-authz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +271,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +293,12 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -438,6 +480,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +641,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ego-tree"
@@ -930,6 +1012,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1169,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]
@@ -1390,6 +1511,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -1799,6 +1926,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,12 +2095,17 @@ dependencies = [
  "assert_cmd",
  "clap",
  "hex",
+ "infer",
  "predicates",
  "rimap-audit",
  "rimap-authz",
  "rimap-config",
  "rimap-content",
  "rimap-core",
+ "rimap-imap",
+ "rmcp",
+ "schemars",
+ "serde",
  "serde_json",
  "sha2",
  "tempfile",
@@ -1975,6 +2127,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -2077,6 +2264,32 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -2190,6 +2403,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2616,6 +2840,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +3051,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3015,10 +3262,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,16 @@ unicode-script = "0.5.8"
 phf = { version = "0.13.1", default-features = false }
 phf_codegen = "0.13.1"
 
+# MCP server (Sprint 5)
+# rmcp 1.4 is the Rust MCP SDK. Transitive proc-macros: rmcp-macros (the
+# macros feature). Reviewed v1.4: published by ModelContextProtocol org,
+# Apache-2.0 OR MIT, standard proc-macro2/quote/syn stack, no build.rs,
+# no network/fs/process access in macro source. Re-audit on minor bump.
+# (SC-PROC-01)
+rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
+schemars = "1.0"
+infer = "0.19"
+
 # Dev dependencies shared across crates
 assert_cmd = "2.0"
 predicates = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,14 @@ scraper = { version = "0.26.0", default-features = false }
 # ammonia MSRV 1.80, MIT OR Apache-2.0
 ammonia = "4.1.2"
 linkify = "0.10.0"
-# idna 1.x is the current Servo URL-standard IDNA implementation; pulled
-# transitively by url crate in other workspace members, pinned here so we
-# control the version.
+# First url/idna entry in the workspace. idna 1.x replaced in-crate
+# Unicode tables with the ICU4X provider stack, pulling ~20 new
+# transitive crates (icu_collections, icu_locale_core, icu_normalizer,
+# icu_normalizer_data, icu_properties, icu_properties_data,
+# icu_provider, idna_adapter, litemap, potential_utf, tinystr,
+# writeable, yoke*, zerofrom*, zerotrie, zerovec*, utf8_iter,
+# displaydoc). Accepted because ICU4X is the unicode-org canonical
+# path; re-audit on any minor bump of the idna or icu_* family.
 idna = "1.1.0"
 # addr 0.15 with default psl feature for registrable-domain extraction.
 addr = "0.15.6"
@@ -124,9 +129,9 @@ unicode-script = "0.5.8"
 # dep for that build.rs; declared here for workspace inheritance, the member
 # crate lists it under [build-dependencies], not [dependencies].
 #
-# Direct deps: phf 0.13.1 and phf_codegen 0.13.1. Our phf line sets
-# default-features = false, so it does NOT itself enable phf_macros; the
-# phf_codegen path runs in build.rs and is reviewed as code we own.
+# Our direct phf declaration disables defaults; phf_macros still
+# enters the graph transitively via cssparser, which is acknowledged
+# in the proc-macro enumeration above.
 #
 # Transitively-introduced proc-macros entering the graph with the Sprint 4b
 # dep additions (each executes arbitrary Rust at build time, so SC-PROC-01
@@ -146,6 +151,11 @@ unicode-script = "0.5.8"
 # expansion respectively. No RUSTSEC advisories apply to any of these
 # versions as of 2026-04-08, and `cargo deny check` passes against the
 # full graph (advisories, bans, licenses, sources).
+#
+# - yoke-derive 0.8.2 (unicode-org via ICU4X, pulled through idna_adapter)
+# - zerofrom-derive 0.1.7 (unicode-org via ICU4X, pulled through idna_adapter)
+# - zerovec-derive 0.11.3 (unicode-org via ICU4X, pulled through idna_adapter)
+# - displaydoc 0.2.5 (unicode-org via ICU4X, pulled through idna_adapter)
 #
 # Re-audit trigger: any minor version bump of scraper, ammonia, or the
 # phf family. (SC-PROC-01)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ rand = "0.8"
 # model? The Sprint 4a adversarial corpus and insta snapshots are
 # the regression-detection mechanism — any snapshot diff on upgrade
 # requires a re-audit, not a cargo insta accept. (SC-DEP-09)
+mail-builder = "0.4"
 mail-parser = "0.11"
 encoding_rs = "0.8"
 unicode-normalization = "0.1"

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -3,6 +3,10 @@ name = "rimap-content"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+# TODO: data/confusables.txt is licensed under Unicode-DFS-2016. If
+# this crate is ever published to crates.io, update the license field
+# to reflect the vendored data and add "Unicode-DFS-2016" to the
+# workspace deny.toml allow list.
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/rimap-content/build.rs
+++ b/crates/rimap-content/build.rs
@@ -57,11 +57,12 @@ fn main() {
             continue;
         }
         let Some(target_string) = parse_codepoint_sequence(tgt) else {
-            eprintln!(
-                "build: skipping malformed target at line {}: {raw_line}",
+            panic!(
+                "build: malformed target at line {}: {raw_line}\n\
+                 Bump EXPECTED_MIN and re-audit when regenerating \
+                 from a new Unicode version.",
                 lineno + 1
             );
-            continue;
         };
         // phf_codegen stores values as Rust source; we emit the escaped
         // string literal directly so targets with quotes/backslashes are
@@ -95,10 +96,13 @@ fn main() {
         seen.len(),
         out_path.display()
     );
+    // Unicode 16.0 produces ~6355 MA rows. This floor catches silent
+    // format drift that drops more than ~2.5% of entries. Bump this
+    // value and re-audit when regenerating from a new Unicode version.
     assert!(
-        seen.len() > 5000,
-        "build: suspiciously small confusables map ({} entries) — \
-         is data/confusables.txt the right file?",
+        seen.len() >= 6200,
+        "build: suspiciously small confusables map ({} entries, \
+         expected >= 6200) — is data/confusables.txt the right file?",
         seen.len()
     );
 }

--- a/crates/rimap-content/data/NOTICE
+++ b/crates/rimap-content/data/NOTICE
@@ -1,0 +1,7 @@
+Unicode Character Database — confusables.txt
+Copyright (c) 1991-2024 Unicode, Inc. All rights reserved.
+
+Licensed under the Unicode License v3 (Unicode-DFS-2016).
+Full text: https://www.unicode.org/license.txt
+
+Vendored from Unicode TR39 (Unicode 16.0).

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -374,7 +374,7 @@ fn warning_code_to_label(code: WarningCode) -> &'static str {
         WarningCode::ParseMimePartCountExceeded => "parse_mime_part_count_exceeded",
         WarningCode::ParseHeaderCountExceeded => "parse_header_count_exceeded",
         WarningCode::ParseAttachmentFilenameRewritten => "parse_attachment_filename_rewritten",
-        WarningCode::HtmlHiddenContentStripped => "html_hidden_content_stripped",
+        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
         WarningCode::HtmlLinkTextHrefMismatch => "html_link_text_href_mismatch",
         WarningCode::HtmlScriptStripped => "html_script_stripped",
         WarningCode::HtmlStyleStripped => "html_style_stripped",

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -379,6 +379,7 @@ fn warning_code_to_label(code: WarningCode) -> &'static str {
         WarningCode::HtmlScriptStripped => "html_script_stripped",
         WarningCode::HtmlStyleStripped => "html_style_stripped",
         WarningCode::HtmlRemoteImageStripped => "html_remote_image_stripped",
+        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
         WarningCode::LookalikeMixedScript => "lookalike_mixed_script",
         WarningCode::LookalikeHomographDomain => "lookalike_homograph_domain",
         WarningCode::LookalikeIdnPunycode => "lookalike_idn_punycode",

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -360,9 +360,10 @@ struct MismatchHit {
 /// Returns `(hits, overflow)`. `hits` contains at most
 /// [`MAX_MISMATCH_HITS`] entries; `overflow` counts additional mismatches
 /// past the cap so the caller can emit a summary warning.
-fn detect_mismatches(document: &Html) -> (Vec<MismatchHit>, usize) {
+fn detect_mismatches(document: &Html) -> (Vec<MismatchHit>, usize, Vec<(String, String)>) {
     let mut hits = Vec::new();
     let mut overflow: usize = 0;
+    let mut unparsable_hrefs: Vec<(String, String)> = Vec::new();
     let mut finder = linkify::LinkFinder::new();
     finder.url_must_have_scheme(false);
     for anchor in document.select(&SEL_ANCHOR) {
@@ -370,6 +371,16 @@ fn detect_mismatches(document: &Html) -> (Vec<MismatchHit>, usize) {
             continue;
         };
         let Some(href_domain) = extract_registrable_domain(href) else {
+            let mut text: String = anchor.text().collect::<Vec<&str>>().join(" ");
+            if text.len() > MAX_ANCHOR_TEXT_SCAN {
+                text.truncate(MAX_ANCHOR_TEXT_SCAN);
+            }
+            let has_url_text = finder
+                .links(&text)
+                .any(|l| l.kind() == &linkify::LinkKind::Url);
+            if has_url_text {
+                unparsable_hrefs.push((href.to_string(), text.trim().to_string()));
+            }
             continue;
         };
         let mut text: String = anchor.text().collect::<Vec<&str>>().join(" ");
@@ -397,7 +408,7 @@ fn detect_mismatches(document: &Html) -> (Vec<MismatchHit>, usize) {
             overflow += 1;
         }
     }
-    (hits, overflow)
+    (hits, overflow, unparsable_hrefs)
 }
 
 /// Walk the document and collect hidden-element hits plus their
@@ -596,7 +607,7 @@ pub(crate) fn process(raw: &[u8], charset: Option<&str>) -> Result<HtmlResult, C
             location: Some("body:html".to_string()),
         });
     }
-    let (mismatches, mismatch_overflow) = detect_mismatches(&document);
+    let (mismatches, mismatch_overflow, unparsable_hrefs) = detect_mismatches(&document);
     for hit in &mismatches {
         warnings.push(SecurityWarning {
             code: crate::output::WarningCode::HtmlLinkTextHrefMismatch,
@@ -612,6 +623,13 @@ pub(crate) fn process(raw: &[u8], charset: Option<&str>) -> Result<HtmlResult, C
             code: crate::output::WarningCode::HtmlLinkTextHrefMismatch,
             detail: Some(format!("additional_hits={mismatch_overflow}")),
             location: Some("html:anchor".to_string()),
+        });
+    }
+    for (href, text) in &unparsable_hrefs {
+        warnings.push(SecurityWarning {
+            code: crate::output::WarningCode::HtmlAnchorUnparsableHref,
+            detail: Some(format!("href={href},text={text}")),
+            location: Some("body_html:anchor".to_string()),
         });
     }
     let hidden_indices: HashSet<ElementIndex> = hidden_hits.iter().map(|(idx, _)| *idx).collect();
@@ -1026,6 +1044,22 @@ mod tests {
                 .warnings
                 .iter()
                 .any(|w| matches!(w.code, crate::output::WarningCode::HtmlLinkTextHrefMismatch))
+        );
+    }
+
+    #[test]
+    fn mismatch_emits_unparsable_href_for_psl_failure() {
+        let input = br#"<html><body>
+            <a href="https://evilserver/phish">Visit paypal.com now</a>
+        </body></html>"#;
+        let result = process(input, None).expect("ok");
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| matches!(w.code, crate::output::WarningCode::HtmlAnchorUnparsableHref)),
+            "expected HtmlAnchorUnparsableHref, got {:?}",
+            result.warnings
         );
     }
 

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -215,6 +215,24 @@ fn font_size_is_zero(val: &str) -> bool {
         .is_some_and(|n| n <= f64::EPSILON)
 }
 
+/// Parse a `transform: translate*(-Npx)` value and return the most
+/// negative pixel offset found, or `None` if no translate pattern
+/// matches.
+fn parse_translate_px(val: &str) -> Option<f64> {
+    let mut min: Option<f64> = None;
+    for part in val.split(['(', ',', ')']) {
+        let trimmed = part.trim();
+        if let Some(px_val) = parse_px(trimmed) {
+            match min {
+                Some(current) if px_val < current => min = Some(px_val),
+                None => min = Some(px_val),
+                _ => {}
+            }
+        }
+    }
+    min
+}
+
 /// Accumulator for off-screen / color-match detection across an inline
 /// style declaration list.
 #[derive(Default)]
@@ -222,6 +240,7 @@ struct StyleHints {
     position: Option<String>,
     left_px: Option<f64>,
     top_px: Option<f64>,
+    transform_offset_px: Option<f64>,
     color: Option<String>,
     bg_color: Option<String>,
 }
@@ -232,6 +251,7 @@ impl StyleHints {
             "position" => self.position = Some(val.to_string()),
             "left" => self.left_px = parse_px(val),
             "top" => self.top_px = parse_px(val),
+            "transform" => self.transform_offset_px = parse_translate_px(val),
             "color" => self.color = Some(val.to_string()),
             "background-color" => self.bg_color = Some(val.to_string()),
             _ => {}
@@ -243,9 +263,10 @@ impl StyleHints {
         if !positioned {
             return false;
         }
-        let off_left = self.left_px.is_some_and(|v| v <= -1000.0);
-        let off_top = self.top_px.is_some_and(|v| v <= -1000.0);
-        off_left || off_top
+        let off_left = self.left_px.is_some_and(|v| v < -100.0);
+        let off_top = self.top_px.is_some_and(|v| v < -100.0);
+        let off_transform = self.transform_offset_px.is_some_and(|v| v < -100.0);
+        off_left || off_top || off_transform
     }
 
     fn is_color_match(&self) -> bool {
@@ -1227,6 +1248,42 @@ mod tests {
                 result.body_html
             );
         }
+    }
+
+    #[test]
+    fn classify_offscreen_minus_999_fires() {
+        assert_eq!(
+            classify_inline_style("position: absolute; left: -999px"),
+            Some(HiddenMethod::OffScreen)
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_minus_50_does_not_fire() {
+        assert_eq!(
+            classify_inline_style("position: absolute; left: -50px"),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_transform_translate() {
+        assert_eq!(
+            classify_inline_style("position: absolute; transform: translateX(-9999px)"),
+            Some(HiddenMethod::OffScreen)
+        );
+        assert_eq!(
+            classify_inline_style("position: fixed; transform: translate(-500px, 0)"),
+            Some(HiddenMethod::OffScreen)
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_transform_small_value_no_fire() {
+        assert_eq!(
+            classify_inline_style("position: absolute; transform: translateX(-50px)"),
+            None
+        );
     }
 
     #[test]

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -136,6 +136,15 @@ fn build_ammonia_builder() -> Builder<'static> {
     builder.url_schemes(schemes);
     builder.rm_tag_attributes("img", &["src", "srcset"]);
     builder.add_tag_attributes("img", &["alt", "width", "height"]);
+    // Pin tag removals against ammonia default drift. details/summary
+    // are explicitly removed: collapsed content is invisible to humans
+    // but visible to LLMs reading HTML tokens.
+    builder.rm_tags(&[
+        "script", "style", "iframe", "object", "embed", "meta", "base", "link", "form", "input",
+        "button", "textarea", "svg", "math", "frame", "frameset", "noframes", "applet", "details",
+        "summary",
+    ]);
+    builder.strip_comments(true);
     builder
 }
 
@@ -1200,5 +1209,39 @@ mod tests {
         let _ = &*SEL_STYLE;
         let _ = &*SEL_BODY_ALL;
         let _ = &*AMMONIA_BUILDER;
+    }
+
+    #[test]
+    fn sanitize_drops_iframe_and_details() {
+        let tags = [
+            "iframe", "object", "embed", "meta", "base", "link", "form", "input", "button",
+            "textarea", "svg", "math", "frame", "frameset", "noframes", "applet", "details",
+            "summary",
+        ];
+        for tag in tags {
+            let input = format!("<html><body><{tag}>hidden content</{tag}></body></html>");
+            let result = process(input.as_bytes(), None).expect("process should succeed");
+            assert!(
+                !result.body_html.contains(&format!("<{tag}")),
+                "tag <{tag}> should be stripped from body_html, got: {}",
+                result.body_html
+            );
+        }
+    }
+
+    #[test]
+    fn body_html_has_no_html_comments() {
+        let input = b"<html><body><!-- secret comment --><p>visible</p></body></html>";
+        let result = process(input, None).expect("process should succeed");
+        assert!(
+            !result.body_html.contains("<!--"),
+            "HTML comments should be stripped, got: {}",
+            result.body_html
+        );
+        assert!(
+            !result.body_html.contains("secret comment"),
+            "comment content should be stripped, got: {}",
+            result.body_html
+        );
     }
 }

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -462,10 +462,20 @@ fn extract_text(
     let body_selector = compile_selector("body");
     if let Some(body_el) = document.select(&body_selector).next() {
         let mut counter: usize = 0;
+        let mut after_cdata = false;
         for child in body_el.children() {
             if let Some(child_el) = scraper::ElementRef::wrap(child) {
+                after_cdata = false;
                 walk_element(child_el, hidden_indices, &mut buf, &mut counter);
-            } else if let Some(text) = child.value().as_text() {
+            } else if child
+                .value()
+                .as_comment()
+                .is_some_and(|c| c.starts_with("[CDATA["))
+            {
+                after_cdata = true;
+            } else if let Some(text) = child.value().as_text()
+                && !after_cdata
+            {
                 push_text(&mut buf, text);
             }
         }
@@ -500,10 +510,20 @@ fn collect_visible_text(
     ) {
         return;
     }
+    let mut after_cdata = false;
     for child in el.children() {
         if let Some(child_el) = scraper::ElementRef::wrap(child) {
+            after_cdata = false;
             walk_element(child_el, hidden_indices, out, counter);
-        } else if let Some(text) = child.value().as_text() {
+        } else if child
+            .value()
+            .as_comment()
+            .is_some_and(|c| c.starts_with("[CDATA["))
+        {
+            after_cdata = true;
+        } else if let Some(text) = child.value().as_text()
+            && !after_cdata
+        {
             push_text(out, text);
         }
     }
@@ -531,11 +551,14 @@ fn walk_element(
 /// whitespace. Internal whitespace is left intact for
 /// [`normalize_whitespace`] to collapse.
 ///
-/// Text nodes containing `]]>` are skipped: html5ever treats
-/// `<![CDATA[` in non-SVG/MathML context as a bogus comment, but
-/// content between the inner tags and the closing `]]>` leaks as
-/// text nodes. The `]]>` marker never appears in legitimate visible
-/// HTML text.
+/// Text nodes containing `]]>` are skipped as a secondary defense
+/// against CDATA leaks. html5ever treats `<![CDATA[` in non-SVG/
+/// `MathML` context as a bogus comment; content between inner tags
+/// and `]]>` leaks as text nodes. The primary defense is the
+/// `after_cdata` flag in [`extract_text`] and
+/// [`collect_visible_text`], which suppresses text siblings that
+/// immediately follow a CDATA bogus-comment node (covering the
+/// unclosed-CDATA case where `]]>` is absent).
 fn push_text(out: &mut String, text: &str) {
     if text.contains("]]>") {
         return;
@@ -1283,6 +1306,20 @@ mod tests {
         assert!(
             result.body_text.contains("visible"),
             "non-CDATA text should still appear: {:?}",
+            result.body_text
+        );
+    }
+
+    #[test]
+    fn unclosed_cdata_script_content_excluded_from_body_text() {
+        let html = br#"<html><body>
+            <p>visible</p>
+            <![CDATA[<script>alert("leaked")
+        </body></html>"#;
+        let result = process(html, None).expect("ok");
+        assert!(
+            !result.body_text.contains("alert"),
+            "unclosed CDATA script content should not leak: {:?}",
             result.body_text
         );
     }

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -554,14 +554,14 @@ pub(crate) fn process(raw: &[u8], charset: Option<&str>) -> Result<HtmlResult, C
     let mut warnings: Vec<SecurityWarning> = Vec::new();
     for (_idx, method) in &hidden_hits {
         warnings.push(SecurityWarning {
-            code: crate::output::WarningCode::HtmlHiddenContentStripped,
+            code: crate::output::WarningCode::HtmlHiddenContentDetected,
             detail: Some(format!("method={}", method.as_detail())),
             location: Some("body:html".to_string()),
         });
     }
     if hidden_overflow > 0 {
         warnings.push(SecurityWarning {
-            code: crate::output::WarningCode::HtmlHiddenContentStripped,
+            code: crate::output::WarningCode::HtmlHiddenContentDetected,
             detail: Some(format!("method=mixed,additional_hits={hidden_overflow}")),
             location: Some("body:html".to_string()),
         });
@@ -855,10 +855,10 @@ mod tests {
             .find(|w| {
                 matches!(
                     w.code,
-                    crate::output::WarningCode::HtmlHiddenContentStripped
+                    crate::output::WarningCode::HtmlHiddenContentDetected
                 )
             })
-            .expect("expected HtmlHiddenContentStripped warning");
+            .expect("expected HtmlHiddenContentDetected warning");
         assert_eq!(hit.detail.as_deref(), Some("method=display_none"));
         assert_eq!(hit.location.as_deref(), Some("body:html"));
     }
@@ -879,7 +879,7 @@ mod tests {
             .filter(|w| {
                 matches!(
                     w.code,
-                    crate::output::WarningCode::HtmlHiddenContentStripped
+                    crate::output::WarningCode::HtmlHiddenContentDetected
                 )
             })
             .collect();

--- a/crates/rimap-content/src/html.rs
+++ b/crates/rimap-content/src/html.rs
@@ -530,7 +530,16 @@ fn walk_element(
 /// space when the buffer is non-empty and does not already end in
 /// whitespace. Internal whitespace is left intact for
 /// [`normalize_whitespace`] to collapse.
+///
+/// Text nodes containing `]]>` are skipped: html5ever treats
+/// `<![CDATA[` in non-SVG/MathML context as a bogus comment, but
+/// content between the inner tags and the closing `]]>` leaks as
+/// text nodes. The `]]>` marker never appears in legitimate visible
+/// HTML text.
 fn push_text(out: &mut String, text: &str) {
+    if text.contains("]]>") {
+        return;
+    }
     if !out.is_empty() && !out.ends_with(char::is_whitespace) {
         out.push(' ');
     }
@@ -1251,6 +1260,30 @@ mod tests {
                 .anchor_hrefs
                 .iter()
                 .any(|h| h.contains("javascript:"))
+        );
+    }
+
+    #[test]
+    fn cdata_script_content_excluded_from_body_text() {
+        let html = br#"<html><body>
+            <p>visible</p>
+            <![CDATA[<script>alert("cdata-bypass")</script>]]>
+        </body></html>"#;
+        let result = process(html, None).expect("ok");
+        assert!(
+            !result.body_text.contains("alert"),
+            "CDATA script content should not leak into body_text: {:?}",
+            result.body_text
+        );
+        assert!(
+            !result.body_text.contains("cdata-bypass"),
+            "CDATA content should not appear in body_text: {:?}",
+            result.body_text
+        );
+        assert!(
+            result.body_text.contains("visible"),
+            "non-CDATA text should still appear: {:?}",
+            result.body_text
         );
     }
 

--- a/crates/rimap-content/src/lookalike.rs
+++ b/crates/rimap-content/src/lookalike.rs
@@ -22,11 +22,16 @@ use crate::output::{ContentMeta, SecurityWarning, WarningCode};
 #[derive(Debug)]
 pub(crate) struct LookalikeInput<'a> {
     /// Header-derived metadata (from, subject, list-id, …).
+    #[expect(dead_code, reason = "retained for future homograph comparison passes")]
     pub meta: &'a ContentMeta,
     /// Sanitized plain-text body, used for body-URL scanning.
     pub body_text: &'a str,
     /// Anchor hrefs collected from the sanitized HTML body.
     pub anchor_hrefs: &'a [String],
+    /// Pre-extracted header address domains with their locations.
+    /// Built at the `parse_message` boundary using structured
+    /// `Addr.address` data rather than re-parsing rendered strings.
+    pub header_domains: Vec<(String, String)>,
 }
 
 /// Maximum `body_text` bytes scanned for URL tokens via linkify.
@@ -141,29 +146,18 @@ fn compute_skeleton(domain: &str) -> String {
 /// of warnings.
 pub(crate) fn audit(input: &LookalikeInput<'_>) -> Vec<SecurityWarning> {
     let mut out: Vec<SecurityWarning> = Vec::new();
-    scan_header_domains(input.meta, &mut out);
+    scan_header_domains(input, &mut out);
     scan_anchor_hrefs(input.anchor_hrefs, &mut out);
     scan_body_urls(input.body_text, &mut out);
     out
 }
 
-/// Pass 1: classify domains pulled from `From`/`To`/`Cc` header
-/// address fields. `Reply-To` is not yet retained on `ContentMeta`.
-fn scan_header_domains(meta: &ContentMeta, out: &mut Vec<SecurityWarning>) {
-    if let Some(from) = meta.from.as_deref()
-        && let Some(domain) = extract_domain_from_address(from)
-    {
-        emit_classification(&domain, "header:from", out);
-    }
-    for addr in &meta.to {
-        if let Some(domain) = extract_domain_from_address(addr) {
-            emit_classification(&domain, "header:to", out);
-        }
-    }
-    for addr in &meta.cc {
-        if let Some(domain) = extract_domain_from_address(addr) {
-            emit_classification(&domain, "header:cc", out);
-        }
+/// Pass 1: classify pre-extracted header address domains from
+/// `LookalikeInput::header_domains` (built at the parse boundary
+/// using structured `Addr.address` data).
+fn scan_header_domains(input: &LookalikeInput<'_>, out: &mut Vec<SecurityWarning>) {
+    for (domain, location) in &input.header_domains {
+        emit_classification(domain, location, out);
     }
 }
 
@@ -198,6 +192,13 @@ fn scan_body_urls(body_text: &str, out: &mut Vec<SecurityWarning>) {
 /// Pull the domain from a header address. Handles `Name <user@host>`
 /// and bare `user@host` forms. Returns `None` if no `@` is present
 /// or the right-hand side is empty.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "used by test helper; retained for future audit passes"
+    )
+)]
 fn extract_domain_from_address(addr: &str) -> Option<String> {
     let trimmed = addr.trim();
     let inner = if let (Some(lt), Some(gt)) = (trimmed.rfind('<'), trimmed.rfind('>'))
@@ -370,10 +371,32 @@ mod tests {
         body_text: &str,
         anchor_hrefs: &[String],
     ) -> Vec<SecurityWarning> {
+        let mut header_domains = Vec::new();
+        if let Some(from) = meta.from.as_deref()
+            && let Some(domain) = extract_domain_from_address(from)
+        {
+            header_domains.push((domain, "header:from".to_string()));
+        }
+        for addr in &meta.to {
+            if let Some(domain) = extract_domain_from_address(addr) {
+                header_domains.push((domain, "header:to".to_string()));
+            }
+        }
+        for addr in &meta.cc {
+            if let Some(domain) = extract_domain_from_address(addr) {
+                header_domains.push((domain, "header:cc".to_string()));
+            }
+        }
+        if let Some(reply_to) = meta.reply_to.as_deref()
+            && let Some(domain) = extract_domain_from_address(reply_to)
+        {
+            header_domains.push((domain, "header:reply_to".to_string()));
+        }
         audit(&LookalikeInput {
             meta,
             body_text,
             anchor_hrefs,
+            header_domains,
         })
     }
 
@@ -394,6 +417,27 @@ mod tests {
                 .iter()
                 .all(|w| w.location.as_deref() == Some("header:from")),
             "all emitted warnings should be located on header:from"
+        );
+    }
+
+    #[test]
+    fn audit_flags_mixed_script_reply_to_domain() {
+        let mut meta = empty_meta();
+        meta.from = Some("legit@example.com".to_string());
+        meta.reply_to = Some("support@p\u{0430}ypal.com".to_string());
+        let warnings = run_audit(&meta, "", &[]);
+        let reply_to_warnings: Vec<_> = warnings
+            .iter()
+            .filter(|w| {
+                w.code == WarningCode::LookalikeMixedScript
+                    && w.location.as_deref() == Some("header:reply_to")
+            })
+            .collect();
+        assert_eq!(
+            reply_to_warnings.len(),
+            1,
+            "expected one mixed-script hit on reply_to, \
+             got {warnings:?}"
         );
     }
 

--- a/crates/rimap-content/src/output.rs
+++ b/crates/rimap-content/src/output.rs
@@ -117,8 +117,11 @@ pub struct Untrusted {
 pub struct SecurityWarning {
     /// Classification of the warning.
     pub code: WarningCode,
-    /// Short human-readable context (e.g. a counter of stripped
-    /// codepoints). `None` when no additional detail is available.
+    /// Human-readable context string. Consumers MUST NOT parse this
+    /// field programmatically — use `code` and other typed fields for
+    /// dispatch. Format may change without notice.
+    ///
+    /// `None` when no additional detail is available.
     pub detail: Option<String>,
     /// Logical location in the message (e.g. `"header:subject"`,
     /// `"body:part[2]"`, `"attachment[0]"`). `None` for crate-wide events.
@@ -175,6 +178,11 @@ pub enum WarningCode {
     /// whose registrable domain differs from the anchor's `href`
     /// registrable domain. Detail format:
     /// `text_domain=<ascii>,href_domain=<ascii>`.
+    ///
+    /// Reflects the original message content (pre-ammonia), not the
+    /// sanitized `body_html`. An anchor stripped by ammonia may still
+    /// produce this warning — the warning signals the message's
+    /// intent, not the sanitized output.
     HtmlLinkTextHrefMismatch,
     /// One or more `<script>` elements were removed during HTML
     /// sanitization. Detail format: `count=N`.
@@ -186,6 +194,12 @@ pub enum WarningCode {
     /// attributes removed during HTML sanitization to prevent
     /// remote tracking-pixel loads. Detail format: `count=N`.
     HtmlRemoteImageStripped,
+    /// An HTML anchor's `href` could not be resolved to a registrable
+    /// domain via the Public Suffix List, but the anchor's visible text
+    /// contained a URL-looking token (detected by `linkify`). This
+    /// distinguishes "we checked and it's fine" from "we couldn't
+    /// check." Consumers should treat the anchor with suspicion.
+    HtmlAnchorUnparsableHref,
     /// A domain label contained characters from multiple Unicode
     /// scripts outside the TR39 Highly Restrictive profile. Detail
     /// format: `domain=<punycode>,scripts=<S1+S2>`.
@@ -253,6 +267,7 @@ impl WarningCode {
             WarningCode::ParseBodyTruncated
             | WarningCode::HtmlStyleStripped
             | WarningCode::HtmlRemoteImageStripped
+            | WarningCode::HtmlAnchorUnparsableHref
             | WarningCode::LookalikeIdnPunycode => WarningSeverity::Informational,
         }
     }
@@ -349,6 +364,10 @@ mod tests {
             WarningSeverity::Informational
         );
         assert_eq!(
+            WarningCode::HtmlAnchorUnparsableHref.severity(),
+            WarningSeverity::Informational
+        );
+        assert_eq!(
             WarningCode::LookalikeMixedScript.severity(),
             WarningSeverity::Adversarial
         );
@@ -382,6 +401,10 @@ mod tests {
             (
                 WarningCode::HtmlRemoteImageStripped,
                 "html_remote_image_stripped",
+            ),
+            (
+                WarningCode::HtmlAnchorUnparsableHref,
+                "html_anchor_unparsable_href",
             ),
             (WarningCode::LookalikeMixedScript, "lookalike_mixed_script"),
             (

--- a/crates/rimap-content/src/output.rs
+++ b/crates/rimap-content/src/output.rs
@@ -165,11 +165,12 @@ pub enum WarningCode {
     ParseAttachmentFilenameRewritten,
     /// HTML content contained hidden elements (e.g. `display:none`,
     /// `visibility:hidden`, `opacity:0`, off-screen positioning,
-    /// zero font size, or background-color-matching text). Stripped
-    /// from the extracted `body_text`. Detail format:
+    /// zero font size, or background-color-matching text). Hidden
+    /// content is stripped from `body_text` but may remain in
+    /// `body_html` when the posture allows HTML exposure. Detail format:
     /// `method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`
     /// optionally followed by `,count=N` when summarized.
-    HtmlHiddenContentStripped,
+    HtmlHiddenContentDetected,
     /// An HTML anchor's visible text contained a URL-looking token
     /// whose registrable domain differs from the anchor's `href`
     /// registrable domain. Detail format:
@@ -243,7 +244,7 @@ impl WarningCode {
             | WarningCode::ParseMimePartCountExceeded
             | WarningCode::ParseHeaderCountExceeded
             | WarningCode::ParseAttachmentFilenameRewritten
-            | WarningCode::HtmlHiddenContentStripped
+            | WarningCode::HtmlHiddenContentDetected
             | WarningCode::HtmlLinkTextHrefMismatch
             | WarningCode::HtmlScriptStripped
             | WarningCode::LookalikeMixedScript
@@ -328,7 +329,7 @@ mod tests {
             WarningSeverity::Adversarial
         );
         assert_eq!(
-            WarningCode::HtmlHiddenContentStripped.severity(),
+            WarningCode::HtmlHiddenContentDetected.severity(),
             WarningSeverity::Adversarial
         );
         assert_eq!(
@@ -369,8 +370,8 @@ mod tests {
     fn new_warning_variants_serialize_snake_case() {
         let cases = [
             (
-                WarningCode::HtmlHiddenContentStripped,
-                "html_hidden_content_stripped",
+                WarningCode::HtmlHiddenContentDetected,
+                "html_hidden_content_detected",
             ),
             (
                 WarningCode::HtmlLinkTextHrefMismatch,

--- a/crates/rimap-content/src/output.rs
+++ b/crates/rimap-content/src/output.rs
@@ -42,6 +42,8 @@ pub struct ContentMeta {
     pub to: Vec<String>,
     /// Parsed `Cc:` header recipients, sanitized.
     pub cc: Vec<String>,
+    /// Parsed `Reply-To:` header, sanitized. `None` if absent.
+    pub reply_to: Option<String>,
     /// Parsed `Subject:` header, sanitized. `None` if absent.
     pub subject: Option<String>,
     /// Parsed `Date:` header as a UTC-normalized `OffsetDateTime`.
@@ -277,6 +279,15 @@ impl WarningCode {
 #[expect(clippy::unwrap_used, reason = "tests may unwrap on constructed values")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn content_meta_has_reply_to_field() {
+        let meta = ContentMeta {
+            reply_to: Some("reply@example.com".to_string()),
+            ..ContentMeta::default()
+        };
+        assert_eq!(meta.reply_to.as_deref(), Some("reply@example.com"));
+    }
 
     #[test]
     fn content_default_meta_is_empty() {

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -733,6 +733,16 @@ fn build_attachment_meta(
                 location: Some(format!("attachment[{idx}]:filename")),
             });
         }
+        if let Some((penult, final_ext)) = detect_double_extension(name) {
+            warnings.push(SecurityWarning {
+                code: WarningCode::LookalikeFilenameExtensionSpoof,
+                detail: Some(format!(
+                    "reason=double_extension,visible=.{penult},\
+                     declared=.{penult}.{final_ext}"
+                )),
+                location: Some(format!("attachment[{idx}]:filename")),
+            });
+        }
         let (unicode_clean, mut ws) = unicode::sanitize(
             name.as_bytes(),
             Some("utf-8"),
@@ -1011,6 +1021,31 @@ fn contains_bidi_override(s: &str) -> bool {
                 | '\u{2069}'
         )
     })
+}
+
+const DOCUMENT_EXTENSIONS: &[&str] = &[
+    "pdf", "doc", "docx", "xls", "xlsx", "png", "jpg", "jpeg", "gif", "txt", "csv", "rtf",
+];
+
+const EXECUTABLE_EXTENSIONS: &[&str] = &[
+    "exe", "dll", "bat", "cmd", "ps1", "vbs", "js", "scr", "msi", "app", "dmg", "sh", "com", "pif",
+    "jar", "lnk",
+];
+
+fn detect_double_extension(name: &str) -> Option<(String, String)> {
+    let segments: Vec<&str> = name.split('.').collect();
+    if segments.len() < 3 {
+        return None;
+    }
+    let penultimate = segments[segments.len() - 2].to_ascii_lowercase();
+    let final_ext = segments[segments.len() - 1].to_ascii_lowercase();
+    if DOCUMENT_EXTENSIONS.contains(&penultimate.as_str())
+        && EXECUTABLE_EXTENSIONS.contains(&final_ext.as_str())
+    {
+        Some((penultimate, final_ext))
+    } else {
+        None
+    }
 }
 
 /// Return the substring after the last `.` in `filename`, if any.
@@ -1810,5 +1845,67 @@ mod tests {
         let content = parse_message(raw).unwrap();
         assert_eq!(content.meta.attachments.len(), 1);
         assert!(content.meta.attachments[0].size_bytes > 0);
+    }
+
+    #[test]
+    fn double_extension_pdf_exe_fires_spoof_warning() {
+        let eml = b"From: test@example.com\r\n\
+            Subject: invoice\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: multipart/mixed; boundary=\"bound\"\r\n\
+            \r\n\
+            --bound\r\n\
+            Content-Type: text/plain\r\n\
+            \r\n\
+            See attached.\r\n\
+            --bound\r\n\
+            Content-Type: application/octet-stream\r\n\
+            Content-Disposition: attachment; filename=\"invoice.pdf.exe\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            AAAA\r\n\
+            --bound--\r\n";
+        let content = parse_message(eml).unwrap();
+        assert!(
+            content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeFilenameExtensionSpoof
+                    && w.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("double_extension"))
+            }),
+            "expected LookalikeFilenameExtensionSpoof with double_extension, \
+             got {:?}",
+            content.security_warnings
+        );
+    }
+
+    #[test]
+    fn single_extension_does_not_fire_double_extension() {
+        let eml = b"From: test@example.com\r\n\
+            Subject: file\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: multipart/mixed; boundary=\"bound\"\r\n\
+            \r\n\
+            --bound\r\n\
+            Content-Type: text/plain\r\n\
+            \r\n\
+            See attached.\r\n\
+            --bound\r\n\
+            Content-Type: application/pdf\r\n\
+            Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            AAAA\r\n\
+            --bound--\r\n";
+        let content = parse_message(eml).unwrap();
+        assert!(
+            !content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeFilenameExtensionSpoof
+                    && w.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("double_extension"))
+            }),
+            "single extension should not fire double_extension spoof"
+        );
     }
 }

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -86,14 +86,64 @@ pub fn parse_message(raw: &[u8]) -> Result<Content, ContentError> {
         security_warnings: warnings,
     };
 
+    let header_domains = collect_header_domains(&message);
     let lookalike_warnings = lookalike::audit(&lookalike::LookalikeInput {
         meta: &content.meta,
         body_text: &content.untrusted.body_text,
         anchor_hrefs: &html_anchor_hrefs,
+        header_domains,
     });
     content.security_warnings.extend(lookalike_warnings);
 
     Ok(content)
+}
+
+/// Pre-extract domains from structured `Addr.address` fields for
+/// all header address sources (From, To, Cc, Reply-To). Using the
+/// parser's structured data is more reliable than re-parsing the
+/// rendered display string.
+fn collect_header_domains(message: &Message<'_>) -> Vec<(String, String)> {
+    let mut domains = Vec::new();
+    if let Some(address) = message.from() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:from".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.to() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:to".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.cc() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:cc".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.reply_to() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:reply_to".to_string()));
+            }
+        }
+    }
+    domains
+}
+
+/// Extract the domain portion from a structured `mail_parser::Addr`.
+fn addr_domain(addr: &mail_parser::Addr<'_>) -> Option<String> {
+    let email = addr.address.as_deref()?;
+    let (_local, domain) = email.rsplit_once('@')?;
+    let trimmed = domain.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_string())
 }
 
 fn enforce_header_count(

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -123,6 +123,7 @@ fn extract_meta(
     let from = first_address_string(message.from(), "header:from", warnings);
     let to = address_strings(message.to(), "header:to", warnings);
     let cc = address_strings(message.cc(), "header:cc", warnings);
+    let reply_to = first_address_string(message.reply_to(), "header:reply_to", warnings);
     let subject = sanitize_opt_str(message.subject(), "header:subject", warnings);
     let date = message.date().and_then(convert_datetime);
     let message_id = sanitize_opt_str(message.message_id(), "header:message_id", warnings);
@@ -136,7 +137,7 @@ fn extract_meta(
         from,
         to,
         cc,
-        reply_to: None,
+        reply_to,
         subject,
         date,
         message_id,
@@ -1875,6 +1876,40 @@ mod tests {
             }),
             "expected LookalikeFilenameExtensionSpoof with double_extension, \
              got {:?}",
+            content.security_warnings
+        );
+    }
+
+    #[test]
+    fn reply_to_extracted_into_meta() {
+        let eml = b"From: sender@example.com\r\n\
+            Reply-To: reply@different.com\r\n\
+            To: recipient@example.com\r\n\
+            Subject: test\r\n\
+            \r\n\
+            body\r\n";
+        let content = parse_message(eml).unwrap();
+        assert_eq!(
+            content.meta.reply_to.as_deref(),
+            Some("reply@different.com")
+        );
+    }
+
+    #[test]
+    fn reply_to_bidi_override_emits_warning() {
+        let eml = "From: sender@example.com\r\n\
+             Reply-To: attacker@evil\u{202E}.com\r\n\
+             To: recipient@example.com\r\n\
+             Subject: test\r\n\
+             \r\n\
+             body\r\n";
+        let content = parse_message(eml.as_bytes()).unwrap();
+        assert!(
+            content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeHomographDomain
+                    && w.location.as_deref() == Some("header:reply_to")
+            }),
+            "expected LookalikeHomographDomain on reply_to, got {:?}",
             content.security_warnings
         );
     }

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -136,6 +136,7 @@ fn extract_meta(
         from,
         to,
         cc,
+        reply_to: None,
         subject,
         date,
         message_id,

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -1387,8 +1387,8 @@ mod tests {
             content
                 .security_warnings
                 .iter()
-                .any(|w| matches!(w.code, WarningCode::HtmlHiddenContentStripped)),
-            "expected HtmlHiddenContentStripped warning, got {:?}",
+                .any(|w| matches!(w.code, WarningCode::HtmlHiddenContentDetected)),
+            "expected HtmlHiddenContentDetected warning, got {:?}",
             content.security_warnings
         );
         assert!(!content.untrusted.body_text.contains("hidden"));

--- a/crates/rimap-content/tests/epvme_integration.rs
+++ b/crates/rimap-content/tests/epvme_integration.rs
@@ -1,0 +1,160 @@
+//! Integration tests for the `epvme_runner` binary.
+
+#![expect(clippy::unwrap_used, reason = "test code")]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Resolve the path to the `epvme_runner` binary built by cargo.
+fn cargo_bin() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    // test binary lives in target/debug/deps/; go up to target/debug/
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("epvme_runner");
+    path
+}
+
+fn write_eml(dir: &Path, name: &str, body: &str) {
+    let content = format!(
+        "From: test@example.com\r\n\
+         To: test@example.com\r\n\
+         Subject: Test\r\n\
+         \r\n\
+         {body}\r\n"
+    );
+    fs::write(dir.join(name), content.as_bytes()).unwrap();
+}
+
+#[test]
+fn normal_run_two_files() {
+    let tmp = TempDir::new().unwrap();
+    write_eml(tmp.path(), "a.eml", "Hello");
+    write_eml(tmp.path(), "b.eml", "World");
+
+    let output = Command::new(cargo_bin()).arg(tmp.path()).output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Discovered .eml files: 2"),
+        "stdout missing file count:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Processed files: 2"),
+        "stdout missing processed count:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Parsed successfully: 2"),
+        "stdout missing ok count:\n{stdout}",
+    );
+}
+
+#[test]
+fn missing_directory_exits_nonzero() {
+    let output = Command::new(cargo_bin())
+        .arg("/tmp/rimap-nonexistent-dir-for-test")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for missing directory",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "stderr should mention missing path:\n{stderr}",
+    );
+}
+
+#[test]
+fn limit_flag_caps_processing() {
+    let tmp = TempDir::new().unwrap();
+    write_eml(tmp.path(), "a.eml", "one");
+    write_eml(tmp.path(), "b.eml", "two");
+    write_eml(tmp.path(), "c.eml", "three");
+
+    let output = Command::new(cargo_bin())
+        .args([tmp.path().as_os_str(), "--limit".as_ref(), "2".as_ref()])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Discovered .eml files: 3"),
+        "should discover all 3 files:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Processed files: 2"),
+        "should process only 2 files:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Limit: 2"),
+        "should display the limit:\n{stdout}",
+    );
+}
+
+#[test]
+fn json_out_writes_valid_json() {
+    let tmp = TempDir::new().unwrap();
+    write_eml(tmp.path(), "sample.eml", "JSON test body");
+
+    let json_path = tmp.path().join("report.json");
+
+    let output = Command::new(cargo_bin())
+        .args([
+            tmp.path().as_os_str(),
+            "--json-out".as_ref(),
+            json_path.as_os_str(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(json_path.exists(), "JSON report file should exist");
+
+    let raw = fs::read_to_string(&json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    assert_eq!(parsed["discovered_files"], 1);
+    assert_eq!(parsed["processed_files"], 1);
+    assert_eq!(parsed["ok_count"], 1);
+    assert_eq!(parsed["parse_error_count"], 0);
+    assert_eq!(parsed["panic_count"], 0);
+}
+
+#[test]
+fn no_args_exits_nonzero() {
+    let output = Command::new(cargo_bin()).output().unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit with no arguments",
+    );
+}

--- a/crates/rimap-content/tests/injection_corpus.rs
+++ b/crates/rimap-content/tests/injection_corpus.rs
@@ -117,6 +117,7 @@ fn warning_code_to_label(code: WarningCode) -> &'static str {
         WarningCode::HtmlScriptStripped => "html_script_stripped",
         WarningCode::HtmlStyleStripped => "html_style_stripped",
         WarningCode::HtmlRemoteImageStripped => "html_remote_image_stripped",
+        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
         WarningCode::LookalikeMixedScript => "lookalike_mixed_script",
         WarningCode::LookalikeHomographDomain => "lookalike_homograph_domain",
         WarningCode::LookalikeIdnPunycode => "lookalike_idn_punycode",

--- a/crates/rimap-content/tests/injection_corpus.rs
+++ b/crates/rimap-content/tests/injection_corpus.rs
@@ -112,7 +112,7 @@ fn warning_code_to_label(code: WarningCode) -> &'static str {
         WarningCode::ParseMimePartCountExceeded => "parse_mime_part_count_exceeded",
         WarningCode::ParseHeaderCountExceeded => "parse_header_count_exceeded",
         WarningCode::ParseAttachmentFilenameRewritten => "parse_attachment_filename_rewritten",
-        WarningCode::HtmlHiddenContentStripped => "html_hidden_content_stripped",
+        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
         WarningCode::HtmlLinkTextHrefMismatch => "html_link_text_href_mismatch",
         WarningCode::HtmlScriptStripped => "html_script_stripped",
         WarningCode::HtmlStyleStripped => "html_style_stripped",

--- a/crates/rimap-content/tests/proptest_charset.rs
+++ b/crates/rimap-content/tests/proptest_charset.rs
@@ -1,0 +1,41 @@
+//! Proptest property: arbitrary charset parameter strings passed to
+//! `parse_message` always produce either a valid `Content` with UTF-8
+//! `body_text` or a structured `ContentError` — never a panic.
+//!
+//! Runs at 10,000 cases.
+
+use proptest::prelude::*;
+use rimap_content::parse_message;
+
+fn config() -> ProptestConfig {
+    ProptestConfig {
+        cases: 10_000,
+        max_shrink_iters: 10_000,
+        ..ProptestConfig::default()
+    }
+}
+
+proptest! {
+    #![proptest_config(config())]
+
+    #[test]
+    fn charset_parameter_produces_valid_utf8_or_error(
+        charset in "[a-zA-Z0-9_:. -]{0,40}"
+    ) {
+        let eml = format!(
+            "From: test@example.com\r\n\
+             Subject: charset test\r\n\
+             MIME-Version: 1.0\r\n\
+             Content-Type: text/plain; charset=\"{charset}\"\r\n\
+             \r\n\
+             Hello world\r\n"
+        );
+        if let Ok(content) = parse_message(eml.as_bytes()) {
+            // body_text must be valid UTF-8 (it's a String, so
+            // this is guaranteed by construction, but we verify
+            // the content is non-panicking and reasonable).
+            let _ = content.untrusted.body_text.len();
+        }
+        // Structured error is also acceptable.
+    }
+}

--- a/crates/rimap-content/tests/snapshots.rs
+++ b/crates/rimap-content/tests/snapshots.rs
@@ -160,3 +160,18 @@ fn snapshot_lookalike_filename_rlo_bidi() {
 fn snapshot_html_tokenizer_divergence() {
     snapshot_one("html-tokenizer-divergence");
 }
+
+#[test]
+fn snapshot_html_offscreen_evasion() {
+    snapshot_one("html-offscreen-evasion");
+}
+
+#[test]
+fn snapshot_html_anchor_unparsable_href() {
+    snapshot_one("html-anchor-unparsable-href");
+}
+
+#[test]
+fn snapshot_lookalike_reply_to_mismatch() {
+    snapshot_one("lookalike-reply-to-mismatch");
+}

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@attachment-path-traversal.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@attachment-path-traversal.snap
@@ -22,6 +22,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 291,
     "references": [],
+    "reply_to": null,
     "subject": null,
     "to": []
   },

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-anchor-unparsable-href.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-anchor-unparsable-href.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rimap-content/tests/snapshots.rs
+expression: value
+---
+{
+  "meta": {
+    "attachments": [],
+    "body_truncated": false,
+    "cc": [],
+    "date": null,
+    "from": "phisher@evil.example",
+    "in_reply_to": null,
+    "mailing_list": null,
+    "message_id": null,
+    "original_size_bytes": 287,
+    "references": [],
+    "reply_to": null,
+    "subject": "Unparsable href test",
+    "to": [
+      "victim@example.com"
+    ]
+  },
+  "security_warnings": [
+    {
+      "code": "html_anchor_unparsable_href",
+      "detail": "href=https://evilserver/phishing-page,text=Visit paypal.com to verify",
+      "location": "body_html:anchor"
+    }
+  ],
+  "untrusted": {
+    "alternate_parts": [],
+    "body_html": "\n<p>Click to verify your account:</p>\n<a href=\"https://evilserver/phishing-page\" rel=\"noopener noreferrer\">Visit paypal.com to verify</a>\n\n",
+    "body_text": "Click to verify your account: Visit paypal.com to verify"
+  }
+}

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-display-none.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-display-none.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 280,
     "references": [],
+    "reply_to": null,
     "subject": "Invoice 4471",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-display-none.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-display-none.snap
@@ -21,7 +21,7 @@ expression: value
   },
   "security_warnings": [
     {
-      "code": "html_hidden_content_stripped",
+      "code": "html_hidden_content_detected",
       "detail": "method=display_none",
       "location": "body:html"
     }

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-offscreen-evasion.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-offscreen-evasion.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rimap-content/tests/snapshots.rs
+expression: value
+---
+{
+  "meta": {
+    "attachments": [],
+    "body_truncated": false,
+    "cc": [],
+    "date": null,
+    "from": "attacker@evil.example",
+    "in_reply_to": null,
+    "mailing_list": null,
+    "message_id": null,
+    "original_size_bytes": 385,
+    "references": [],
+    "reply_to": null,
+    "subject": "Offscreen evasion test",
+    "to": [
+      "victim@example.com"
+    ]
+  },
+  "security_warnings": [
+    {
+      "code": "html_hidden_content_detected",
+      "detail": "method=offscreen",
+      "location": "body:html"
+    },
+    {
+      "code": "html_hidden_content_detected",
+      "detail": "method=offscreen",
+      "location": "body:html"
+    }
+  ],
+  "untrusted": {
+    "alternate_parts": [],
+    "body_html": "\n<p>Please review the attached document.</p>\n<div>HIDDEN BY LEFT OFFSET</div>\n<div>HIDDEN BY TRANSFORM</div>\n\n",
+    "body_text": "Please review the attached document."
+  }
+}

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-only-hidden-instructions.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-only-hidden-instructions.snap
@@ -21,7 +21,7 @@ expression: value
   },
   "security_warnings": [
     {
-      "code": "html_hidden_content_stripped",
+      "code": "html_hidden_content_detected",
       "detail": "method=display_none",
       "location": "body:html"
     }

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-only-hidden-instructions.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-only-hidden-instructions.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 292,
     "references": [],
+    "reply_to": null,
     "subject": "Important",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-remote-image-tracker.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-remote-image-tracker.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 266,
     "references": [],
+    "reply_to": null,
     "subject": "Welcome",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-script-payload.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-script-payload.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 257,
     "references": [],
+    "reply_to": null,
     "subject": "Account update",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-text-href-mismatch.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-text-href-mismatch.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 264,
     "references": [],
+    "reply_to": null,
     "subject": "Statement ready",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-tokenizer-divergence.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-tokenizer-divergence.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 332,
     "references": [],
+    "reply_to": null,
     "subject": "Policy update",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-tokenizer-divergence.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-tokenizer-divergence.snap
@@ -12,7 +12,7 @@ expression: value
     "in_reply_to": null,
     "mailing_list": null,
     "message_id": null,
-    "original_size_bytes": 332,
+    "original_size_bytes": 382,
     "references": [],
     "reply_to": null,
     "subject": "Policy update",
@@ -29,7 +29,7 @@ expression: value
   ],
   "untrusted": {
     "alternate_parts": [],
-    "body_html": "<p>Notice: please review the policy update.</p>\n",
+    "body_html": "<p>Notice: please review the policy update.</p>alert(\"cdata-bypass\")]]&gt;\n",
     "body_text": "Notice: please review the policy update."
   }
 }

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-white-on-white.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-white-on-white.snap
@@ -21,7 +21,7 @@ expression: value
   },
   "security_warnings": [
     {
-      "code": "html_hidden_content_stripped",
+      "code": "html_hidden_content_detected",
       "detail": "method=color_match",
       "location": "body:html"
     }

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-white-on-white.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@html-white-on-white.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 315,
     "references": [],
+    "reply_to": null,
     "subject": "Q4 results",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-filename-rlo-bidi.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-filename-rlo-bidi.snap
@@ -22,6 +22,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 488,
     "references": [],
+    "reply_to": null,
     "subject": "Photo attached",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-homograph-paypal.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-homograph-paypal.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 274,
     "references": [],
+    "reply_to": null,
     "subject": "Your balance",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-idn-positive.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-idn-positive.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 260,
     "references": [],
+    "reply_to": null,
     "subject": "Begruessung",
     "to": [
       "empfaenger@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-idn-punycode.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-idn-punycode.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 190,
     "references": [],
+    "reply_to": null,
     "subject": "Payment link",
     "to": [
       "victim@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-reply-to-mismatch.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@lookalike-reply-to-mismatch.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rimap-content/tests/snapshots.rs
+expression: value
+---
+{
+  "meta": {
+    "attachments": [],
+    "body_truncated": false,
+    "cc": [],
+    "date": null,
+    "from": "support@paypal.com",
+    "in_reply_to": null,
+    "mailing_list": null,
+    "message_id": null,
+    "original_size_bytes": 238,
+    "references": [],
+    "reply_to": "support@pаypal.com",
+    "subject": "Account verification required",
+    "to": [
+      "victim@example.com"
+    ]
+  },
+  "security_warnings": [
+    {
+      "code": "lookalike_mixed_script",
+      "detail": "domain=xn--pypal-4ve.com,unicode=pаypal.com",
+      "location": "header:reply_to"
+    },
+    {
+      "code": "lookalike_idn_punycode",
+      "detail": "domain=xn--pypal-4ve.com,ulabel=pаypal.com",
+      "location": "header:reply_to"
+    }
+  ],
+  "untrusted": {
+    "alternate_parts": [],
+    "body_html": null,
+    "body_text": "Please verify your account by replying to this email.\n"
+  }
+}

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@mailing-list.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@mailing-list.snap
@@ -18,6 +18,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 308,
     "references": [],
+    "reply_to": null,
     "subject": "[dev] new release",
     "to": [
       "subscribers@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@mime-type-spoofing.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@mime-type-spoofing.snap
@@ -22,6 +22,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 327,
     "references": [],
+    "reply_to": null,
     "subject": "attachment with spoofed type",
     "to": []
   },

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@multilingual-negative.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@multilingual-negative.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 250,
     "references": [],
+    "reply_to": null,
     "subject": "Multilingual greeting",
     "to": [
       "reader@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@nested-rfc822.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@nested-rfc822.snap
@@ -22,6 +22,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 396,
     "references": [],
+    "reply_to": null,
     "subject": "FWD: original message",
     "to": []
   },

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@oversized-body.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@oversized-body.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 1049684,
     "references": [],
+    "reply_to": null,
     "subject": "oversized",
     "to": []
   },

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@prompt-injection-plaintext.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@prompt-injection-plaintext.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 218,
     "references": [],
+    "reply_to": null,
     "subject": "Important task",
     "to": [
       "Victim <victim@example.com>"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@rfc2047-crlf-smuggling.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@rfc2047-crlf-smuggling.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 138,
     "references": [],
+    "reply_to": null,
     "subject": null,
     "to": [
       "bob@example.com"

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@trojan-source-bidi.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@trojan-source-bidi.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 133,
     "references": [],
+    "reply_to": null,
     "subject": "filename.txt.exe",
     "to": []
   },

--- a/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@zero-width-poisoning.snap
+++ b/crates/rimap-content/tests/snapshots/snapshots__snapshot_one@zero-width-poisoning.snap
@@ -14,6 +14,7 @@ expression: value
     "message_id": null,
     "original_size_bytes": 119,
     "references": [],
+    "reply_to": null,
     "subject": "hello",
     "to": []
   },

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -565,7 +565,7 @@ impl Connection {
             crate::ops::store::store(session, uids, flags, action).await
         })
         .await;
-        if let Err(Error::ConnectionLost) = &result {
+        if let Err(Error::ConnectionLost | Error::Timeout { .. }) = &result {
             self.invalidate().await;
         }
         result
@@ -598,7 +598,7 @@ impl Connection {
             crate::ops::move_msg::move_messages(session, dest_folder, uids).await
         })
         .await;
-        if let Err(Error::ConnectionLost) = &result {
+        if let Err(Error::ConnectionLost | Error::Timeout { .. }) = &result {
             self.invalidate().await;
         }
         result
@@ -628,7 +628,7 @@ impl Connection {
             crate::ops::append::append(session, folder, message, flags, keywords).await
         })
         .await;
-        if let Err(Error::ConnectionLost) = &result {
+        if let Err(Error::ConnectionLost | Error::Timeout { .. }) = &result {
             self.invalidate().await;
         }
         result

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -540,6 +540,36 @@ impl Connection {
         }
         result
     }
+
+    /// `UID STORE` — add or remove flags on messages.
+    ///
+    /// Batch limit: 100 UIDs. Returns the UIDs the server confirmed.
+    ///
+    /// # Errors
+    /// Returns `Error::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn store_flags(
+        &self,
+        folder: &str,
+        uids: &[crate::types::Uid],
+        flags: &[crate::types::Flag],
+        action: crate::types::FlagAction,
+    ) -> Result<Vec<crate::types::Uid>, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("store", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            crate::ops::folders::select(session, folder, false).await?;
+            crate::ops::store::store(session, uids, flags, action).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
 }
 
 /// Drain the unsolicited-response channel and return `true` if any

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -530,6 +530,7 @@ impl Connection {
                 | Error::Auth { .. }
                 | Error::Protocol(_)
                 | Error::InvalidInput { .. }
+                | Error::BatchTooLarge { .. }
                 | Error::Audit { .. },
             )
             | Ok(_) => false,
@@ -580,7 +581,7 @@ fn error_code_for(err: &Error) -> &'static str {
         Error::Auth { .. } => "ERR_AUTH",
         Error::SizeLimit { .. } => "ERR_ATTACHMENT_TOO_LARGE",
         Error::Protocol(_) => "ERR_IMAP_PROTOCOL",
-        Error::InvalidInput { .. } => "ERR_INVALID_INPUT",
+        Error::InvalidInput { .. } | Error::BatchTooLarge { .. } => "ERR_INVALID_INPUT",
         Error::Audit { .. } => "ERR_AUDIT",
     }
 }

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -603,6 +603,36 @@ impl Connection {
         }
         result
     }
+
+    /// `APPEND` a raw RFC 5322 message to `folder` with the given
+    /// flags and keywords.
+    ///
+    /// Does NOT select the folder first -- APPEND targets a named
+    /// mailbox directly per RFC 3501 section 6.3.11.
+    ///
+    /// # Errors
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn append_message(
+        &self,
+        folder: &str,
+        message: &[u8],
+        flags: &[crate::types::Flag],
+        keywords: &[&str],
+    ) -> Result<crate::types::AppendResult, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("append", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            crate::ops::append::append(session, folder, message, flags, keywords).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
 }
 
 /// Drain the unsolicited-response channel and return `true` if any

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -570,6 +570,39 @@ impl Connection {
         }
         result
     }
+
+    /// Move messages from `source_folder` to `dest_folder`.
+    ///
+    /// Uses IMAP MOVE extension (RFC 6851) when available; falls back
+    /// to COPY + STORE \Deleted + EXPUNGE otherwise. The fallback is
+    /// not atomic.
+    ///
+    /// Batch limit: 100 UIDs.
+    ///
+    /// # Errors
+    /// Returns `Error::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn move_messages(
+        &self,
+        source_folder: &str,
+        dest_folder: &str,
+        uids: &[crate::types::Uid],
+    ) -> Result<Vec<crate::types::MoveResult>, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("move", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            crate::ops::folders::select(session, source_folder, false).await?;
+            crate::ops::move_msg::move_messages(session, dest_folder, uids).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
 }
 
 /// Drain the unsolicited-response channel and return `true` if any

--- a/crates/rimap-imap/src/error.rs
+++ b/crates/rimap-imap/src/error.rs
@@ -55,6 +55,14 @@ pub enum Error {
         /// Human-readable explanation of the validation failure.
         reason: &'static str,
     },
+    /// Caller passed more UIDs than the per-command batch limit.
+    #[error("ERR_BATCH_TOO_LARGE: {count} UIDs exceeds limit of {limit}")]
+    BatchTooLarge {
+        /// Number of UIDs the caller provided.
+        count: usize,
+        /// Maximum UIDs allowed per command.
+        limit: usize,
+    },
     /// Audit-subsystem failure during a tool call. The IMAP transport may
     /// be healthy; this variant exists so audit-write failures stay
     /// distinguishable from network failures in metrics and observability.
@@ -111,7 +119,7 @@ impl From<Error> for RimapError {
             Error::Auth { .. } => ErrorCode::Auth,
             Error::SizeLimit { .. } => ErrorCode::AttachmentTooLarge,
             Error::Protocol(_) => ErrorCode::ImapProtocol,
-            Error::InvalidInput { .. } => ErrorCode::InvalidInput,
+            Error::InvalidInput { .. } | Error::BatchTooLarge { .. } => ErrorCode::InvalidInput,
             Error::Audit { .. } => ErrorCode::Internal,
         };
         let message = err.to_string();

--- a/crates/rimap-imap/src/ops/append.rs
+++ b/crates/rimap-imap/src/ops/append.rs
@@ -20,7 +20,7 @@ pub async fn append(
     flags: &[Flag],
     keywords: &[&str],
 ) -> Result<AppendResult, Error> {
-    let flag_str = build_flags_string(flags, keywords);
+    let flag_str = build_flags_string(flags, keywords)?;
     let flags_arg = if flag_str.is_empty() {
         None
     } else {
@@ -36,14 +36,41 @@ pub async fn append(
 }
 
 /// Build the combined flags string from system flags and keywords.
-fn build_flags_string(flags: &[Flag], keywords: &[&str]) -> String {
-    use crate::ops::store::flags_string;
-    let mut s = flags_string(flags);
+///
+/// # Errors
+///
+/// Returns `Error::InvalidInput` if any keyword or `Flag::Keyword`
+/// content contains non-atom characters.
+fn build_flags_string(flags: &[Flag], keywords: &[&str]) -> Result<String, Error> {
+    use crate::ops::store;
+    let mut s = store::flags_string(flags)?;
     for kw in keywords {
+        store::validate_keyword(kw)?;
         if !s.is_empty() {
             s.push(' ');
         }
         s.push_str(kw);
     }
-    s
+    Ok(s)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_flags_string_rejects_bad_keyword() {
+        let flags = vec![Flag::Seen];
+        let keywords = &["good", "inject\r\nDATA"];
+        assert!(build_flags_string(&flags, keywords).is_err());
+    }
+
+    #[test]
+    fn build_flags_string_accepts_valid() {
+        let flags = vec![Flag::Flagged];
+        let keywords = &["$label1", "Important"];
+        let s = build_flags_string(&flags, keywords).unwrap();
+        assert_eq!(s, "\\Flagged $label1 Important");
+    }
 }

--- a/crates/rimap-imap/src/ops/append.rs
+++ b/crates/rimap-imap/src/ops/append.rs
@@ -1,0 +1,49 @@
+//! IMAP APPEND: upload a message to a mailbox.
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::types::{AppendResult, Flag};
+
+/// Append a raw RFC 5322 message to `folder` with the given system
+/// flags and keywords.
+///
+/// Does NOT select the folder first — APPEND targets a named mailbox
+/// directly per RFC 3501 section 6.3.11.
+///
+/// # Errors
+///
+/// Propagates connection-lost or protocol errors from async-imap.
+pub async fn append(
+    session: &mut ImapSession,
+    folder: &str,
+    message: &[u8],
+    flags: &[Flag],
+    keywords: &[&str],
+) -> Result<AppendResult, Error> {
+    let flag_str = build_flags_string(flags, keywords);
+    let flags_arg = if flag_str.is_empty() {
+        None
+    } else {
+        Some(format!("({flag_str})"))
+    };
+
+    session
+        .append(folder, flags_arg.as_deref(), None, message)
+        .await
+        .map_err(super::folders::map_err)?;
+
+    Ok(AppendResult { uid: None })
+}
+
+/// Build the combined flags string from system flags and keywords.
+fn build_flags_string(flags: &[Flag], keywords: &[&str]) -> String {
+    use crate::ops::store::flags_string;
+    let mut s = flags_string(flags);
+    for kw in keywords {
+        if !s.is_empty() {
+            s.push(' ');
+        }
+        s.push_str(kw);
+    }
+    s
+}

--- a/crates/rimap-imap/src/ops/mod.rs
+++ b/crates/rimap-imap/src/ops/mod.rs
@@ -3,3 +3,4 @@
 pub mod fetch;
 pub mod folders;
 pub mod search;
+pub mod store;

--- a/crates/rimap-imap/src/ops/mod.rs
+++ b/crates/rimap-imap/src/ops/mod.rs
@@ -1,5 +1,6 @@
 //! IMAP operations grouped by verb family.
 
+pub mod append;
 pub mod fetch;
 pub mod folders;
 pub mod move_msg;

--- a/crates/rimap-imap/src/ops/mod.rs
+++ b/crates/rimap-imap/src/ops/mod.rs
@@ -1,6 +1,7 @@
-//! IMAP read operations grouped by verb family.
+//! IMAP operations grouped by verb family.
 
 pub mod fetch;
 pub mod folders;
+pub mod move_msg;
 pub mod search;
 pub mod store;

--- a/crates/rimap-imap/src/ops/move_msg.rs
+++ b/crates/rimap-imap/src/ops/move_msg.rs
@@ -1,0 +1,110 @@
+//! UID MOVE with COPY+DELETE fallback for servers without the MOVE
+//! extension (RFC 6851).
+
+use futures_util::StreamExt;
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::ops::store;
+use crate::types::{Flag, FlagAction, MoveResult, Uid};
+
+/// Maximum UIDs per MOVE command.
+const MAX_BATCH: usize = 100;
+
+/// Move `uids` from the currently selected folder to `dest_folder`.
+///
+/// Tries `UID MOVE` first (RFC 6851). If the server rejects the
+/// command (BAD / unknown / not supported), falls back to
+/// COPY + STORE \Deleted + EXPUNGE.
+///
+/// # Errors
+///
+/// Returns `Error::BatchTooLarge` if `uids.len() > MAX_BATCH`.
+/// Propagates connection-lost or protocol errors from async-imap.
+pub async fn move_messages(
+    session: &mut ImapSession,
+    dest_folder: &str,
+    uids: &[Uid],
+) -> Result<Vec<MoveResult>, Error> {
+    if uids.len() > MAX_BATCH {
+        return Err(Error::BatchTooLarge {
+            count: uids.len(),
+            limit: MAX_BATCH,
+        });
+    }
+    if uids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let uid_set = store::uid_set_string(uids);
+
+    // Try MOVE first; fall back to COPY+DELETE if the server rejects it.
+    let move_result = session.uid_mv(&uid_set, dest_folder).await;
+
+    match move_result {
+        Ok(()) => Ok(build_results(uids)),
+        Err(e) if is_move_unsupported(&e) => copy_delete_fallback(session, dest_folder, uids).await,
+        Err(e) => Err(super::folders::map_err(e)),
+    }
+}
+
+/// Fallback: COPY + STORE \Deleted + EXPUNGE. Not atomic.
+async fn copy_delete_fallback(
+    session: &mut ImapSession,
+    dest_folder: &str,
+    uids: &[Uid],
+) -> Result<Vec<MoveResult>, Error> {
+    let uid_set = store::uid_set_string(uids);
+
+    // Step 1: COPY to destination.
+    session
+        .uid_copy(&uid_set, dest_folder)
+        .await
+        .map_err(super::folders::map_err)?;
+
+    // Step 2: STORE +FLAGS \Deleted on the originals.
+    store::store(session, uids, &[Flag::Deleted], FlagAction::Add).await?;
+
+    // Step 3: EXPUNGE to remove deleted messages. The stream yields
+    // sequence numbers of expunged messages; drain it to completion.
+    // The stream is !Unpin, so we pin it before polling.
+    let stream = session.expunge().await.map_err(super::folders::map_err)?;
+    futures_util::pin_mut!(stream);
+    while let Some(item) = stream.next().await {
+        let _seq = item.map_err(super::folders::map_err)?;
+    }
+
+    Ok(build_results(uids))
+}
+
+/// Check whether the async-imap error indicates that the MOVE command
+/// is not supported by the server (BAD response, "unknown command",
+/// "not supported").
+fn is_move_unsupported(err: &async_imap::error::Error) -> bool {
+    match err {
+        async_imap::error::Error::Bad(_) => true,
+        async_imap::error::Error::No(msg) => {
+            let lower = msg.to_ascii_lowercase();
+            lower.contains("unknown command") || lower.contains("not supported")
+        }
+        async_imap::error::Error::Io(_)
+        | async_imap::error::Error::ConnectionLost
+        | async_imap::error::Error::Parse(_)
+        | async_imap::error::Error::Validate(_)
+        | async_imap::error::Error::Append
+        | _ => false,
+    }
+}
+
+/// Build `MoveResult` entries with `new_uid: None` (async-imap does
+/// not expose UIDPLUS data).
+fn build_results(uids: &[Uid]) -> Vec<MoveResult> {
+    let mut results = Vec::with_capacity(uids.len());
+    for &uid in uids {
+        results.push(MoveResult {
+            old_uid: uid,
+            new_uid: None,
+        });
+    }
+    results
+}

--- a/crates/rimap-imap/src/ops/move_msg.rs
+++ b/crates/rimap-imap/src/ops/move_msg.rs
@@ -49,6 +49,11 @@ pub async fn move_messages(
 }
 
 /// Fallback: COPY + STORE \Deleted + EXPUNGE. Not atomic.
+///
+/// The plain `EXPUNGE` command removes all messages with `\Deleted` in
+/// the selected mailbox, not just the UIDs this operation flagged.
+/// `UID EXPUNGE` (RFC 4315) would be UID-scoped but async-imap 0.11
+/// does not expose it. Servers that support MOVE never reach this path.
 async fn copy_delete_fallback(
     session: &mut ImapSession,
     dest_folder: &str,
@@ -87,12 +92,10 @@ fn is_move_unsupported(err: &async_imap::error::Error) -> bool {
             let lower = msg.to_ascii_lowercase();
             lower.contains("unknown command") || lower.contains("not supported")
         }
-        async_imap::error::Error::Io(_)
-        | async_imap::error::Error::ConnectionLost
-        | async_imap::error::Error::Parse(_)
-        | async_imap::error::Error::Validate(_)
-        | async_imap::error::Error::Append
-        | _ => false,
+        // async_imap::error::Error is #[non_exhaustive], so the
+        // wildcard is required. All other known variants (Io,
+        // ConnectionLost, Parse, Validate, Append) are real failures.
+        _ => false,
     }
 }
 

--- a/crates/rimap-imap/src/ops/store.rs
+++ b/crates/rimap-imap/src/ops/store.rs
@@ -34,7 +34,7 @@ pub async fn store(
     }
 
     let uid_set = uid_set_string(uids);
-    let flag_str = flags_string(flags);
+    let flag_str = flags_string(flags)?;
     let query = match action {
         FlagAction::Add => format!("+FLAGS ({flag_str})"),
         FlagAction::Remove => format!("-FLAGS ({flag_str})"),
@@ -70,8 +70,52 @@ pub(crate) fn uid_set_string(uids: &[Uid]) -> String {
     s
 }
 
+/// Validate that a keyword string contains only IMAP atom characters.
+/// Returns `Error::InvalidInput` if any non-atom byte is found.
+///
+/// IMAP atom = 1*ATOM-CHAR (RFC 3501 section 9 formal syntax)
+/// ATOM-CHAR = any CHAR except atom-specials
+/// atom-specials = "(" / ")" / "{" / SP / CTL /
+///                 list-wildcards / quoted-specials / resp-specials
+pub(crate) fn validate_keyword(keyword: &str) -> Result<(), Error> {
+    if keyword.is_empty() {
+        return Err(Error::InvalidInput {
+            field: "keyword",
+            reason: "keyword must not be empty",
+        });
+    }
+    for byte in keyword.bytes() {
+        match byte {
+            // CTL (0x00-0x1f, 0x7f)
+            0x00..=0x1f | 0x7f => {
+                return Err(Error::InvalidInput {
+                    field: "keyword",
+                    reason: "contains control characters",
+                });
+            }
+            // atom-specials: ( ) { SP % * " \ ] [
+            b'(' | b')' | b'{' | b' ' | b'%' | b'*' | b'"' | b'\\' | b']' | b'[' => {
+                return Err(Error::InvalidInput {
+                    field: "keyword",
+                    reason: "contains IMAP atom-special characters",
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Format flags as space-separated IMAP flag atoms.
-pub(crate) fn flags_string(flags: &[Flag]) -> String {
+///
+/// Validates `Flag::Keyword` content against RFC 3501 atom syntax
+/// to prevent IMAP command injection.
+///
+/// # Errors
+///
+/// Returns `Error::InvalidInput` if a keyword contains non-atom
+/// characters (control bytes, spaces, specials).
+pub(crate) fn flags_string(flags: &[Flag]) -> Result<String, Error> {
     let mut s = String::new();
     for (i, flag) in flags.iter().enumerate() {
         if i > 0 {
@@ -84,8 +128,76 @@ pub(crate) fn flags_string(flags: &[Flag]) -> String {
             Flag::Deleted => s.push_str("\\Deleted"),
             Flag::Draft => s.push_str("\\Draft"),
             Flag::Recent => s.push_str("\\Recent"),
-            Flag::Keyword(k) => s.push_str(k),
+            Flag::Keyword(k) => {
+                validate_keyword(k)?;
+                s.push_str(k);
+            }
         }
     }
-    s
+    Ok(s)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_keyword_accepts_valid_atom() {
+        assert!(validate_keyword("Important").is_ok());
+        assert!(validate_keyword("$label1").is_ok());
+        assert!(validate_keyword("my-tag").is_ok());
+    }
+
+    #[test]
+    fn validate_keyword_rejects_crlf() {
+        let result = validate_keyword("bad\r\nSTORE");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InvalidInput {
+                field: "keyword",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_keyword_rejects_space() {
+        assert!(validate_keyword("has space").is_err());
+    }
+
+    #[test]
+    fn validate_keyword_rejects_empty() {
+        let err = validate_keyword("").unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InvalidInput {
+                field: "keyword",
+                reason: "keyword must not be empty"
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_keyword_rejects_atom_specials() {
+        for ch in ['(', ')', '{', '%', '*', '"', '\\', ']', '['] {
+            let s = format!("bad{ch}kw");
+            assert!(validate_keyword(&s).is_err(), "should reject '{ch}'");
+        }
+    }
+
+    #[test]
+    fn flags_string_propagates_keyword_error() {
+        let flags = vec![Flag::Seen, Flag::Keyword("inject\r\n".to_string())];
+        assert!(flags_string(&flags).is_err());
+    }
+
+    #[test]
+    fn flags_string_valid_keywords() {
+        let flags = vec![Flag::Seen, Flag::Keyword("Important".to_string())];
+        let s = flags_string(&flags).unwrap();
+        assert_eq!(s, "\\Seen Important");
+    }
 }

--- a/crates/rimap-imap/src/ops/store.rs
+++ b/crates/rimap-imap/src/ops/store.rs
@@ -1,0 +1,91 @@
+//! UID STORE: add or remove flags on messages by UID.
+
+use futures_util::StreamExt;
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::types::{Flag, FlagAction, Uid};
+
+/// Maximum UIDs per STORE command.
+const MAX_BATCH: usize = 100;
+
+/// Add or remove `flags` on `uids` in the currently selected folder.
+///
+/// Returns the UIDs the server confirmed as updated.
+///
+/// # Errors
+///
+/// Returns `Error::BatchTooLarge` if `uids.len() > MAX_BATCH`.
+/// Propagates connection-lost or protocol errors from async-imap.
+pub async fn store(
+    session: &mut ImapSession,
+    uids: &[Uid],
+    flags: &[Flag],
+    action: FlagAction,
+) -> Result<Vec<Uid>, Error> {
+    if uids.len() > MAX_BATCH {
+        return Err(Error::BatchTooLarge {
+            count: uids.len(),
+            limit: MAX_BATCH,
+        });
+    }
+    if uids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let uid_set = uid_set_string(uids);
+    let flag_str = flags_string(flags);
+    let query = match action {
+        FlagAction::Add => format!("+FLAGS ({flag_str})"),
+        FlagAction::Remove => format!("-FLAGS ({flag_str})"),
+    };
+
+    let mut stream = session
+        .uid_store(&uid_set, &query)
+        .await
+        .map_err(super::folders::map_err)?;
+
+    let mut updated = Vec::new();
+    while let Some(item) = stream.next().await {
+        let item = item.map_err(super::folders::map_err)?;
+        if let Some(uid_val) = item.uid
+            && let Some(uid) = Uid::new(uid_val)
+        {
+            updated.push(uid);
+        }
+    }
+
+    Ok(updated)
+}
+
+/// Format UIDs as a comma-separated set for IMAP commands.
+pub(crate) fn uid_set_string(uids: &[Uid]) -> String {
+    let mut s = String::new();
+    for (i, uid) in uids.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&uid.get().to_string());
+    }
+    s
+}
+
+/// Format flags as space-separated IMAP flag atoms.
+pub(crate) fn flags_string(flags: &[Flag]) -> String {
+    let mut s = String::new();
+    for (i, flag) in flags.iter().enumerate() {
+        if i > 0 {
+            s.push(' ');
+        }
+        match flag {
+            Flag::Seen => s.push_str("\\Seen"),
+            Flag::Answered => s.push_str("\\Answered"),
+            Flag::Flagged => s.push_str("\\Flagged"),
+            Flag::Deleted => s.push_str("\\Deleted"),
+            Flag::Draft => s.push_str("\\Draft"),
+            Flag::Recent => s.push_str("\\Recent"),
+            Flag::Keyword(k) => s.push_str(k),
+        }
+    }
+    s
+}

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -155,6 +155,15 @@ pub struct MoveResult {
     pub new_uid: Option<Uid>,
 }
 
+/// Result of appending a message to a mailbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendResult {
+    /// UID assigned by the server. `None` if the server lacks UIDPLUS.
+    /// async-imap 0.11's `append()` does not expose the APPENDUID
+    /// response code, so this is always `None` for now.
+    pub uid: Option<Uid>,
+}
+
 /// IMAP `ENVELOPE` response. Header values stay raw bytes — RFC 2047 decoding
 /// is Sprint 4's responsibility.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -135,6 +135,15 @@ pub enum Flag {
     Keyword(String),
 }
 
+/// Whether to add or remove flags in a STORE command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagAction {
+    /// `+FLAGS` — add the given flags.
+    Add,
+    /// `-FLAGS` — remove the given flags.
+    Remove,
+}
+
 /// IMAP `ENVELOPE` response. Header values stay raw bytes — RFC 2047 decoding
 /// is Sprint 4's responsibility.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -144,6 +144,17 @@ pub enum FlagAction {
     Remove,
 }
 
+/// Result of moving a single message. `new_uid` is `None` when the
+/// server lacks UIDPLUS or when using the COPY+DELETE fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveResult {
+    /// UID in the source folder (before the move).
+    pub old_uid: Uid,
+    /// UID in the destination folder (after the move). `None` if the
+    /// server does not report it (no UIDPLUS, or COPY+DELETE fallback).
+    pub new_uid: Option<Uid>,
+}
+
 /// IMAP `ENVELOPE` response. Header values stay raw bytes — RFC 2047 decoding
 /// is Sprint 4's responsibility.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -314,3 +314,271 @@ async fn case_11_tcp_half_open_recovery() {
     let folders = h.connection.list_folders("*").await.unwrap();
     assert!(!folders.is_empty());
 }
+
+#[tokio::test]
+async fn case_12_store_add_seen_flag() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message via APPEND.
+    let msg = support::fixtures::minimal_rfc5322("store-seen");
+    h.connection
+        .append_message("INBOX", &msg, &[], &[])
+        .await
+        .unwrap();
+
+    // Search for it.
+    let uids = h
+        .connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("store-seen".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "seeded message not found");
+    let uid = uids[0];
+
+    // Add \Seen flag.
+    let updated = h
+        .connection
+        .store_flags(
+            "INBOX",
+            &[uid],
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Add,
+        )
+        .await
+        .unwrap();
+    assert!(updated.contains(&uid));
+
+    // Verify the flag is set.
+    let fetched = h
+        .connection
+        .fetch(
+            "INBOX",
+            &[uid],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(flags.contains(&rimap_imap::types::Flag::Seen));
+}
+
+#[tokio::test]
+async fn case_13_store_remove_seen_flag() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message with \Seen.
+    let msg = support::fixtures::minimal_rfc5322("store-unseen");
+    h.connection
+        .append_message("INBOX", &msg, &[rimap_imap::types::Flag::Seen], &[])
+        .await
+        .unwrap();
+
+    let uids = h
+        .connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("store-unseen".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty());
+    let uid = uids[0];
+
+    // Remove \Seen flag.
+    let updated = h
+        .connection
+        .store_flags(
+            "INBOX",
+            &[uid],
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Remove,
+        )
+        .await
+        .unwrap();
+    assert!(updated.contains(&uid));
+
+    // Verify the flag is removed.
+    let fetched = h
+        .connection
+        .fetch(
+            "INBOX",
+            &[uid],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(!flags.contains(&rimap_imap::types::Flag::Seen));
+}
+
+#[tokio::test]
+async fn case_14_store_batch_too_large() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    let uids: Vec<rimap_imap::types::Uid> = (1..=101)
+        .map(|n| rimap_imap::types::Uid::new(n).unwrap())
+        .collect();
+
+    let result = h
+        .connection
+        .store_flags(
+            "INBOX",
+            &uids,
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Add,
+        )
+        .await;
+
+    match result {
+        Err(rimap_imap::error::Error::BatchTooLarge {
+            count: 101,
+            limit: 100,
+        }) => {}
+        #[expect(clippy::panic, reason = "test failure path")]
+        other => panic!("expected BatchTooLarge, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn case_15_append_message_to_inbox() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    let msg = support::fixtures::minimal_rfc5322("append-test");
+    let result = h
+        .connection
+        .append_message(
+            "INBOX",
+            &msg,
+            &[rimap_imap::types::Flag::Draft],
+            &["$PendingReview"],
+        )
+        .await
+        .unwrap();
+
+    // async-imap doesn't expose APPENDUID, so uid is None.
+    assert_eq!(result.uid, None);
+
+    // Verify the message is in INBOX by searching for it.
+    let uids = h
+        .connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("append-test".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "appended message not found");
+
+    // Verify it has the \Draft flag.
+    let fetched = h
+        .connection
+        .fetch(
+            "INBOX",
+            &[uids[0]],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(flags.contains(&rimap_imap::types::Flag::Draft));
+}
+
+#[tokio::test]
+async fn case_16_move_message_between_folders() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message in INBOX.
+    let msg = support::fixtures::minimal_rfc5322("move-test");
+    h.connection
+        .append_message("INBOX", &msg, &[], &[])
+        .await
+        .unwrap();
+
+    let uids = h
+        .connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("move-test".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "seeded message not found");
+    let uid = uids[0];
+
+    // Move to Archive (seeded in Dovecot entrypoint.sh).
+    let results = h
+        .connection
+        .move_messages("INBOX", "Archive", &[uid])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].old_uid, uid);
+
+    // Verify the message is gone from INBOX.
+    let after_uids = h
+        .connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("move-test".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        after_uids.is_empty(),
+        "message should be gone from INBOX after move"
+    );
+
+    // Verify the message is in Archive.
+    let archive_uids = h
+        .connection
+        .search(
+            "Archive",
+            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+                subject: Some("move-test".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !archive_uids.is_empty(),
+        "message should be in Archive after move"
+    );
+}

--- a/crates/rimap-imap/tests/integration/support/fixtures.rs
+++ b/crates/rimap-imap/tests/integration/support/fixtures.rs
@@ -1,13 +1,32 @@
-//! Path helpers for the seeded fixtures.
+//! Path helpers and message builders for the seeded fixtures.
+//!
+//! This module is compiled into multiple test binaries (dovecot, proton)
+//! that each use a different subset of helpers. Suppress dead-code
+//! warnings at the module level rather than per-function.
+#![expect(dead_code, reason = "shared across test binaries with partial use")]
 
 use std::path::PathBuf;
 
 #[must_use]
-#[expect(dead_code, reason = "consumed by Task 15 integration tests")]
 pub fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("integration")
         .join("dovecot")
         .join("fixtures")
+}
+
+/// Minimal RFC 5322 message for test seeding.
+#[must_use]
+pub fn minimal_rfc5322(subject: &str) -> Vec<u8> {
+    format!(
+        "From: test@example.com\r\n\
+         To: recipient@example.com\r\n\
+         Subject: {subject}\r\n\
+         Date: Sat, 12 Apr 2026 12:00:00 +0000\r\n\
+         Message-ID: <test-{subject}@example.com>\r\n\
+         \r\n\
+         Test body for {subject}.\r\n"
+    )
+    .into_bytes()
 }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -22,6 +22,7 @@ rimap-authz = { path = "../rimap-authz", version = "0.0.0" }
 rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
 rimap-content = { path = "../rimap-content", version = "0.0.0" }
 rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
+mail-builder = { workspace = true }
 mail-parser = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -21,6 +21,10 @@ rimap-config = { path = "../rimap-config", version = "0.0.0" }
 rimap-authz = { path = "../rimap-authz", version = "0.0.0" }
 rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
 rimap-content = { path = "../rimap-content", version = "0.0.0" }
+rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+infer = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -25,6 +25,7 @@ rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 infer = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -22,6 +22,7 @@ rimap-authz = { path = "../rimap-authz", version = "0.0.0" }
 rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
 rimap-content = { path = "../rimap-content", version = "0.0.0" }
 rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
+mail-parser = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 infer = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -20,6 +20,7 @@ rimap-core = { path = "../rimap-core", version = "0.0.0" }
 rimap-config = { path = "../rimap-config", version = "0.0.0" }
 rimap-authz = { path = "../rimap-authz", version = "0.0.0" }
 rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
+rimap-content = { path = "../rimap-content", version = "0.0.0" }
 serde_json = { workspace = true }
 time = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -42,3 +42,4 @@ tracing-subscriber = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rimap-server/src/content.rs
+++ b/crates/rimap-server/src/content.rs
@@ -9,10 +9,6 @@ use rimap_content::{Content, ContentError, parse_message};
 ///
 /// Returns `ContentError` from the inner call, or
 /// `ContentError::Malformed` if the blocking task panicked.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired in Sprint 5 MCP tool handlers")
-)]
 pub async fn parse_message_async(raw: Vec<u8>) -> Result<Content, ContentError> {
     tokio::task::spawn_blocking(move || parse_message(&raw))
         .await

--- a/crates/rimap-server/src/content.rs
+++ b/crates/rimap-server/src/content.rs
@@ -1,0 +1,48 @@
+//! Async wrapper for the synchronous `rimap_content::parse_message`.
+
+use rimap_content::{Content, ContentError, parse_message};
+
+/// Run `parse_message` on the blocking threadpool to avoid starving
+/// the tokio runtime. `parse_message` is CPU-bound (~2 ms per message).
+///
+/// # Errors
+///
+/// Returns `ContentError` from the inner call, or
+/// `ContentError::Malformed` if the blocking task panicked.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired in Sprint 5 MCP tool handlers")
+)]
+pub async fn parse_message_async(raw: Vec<u8>) -> Result<Content, ContentError> {
+    tokio::task::spawn_blocking(move || parse_message(&raw))
+        .await
+        .unwrap_or_else(|e| {
+            Err(ContentError::Malformed {
+                reason: format!("spawn_blocking panicked: {e}"),
+            })
+        })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parse_message_async_matches_sync() {
+        let raw = b"From: test@example.com\r\n\
+                     Subject: async test\r\n\
+                     \r\n\
+                     Body.\r\n"
+            .to_vec();
+
+        let sync_result = parse_message(&raw).unwrap();
+        let async_result = parse_message_async(raw).await.unwrap();
+
+        assert_eq!(sync_result.meta.subject, async_result.meta.subject);
+        assert_eq!(
+            sync_result.untrusted.body_text,
+            async_result.untrusted.body_text
+        );
+    }
+}

--- a/crates/rimap-server/src/dispatch.rs
+++ b/crates/rimap-server/src/dispatch.rs
@@ -14,10 +14,6 @@ use rimap_core::tool::ToolName;
 /// Run the pre-call guard chain.
 ///
 /// Returns `Ok(())` if all guards pass, or the first `RimapError`.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "scaffolding for tool handlers in later tasks")
-)]
 pub fn pre_call_guards<C: Clock>(
     guard: &DispatchGuard<C>,
     tool: ToolName,

--- a/crates/rimap-server/src/dispatch.rs
+++ b/crates/rimap-server/src/dispatch.rs
@@ -1,0 +1,77 @@
+//! Shared tool dispatch pipeline.
+//!
+//! The guard chain runs before every tool handler:
+//! posture check -> circuit breaker -> rate limiter.
+//!
+//! This module bridges `rimap_authz::DispatchGuard` (which returns
+//! `AuthzError`) into `RimapError` for the server layer.
+
+use rimap_authz::DispatchGuard;
+use rimap_authz::breaker::Clock;
+use rimap_core::RimapError;
+use rimap_core::tool::ToolName;
+
+/// Run the pre-call guard chain.
+///
+/// Returns `Ok(())` if all guards pass, or the first `RimapError`.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "scaffolding for tool handlers in later tasks")
+)]
+pub fn pre_call_guards<C: Clock>(
+    guard: &DispatchGuard<C>,
+    tool: ToolName,
+) -> Result<(), RimapError> {
+    guard.pre_dispatch(tool).map_err(|e| RimapError::Authz {
+        code: e.code(),
+        message: e.to_string(),
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    use rimap_authz::DispatchGuard;
+    use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, ManualClock};
+    use rimap_authz::matrix::EffectiveMatrix;
+    use rimap_authz::rate_limit::Governor;
+    use rimap_core::error::ErrorCode;
+    use rimap_core::posture::Posture;
+    use rimap_core::tool::ToolName;
+
+    use super::pre_call_guards;
+
+    fn test_guard() -> DispatchGuard<ManualClock> {
+        let matrix = EffectiveMatrix::build(Posture::Readonly, &BTreeMap::new());
+        let breaker = CircuitBreaker::new(
+            ManualClock::new(),
+            BreakerConfig {
+                error_threshold: 2,
+                window: Duration::from_secs(10),
+                starting_cooldown: Duration::from_secs(5),
+                max_cooldown: Duration::from_secs(60),
+                auth_starting_cooldown: Duration::from_secs(30),
+                auth_max_cooldown: Duration::from_secs(600),
+            },
+        );
+        let governor = Governor::new(100, 5).expect("valid governor config");
+        DispatchGuard::new(matrix, breaker, governor)
+    }
+
+    #[test]
+    fn allowed_tool_passes() {
+        let guard = test_guard();
+        assert!(pre_call_guards(&guard, ToolName::ListFolders).is_ok());
+    }
+
+    #[test]
+    fn denied_tool_returns_posture_denied() {
+        let guard = test_guard();
+        let err = pre_call_guards(&guard, ToolName::CreateDraft)
+            .expect_err("should deny create_draft in readonly");
+        assert_eq!(err.code(), ErrorCode::PostureDenied);
+    }
+}

--- a/crates/rimap-server/src/download.rs
+++ b/crates/rimap-server/src/download.rs
@@ -48,14 +48,20 @@ pub fn resolve_dest_dir(
 /// Returns `RimapError::Internal` if writing fails or if more than
 /// 1000 filename collisions occur.
 pub fn write_attachment(dir: &Path, filename: &str, data: &[u8]) -> Result<PathBuf, RimapError> {
-    let base = Path::new(filename);
+    // Strip path components to prevent directory traversal.
+    let safe_name = Path::new(filename)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("attachment");
+
+    let base = Path::new(safe_name);
     let stem = base
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("attachment");
     let ext = base.extension().and_then(|s| s.to_str());
 
-    let mut path = dir.join(filename);
+    let mut path = dir.join(safe_name);
     let mut counter = 1u32;
     while path.exists() {
         let new_name = match ext {
@@ -67,6 +73,20 @@ pub fn write_attachment(dir: &Path, filename: &str, data: &[u8]) -> Result<PathB
         if counter > 1000 {
             return Err(RimapError::Internal("too many filename collisions".into()));
         }
+    }
+
+    // Verify the resolved path is still inside the target directory.
+    let canonical_dir = dir
+        .canonicalize()
+        .map_err(|e| RimapError::Internal(format!("cannot canonicalize download dir: {e}")))?;
+    let canonical_path =
+        path.parent().unwrap_or(dir).canonicalize().map_err(|e| {
+            RimapError::Internal(format!("cannot canonicalize attachment path: {e}"))
+        })?;
+    if !canonical_path.starts_with(&canonical_dir) {
+        return Err(RimapError::Internal(
+            "attachment path escapes download directory".into(),
+        ));
     }
 
     std::fs::write(&path, data)
@@ -148,6 +168,33 @@ mod tests {
         std::fs::write(tmp.path().join("readme"), b"old").unwrap();
         let path = write_attachment(tmp.path(), "readme", b"new").unwrap();
         assert_eq!(path, tmp.path().join("readme_1"));
+    }
+
+    #[test]
+    fn write_attachment_rejects_relative_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_attachment(tmp.path(), "../escape.txt", b"data").unwrap();
+        // Must land inside tmp, not escape.
+        assert!(path.starts_with(tmp.path()));
+        assert_eq!(path.file_name().unwrap(), "escape.txt");
+        assert_eq!(std::fs::read(&path).unwrap(), b"data");
+    }
+
+    #[test]
+    fn write_attachment_rejects_absolute_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_attachment(tmp.path(), "/etc/passwd", b"data").unwrap();
+        assert!(path.starts_with(tmp.path()));
+        assert_eq!(path.file_name().unwrap(), "passwd");
+        assert_eq!(std::fs::read(&path).unwrap(), b"data");
+    }
+
+    #[test]
+    fn write_attachment_handles_deep_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_attachment(tmp.path(), "../../.ssh/authorized_keys", b"data").unwrap();
+        assert!(path.starts_with(tmp.path()));
+        assert_eq!(path.file_name().unwrap(), "authorized_keys");
     }
 
     #[test]

--- a/crates/rimap-server/src/download.rs
+++ b/crates/rimap-server/src/download.rs
@@ -1,0 +1,176 @@
+//! Attachment download sandboxing.
+//!
+//! Validates download destinations against an allowed root directory,
+//! writes attachment data with collision-safe filenames, and provides
+//! MIME sniffing and SHA-256 hashing utilities.
+
+use std::path::{Path, PathBuf};
+
+use rimap_core::RimapError;
+
+/// Resolve and validate the download destination.
+///
+/// If `dest_dir` is provided, canonicalize it and verify it starts
+/// with `allowed_root`. If absent, use `fallback_dir`.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` if `dest_dir` cannot be
+/// canonicalized or falls outside `allowed_root`.
+pub fn resolve_dest_dir(
+    dest_dir: Option<&str>,
+    allowed_root: &Path,
+    fallback_dir: &Path,
+) -> Result<PathBuf, RimapError> {
+    let dir = match dest_dir {
+        Some(d) => {
+            let p = PathBuf::from(d);
+            let canonical = p
+                .canonicalize()
+                .map_err(|e| RimapError::Internal(format!("cannot resolve dest_dir: {e}")))?;
+            if !canonical.starts_with(allowed_root) {
+                return Err(RimapError::Internal(
+                    "dest_dir is outside allowed download directory".into(),
+                ));
+            }
+            canonical
+        }
+        None => fallback_dir.to_path_buf(),
+    };
+    Ok(dir)
+}
+
+/// Write `data` to `dir/filename`, de-duplicating on collision.
+/// Returns the final path.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` if writing fails or if more than
+/// 1000 filename collisions occur.
+pub fn write_attachment(dir: &Path, filename: &str, data: &[u8]) -> Result<PathBuf, RimapError> {
+    let base = Path::new(filename);
+    let stem = base
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("attachment");
+    let ext = base.extension().and_then(|s| s.to_str());
+
+    let mut path = dir.join(filename);
+    let mut counter = 1u32;
+    while path.exists() {
+        let new_name = match ext {
+            Some(e) => format!("{stem}_{counter}.{e}"),
+            None => format!("{stem}_{counter}"),
+        };
+        path = dir.join(new_name);
+        counter += 1;
+        if counter > 1000 {
+            return Err(RimapError::Internal("too many filename collisions".into()));
+        }
+    }
+
+    std::fs::write(&path, data)
+        .map_err(|e| RimapError::Internal(format!("failed to write attachment: {e}")))?;
+
+    Ok(path)
+}
+
+/// MIME-sniff `data` using magic bytes.
+#[must_use]
+pub fn sniff_mime(data: &[u8]) -> Option<String> {
+    infer::get(data).map(|t| t.mime_type().to_string())
+}
+
+/// SHA-256 hex digest.
+#[must_use]
+pub fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(data);
+    hex::encode(hash)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_dest_dir_uses_fallback_when_none() {
+        let fallback = PathBuf::from("/tmp/fallback");
+        let allowed = Path::new("/tmp");
+        let result = resolve_dest_dir(None, allowed, &fallback).unwrap();
+        assert_eq!(result, fallback);
+    }
+
+    #[test]
+    fn resolve_dest_dir_accepts_valid_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let allowed = tmp.path();
+        let fallback = tmp.path();
+        let result = resolve_dest_dir(Some(sub.to_str().unwrap()), allowed, fallback).unwrap();
+        assert!(result.starts_with(allowed));
+    }
+
+    #[test]
+    fn resolve_dest_dir_rejects_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&allowed).unwrap();
+        // Try to escape to the parent.
+        let result = resolve_dest_dir(Some(tmp.path().to_str().unwrap()), &allowed, &allowed);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("outside allowed"));
+    }
+
+    #[test]
+    fn write_attachment_normal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_attachment(tmp.path(), "doc.pdf", b"data").unwrap();
+        assert_eq!(path, tmp.path().join("doc.pdf"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"data");
+    }
+
+    #[test]
+    fn write_attachment_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("doc.pdf"), b"old").unwrap();
+        let path = write_attachment(tmp.path(), "doc.pdf", b"new").unwrap();
+        assert_eq!(path, tmp.path().join("doc_1.pdf"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    }
+
+    #[test]
+    fn write_attachment_no_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("readme"), b"old").unwrap();
+        let path = write_attachment(tmp.path(), "readme", b"new").unwrap();
+        assert_eq!(path, tmp.path().join("readme_1"));
+    }
+
+    #[test]
+    fn sha256_hex_known_value() {
+        // SHA-256 of empty input.
+        let digest = sha256_hex(b"");
+        assert_eq!(
+            digest,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934\
+             ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sniff_mime_detects_png() {
+        // Minimal PNG header.
+        let png_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let result = sniff_mime(&png_header);
+        assert_eq!(result.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn sniff_mime_returns_none_for_unknown() {
+        assert!(sniff_mime(b"hello world").is_none());
+    }
+}

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -1,0 +1,521 @@
+//! Dovecot e2e smoke test: exercises the full MCP tool chain against
+//! a real Dovecot IMAP server running in a container.
+//!
+//! Skips silently when no container runtime is available or the host
+//! architecture is not `x86_64` (dovecot image is amd64-only).
+
+#![expect(clippy::unwrap_used, reason = "tests")]
+#![expect(clippy::expect_used, reason = "tests")]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_authz::DispatchGuard;
+use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, SystemClock};
+use rimap_authz::matrix::EffectiveMatrix;
+use rimap_authz::rate_limit::Governor;
+use rimap_config::credential::CredentialStore;
+use rimap_config::model::{
+    AttachmentsConfig, AuditConfig, Config, ImapConfig, LimitsConfig, SecurityConfig,
+};
+use rimap_config::validate::ValidatedConfig;
+use rimap_core::TlsFingerprint;
+use rimap_core::posture::Posture;
+use rimap_imap::{Connection, ConnectionConfig};
+use tempfile::TempDir;
+
+use crate::server::ImapMcpServer;
+
+// ── Container harness (adapted from rimap-imap) ─────────────────────
+
+fn runtime() -> &'static str {
+    static TOOL: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    TOOL.get_or_init(|| {
+        match std::env::var("RIMAP_CONTAINER_TOOL").as_deref() {
+            Ok("docker") => return "docker",
+            Ok("podman") => return "podman",
+            _ => {}
+        }
+        if binary_present("docker") {
+            "docker"
+        } else if binary_present("podman") {
+            "podman"
+        } else {
+            "docker"
+        }
+    })
+}
+
+fn binary_present(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn runtime_available() -> bool {
+    binary_present("docker") || binary_present("podman")
+}
+
+fn container_name(project: &str) -> String {
+    format!("{project}-dovecot")
+}
+
+struct DovecotHarness {
+    project: String,
+    compose_dir: PathBuf,
+    fingerprint: TlsFingerprint,
+    port: u16,
+}
+
+impl DovecotHarness {
+    fn try_start() -> Option<Self> {
+        if std::env::consts::ARCH != "x86_64" {
+            return None;
+        }
+        if !runtime_available() {
+            return None;
+        }
+
+        let compose_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("rimap-imap")
+            .join("tests")
+            .join("integration")
+            .join("dovecot");
+
+        let project = format!(
+            "rimap-e2e-{:x}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+
+        let host_port = pick_free_port()?;
+
+        let status = Command::new(runtime())
+            .arg("compose")
+            .arg("-p")
+            .arg(&project)
+            .arg("up")
+            .arg("-d")
+            .env("RIMAP_DOVECOT_HOST_PORT", host_port.to_string())
+            .current_dir(&compose_dir)
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+
+        wait_for_ready(&project, host_port, &compose_dir)
+    }
+
+    /// Create a mailbox via `doveadm` inside the container.
+    fn create_mailbox(&self, name: &str) {
+        let status = Command::new(runtime())
+            .arg("exec")
+            .arg(container_name(&self.project))
+            .arg("doveadm")
+            .arg("mailbox")
+            .arg("create")
+            .arg("-u")
+            .arg("rimap-test")
+            .arg(name)
+            .status()
+            .expect("doveadm exec failed");
+        assert!(status.success(), "doveadm mailbox create {name} failed",);
+    }
+}
+
+fn wait_for_ready(
+    project: &str,
+    host_port: u16,
+    compose_dir: &std::path::Path,
+) -> Option<DovecotHarness> {
+    let started = Instant::now();
+    let timeout = Duration::from_secs(60);
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
+    loop {
+        if started.elapsed() > timeout {
+            compose_down(project, compose_dir);
+            return None;
+        }
+        let Ok(fp) = read_fingerprint(project) else {
+            std::thread::sleep(Duration::from_millis(500));
+            continue;
+        };
+        if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
+            return Some(DovecotHarness {
+                project: project.to_string(),
+                compose_dir: compose_dir.to_path_buf(),
+                fingerprint: fp,
+                port: host_port,
+            });
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+impl Drop for DovecotHarness {
+    fn drop(&mut self) {
+        compose_down(&self.project, &self.compose_dir);
+    }
+}
+
+fn compose_down(project: &str, compose_dir: &std::path::Path) {
+    let _ = Command::new(runtime())
+        .arg("compose")
+        .arg("-p")
+        .arg(project)
+        .arg("down")
+        .arg("-v")
+        .arg("--remove-orphans")
+        .current_dir(compose_dir)
+        .status();
+}
+
+fn read_fingerprint(project: &str) -> Result<TlsFingerprint, String> {
+    let out = Command::new(runtime())
+        .arg("exec")
+        .arg(container_name(project))
+        .arg("cat")
+        .arg("/shared/fingerprint.hex")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err("not ready".into());
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    TlsFingerprint::from_hex(&s).map_err(|e| e.to_string())
+}
+
+fn pick_free_port() -> Option<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+    Some(listener.local_addr().ok()?.port())
+}
+
+struct StaticCreds(String);
+
+impl CredentialStore for StaticCreds {
+    fn get_password(&self, _account: &str) -> Result<Option<String>, rimap_config::ConfigError> {
+        Ok(Some(self.0.clone()))
+    }
+
+    fn set_password(
+        &self,
+        _account: &str,
+        _password: &str,
+    ) -> Result<(), rimap_config::ConfigError> {
+        unreachable!("tests do not write credentials")
+    }
+}
+
+// ── Server builder ──────────────────────────────────────────────────
+
+struct TestEnv {
+    _harness: DovecotHarness,
+    _audit_dir: TempDir,
+    _download_dir: TempDir,
+    server: ImapMcpServer,
+}
+
+fn build_test_env(harness: DovecotHarness) -> TestEnv {
+    let audit_dir = TempDir::new().expect("audit tempdir");
+    let download_dir = TempDir::new().expect("download tempdir");
+
+    let audit = AuditWriter::open(&AuditOptions {
+        path: audit_dir.path().join("audit.jsonl"),
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let config = test_config(&harness, &audit_dir);
+    let imap = test_connection(&harness, &audit);
+    let guard = test_guard(&config);
+
+    let server = ImapMcpServer {
+        config,
+        imap,
+        guard,
+        audit,
+        download_dir: download_dir.path().to_path_buf(),
+    };
+
+    TestEnv {
+        _harness: harness,
+        _audit_dir: audit_dir,
+        _download_dir: download_dir,
+        server,
+    }
+}
+
+fn test_config(harness: &DovecotHarness, audit_dir: &TempDir) -> ValidatedConfig {
+    ValidatedConfig {
+        config: Config {
+            imap: ImapConfig {
+                host: "127.0.0.1".into(),
+                port: harness.port,
+                username: "rimap-test".into(),
+                tls_fingerprint_sha256: None,
+                connect_timeout_seconds: 10,
+                command_timeout_seconds: 30,
+            },
+            security: SecurityConfig {
+                posture: Posture::DraftSafe,
+                ..SecurityConfig::default()
+            },
+            limits: LimitsConfig::default(),
+            audit: AuditConfig {
+                path: audit_dir.path().join("audit.jsonl"),
+                rotate_bytes: 0,
+                rotate_keep: 0,
+                provenance_window_seconds: 60,
+                fail_open: false,
+                allowed_base_dir: Some(audit_dir.path().to_path_buf()),
+            },
+            attachments: AttachmentsConfig::default(),
+        },
+        tool_overrides: BTreeMap::new(),
+        tls_fingerprint: Some(harness.fingerprint),
+    }
+}
+
+fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection {
+    let conn_cfg = ConnectionConfig {
+        host: "127.0.0.1".into(),
+        port: harness.port,
+        username: "rimap-test".into(),
+        pinned_fingerprint: Some(harness.fingerprint),
+        connect_timeout: Duration::from_secs(10),
+        command_timeout: Duration::from_secs(30),
+        max_fetch_body_bytes: 5_242_880,
+    };
+    let creds: Arc<dyn CredentialStore> = Arc::new(StaticCreds("testpass".into()));
+    Connection::new(conn_cfg, audit.clone(), creds)
+}
+
+fn test_guard(config: &ValidatedConfig) -> DispatchGuard<SystemClock> {
+    let matrix = EffectiveMatrix::from_validated(config);
+    let breaker = CircuitBreaker::new(SystemClock::new(), BreakerConfig::default_spec());
+    let governor = Governor::new(
+        config.config.limits.commands_per_second,
+        config.config.limits.drafts_per_minute,
+    )
+    .expect("governor");
+    DispatchGuard::new(matrix, breaker, governor)
+}
+
+// ── Tool dispatch helper ────────────────────────────────────────────
+
+async fn call_tool(
+    server: &ImapMcpServer,
+    tool_name: &str,
+    args: serde_json::Value,
+) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
+    let tool = std::str::FromStr::from_str(tool_name).map_err(
+        |e: rimap_core::tool::ParseToolNameError| rimap_core::RimapError::Internal(e.to_string()),
+    )?;
+
+    crate::dispatch::pre_call_guards(&server.guard, tool)?;
+
+    let args_map = match args {
+        serde_json::Value::Object(m) => m,
+        _ => serde_json::Map::new(),
+    };
+
+    server.dispatch_tool(tool, &args_map).await
+}
+
+/// Extract a u32 from a JSON value (safe truncation check).
+fn json_u32(val: &serde_json::Value) -> u32 {
+    let n = val.as_u64().expect("expected u64");
+    u32::try_from(n).expect("value exceeds u32")
+}
+
+// ── Seed message ────────────────────────────────────────────────────
+
+fn test_message() -> Vec<u8> {
+    concat!(
+        "From: sender@example.com\r\n",
+        "To: rimap-test@localhost\r\n",
+        "Subject: e2e-test-smoke\r\n",
+        "Date: Sat, 12 Apr 2026 10:00:00 +0000\r\n",
+        "Message-ID: <e2e-smoke-001@example.com>\r\n",
+        "MIME-Version: 1.0\r\n",
+        "Content-Type: text/plain; charset=utf-8\r\n",
+        "\r\n",
+        "Hello from the e2e smoke test.\r\n",
+    )
+    .as_bytes()
+    .to_vec()
+}
+
+// ── The test ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_full_session() {
+    let Some(harness) = DovecotHarness::try_start() else {
+        return; // silent skip
+    };
+
+    harness.create_mailbox("Drafts");
+    harness.create_mailbox("Trash");
+
+    let env = build_test_env(harness);
+    let server = &env.server;
+
+    assert_list_folders(server).await;
+    seed_message(server).await;
+    let uid = assert_search(server).await;
+    assert_fetch(server, uid).await;
+    assert_mark_read(server, uid).await;
+    assert_create_draft(server, uid).await;
+    assert_move_and_gone(server, uid).await;
+}
+
+async fn assert_list_folders(server: &ImapMcpServer) {
+    let result = call_tool(server, "list_folders", serde_json::json!({}))
+        .await
+        .expect("list_folders failed");
+    let folders = result.meta["folders"].as_array().expect("folders");
+    let names: Vec<&str> = folders.iter().filter_map(|f| f["name"].as_str()).collect();
+    assert!(names.contains(&"INBOX"), "INBOX not in {names:?}",);
+}
+
+async fn seed_message(server: &ImapMcpServer) {
+    server
+        .imap
+        .append_message("INBOX", &test_message(), &[], &[])
+        .await
+        .expect("APPEND failed");
+}
+
+async fn assert_search(server: &ImapMcpServer) -> u32 {
+    let result = call_tool(
+        server,
+        "search",
+        serde_json::json!({
+            "folder": "INBOX",
+            "subject": "e2e-test-smoke"
+        }),
+    )
+    .await
+    .expect("search failed");
+
+    let total = result.meta["total_matched"].as_u64().unwrap();
+    assert!(total >= 1, "expected at least one match");
+
+    let messages = result.untrusted.as_ref().unwrap()["messages"]
+        .as_array()
+        .expect("messages array");
+    let uid = json_u32(&messages[0]["uid"]);
+    assert!(uid > 0);
+    uid
+}
+
+async fn assert_fetch(server: &ImapMcpServer, uid: u32) {
+    let result = call_tool(
+        server,
+        "fetch_message",
+        serde_json::json!({"folder": "INBOX", "uid": uid}),
+    )
+    .await
+    .expect("fetch_message failed");
+
+    let body = result.untrusted.as_ref().unwrap()["body_text"]
+        .as_str()
+        .expect("body_text");
+    assert!(
+        body.contains("Hello from the e2e smoke test"),
+        "unexpected body: {body}",
+    );
+    assert_eq!(json_u32(&result.meta["uid"]), uid);
+}
+
+async fn assert_mark_read(server: &ImapMcpServer, uid: u32) {
+    let result = call_tool(
+        server,
+        "mark_read",
+        serde_json::json!({"folder": "INBOX", "uid": uid}),
+    )
+    .await
+    .expect("mark_read failed");
+
+    let updated = result.meta["uids_updated"]
+        .as_array()
+        .expect("uids_updated");
+    assert!(
+        updated.iter().any(|u| json_u32(u) == uid),
+        "uid {uid} not in updated list",
+    );
+}
+
+async fn assert_create_draft(server: &ImapMcpServer, reply_uid: u32) {
+    let result = call_tool(
+        server,
+        "create_draft",
+        serde_json::json!({
+            "to": [{"address": "reply@example.com"}],
+            "subject": "Re: e2e-test-smoke",
+            "body_text": "Acknowledged.",
+            "in_reply_to_uid": reply_uid,
+            "in_reply_to_folder": "INBOX"
+        }),
+    )
+    .await
+    .expect("create_draft failed");
+
+    assert_eq!(result.meta["folder"].as_str().unwrap(), "Drafts",);
+    let keywords = result.meta["keywords"].as_array().expect("keywords");
+    assert!(
+        keywords
+            .iter()
+            .any(|k| k.as_str() == Some("$PendingReview")),
+        "missing $PendingReview keyword",
+    );
+}
+
+async fn assert_move_and_gone(server: &ImapMcpServer, uid: u32) {
+    let result = call_tool(
+        server,
+        "move_message",
+        serde_json::json!({
+            "source_folder": "INBOX",
+            "dest_folder": "Trash",
+            "uid": uid
+        }),
+    )
+    .await
+    .expect("move_message failed");
+
+    let moves = result.meta["moves"].as_array().expect("moves");
+    assert_eq!(moves.len(), 1);
+    assert_eq!(json_u32(&moves[0]["old_uid"]), uid);
+
+    // Verify message is gone from INBOX.
+    let result = call_tool(
+        server,
+        "search",
+        serde_json::json!({
+            "folder": "INBOX",
+            "subject": "e2e-test-smoke"
+        }),
+    )
+    .await
+    .expect("post-move search failed");
+    assert_eq!(
+        result.meta["total_matched"].as_u64().unwrap(),
+        0,
+        "message should be gone from INBOX after move",
+    );
+}

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod content;
 mod dry_run;
 mod logging;
+mod response;
 
 use std::io::Write;
 use std::path::PathBuf;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod content;
 mod dry_run;
 mod logging;
+mod mcp_error;
 mod response;
 
 use std::io::Write;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -12,6 +12,7 @@ mod logging;
 mod mcp_error;
 mod response;
 mod server;
+mod tools;
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -112,7 +113,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
     rt.block_on(async {
         let transport = rmcp::transport::io::stdio();
-        let service = rmcp::serve_server(mcp_server, transport)
+        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
             .await
             .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
         service

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -15,6 +15,9 @@ mod response;
 mod server;
 mod tools;
 
+#[cfg(test)]
+mod e2e_test;
+
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -6,6 +6,7 @@ mod audit_cmd;
 mod audit_init;
 mod cli;
 mod content;
+mod dispatch;
 mod dry_run;
 mod logging;
 mod mcp_error;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -11,17 +11,25 @@ mod dry_run;
 mod logging;
 mod mcp_error;
 mod response;
+mod server;
 
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use clap::Parser;
-use rimap_config::credential::KeyringStore;
+use rimap_authz::DispatchGuard;
+use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, SystemClock};
+use rimap_authz::matrix::EffectiveMatrix;
+use rimap_authz::rate_limit::Governor;
+use rimap_config::credential::{CredentialStore, KeyringStore};
 use rimap_config::loader::{load_from_path, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
-use rimap_config::validate::validate;
+use rimap_config::validate::{ValidatedConfig, validate};
+use rimap_imap::{Connection, ConnectionConfig};
 
 use crate::cli::{AuditAction, Cli, Command};
 
@@ -75,24 +83,44 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         return dry_run::run(&path, &mut stdout);
     }
 
-    // Server mode: load config, open audit writer, emit process_start.
-    // The MCP transport loop itself lands in Sprint 5; this scaffolding
-    // ensures the audit chain is correctly initialized before it runs.
+    // Server mode: load config, build subsystems, run MCP transport.
     let config_path = resolve_cli_config_path(&cli)?;
     let raw = load_from_path(&config_path)
         .with_context(|| format!("loading config {}", config_path.display()))?;
     let validated = validate(raw).context("validating config")?;
-    let _audit = audit_init::init_audit_writer(&validated, &config_path).with_context(|| {
+    let audit = audit_init::init_audit_writer(&validated, &config_path).with_context(|| {
         format!(
             "opening audit log at {}",
             validated.config.audit.path.display()
         )
     })?;
 
-    Err(anyhow::anyhow!(
-        "MCP server mode is not implemented until Sprint 5; \
-         use --dry-run or the `login` subcommand"
-    ))
+    let guard = build_dispatch_guard(&validated).context("building dispatch guard")?;
+    let conn_cfg = build_connection_config(&validated);
+    let credentials: Arc<dyn CredentialStore> = Arc::new(KeyringStore);
+    let imap = Connection::new(conn_cfg, audit.clone(), credentials);
+    let download_dir = resolve_download_dir(&validated)?;
+
+    let mcp_server = server::ImapMcpServer {
+        config: validated,
+        imap,
+        guard,
+        audit,
+        download_dir,
+    };
+
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    rt.block_on(async {
+        let transport = rmcp::transport::io::stdio();
+        let service = rmcp::serve_server(mcp_server, transport)
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))
+    })?;
+    Ok(())
 }
 
 /// Resolve the config file path from `--config` or the
@@ -104,4 +132,54 @@ fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
         .ok_or_else(|| {
             anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
         })
+}
+
+/// Build the composed authz guard from validated config.
+fn build_dispatch_guard(cfg: &ValidatedConfig) -> anyhow::Result<DispatchGuard<SystemClock>> {
+    let matrix = EffectiveMatrix::from_validated(cfg);
+    let limits = &cfg.config.limits;
+    let breaker_cfg = BreakerConfig {
+        error_threshold: limits.circuit_breaker_error_threshold,
+        window: Duration::from_secs(u64::from(limits.circuit_breaker_window_seconds)),
+        ..BreakerConfig::default_spec()
+    };
+    let breaker = CircuitBreaker::new(SystemClock::new(), breaker_cfg);
+    let governor = Governor::new(limits.commands_per_second, limits.drafts_per_minute)
+        .map_err(|e| anyhow::anyhow!("governor: {e}"))?;
+    Ok(DispatchGuard::new(matrix, breaker, governor))
+}
+
+/// Map validated config fields to a `ConnectionConfig`.
+fn build_connection_config(cfg: &ValidatedConfig) -> ConnectionConfig {
+    let imap = &cfg.config.imap;
+    ConnectionConfig {
+        host: imap.host.clone(),
+        port: imap.port,
+        username: imap.username.clone(),
+        pinned_fingerprint: cfg.tls_fingerprint,
+        connect_timeout: Duration::from_secs(u64::from(imap.connect_timeout_seconds)),
+        command_timeout: Duration::from_secs(u64::from(imap.command_timeout_seconds)),
+        max_fetch_body_bytes: cfg.config.limits.max_fetch_body_bytes,
+    }
+}
+
+/// Resolve the attachment download directory. Uses the configured
+/// path if non-empty, otherwise creates a temporary directory.
+fn resolve_download_dir(cfg: &ValidatedConfig) -> anyhow::Result<PathBuf> {
+    let dir_str = &cfg.config.attachments.download_dir;
+    if dir_str.is_empty() {
+        let tmp = std::env::temp_dir().join("rusty-imap-mcp-downloads");
+        std::fs::create_dir_all(&tmp)
+            .with_context(|| format!("creating download dir {}", tmp.display()))?;
+        Ok(tmp)
+    } else {
+        let path = PathBuf::from(dir_str);
+        if !path.is_dir() {
+            anyhow::bail!(
+                "download_dir {} does not exist or is not a directory",
+                path.display()
+            );
+        }
+        Ok(path)
+    }
 }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -7,6 +7,7 @@ mod audit_init;
 mod cli;
 mod content;
 mod dispatch;
+mod download;
 mod dry_run;
 mod logging;
 mod mcp_error;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -5,6 +5,7 @@
 mod audit_cmd;
 mod audit_init;
 mod cli;
+mod content;
 mod dry_run;
 mod logging;
 

--- a/crates/rimap-server/src/mcp_error.rs
+++ b/crates/rimap-server/src/mcp_error.rs
@@ -27,10 +27,6 @@ pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
 /// Maps each `ErrorCode` variant to the closest JSON-RPC / MCP
 /// error code. Application-specific codes use the JSON-RPC
 /// "server error" range (-32000 to -32099).
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "scaffolding for tool handlers in later tasks")
-)]
 pub fn to_mcp_error(err: &RimapError) -> ErrorData {
     let message = err.to_string();
     match err.code() {

--- a/crates/rimap-server/src/mcp_error.rs
+++ b/crates/rimap-server/src/mcp_error.rs
@@ -1,0 +1,105 @@
+//! Map `RimapError` to rmcp `ErrorData` for MCP tool error responses.
+//!
+//! Custom error codes in the JSON-RPC "server error" range
+//! (-32000 to -32099):
+//! - -32001: posture denied
+//! - -32003: rate limited
+//! - -32004: circuit breaker open
+//! - -32005: attachment too large
+
+use rimap_core::{ErrorCode, RimapError};
+use rmcp::model::{ErrorCode as McpCode, ErrorData};
+
+/// Posture denied (tool not allowed by current posture).
+pub const POSTURE_DENIED: McpCode = McpCode(-32001);
+
+/// Rate limiter rejected the call.
+pub const RATE_LIMITED: McpCode = McpCode(-32003);
+
+/// Circuit breaker is open.
+pub const CIRCUIT_OPEN: McpCode = McpCode(-32004);
+
+/// Attachment exceeded size cap.
+pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
+
+/// Convert a `RimapError` into an rmcp `ErrorData`.
+///
+/// Maps each `ErrorCode` variant to the closest JSON-RPC / MCP
+/// error code. Application-specific codes use the JSON-RPC
+/// "server error" range (-32000 to -32099).
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "scaffolding for tool handlers in later tasks")
+)]
+pub fn to_mcp_error(err: &RimapError) -> ErrorData {
+    let message = err.to_string();
+    match err.code() {
+        ErrorCode::InvalidInput => ErrorData::invalid_params(message, None),
+        ErrorCode::NotFound => ErrorData::new(McpCode::RESOURCE_NOT_FOUND, message, None),
+        ErrorCode::PostureDenied => ErrorData::new(POSTURE_DENIED, message, None),
+        ErrorCode::RateLimited => ErrorData::new(RATE_LIMITED, message, None),
+        ErrorCode::CircuitOpen => ErrorData::new(CIRCUIT_OPEN, message, None),
+        ErrorCode::AttachmentTooLarge => ErrorData::new(ATTACHMENT_TOO_LARGE, message, None),
+        ErrorCode::ImapProtocol
+        | ErrorCode::Tls
+        | ErrorCode::Auth
+        | ErrorCode::ConnectionLost
+        | ErrorCode::Timeout
+        | ErrorCode::Config
+        | ErrorCode::Internal => ErrorData::internal_error(message, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rimap_core::{ErrorCode, RimapError};
+    use rmcp::model::ErrorCode as McpCode;
+
+    use super::to_mcp_error;
+
+    fn authz_error(code: ErrorCode, msg: &str) -> RimapError {
+        RimapError::Authz {
+            code,
+            message: msg.to_owned(),
+        }
+    }
+
+    #[test]
+    fn invalid_input_maps_to_invalid_params() {
+        let err = authz_error(ErrorCode::InvalidInput, "bad uid");
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, McpCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn not_found_maps_to_resource_not_found() {
+        let err = RimapError::Imap {
+            code: ErrorCode::NotFound,
+            message: "no such UID".to_owned(),
+            source: None,
+        };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, McpCode::RESOURCE_NOT_FOUND);
+    }
+
+    #[test]
+    fn posture_denied_maps_to_custom_code() {
+        let err = authz_error(ErrorCode::PostureDenied, "tool denied");
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::POSTURE_DENIED);
+    }
+
+    #[test]
+    fn internal_errors_map_to_internal_error() {
+        let err = RimapError::Internal("bug".to_owned());
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, McpCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn message_is_preserved() {
+        let err = authz_error(ErrorCode::RateLimited, "slow down");
+        let mcp = to_mcp_error(&err);
+        assert!(mcp.message.contains("slow down"));
+    }
+}

--- a/crates/rimap-server/src/response.rs
+++ b/crates/rimap-server/src/response.rs
@@ -1,0 +1,21 @@
+//! Response envelope types for MCP tool responses.
+//!
+//! Every tool returns a JSON object with three top-level fields:
+//! `meta` (trusted server metadata), `untrusted` (sanitized email
+//! content), and `security_warnings` (structured observations).
+
+use serde::Serialize;
+
+/// Top-level tool response envelope.
+#[expect(dead_code, reason = "used by tool handlers in later tasks")]
+#[derive(Debug, Serialize)]
+pub struct ToolResponse {
+    /// Server-controlled metadata. Trusted.
+    pub meta: serde_json::Value,
+    /// Sanitized content derived from email data. Untrusted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub untrusted: Option<serde_json::Value>,
+    /// Structured security observations. Trusted metadata.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security_warnings: Vec<serde_json::Value>,
+}

--- a/crates/rimap-server/src/response.rs
+++ b/crates/rimap-server/src/response.rs
@@ -7,7 +7,7 @@
 use serde::Serialize;
 
 /// Top-level tool response envelope.
-#[expect(dead_code, reason = "used by tool handlers in later tasks")]
+#[expect(dead_code, reason = "scaffolding for tool handlers in later tasks")]
 #[derive(Debug, Serialize)]
 pub struct ToolResponse {
     /// Server-controlled metadata. Trusted.

--- a/crates/rimap-server/src/response.rs
+++ b/crates/rimap-server/src/response.rs
@@ -7,7 +7,6 @@
 use serde::Serialize;
 
 /// Top-level tool response envelope.
-#[expect(dead_code, reason = "scaffolding for tool handlers in later tasks")]
 #[derive(Debug, Serialize)]
 pub struct ToolResponse {
     /// Server-controlled metadata. Trusted.

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -24,7 +24,10 @@ use rmcp::model::{
 use rmcp::service::RequestContext;
 
 /// Core MCP server. Owns every resource the handler methods need.
-#[expect(dead_code, reason = "fields used by tool handlers in later tasks")]
+#[expect(
+    dead_code,
+    reason = "config/audit/download_dir used by tool handlers in later tasks"
+)]
 pub struct ImapMcpServer {
     /// Validated configuration snapshot.
     pub(crate) config: ValidatedConfig,
@@ -71,7 +74,8 @@ impl ServerHandler for ImapMcpServer {
             return Err(crate::mcp_error::to_mcp_error(&e));
         }
 
-        let result = dispatch_tool(tool_name);
+        let args = request.arguments.unwrap_or_default();
+        let result = Box::pin(self.dispatch_tool(tool_name, &args)).await;
 
         match result {
             Ok(resp) => {
@@ -84,41 +88,62 @@ impl ServerHandler for ImapMcpServer {
     }
 }
 
-/// Dispatch to the tool handler for `tool`. All arms return a
-/// placeholder until real handlers land in later tasks.
-///
-/// The `Result` return and per-arm match structure are intentional:
-/// each arm will be replaced with a real handler that can fail.
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "real handlers will return Err; scaffolding"
-)]
-#[expect(
-    clippy::match_same_arms,
-    reason = "each arm will diverge when handlers land"
-)]
-fn dispatch_tool(tool: ToolName) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
-    let placeholder = || crate::response::ToolResponse {
-        meta: serde_json::json!({"status": "not_implemented"}),
-        untrusted: None,
-        security_warnings: Vec::new(),
-    };
+impl ImapMcpServer {
+    /// Dispatch to the tool handler for `tool`.
+    #[expect(
+        clippy::match_same_arms,
+        reason = "placeholder arms will diverge when handlers land"
+    )]
+    async fn dispatch_tool(
+        &self,
+        tool: ToolName,
+        args: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
+        let placeholder = || crate::response::ToolResponse {
+            meta: serde_json::json!({"status": "not_implemented"}),
+            untrusted: None,
+            security_warnings: Vec::new(),
+        };
 
-    match tool {
-        ToolName::ListFolders => Ok(placeholder()),
-        ToolName::Search => Ok(placeholder()),
-        ToolName::SearchAdvanced => Ok(placeholder()),
-        ToolName::FetchMessage => Ok(placeholder()),
-        ToolName::FetchMessageHtml => Ok(placeholder()),
-        ToolName::ListAttachments => Ok(placeholder()),
-        ToolName::DownloadAttachment => Ok(placeholder()),
-        ToolName::MarkRead => Ok(placeholder()),
-        ToolName::MarkUnread => Ok(placeholder()),
-        ToolName::Flag => Ok(placeholder()),
-        ToolName::Unflag => Ok(placeholder()),
-        ToolName::MoveMessage => Ok(placeholder()),
-        ToolName::CreateDraft => Ok(placeholder()),
+        match tool {
+            ToolName::ListFolders => Box::pin(crate::tools::list_folders::handle(self)).await,
+            ToolName::MarkRead => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::flags::handle_mark_read(self, input)).await
+            }
+            ToolName::MarkUnread => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::flags::handle_mark_unread(self, input)).await
+            }
+            ToolName::Flag => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::flags::handle_flag(self, input)).await
+            }
+            ToolName::Unflag => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::flags::handle_unflag(self, input)).await
+            }
+            ToolName::MoveMessage => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::move_message::handle(self, input)).await
+            }
+            ToolName::Search => Ok(placeholder()),
+            ToolName::SearchAdvanced => Ok(placeholder()),
+            ToolName::FetchMessage => Ok(placeholder()),
+            ToolName::FetchMessageHtml => Ok(placeholder()),
+            ToolName::ListAttachments => Ok(placeholder()),
+            ToolName::DownloadAttachment => Ok(placeholder()),
+            ToolName::CreateDraft => Ok(placeholder()),
+        }
     }
+}
+
+/// Deserialize tool arguments into a typed input struct.
+fn parse_args<T: serde::de::DeserializeOwned>(
+    args: &serde_json::Map<String, serde_json::Value>,
+) -> Result<T, rimap_core::RimapError> {
+    serde_json::from_value(serde_json::Value::Object(args.clone()))
+        .map_err(|e| rimap_core::RimapError::Internal(format!("invalid arguments: {e}")))
 }
 
 /// Build an rmcp `Tool` definition for a `ToolName`. Returns `None`

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -127,10 +127,14 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::move_message::handle(self, input)).await
             }
-            ToolName::Search => Ok(placeholder()),
-            ToolName::SearchAdvanced => Ok(placeholder()),
-            ToolName::FetchMessage => Ok(placeholder()),
-            ToolName::FetchMessageHtml => Ok(placeholder()),
+            ToolName::Search | ToolName::SearchAdvanced => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::search::handle(self, input)).await
+            }
+            ToolName::FetchMessage | ToolName::FetchMessageHtml => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::fetch_message::handle(self, input)).await
+            }
             ToolName::ListAttachments => Ok(placeholder()),
             ToolName::DownloadAttachment => Ok(placeholder()),
             ToolName::CreateDraft => Ok(placeholder()),

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -90,10 +90,6 @@ impl ServerHandler for ImapMcpServer {
 
 impl ImapMcpServer {
     /// Dispatch to the tool handler for `tool`.
-    #[expect(
-        clippy::match_same_arms,
-        reason = "placeholder arms will diverge when handlers land"
-    )]
     async fn dispatch_tool(
         &self,
         tool: ToolName,
@@ -135,8 +131,14 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::fetch_message::handle(self, input)).await
             }
-            ToolName::ListAttachments => Ok(placeholder()),
-            ToolName::DownloadAttachment => Ok(placeholder()),
+            ToolName::ListAttachments => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::list_attachments::handle(self, input)).await
+            }
+            ToolName::DownloadAttachment => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::download_attachment::handle(self, input)).await
+            }
             ToolName::CreateDraft => Ok(placeholder()),
         }
     }

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -3,7 +3,7 @@
 //! `ImapMcpServer` holds the validated config, IMAP connection, authz
 //! guard, audit writer, and download directory. The `ServerHandler`
 //! trait wires `list_tools` (posture-filtered) and `call_tool`
-//! (dispatch pipeline + placeholder handlers).
+//! (dispatch pipeline).
 
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -95,12 +95,6 @@ impl ImapMcpServer {
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
-        let placeholder = || crate::response::ToolResponse {
-            meta: serde_json::json!({"status": "not_implemented"}),
-            untrusted: None,
-            security_warnings: Vec::new(),
-        };
-
         match tool {
             ToolName::ListFolders => Box::pin(crate::tools::list_folders::handle(self)).await,
             ToolName::MarkRead => {
@@ -139,7 +133,10 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::download_attachment::handle(self, input)).await
             }
-            ToolName::CreateDraft => Ok(placeholder()),
+            ToolName::CreateDraft => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::create_draft::handle(self, input)).await
+            }
         }
     }
 }

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -90,7 +90,7 @@ impl ServerHandler for ImapMcpServer {
 
 impl ImapMcpServer {
     /// Dispatch to the tool handler for `tool`.
-    async fn dispatch_tool(
+    pub(crate) async fn dispatch_tool(
         &self,
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -1,0 +1,200 @@
+//! MCP server struct and `ServerHandler` implementation.
+//!
+//! `ImapMcpServer` holds the validated config, IMAP connection, authz
+//! guard, audit writer, and download directory. The `ServerHandler`
+//! trait wires `list_tools` (posture-filtered) and `call_tool`
+//! (dispatch pipeline + placeholder handlers).
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use rimap_audit::AuditWriter;
+use rimap_authz::DispatchGuard;
+use rimap_authz::breaker::SystemClock;
+use rimap_config::validate::ValidatedConfig;
+use rimap_core::tool::ToolName;
+use rimap_imap::Connection;
+use rmcp::RoleServer;
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ErrorData, Implementation, ListToolsResult,
+    PaginatedRequestParams, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+
+/// Core MCP server. Owns every resource the handler methods need.
+#[expect(dead_code, reason = "fields used by tool handlers in later tasks")]
+pub struct ImapMcpServer {
+    /// Validated configuration snapshot.
+    pub(crate) config: ValidatedConfig,
+    /// Lazy-connect IMAP connection handle.
+    pub(crate) imap: Connection,
+    /// Posture + circuit breaker + rate limiter guard.
+    pub(crate) guard: DispatchGuard<SystemClock>,
+    /// Append-only audit writer.
+    pub(crate) audit: AuditWriter,
+    /// Directory for attachment downloads.
+    pub(crate) download_dir: PathBuf,
+}
+
+impl ServerHandler for ImapMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::default().with_server_info(Implementation::new(
+            "rusty-imap-mcp",
+            env!("CARGO_PKG_VERSION"),
+        ))
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let allowed = self.guard.matrix().advertised();
+        let tools: Vec<Tool> = allowed
+            .iter()
+            .filter_map(|&tn| tool_definition(tn))
+            .collect();
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let tool_name = ToolName::from_str(&request.name)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+
+        if let Err(e) = crate::dispatch::pre_call_guards(&self.guard, tool_name) {
+            return Err(crate::mcp_error::to_mcp_error(&e));
+        }
+
+        let result = dispatch_tool(tool_name);
+
+        match result {
+            Ok(resp) => {
+                let value = serde_json::to_value(&resp)
+                    .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+                Ok(CallToolResult::structured(value))
+            }
+            Err(e) => Err(crate::mcp_error::to_mcp_error(&e)),
+        }
+    }
+}
+
+/// Dispatch to the tool handler for `tool`. All arms return a
+/// placeholder until real handlers land in later tasks.
+///
+/// The `Result` return and per-arm match structure are intentional:
+/// each arm will be replaced with a real handler that can fail.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "real handlers will return Err; scaffolding"
+)]
+#[expect(
+    clippy::match_same_arms,
+    reason = "each arm will diverge when handlers land"
+)]
+fn dispatch_tool(tool: ToolName) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
+    let placeholder = || crate::response::ToolResponse {
+        meta: serde_json::json!({"status": "not_implemented"}),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    };
+
+    match tool {
+        ToolName::ListFolders => Ok(placeholder()),
+        ToolName::Search => Ok(placeholder()),
+        ToolName::SearchAdvanced => Ok(placeholder()),
+        ToolName::FetchMessage => Ok(placeholder()),
+        ToolName::FetchMessageHtml => Ok(placeholder()),
+        ToolName::ListAttachments => Ok(placeholder()),
+        ToolName::DownloadAttachment => Ok(placeholder()),
+        ToolName::MarkRead => Ok(placeholder()),
+        ToolName::MarkUnread => Ok(placeholder()),
+        ToolName::Flag => Ok(placeholder()),
+        ToolName::Unflag => Ok(placeholder()),
+        ToolName::MoveMessage => Ok(placeholder()),
+        ToolName::CreateDraft => Ok(placeholder()),
+    }
+}
+
+/// Build an rmcp `Tool` definition for a `ToolName`. Returns `None`
+/// for sub-capabilities that share an MCP tool name with a parent
+/// (e.g. `SearchAdvanced` and `FetchMessageHtml` are gated
+/// sub-capabilities, not separate MCP tools).
+fn tool_definition(name: ToolName) -> Option<Tool> {
+    let (tool_name, description): (&str, &str) = match name {
+        ToolName::ListFolders => ("list_folders", "List all IMAP folders"),
+        ToolName::Search => ("search", "Search messages with structured query"),
+        ToolName::SearchAdvanced | ToolName::FetchMessageHtml => return None,
+        ToolName::FetchMessage => ("fetch_message", "Fetch message metadata and text body"),
+        ToolName::ListAttachments => ("list_attachments", "List attachments on a message"),
+        ToolName::DownloadAttachment => (
+            "download_attachment",
+            "Download an attachment to the sandbox directory",
+        ),
+        ToolName::MarkRead => ("mark_read", "Mark messages as read"),
+        ToolName::MarkUnread => ("mark_unread", "Mark messages as unread"),
+        ToolName::Flag => ("flag", "Add the flagged flag to messages"),
+        ToolName::Unflag => ("unflag", "Remove the flagged flag from messages"),
+        ToolName::MoveMessage => ("move_message", "Move messages to another folder"),
+        ToolName::CreateDraft => (
+            "create_draft",
+            "Create a draft email with $PendingReview flag",
+        ),
+    };
+
+    Some(Tool::new(
+        tool_name,
+        description,
+        Arc::new(serde_json::Map::new()),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use rimap_core::tool::ToolName;
+
+    use super::tool_definition;
+
+    #[test]
+    fn tool_definition_covers_all_mcp_tools() {
+        let defs: Vec<_> = ToolName::all()
+            .into_iter()
+            .filter_map(tool_definition)
+            .collect();
+        // 13 capabilities minus 2 sub-capabilities = 11 MCP tools
+        assert_eq!(defs.len(), 11);
+    }
+
+    #[test]
+    fn sub_capabilities_return_none() {
+        assert!(tool_definition(ToolName::SearchAdvanced).is_none());
+        assert!(tool_definition(ToolName::FetchMessageHtml).is_none());
+    }
+
+    #[test]
+    fn tool_names_are_snake_case() {
+        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+            assert!(
+                def.name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "tool name {} is not snake_case",
+                def.name,
+            );
+        }
+    }
+
+    #[test]
+    fn every_tool_has_a_description() {
+        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+            assert!(
+                def.description.is_some(),
+                "tool {} missing description",
+                def.name,
+            );
+        }
+    }
+}

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -1,0 +1,356 @@
+//! `create_draft` tool handler: compose a draft email and APPEND it
+//! to the Drafts folder with a `$PendingReview` keyword.
+
+use mail_builder::MessageBuilder;
+use mail_builder::headers::address::Address;
+use mail_builder::headers::message_id::MessageId;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Input for `create_draft`.
+#[derive(Debug, Deserialize)]
+pub struct CreateDraftInput {
+    /// Recipient addresses.
+    pub to: Vec<AddressInput>,
+    /// CC addresses.
+    pub cc: Option<Vec<AddressInput>>,
+    /// BCC addresses.
+    pub bcc: Option<Vec<AddressInput>>,
+    /// Email subject.
+    pub subject: String,
+    /// Plain text body.
+    pub body_text: String,
+    /// UID of message to reply to (for threading headers).
+    pub in_reply_to_uid: Option<u32>,
+    /// Folder containing the message to reply to (default INBOX).
+    pub in_reply_to_folder: Option<String>,
+}
+
+/// An email address with optional display name.
+#[derive(Debug, Deserialize)]
+pub struct AddressInput {
+    /// Display name (optional).
+    pub name: Option<String>,
+    /// Email address.
+    pub address: String,
+}
+
+/// `create_draft` handler.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: CreateDraftInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let raw_msg = build_draft(server, &input).await?;
+
+    let drafts_folder = "Drafts";
+    let result = server
+        .imap
+        .append_message(
+            drafts_folder,
+            &raw_msg,
+            &[rimap_imap::types::Flag::Draft],
+            &["$PendingReview"],
+        )
+        .await?;
+
+    let generated_msg_id = mail_parser::MessageParser::new()
+        .parse(&raw_msg)
+        .and_then(|m| m.message_id().map(ToString::to_string));
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": drafts_folder,
+            "uid": result.uid.map(rimap_imap::types::Uid::get),
+            "message_id": generated_msg_id,
+            "keywords": ["$PendingReview"],
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Build a raw RFC 5322 message from the draft input.
+///
+/// Separated from `handle` so unit tests can exercise message
+/// construction without an IMAP connection.
+async fn build_draft(
+    server: &ImapMcpServer,
+    input: &CreateDraftInput,
+) -> Result<Vec<u8>, rimap_core::RimapError> {
+    let builder = build_message_headers(&server.config.config.imap.username, input);
+
+    let builder = if let Some(reply_uid) = input.in_reply_to_uid {
+        Box::pin(apply_threading_headers(server, builder, reply_uid, input)).await?
+    } else {
+        builder
+    };
+
+    builder.write_to_vec().map_err(|e| {
+        rimap_core::RimapError::Internal(format!("failed to build draft message: {e}"))
+    })
+}
+
+/// Set From, To, CC, BCC, Subject, and body on a `MessageBuilder`.
+fn build_message_headers<'a>(
+    from_addr: &'a str,
+    input: &'a CreateDraftInput,
+) -> MessageBuilder<'a> {
+    let builder = MessageBuilder::new()
+        .from(from_addr)
+        .to(addresses_to_builder(&input.to))
+        .subject(input.subject.as_str())
+        .text_body(input.body_text.as_str());
+
+    let builder = if let Some(cc) = &input.cc {
+        builder.cc(addresses_to_builder(cc))
+    } else {
+        builder
+    };
+
+    if let Some(bcc) = &input.bcc {
+        builder.bcc(addresses_to_builder(bcc))
+    } else {
+        builder
+    }
+}
+
+/// Convert a slice of `AddressInput` into a mail-builder `Address`.
+fn addresses_to_builder(addrs: &[AddressInput]) -> Address<'_> {
+    if addrs.len() == 1 {
+        return single_address(&addrs[0]);
+    }
+    let list: Vec<Address<'_>> = addrs.iter().map(single_address).collect();
+    Address::new_list(list)
+}
+
+/// Convert a single `AddressInput` to a mail-builder `Address`.
+fn single_address(addr: &AddressInput) -> Address<'_> {
+    match &addr.name {
+        Some(name) => Address::new_address(Some(name.as_str()), addr.address.as_str()),
+        None => Address::new_address(None::<&str>, addr.address.as_str()),
+    }
+}
+
+/// Fetch the referenced message and set In-Reply-To / References.
+async fn apply_threading_headers<'a>(
+    server: &ImapMcpServer,
+    builder: MessageBuilder<'a>,
+    reply_uid: u32,
+    input: &CreateDraftInput,
+) -> Result<MessageBuilder<'a>, rimap_core::RimapError> {
+    let folder = input.in_reply_to_folder.as_deref().unwrap_or("INBOX");
+    let uid =
+        rimap_imap::types::Uid::new(reply_uid).ok_or_else(|| rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "in_reply_to_uid must be non-zero".into(),
+        })?;
+
+    let raw = server.imap.fetch_body(folder, uid).await?;
+    let parsed = mail_parser::MessageParser::new()
+        .parse(&raw)
+        .ok_or_else(|| {
+            rimap_core::RimapError::Internal("failed to parse referenced message".into())
+        })?;
+
+    let Some(msg_id) = parsed.message_id() else {
+        return Ok(builder);
+    };
+
+    let builder = builder.in_reply_to(msg_id.to_string());
+
+    // Build References chain: existing References + this Message-ID.
+    let mut ref_ids: Vec<String> = Vec::new();
+    // HeaderValue is an external #[non_exhaustive]-style enum with
+    // many variants; we only care about Text and TextList for
+    // References headers.
+    match parsed.references() {
+        mail_parser::HeaderValue::Text(t) => {
+            ref_ids.push(t.to_string());
+        }
+        mail_parser::HeaderValue::TextList(list) => {
+            for r in list {
+                ref_ids.push(r.to_string());
+            }
+        }
+        // External type with many variants; other shapes are not
+        // expected for References but are harmless to ignore.
+        _ => {}
+    }
+    ref_ids.push(msg_id.to_string());
+
+    let builder = builder.references(MessageId::new_list(ref_ids.into_iter()));
+
+    Ok(builder)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::panic, reason = "tests")]
+mod tests {
+    use mail_builder::MessageBuilder;
+    use mail_builder::headers::address::Address;
+    use mail_builder::headers::message_id::MessageId;
+
+    use super::{AddressInput, CreateDraftInput, addresses_to_builder};
+
+    /// Build a minimal draft, parse it, verify headers round-trip.
+    #[test]
+    fn round_trip_simple_draft() {
+        let input = CreateDraftInput {
+            to: vec![AddressInput {
+                name: Some("Bob".into()),
+                address: "bob@example.com".into(),
+            }],
+            cc: Some(vec![AddressInput {
+                name: None,
+                address: "cc@example.com".into(),
+            }]),
+            bcc: None,
+            subject: "Test subject".into(),
+            body_text: "Hello, world!".into(),
+            in_reply_to_uid: None,
+            in_reply_to_folder: None,
+        };
+
+        let builder = super::build_message_headers("alice@example.com", &input);
+        let raw = builder.write_to_vec().unwrap();
+        let parsed = mail_parser::MessageParser::new().parse(&raw).unwrap();
+
+        // From
+        let from = parsed.from().unwrap().first().unwrap();
+        assert_eq!(from.address().unwrap(), "alice@example.com");
+
+        // To
+        let to = parsed.to().unwrap().first().unwrap();
+        assert_eq!(to.name().unwrap(), "Bob");
+        assert_eq!(to.address().unwrap(), "bob@example.com");
+
+        // CC
+        let cc = parsed.cc().unwrap().first().unwrap();
+        assert_eq!(cc.address().unwrap(), "cc@example.com");
+
+        // Subject
+        assert_eq!(parsed.subject().unwrap(), "Test subject");
+
+        // Body
+        assert_eq!(parsed.body_text(0).unwrap().as_ref(), "Hello, world!");
+
+        // Auto-generated Message-ID
+        assert!(parsed.message_id().is_some());
+    }
+
+    /// Build an "original" message, then a reply, verify threading.
+    #[test]
+    fn threading_headers_round_trip() {
+        // Simulate an original message with known Message-ID and
+        // References.
+        let original = MessageBuilder::new()
+            .from("sender@example.com")
+            .to("me@example.com")
+            .message_id("original-id-123@example.com")
+            .references(MessageId::new_list(["root-id@example.com"].into_iter()))
+            .subject("Original")
+            .text_body("original body")
+            .write_to_vec()
+            .unwrap();
+
+        let parsed_original = mail_parser::MessageParser::new().parse(&original).unwrap();
+
+        // Verify we can read the original's Message-ID.
+        let orig_msg_id = parsed_original.message_id().unwrap();
+        assert_eq!(orig_msg_id, "original-id-123@example.com");
+
+        // Build the reply's threading headers manually (simulating
+        // what apply_threading_headers does without IMAP).
+        let mut ref_ids: Vec<String> = Vec::new();
+        match parsed_original.references() {
+            mail_parser::HeaderValue::Text(t) => {
+                ref_ids.push(t.to_string());
+            }
+            mail_parser::HeaderValue::TextList(list) => {
+                for r in list {
+                    ref_ids.push(r.to_string());
+                }
+            }
+            _ => {}
+        }
+        ref_ids.push(orig_msg_id.to_string());
+
+        let reply = MessageBuilder::new()
+            .from("me@example.com")
+            .to("sender@example.com")
+            .subject("Re: Original")
+            .text_body("reply body")
+            .in_reply_to(orig_msg_id.to_string())
+            .references(MessageId::new_list(ref_ids.into_iter()))
+            .write_to_vec()
+            .unwrap();
+
+        let parsed_reply = mail_parser::MessageParser::new().parse(&reply).unwrap();
+
+        // In-Reply-To should match original's Message-ID.
+        let in_reply_to = parsed_reply.in_reply_to();
+        assert_eq!(
+            in_reply_to.as_text().unwrap(),
+            "original-id-123@example.com"
+        );
+
+        // References should contain root + original.
+        match parsed_reply.references() {
+            mail_parser::HeaderValue::TextList(list) => {
+                let refs: Vec<&str> = list.iter().map(AsRef::as_ref).collect();
+                assert_eq!(
+                    refs,
+                    vec!["root-id@example.com", "original-id-123@example.com",]
+                );
+            }
+            other => panic!("expected TextList for References, got {other:?}"),
+        }
+    }
+
+    /// Multiple To addresses produce a single To header with all
+    /// addresses.
+    #[test]
+    fn multiple_to_addresses() {
+        let addrs = vec![
+            AddressInput {
+                name: Some("A".into()),
+                address: "a@example.com".into(),
+            },
+            AddressInput {
+                name: None,
+                address: "b@example.com".into(),
+            },
+        ];
+        let addr = addresses_to_builder(&addrs);
+        let builder = MessageBuilder::new()
+            .from("from@example.com")
+            .to(addr)
+            .subject("multi")
+            .text_body("body");
+        let raw = builder.write_to_vec().unwrap();
+        let parsed = mail_parser::MessageParser::new().parse(&raw).unwrap();
+
+        let to_addrs = parsed.to().unwrap();
+        let list = to_addrs.as_list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].address().unwrap(), "a@example.com");
+        assert_eq!(list[1].address().unwrap(), "b@example.com");
+    }
+
+    /// Single address does not wrap in a list.
+    #[test]
+    fn single_address_no_list_wrap() {
+        let addrs = vec![AddressInput {
+            name: None,
+            address: "solo@example.com".into(),
+        }];
+        let addr = addresses_to_builder(&addrs);
+        if let Address::Address(email) = &addr {
+            assert_eq!(email.email, "solo@example.com");
+        } else {
+            panic!("expected Address::Address for single input");
+        }
+    }
+}

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -37,11 +37,46 @@ pub struct AddressInput {
     pub address: String,
 }
 
+/// Reject strings containing bytes that could inject RFC 5322 headers
+/// or break angle-bracket quoting when passed to `mail-builder`.
+fn validate_header_text(field: &str, value: &str) -> Result<(), rimap_core::RimapError> {
+    if value
+        .bytes()
+        .any(|b| matches!(b, b'\r' | b'\n' | b'\0' | b'<' | b'>'))
+    {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: format!("{field} contains forbidden characters"),
+        });
+    }
+    Ok(())
+}
+
+/// Validate all address fields in a slice of [`AddressInput`].
+fn validate_addresses(field: &str, addrs: &[AddressInput]) -> Result<(), rimap_core::RimapError> {
+    for addr in addrs {
+        validate_header_text(&format!("{field} address"), &addr.address)?;
+        if let Some(name) = &addr.name {
+            validate_header_text(&format!("{field} name"), name)?;
+        }
+    }
+    Ok(())
+}
+
+/// Strip characters from a parsed Message-ID that could inject
+/// headers if written back into an RFC 5322 message.
+fn sanitize_message_id(id: &str) -> String {
+    id.chars()
+        .filter(|c| !matches!(c, '\r' | '\n' | '\0' | '<' | '>'))
+        .collect()
+}
+
 /// `create_draft` handler.
 pub async fn handle(
     server: &ImapMcpServer,
     input: CreateDraftInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
+    validate_draft_input(&input)?;
     let raw_msg = build_draft(server, &input).await?;
 
     let drafts_folder = "Drafts";
@@ -71,6 +106,36 @@ pub async fn handle(
     })
 }
 
+/// Validate all user-supplied fields in the draft input.
+fn validate_draft_input(input: &CreateDraftInput) -> Result<(), rimap_core::RimapError> {
+    if input.to.is_empty() {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "at least one To recipient is required".into(),
+        });
+    }
+    validate_addresses("To", &input.to)?;
+    if let Some(cc) = &input.cc {
+        validate_addresses("CC", cc)?;
+    }
+    if let Some(bcc) = &input.bcc {
+        validate_addresses("BCC", bcc)?;
+    }
+    // Defense-in-depth: mail-builder Q-encodes subjects, but
+    // reject CR/LF anyway to prevent surprises.
+    if input
+        .subject
+        .bytes()
+        .any(|b| matches!(b, b'\r' | b'\n' | b'\0'))
+    {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "subject contains forbidden characters".into(),
+        });
+    }
+    Ok(())
+}
+
 /// Build a raw RFC 5322 message from the draft input.
 ///
 /// Separated from `handle` so unit tests can exercise message
@@ -92,16 +157,32 @@ async fn build_draft(
     })
 }
 
-/// Set From, To, CC, BCC, Subject, and body on a `MessageBuilder`.
+/// Generate a Message-ID that does not leak the local hostname.
+///
+/// Uses PID + monotonic nanosecond timestamp + the domain portion
+/// of the From address. Collisions are acceptable for drafts — the
+/// IMAP server assigns the canonical UID.
+fn generate_message_id(from_addr: &str) -> String {
+    let domain = from_addr.rsplit('@').next().unwrap_or("local");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("{}.{}@{domain}", std::process::id(), nanos)
+}
+
+/// Set From, To, CC, BCC, Subject, body, and Message-ID on a
+/// `MessageBuilder`.
 fn build_message_headers<'a>(
     from_addr: &'a str,
     input: &'a CreateDraftInput,
 ) -> MessageBuilder<'a> {
+    let msg_id = generate_message_id(from_addr);
     let builder = MessageBuilder::new()
         .from(from_addr)
         .to(addresses_to_builder(&input.to))
         .subject(input.subject.as_str())
-        .text_body(input.body_text.as_str());
+        .text_body(input.body_text.as_str())
+        .message_id(msg_id);
 
     let builder = if let Some(cc) = &input.cc {
         builder.cc(addresses_to_builder(cc))
@@ -154,11 +235,12 @@ async fn apply_threading_headers<'a>(
             rimap_core::RimapError::Internal("failed to parse referenced message".into())
         })?;
 
-    let Some(msg_id) = parsed.message_id() else {
+    let Some(raw_msg_id) = parsed.message_id() else {
         return Ok(builder);
     };
 
-    let builder = builder.in_reply_to(msg_id.to_string());
+    let msg_id = sanitize_message_id(raw_msg_id);
+    let builder = builder.in_reply_to(msg_id.clone());
 
     // Build References chain: existing References + this Message-ID.
     let mut ref_ids: Vec<String> = Vec::new();
@@ -167,18 +249,18 @@ async fn apply_threading_headers<'a>(
     // References headers.
     match parsed.references() {
         mail_parser::HeaderValue::Text(t) => {
-            ref_ids.push(t.to_string());
+            ref_ids.push(sanitize_message_id(t));
         }
         mail_parser::HeaderValue::TextList(list) => {
             for r in list {
-                ref_ids.push(r.to_string());
+                ref_ids.push(sanitize_message_id(r));
             }
         }
         // External type with many variants; other shapes are not
         // expected for References but are harmless to ignore.
         _ => {}
     }
-    ref_ids.push(msg_id.to_string());
+    ref_ids.push(msg_id);
 
     let builder = builder.references(MessageId::new_list(ref_ids.into_iter()));
 
@@ -192,7 +274,10 @@ mod tests {
     use mail_builder::headers::address::Address;
     use mail_builder::headers::message_id::MessageId;
 
-    use super::{AddressInput, CreateDraftInput, addresses_to_builder};
+    use super::{
+        AddressInput, CreateDraftInput, addresses_to_builder, sanitize_message_id,
+        validate_draft_input,
+    };
 
     /// Build a minimal draft, parse it, verify headers round-trip.
     #[test]
@@ -352,5 +437,127 @@ mod tests {
         } else {
             panic!("expected Address::Address for single input");
         }
+    }
+
+    fn make_input(to: Vec<AddressInput>) -> CreateDraftInput {
+        CreateDraftInput {
+            to,
+            cc: None,
+            bcc: None,
+            subject: "Test".into(),
+            body_text: "body".into(),
+            in_reply_to_uid: None,
+            in_reply_to_folder: None,
+        }
+    }
+
+    /// CRLF in address field is rejected.
+    #[test]
+    fn crlf_in_address_rejected() {
+        let input = make_input(vec![AddressInput {
+            name: None,
+            address: "a@b>\r\nBcc: spy@evil".into(),
+        }]);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+    }
+
+    /// CRLF in display name is rejected.
+    #[test]
+    fn crlf_in_name_rejected() {
+        let input = make_input(vec![AddressInput {
+            name: Some("Evil\r\nBcc: spy@evil".into()),
+            address: "ok@example.com".into(),
+        }]);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+    }
+
+    /// Angle brackets in address are rejected.
+    #[test]
+    fn angle_brackets_in_address_rejected() {
+        let input = make_input(vec![AddressInput {
+            name: None,
+            address: "<injected>@example.com".into(),
+        }]);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+    }
+
+    /// Empty `to` vec is rejected.
+    #[test]
+    fn empty_to_rejected() {
+        let input = make_input(vec![]);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+        assert!(
+            err.to_string().contains("at least one To"),
+            "unexpected message: {err}",
+        );
+    }
+
+    /// Subject with CR/LF is rejected.
+    #[test]
+    fn subject_crlf_rejected() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.subject = "Hello\r\nBcc: spy@evil".into();
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+    }
+
+    /// CC address validation is exercised.
+    #[test]
+    fn cc_address_validated() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.cc = Some(vec![AddressInput {
+            name: None,
+            address: "bad\n@example.com".into(),
+        }]);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput,);
+    }
+
+    /// `sanitize_message_id` strips dangerous characters.
+    #[test]
+    fn sanitize_message_id_strips_crlf_and_angles() {
+        assert_eq!(sanitize_message_id("<id\r\n@host>"), "id@host",);
+        assert_eq!(sanitize_message_id("clean@host"), "clean@host",);
+    }
+
+    /// Generated Message-ID uses the from-address domain, not the
+    /// local hostname.
+    #[test]
+    fn message_id_uses_from_domain() {
+        let input = make_input(vec![AddressInput {
+            name: None,
+            address: "bob@example.com".into(),
+        }]);
+        let builder = super::build_message_headers("alice@secret-host.internal", &input);
+        let raw = builder.write_to_vec().unwrap();
+        let parsed = mail_parser::MessageParser::new().parse(&raw).unwrap();
+        let mid = parsed.message_id().unwrap();
+        assert!(
+            mid.ends_with("@secret-host.internal"),
+            "Message-ID should use from domain: {mid}",
+        );
+        // Must not contain the machine hostname (heuristic: no
+        // space or slash, which gethostname wouldn't produce either,
+        // but at minimum it should use the from domain).
+    }
+
+    /// Valid input passes validation.
+    #[test]
+    fn valid_input_passes() {
+        let input = make_input(vec![AddressInput {
+            name: Some("Bob".into()),
+            address: "bob@example.com".into(),
+        }]);
+        validate_draft_input(&input).unwrap();
     }
 }

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -1,0 +1,172 @@
+//! `download_attachment` tool handler.
+
+use mail_parser::MimeHeaders;
+use rimap_imap::types::Uid;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::download;
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Input for the `download_attachment` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadAttachmentInput {
+    /// IMAP folder containing the message.
+    pub folder: String,
+    /// UID of the message.
+    pub uid: u32,
+    /// MIME part ID of the attachment (e.g. "2", "1.2").
+    pub part_id: String,
+    /// Optional destination directory. Must be within the
+    /// configured download root.
+    pub dest_dir: Option<String>,
+}
+
+/// Execute the `download_attachment` tool.
+///
+/// Fetches the full message, parses it with `mail_parser`, extracts
+/// the attachment part matching `part_id`, and writes it to the
+/// sandbox directory.
+///
+/// # Errors
+///
+/// Returns `RimapError` on invalid input, IMAP failure, part not
+/// found, or filesystem errors.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: DownloadAttachmentInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uid = Uid::new(input.uid).ok_or_else(|| rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: "UID must be non-zero".to_string(),
+    })?;
+
+    if input.part_id.is_empty() {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "part_id must not be empty".to_string(),
+        });
+    }
+
+    let dest = download::resolve_dest_dir(
+        input.dest_dir.as_deref(),
+        &server.download_dir,
+        &server.download_dir,
+    )?;
+
+    let raw = server.imap.fetch_body(&input.folder, uid).await?;
+
+    let parsed = mail_parser::MessageParser::new()
+        .parse(&raw)
+        .ok_or_else(|| {
+            rimap_core::RimapError::Internal(
+                "failed to parse message for attachment extraction".into(),
+            )
+        })?;
+
+    let (part_body, declared_type, original_filename) = find_part_by_id(&parsed, &input.part_id)?;
+
+    let safe_filename = original_filename.as_deref().unwrap_or("attachment");
+
+    let path = download::write_attachment(&dest, safe_filename, &part_body)?;
+    let size = part_body.len();
+    let sha256 = download::sha256_hex(&part_body);
+    let mime_sniffed = download::sniff_mime(&part_body);
+
+    let path_str = path.to_string_lossy().to_string();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uid": input.uid,
+            "part_id": input.part_id,
+            "path": path_str,
+            "size_bytes": size,
+            "sha256": sha256,
+            "mime_declared": declared_type,
+            "mime_sniffed": mime_sniffed,
+        }),
+        untrusted: Some(serde_json::json!({
+            "filename_original": original_filename,
+        })),
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Find the MIME part matching `part_id` in a parsed message.
+///
+/// Walks the `mail_parser` parts array and reconstructs IMAP-style
+/// part numbering to find the target part.
+fn find_part_by_id(
+    msg: &mail_parser::Message<'_>,
+    target_part_id: &str,
+) -> Result<(Vec<u8>, String, Option<String>), rimap_core::RimapError> {
+    let part_ids = compute_part_ids(msg);
+
+    for (idx, computed_id) in &part_ids {
+        if computed_id == target_part_id {
+            let part = &msg.parts[*idx];
+            let body = part.contents().to_vec();
+            let content_type = if let Some(ct) = part.content_type() {
+                let main = ct.ctype();
+                let sub = ct.subtype().unwrap_or("octet-stream");
+                format!("{main}/{sub}")
+            } else {
+                "application/octet-stream".to_string()
+            };
+            let filename = part.attachment_name().map(String::from);
+            return Ok((body, content_type, filename));
+        }
+    }
+
+    Err(rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::NotFound,
+        message: format!("part_id {target_part_id} not found in message"),
+    })
+}
+
+/// Compute IMAP-style part IDs for all leaf parts in a parsed
+/// message. Returns `(part_index, imap_part_id)` pairs.
+fn compute_part_ids(msg: &mail_parser::Message<'_>) -> Vec<(usize, String)> {
+    let mut result = Vec::new();
+    let root = &msg.parts[0];
+
+    if root.is_multipart() {
+        walk_parts(msg, 0, "", &mut result);
+    } else {
+        // Single-part message: the sole part is "1".
+        result.push((0, "1".to_string()));
+    }
+
+    result
+}
+
+/// Recursively walk parts and assign IMAP-style IDs.
+fn walk_parts(
+    msg: &mail_parser::Message<'_>,
+    part_idx: usize,
+    prefix: &str,
+    out: &mut Vec<(usize, String)>,
+) {
+    let part = &msg.parts[part_idx];
+
+    if let Some(children) = part.sub_parts() {
+        for (i, &child_idx) in children.iter().enumerate() {
+            let num = i + 1;
+            let child_id = if prefix.is_empty() {
+                num.to_string()
+            } else {
+                format!("{prefix}.{num}")
+            };
+            walk_parts(msg, child_idx as usize, &child_id, out);
+        }
+    } else {
+        let part_id = if prefix.is_empty() {
+            "1".to_string()
+        } else {
+            prefix.to_string()
+        };
+        out.push((part_idx, part_id));
+    }
+}

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -102,11 +102,13 @@ fn find_part_by_id(
     msg: &mail_parser::Message<'_>,
     target_part_id: &str,
 ) -> Result<(Vec<u8>, String, Option<String>), rimap_core::RimapError> {
-    let part_ids = compute_part_ids(msg);
+    let part_ids = compute_part_ids(msg)?;
 
     for (idx, computed_id) in &part_ids {
         if computed_id == target_part_id {
-            let part = &msg.parts[*idx];
+            let part = msg.parts.get(*idx).ok_or_else(|| {
+                rimap_core::RimapError::Internal(format!("part index {idx} out of range"))
+            })?;
             let body = part.contents().to_vec();
             let content_type = if let Some(ct) = part.content_type() {
                 let main = ct.ctype();
@@ -128,18 +130,23 @@ fn find_part_by_id(
 
 /// Compute IMAP-style part IDs for all leaf parts in a parsed
 /// message. Returns `(part_index, imap_part_id)` pairs.
-fn compute_part_ids(msg: &mail_parser::Message<'_>) -> Vec<(usize, String)> {
+fn compute_part_ids(
+    msg: &mail_parser::Message<'_>,
+) -> Result<Vec<(usize, String)>, rimap_core::RimapError> {
     let mut result = Vec::new();
-    let root = &msg.parts[0];
+    let root = msg
+        .parts
+        .first()
+        .ok_or_else(|| rimap_core::RimapError::Internal("message has no parts".into()))?;
 
     if root.is_multipart() {
-        walk_parts(msg, 0, "", &mut result);
+        walk_parts(msg, 0, "", &mut result)?;
     } else {
         // Single-part message: the sole part is "1".
         result.push((0, "1".to_string()));
     }
 
-    result
+    Ok(result)
 }
 
 /// Recursively walk parts and assign IMAP-style IDs.
@@ -148,8 +155,10 @@ fn walk_parts(
     part_idx: usize,
     prefix: &str,
     out: &mut Vec<(usize, String)>,
-) {
-    let part = &msg.parts[part_idx];
+) -> Result<(), rimap_core::RimapError> {
+    let part = msg.parts.get(part_idx).ok_or_else(|| {
+        rimap_core::RimapError::Internal(format!("part index {part_idx} out of range"))
+    })?;
 
     if let Some(children) = part.sub_parts() {
         for (i, &child_idx) in children.iter().enumerate() {
@@ -159,7 +168,7 @@ fn walk_parts(
             } else {
                 format!("{prefix}.{num}")
             };
-            walk_parts(msg, child_idx as usize, &child_id, out);
+            walk_parts(msg, child_idx as usize, &child_id, out)?;
         }
     } else {
         let part_id = if prefix.is_empty() {
@@ -169,4 +178,5 @@ fn walk_parts(
         };
         out.push((part_idx, part_id));
     }
+    Ok(())
 }

--- a/crates/rimap-server/src/tools/fetch_message.rs
+++ b/crates/rimap-server/src/tools/fetch_message.rs
@@ -1,0 +1,142 @@
+//! `fetch_message` tool handler.
+
+use rimap_imap::types::Uid;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Input for the `fetch_message` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FetchMessageInput {
+    /// IMAP folder containing the message.
+    pub folder: String,
+    /// UID of the message to fetch.
+    pub uid: u32,
+    /// Include sanitized HTML body in the response.
+    pub include_html: Option<bool>,
+    /// Truncate body text (and HTML if included) to this many bytes.
+    pub max_body_bytes: Option<usize>,
+}
+
+/// Execute the `fetch_message` tool.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: FetchMessageInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let include_html = input.include_html.unwrap_or(false);
+    if include_html {
+        use rimap_core::tool::ToolName;
+        server
+            .guard
+            .matrix()
+            .check(ToolName::FetchMessageHtml)
+            .map_err(|e| rimap_core::RimapError::Authz {
+                code: e.code(),
+                message: e.to_string(),
+            })?;
+    }
+
+    let uid = Uid::new(input.uid).ok_or_else(|| rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: "UID must be non-zero".to_string(),
+    })?;
+
+    let raw = server.imap.fetch_body(&input.folder, uid).await?;
+    let raw_size = raw.len();
+
+    let content = crate::content::parse_message_async(raw)
+        .await
+        .map_err(|e| rimap_core::RimapError::Internal(e.to_string()))?;
+
+    let mut body_text = content.untrusted.body_text;
+    let mut body_html = if include_html {
+        content.untrusted.body_html
+    } else {
+        None
+    };
+
+    let mut truncated = content.meta.body_truncated;
+
+    if let Some(max) = input.max_body_bytes {
+        if body_text.len() > max {
+            truncate_string(&mut body_text, max);
+            truncated = true;
+        }
+        if let Some(html) = &mut body_html
+            && html.len() > max
+        {
+            truncate_string(html, max);
+            truncated = true;
+        }
+    }
+
+    let attachments: Vec<serde_json::Value> = content
+        .meta
+        .attachments
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "filename": a.filename,
+                "content_type": a.content_type,
+                "size_bytes": a.size_bytes,
+                "content_id": a.content_id,
+                "is_inline": a.is_inline,
+            })
+        })
+        .collect();
+
+    let warnings: Vec<serde_json::Value> = content
+        .security_warnings
+        .iter()
+        .map(|w| {
+            serde_json::json!({
+                "code": w.code,
+                "detail": w.detail,
+                "location": w.location,
+            })
+        })
+        .collect();
+
+    let mut untrusted = serde_json::json!({
+        "body_text": body_text,
+        "subject": content.meta.subject,
+        "from": content.meta.from,
+        "to": content.meta.to,
+        "cc": content.meta.cc,
+        "reply_to": content.meta.reply_to,
+        "date": content.meta.date,
+        "attachments": attachments,
+    });
+
+    if let Some(html) = body_html {
+        untrusted["body_html"] = serde_json::json!(html);
+    }
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uid": input.uid,
+            "message_id": content.meta.message_id,
+            "size": raw_size,
+            "truncated": truncated,
+        }),
+        untrusted: Some(untrusted),
+        security_warnings: warnings,
+    })
+}
+
+/// Truncate a string to at most `max` bytes on a valid UTF-8
+/// boundary.
+fn truncate_string(s: &mut String, max: usize) {
+    if s.len() <= max {
+        return;
+    }
+    // Find the last valid char boundary at or before `max`.
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+}

--- a/crates/rimap-server/src/tools/flags.rs
+++ b/crates/rimap-server/src/tools/flags.rs
@@ -98,6 +98,9 @@ async fn handle_flag_op(
     })
 }
 
+/// Maximum number of UIDs in a single batch operation.
+pub(crate) const MAX_BATCH_UIDS: usize = 100;
+
 /// Resolve `uid` or `uids` from input to a `Vec<Uid>`.
 pub fn resolve_uids(
     uid: Option<u32>,
@@ -105,25 +108,88 @@ pub fn resolve_uids(
 ) -> Result<Vec<Uid>, rimap_core::RimapError> {
     match (uid, uids) {
         (Some(u), None) => {
-            let uid = Uid::new(u)
-                .ok_or_else(|| rimap_core::RimapError::Internal("UID must be non-zero".into()))?;
+            let uid = Uid::new(u).ok_or_else(|| rimap_core::RimapError::Authz {
+                code: rimap_core::error::ErrorCode::InvalidInput,
+                message: "UID must be non-zero".into(),
+            })?;
             Ok(vec![uid])
         }
         (None, Some(us)) => {
+            if us.len() > MAX_BATCH_UIDS {
+                return Err(rimap_core::RimapError::Authz {
+                    code: rimap_core::error::ErrorCode::InvalidInput,
+                    message: format!(
+                        "uids batch size {} exceeds maximum of {MAX_BATCH_UIDS}",
+                        us.len()
+                    ),
+                });
+            }
             let mut result = Vec::with_capacity(us.len());
             for u in us {
-                let uid = Uid::new(u).ok_or_else(|| {
-                    rimap_core::RimapError::Internal("UID must be non-zero".into())
+                let uid = Uid::new(u).ok_or_else(|| rimap_core::RimapError::Authz {
+                    code: rimap_core::error::ErrorCode::InvalidInput,
+                    message: "UID must be non-zero".into(),
                 })?;
                 result.push(uid);
             }
             Ok(result)
         }
-        (Some(_), Some(_)) => Err(rimap_core::RimapError::Internal(
-            "provide uid or uids, not both".into(),
-        )),
-        (None, None) => Err(rimap_core::RimapError::Internal(
-            "provide uid or uids".into(),
-        )),
+        (Some(_), Some(_)) => Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "provide uid or uids, not both".into(),
+        }),
+        (None, None) => Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: "provide uid or uids".into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_uids_single() {
+        let result = resolve_uids(Some(42), None).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].get(), 42);
+    }
+
+    #[test]
+    fn resolve_uids_batch_within_limit() {
+        let uids: Vec<u32> = (1..=100).collect();
+        let result = resolve_uids(None, Some(uids)).unwrap();
+        assert_eq!(result.len(), 100);
+    }
+
+    #[test]
+    fn resolve_uids_batch_exceeds_limit() {
+        let uids: Vec<u32> = (1..=101).collect();
+        let result = resolve_uids(None, Some(uids));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn resolve_uids_rejects_zero() {
+        let result = resolve_uids(Some(0), None);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("non-zero"));
+    }
+
+    #[test]
+    fn resolve_uids_rejects_both() {
+        let result = resolve_uids(Some(1), Some(vec![2]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_uids_rejects_neither() {
+        let result = resolve_uids(None, None);
+        assert!(result.is_err());
     }
 }

--- a/crates/rimap-server/src/tools/flags.rs
+++ b/crates/rimap-server/src/tools/flags.rs
@@ -1,0 +1,129 @@
+//! Flag mutation tool handlers: `mark_read`, `mark_unread`, `flag`,
+//! `unflag`.
+
+use rimap_imap::types::{Flag, FlagAction, Uid};
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Input for flag mutation tools.
+#[derive(Debug, Deserialize)]
+pub struct FlagInput {
+    /// Target folder.
+    pub folder: String,
+    /// Single UID.
+    pub uid: Option<u32>,
+    /// Batch of UIDs (max 100).
+    pub uids: Option<Vec<u32>>,
+}
+
+/// `mark_read` handler.
+pub async fn handle_mark_read(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    Box::pin(handle_flag_op(
+        server,
+        input,
+        &[Flag::Seen],
+        FlagAction::Add,
+    ))
+    .await
+}
+
+/// `mark_unread` handler.
+pub async fn handle_mark_unread(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    Box::pin(handle_flag_op(
+        server,
+        input,
+        &[Flag::Seen],
+        FlagAction::Remove,
+    ))
+    .await
+}
+
+/// `flag` handler.
+pub async fn handle_flag(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    Box::pin(handle_flag_op(
+        server,
+        input,
+        &[Flag::Flagged],
+        FlagAction::Add,
+    ))
+    .await
+}
+
+/// `unflag` handler.
+pub async fn handle_unflag(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    Box::pin(handle_flag_op(
+        server,
+        input,
+        &[Flag::Flagged],
+        FlagAction::Remove,
+    ))
+    .await
+}
+
+async fn handle_flag_op(
+    server: &ImapMcpServer,
+    input: FlagInput,
+    flags: &[Flag],
+    action: FlagAction,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let updated = server
+        .imap
+        .store_flags(&input.folder, &uids, flags, action)
+        .await?;
+
+    let updated_ids: Vec<u32> = updated.iter().map(|u| u.get()).collect();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uids_updated": updated_ids,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Resolve `uid` or `uids` from input to a `Vec<Uid>`.
+pub fn resolve_uids(
+    uid: Option<u32>,
+    uids: Option<Vec<u32>>,
+) -> Result<Vec<Uid>, rimap_core::RimapError> {
+    match (uid, uids) {
+        (Some(u), None) => {
+            let uid = Uid::new(u)
+                .ok_or_else(|| rimap_core::RimapError::Internal("UID must be non-zero".into()))?;
+            Ok(vec![uid])
+        }
+        (None, Some(us)) => {
+            let mut result = Vec::with_capacity(us.len());
+            for u in us {
+                let uid = Uid::new(u).ok_or_else(|| {
+                    rimap_core::RimapError::Internal("UID must be non-zero".into())
+                })?;
+                result.push(uid);
+            }
+            Ok(result)
+        }
+        (Some(_), Some(_)) => Err(rimap_core::RimapError::Internal(
+            "provide uid or uids, not both".into(),
+        )),
+        (None, None) => Err(rimap_core::RimapError::Internal(
+            "provide uid or uids".into(),
+        )),
+    }
+}

--- a/crates/rimap-server/src/tools/list_attachments.rs
+++ b/crates/rimap-server/src/tools/list_attachments.rs
@@ -1,0 +1,288 @@
+//! `list_attachments` tool handler.
+
+use rimap_imap::types::{BodyStructure, FetchSpec, Uid};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Input for the `list_attachments` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListAttachmentsInput {
+    /// IMAP folder containing the message.
+    pub folder: String,
+    /// UID of the message.
+    pub uid: u32,
+}
+
+/// Metadata for a single attachment discovered in the MIME tree.
+#[derive(Debug, serde::Serialize)]
+struct AttachmentInfo {
+    part_id: String,
+    mime_type: String,
+    size_bytes: u32,
+    filename: Option<String>,
+}
+
+/// Execute the `list_attachments` tool.
+///
+/// Fetches `BODYSTRUCTURE` for the given message and walks the MIME
+/// tree to find non-text attachment parts.
+///
+/// # Errors
+///
+/// Returns `RimapError` on invalid input or IMAP failure.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: ListAttachmentsInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uid = Uid::new(input.uid).ok_or_else(|| rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: "UID must be non-zero".to_string(),
+    })?;
+
+    let spec = FetchSpec {
+        bodystructure: true,
+        ..FetchSpec::default()
+    };
+    let messages = server.imap.fetch(&input.folder, &[uid], spec).await?;
+
+    let msg = messages
+        .into_iter()
+        .next()
+        .ok_or_else(|| rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::NotFound,
+            message: format!("UID {} not found in {}", input.uid, input.folder),
+        })?;
+
+    let bodystructure = msg.bodystructure.ok_or_else(|| {
+        rimap_core::RimapError::Internal("server did not return BODYSTRUCTURE".into())
+    })?;
+
+    let mut attachments = Vec::new();
+    collect_attachments(&bodystructure, &mut String::new(), &mut attachments);
+
+    let attachment_values: Vec<serde_json::Value> = attachments
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "part_id": a.part_id,
+                "mime_type": a.mime_type,
+                "size_bytes": a.size_bytes,
+                "filename": a.filename,
+            })
+        })
+        .collect();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uid": input.uid,
+            "attachment_count": attachments.len(),
+        }),
+        untrusted: Some(serde_json::json!({
+            "attachments": attachment_values,
+        })),
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Walk the `BodyStructure` tree and collect attachment parts.
+///
+/// IMAP part numbering: for a multipart message the top-level parts
+/// are "1", "2", "3", etc. Nested multipart sub-parts are "1.1",
+/// "1.2", etc. For a non-multipart (single-part) message at the
+/// root, the sole part is "1".
+fn collect_attachments(bs: &BodyStructure, prefix: &mut String, out: &mut Vec<AttachmentInfo>) {
+    match bs {
+        BodyStructure::Single {
+            mime_type,
+            mime_subtype,
+            params,
+            size,
+            ..
+        } => {
+            let part_id = if prefix.is_empty() {
+                "1".to_string()
+            } else {
+                prefix.clone()
+            };
+            if !is_inline_text(mime_type, mime_subtype) {
+                let filename = extract_filename(params);
+                let full_type = format!(
+                    "{}/{}",
+                    mime_type.to_lowercase(),
+                    mime_subtype.to_lowercase()
+                );
+                out.push(AttachmentInfo {
+                    part_id,
+                    mime_type: full_type,
+                    size_bytes: *size,
+                    filename,
+                });
+            }
+        }
+        BodyStructure::Multipart { parts, .. } => {
+            for (i, part) in parts.iter().enumerate() {
+                let idx = i + 1;
+                let child_prefix = if prefix.is_empty() {
+                    idx.to_string()
+                } else {
+                    format!("{prefix}.{idx}")
+                };
+                let mut child = child_prefix;
+                collect_attachments(part, &mut child, out);
+            }
+        }
+        BodyStructure::Message { body, .. } => {
+            let part_id = if prefix.is_empty() {
+                "1".to_string()
+            } else {
+                prefix.clone()
+            };
+            // Walk into the embedded message's body structure.
+            collect_attachments(body, &mut part_id.clone(), out);
+        }
+    }
+}
+
+/// Returns `true` for `text/plain` and `text/html`, which are
+/// typically inline body parts rather than attachments.
+fn is_inline_text(mime_type: &str, mime_subtype: &str) -> bool {
+    mime_type.eq_ignore_ascii_case("text")
+        && (mime_subtype.eq_ignore_ascii_case("plain") || mime_subtype.eq_ignore_ascii_case("html"))
+}
+
+/// Extract a filename from MIME content-type parameters.
+/// Looks for `name` or `filename` (case-insensitive).
+fn extract_filename(params: &[(String, String)]) -> Option<String> {
+    for (key, value) in params {
+        if (key.eq_ignore_ascii_case("name") || key.eq_ignore_ascii_case("filename"))
+            && !value.is_empty()
+        {
+            return Some(value.clone());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single(mime_type: &str, sub: &str, size: u32) -> BodyStructure {
+        BodyStructure::Single {
+            mime_type: mime_type.to_string(),
+            mime_subtype: sub.to_string(),
+            params: Vec::new(),
+            encoding: "7bit".to_string(),
+            size,
+        }
+    }
+
+    fn single_with_name(mime_type: &str, sub: &str, size: u32, name: &str) -> BodyStructure {
+        BodyStructure::Single {
+            mime_type: mime_type.to_string(),
+            mime_subtype: sub.to_string(),
+            params: vec![("name".to_string(), name.to_string())],
+            encoding: "base64".to_string(),
+            size,
+        }
+    }
+
+    #[test]
+    fn single_text_plain_is_not_attachment() {
+        let bs = single("text", "plain", 100);
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_text_html_is_not_attachment() {
+        let bs = single("text", "html", 200);
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_image_is_attachment() {
+        let bs = single_with_name("image", "png", 5000, "photo.png");
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].part_id, "1");
+        assert_eq!(out[0].mime_type, "image/png");
+        assert_eq!(out[0].size_bytes, 5000);
+        assert_eq!(out[0].filename.as_deref(), Some("photo.png"));
+    }
+
+    #[test]
+    fn multipart_mixed_extracts_attachments() {
+        let bs = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![
+                single("text", "plain", 100),
+                single_with_name("application", "pdf", 20000, "report.pdf"),
+                single_with_name("image", "jpeg", 8000, "cat.jpg"),
+            ],
+        };
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].part_id, "2");
+        assert_eq!(out[0].mime_type, "application/pdf");
+        assert_eq!(out[1].part_id, "3");
+        assert_eq!(out[1].mime_type, "image/jpeg");
+    }
+
+    #[test]
+    fn nested_multipart_numbering() {
+        let inner = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![
+                single("text", "plain", 50),
+                single_with_name("image", "gif", 1000, "anim.gif"),
+            ],
+        };
+        let bs = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![
+                inner,
+                single_with_name("application", "zip", 50000, "archive.zip"),
+            ],
+        };
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].part_id, "1.2");
+        assert_eq!(out[0].filename.as_deref(), Some("anim.gif"));
+        assert_eq!(out[1].part_id, "2");
+        assert_eq!(out[1].filename.as_deref(), Some("archive.zip"));
+    }
+
+    #[test]
+    fn is_inline_text_case_insensitive() {
+        assert!(is_inline_text("TEXT", "PLAIN"));
+        assert!(is_inline_text("Text", "Html"));
+        assert!(!is_inline_text("text", "csv"));
+        assert!(!is_inline_text("image", "plain"));
+    }
+
+    #[test]
+    fn extract_filename_finds_name_param() {
+        let params = vec![
+            ("charset".to_string(), "utf-8".to_string()),
+            ("name".to_string(), "doc.pdf".to_string()),
+        ];
+        assert_eq!(extract_filename(&params), Some("doc.pdf".to_string()));
+    }
+
+    #[test]
+    fn extract_filename_returns_none_when_absent() {
+        let params = vec![("charset".to_string(), "utf-8".to_string())];
+        assert_eq!(extract_filename(&params), None);
+    }
+}

--- a/crates/rimap-server/src/tools/list_folders.rs
+++ b/crates/rimap-server/src/tools/list_folders.rs
@@ -1,0 +1,34 @@
+//! `list_folders` tool handler.
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Execute the `list_folders` tool.
+pub async fn handle(server: &ImapMcpServer) -> Result<ToolResponse, rimap_core::RimapError> {
+    let folders = server.imap.list_folders("*").await?;
+
+    let mut folder_entries = Vec::with_capacity(folders.len());
+    for folder in &folders {
+        let status = server
+            .imap
+            .status(&folder.name, rimap_imap::types::StatusItems::all())
+            .await?;
+
+        folder_entries.push(serde_json::json!({
+            "name": folder.name,
+            "delimiter": folder.delimiter,
+            "flags": folder.attributes,
+            "exists": status.messages,
+            "unseen": status.unseen,
+            "uid_validity": status.uid_validity,
+        }));
+    }
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folders": folder_entries,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -1,0 +1,5 @@
+//! MCP tool handlers.
+
+pub mod flags;
+pub mod list_folders;
+pub mod move_message;

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -1,7 +1,9 @@
 //! MCP tool handlers.
 
+pub mod download_attachment;
 pub mod fetch_message;
 pub mod flags;
+pub mod list_attachments;
 pub mod list_folders;
 pub mod move_message;
 pub mod search;

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -1,5 +1,6 @@
 //! MCP tool handlers.
 
+pub mod create_draft;
 pub mod download_attachment;
 pub mod fetch_message;
 pub mod flags;

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -1,5 +1,7 @@
 //! MCP tool handlers.
 
+pub mod fetch_message;
 pub mod flags;
 pub mod list_folders;
 pub mod move_message;
+pub mod search;

--- a/crates/rimap-server/src/tools/move_message.rs
+++ b/crates/rimap-server/src/tools/move_message.rs
@@ -1,0 +1,53 @@
+//! `move_message` tool handler.
+
+use rimap_imap::types::Uid;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+use crate::tools::flags::resolve_uids;
+
+/// Input for `move_message`.
+#[derive(Debug, Deserialize)]
+pub struct MoveInput {
+    /// Source folder.
+    pub source_folder: String,
+    /// Destination folder.
+    pub dest_folder: String,
+    /// Single UID.
+    pub uid: Option<u32>,
+    /// Batch of UIDs (max 100).
+    pub uids: Option<Vec<u32>>,
+}
+
+/// Execute the `move_message` tool.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: MoveInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let results = server
+        .imap
+        .move_messages(&input.source_folder, &input.dest_folder, &uids)
+        .await?;
+
+    let moves: Vec<serde_json::Value> = results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "old_uid": r.old_uid.get(),
+                "new_uid": r.new_uid.map(Uid::get),
+            })
+        })
+        .collect();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "source_folder": input.source_folder,
+            "dest_folder": input.dest_folder,
+            "moves": moves,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}

--- a/crates/rimap-server/src/tools/search.rs
+++ b/crates/rimap-server/src/tools/search.rs
@@ -1,0 +1,215 @@
+//! `search` tool handler.
+
+use rimap_core::error::ErrorCode;
+use rimap_core::tool::ToolName;
+use rimap_imap::types::{
+    Address, FetchSpec, FetchedMessage, Flag, SearchQuery, StructuredQuery, Uid,
+};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+
+/// Maximum number of results per page.
+const MAX_LIMIT: usize = 100;
+
+/// Input for the `search` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchInput {
+    /// IMAP folder to search in.
+    pub folder: String,
+    /// Filter by `From` header substring.
+    pub from: Option<String>,
+    /// Filter by `To` header substring.
+    pub to: Option<String>,
+    /// Filter by `Subject` header substring.
+    pub subject: Option<String>,
+    /// Messages since this ISO date (inclusive), e.g. "2026-01-01".
+    pub since: Option<String>,
+    /// Messages before this ISO date (exclusive), e.g. "2026-02-01".
+    pub before: Option<String>,
+    /// Filter by seen/unseen status.
+    pub seen: Option<bool>,
+    /// Filter for messages with attachments.
+    pub has_attachment: Option<bool>,
+    /// Raw IMAP SEARCH query (full posture only).
+    pub advanced_query: Option<String>,
+    /// Max results to return (default 100, max 100).
+    pub limit: Option<usize>,
+    /// Offset into the result set (default 0).
+    pub offset: Option<usize>,
+}
+
+/// Execute the `search` tool.
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: SearchInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let query = build_query(server, &input)?;
+
+    let uids = server.imap.search(&input.folder, query).await?;
+    let total_matched = uids.len();
+
+    let offset = input.offset.unwrap_or(0);
+    let limit = input.limit.unwrap_or(MAX_LIMIT).min(MAX_LIMIT);
+
+    let page_uids: Vec<Uid> = uids.into_iter().skip(offset).take(limit).collect();
+
+    let truncated = total_matched > offset + page_uids.len();
+
+    let messages = if page_uids.is_empty() {
+        Vec::new()
+    } else {
+        let fetched = server
+            .imap
+            .fetch(
+                &input.folder,
+                &page_uids,
+                FetchSpec {
+                    envelope: true,
+                    flags: true,
+                    size: true,
+                    ..FetchSpec::default()
+                },
+            )
+            .await?;
+        fetched.iter().map(format_search_result).collect()
+    };
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "total_matched": total_matched,
+            "returned": messages.len(),
+            "truncated": truncated,
+        }),
+        untrusted: Some(serde_json::json!({
+            "messages": messages,
+        })),
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Build a `SearchQuery` from the input, checking posture for
+/// advanced queries.
+fn build_query(
+    server: &ImapMcpServer,
+    input: &SearchInput,
+) -> Result<SearchQuery, rimap_core::RimapError> {
+    if let Some(raw) = &input.advanced_query {
+        server
+            .guard
+            .matrix()
+            .check(ToolName::SearchAdvanced)
+            .map_err(|e| rimap_core::RimapError::Authz {
+                code: e.code(),
+                message: e.to_string(),
+            })?;
+        return Ok(SearchQuery::Raw(raw.clone()));
+    }
+
+    let since = input.since.as_deref().map(parse_iso_date).transpose()?;
+    let before = input.before.as_deref().map(parse_iso_date).transpose()?;
+
+    Ok(SearchQuery::Structured(StructuredQuery {
+        from: input.from.clone(),
+        to: input.to.clone(),
+        subject: input.subject.clone(),
+        since,
+        before,
+        seen: input.seen,
+        has_attachment: input.has_attachment.unwrap_or(false),
+    }))
+}
+
+/// Parse an ISO 8601 date string ("YYYY-MM-DD") into a `time::Date`.
+fn parse_iso_date(s: &str) -> Result<time::Date, rimap_core::RimapError> {
+    let format = time::format_description::well_known::Iso8601::DATE;
+    time::Date::parse(s, &format).map_err(|e| rimap_core::RimapError::Authz {
+        code: ErrorCode::InvalidInput,
+        message: format!("invalid date '{s}': {e}"),
+    })
+}
+
+/// Format an address as `"name <mailbox@host>"` or `"mailbox@host"`.
+fn format_address(addr: &Address) -> String {
+    let mailbox = addr
+        .mailbox
+        .as_deref()
+        .map(String::from_utf8_lossy)
+        .unwrap_or_default();
+    let host = addr
+        .host
+        .as_deref()
+        .map(String::from_utf8_lossy)
+        .unwrap_or_default();
+    let email = format!("{mailbox}@{host}");
+
+    match &addr.name {
+        Some(name) => {
+            let name = String::from_utf8_lossy(name);
+            if name.is_empty() {
+                email
+            } else {
+                format!("{name} <{email}>")
+            }
+        }
+        None => email,
+    }
+}
+
+/// Format addresses list.
+fn format_addresses(addrs: &[Address]) -> Vec<String> {
+    addrs.iter().map(format_address).collect()
+}
+
+/// Format a flag for JSON output.
+fn format_flag(flag: &Flag) -> &str {
+    match flag {
+        Flag::Seen => "\\Seen",
+        Flag::Answered => "\\Answered",
+        Flag::Flagged => "\\Flagged",
+        Flag::Deleted => "\\Deleted",
+        Flag::Draft => "\\Draft",
+        Flag::Recent => "\\Recent",
+        Flag::Keyword(kw) => kw.as_str(),
+    }
+}
+
+/// Format a single `FetchedMessage` into a JSON value for search
+/// results.
+fn format_search_result(msg: &FetchedMessage) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "uid": msg.uid.get(),
+    });
+
+    if let Some(size) = msg.size {
+        entry["size"] = serde_json::json!(size);
+    }
+
+    if let Some(flags) = &msg.flags {
+        let flag_strs: Vec<&str> = flags.iter().map(format_flag).collect();
+        entry["flags"] = serde_json::json!(flag_strs);
+    }
+
+    if let Some(env) = &msg.envelope {
+        if let Some(subj) = &env.subject_raw {
+            entry["subject"] = serde_json::json!(String::from_utf8_lossy(subj));
+        }
+        if let Some(date) = &env.date {
+            entry["date"] = serde_json::json!(String::from_utf8_lossy(date));
+        }
+        if !env.from.is_empty() {
+            entry["from"] = serde_json::json!(format_addresses(&env.from));
+        }
+        if !env.to.is_empty() {
+            entry["to"] = serde_json::json!(format_addresses(&env.to));
+        }
+        if let Some(mid) = &env.message_id {
+            entry["message_id"] = serde_json::json!(String::from_utf8_lossy(mid.as_bytes()));
+        }
+    }
+
+    entry
+}

--- a/crates/rimap-server/src/tools/search.rs
+++ b/crates/rimap-server/src/tools/search.rs
@@ -106,6 +106,12 @@ fn build_query(
                 code: e.code(),
                 message: e.to_string(),
             })?;
+        if raw.bytes().any(|b| b == b'\r' || b == b'\n' || b == b'\0') {
+            return Err(rimap_core::RimapError::Authz {
+                code: ErrorCode::InvalidInput,
+                message: "advanced_query contains forbidden control bytes".into(),
+            });
+        }
         return Ok(SearchQuery::Raw(raw.clone()));
     }
 
@@ -130,6 +136,34 @@ fn parse_iso_date(s: &str) -> Result<time::Date, rimap_core::RimapError> {
         code: ErrorCode::InvalidInput,
         message: format!("invalid date '{s}': {e}"),
     })
+}
+
+/// Strip control characters and Unicode tag/bidi characters from
+/// a string destined for MCP response output.
+fn sanitize_for_output(s: &str) -> String {
+    s.chars()
+        .filter(|c| !is_forbidden_output_char(*c))
+        .collect()
+}
+
+/// Returns `true` for characters that must not appear in MCP output:
+/// C0 controls (except `\n` and `\t`), DEL, Unicode tag characters,
+/// bidi overrides, and zero-width characters.
+fn is_forbidden_output_char(c: char) -> bool {
+    // `matches!` is appropriate here: char ranges have no fields to
+    // destructure, so the "no matches!" guideline does not apply.
+    matches!(
+        c,
+        '\x00'..='\x08'
+            | '\x0b'..='\x0c'
+            | '\x0e'..='\x1f'
+            | '\x7f'
+            | '\u{E0001}'..='\u{E007F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2066}'..='\u{2069}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{FEFF}'
+    )
 }
 
 /// Format an address as `"name <mailbox@host>"` or `"mailbox@host"`.
@@ -195,21 +229,83 @@ fn format_search_result(msg: &FetchedMessage) -> serde_json::Value {
 
     if let Some(env) = &msg.envelope {
         if let Some(subj) = &env.subject_raw {
-            entry["subject"] = serde_json::json!(String::from_utf8_lossy(subj));
+            let raw = String::from_utf8_lossy(subj);
+            entry["subject"] = serde_json::json!(sanitize_for_output(&raw));
         }
         if let Some(date) = &env.date {
-            entry["date"] = serde_json::json!(String::from_utf8_lossy(date));
+            let raw = String::from_utf8_lossy(date);
+            entry["date"] = serde_json::json!(sanitize_for_output(&raw));
         }
         if !env.from.is_empty() {
-            entry["from"] = serde_json::json!(format_addresses(&env.from));
+            let addrs: Vec<String> = format_addresses(&env.from)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect();
+            entry["from"] = serde_json::json!(addrs);
         }
         if !env.to.is_empty() {
-            entry["to"] = serde_json::json!(format_addresses(&env.to));
+            let addrs: Vec<String> = format_addresses(&env.to)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect();
+            entry["to"] = serde_json::json!(addrs);
         }
         if let Some(mid) = &env.message_id {
-            entry["message_id"] = serde_json::json!(String::from_utf8_lossy(mid.as_bytes()));
+            let raw = String::from_utf8_lossy(mid.as_bytes());
+            entry["message_id"] = serde_json::json!(sanitize_for_output(&raw));
         }
     }
 
     entry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_null_byte() {
+        assert_eq!(sanitize_for_output("hello\x00world"), "helloworld");
+    }
+
+    #[test]
+    fn sanitize_strips_bidi_overrides() {
+        let input = "normal\u{202A}injected\u{202C}text";
+        let result = sanitize_for_output(input);
+        assert_eq!(result, "normalinjectedtext");
+    }
+
+    #[test]
+    fn sanitize_strips_unicode_tags() {
+        let input = "safe\u{E0001}tagged\u{E007F}end";
+        let result = sanitize_for_output(input);
+        assert_eq!(result, "safetaggedend");
+    }
+
+    #[test]
+    fn sanitize_strips_zero_width_chars() {
+        let input = "a\u{200B}b\u{200D}c\u{FEFF}d";
+        // U+200D (ZWJ) is outside the filtered range 200B..200F,
+        // so it passes through.
+        let result = sanitize_for_output(input);
+        assert!(!result.contains('\u{200B}'));
+        assert!(!result.contains('\u{FEFF}'));
+    }
+
+    #[test]
+    fn sanitize_preserves_newline_and_tab() {
+        assert_eq!(sanitize_for_output("a\nb\tc"), "a\nb\tc");
+    }
+
+    #[test]
+    fn sanitize_strips_c0_controls() {
+        let input = "hello\x01\x02\x03world";
+        assert_eq!(sanitize_for_output(input), "helloworld");
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_unicode() {
+        let input = "cafe\u{0301} naïve résumé 日本語";
+        assert_eq!(sanitize_for_output(input), input);
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -108,9 +108,16 @@ skip-tree = [
     # when ammonia publishes a release that bumps to html5ever 0.39+ /
     # cssparser 0.36+; track https://github.com/rust-ammonia/ammonia for
     # the upstream bump.
+    # NOTE: cargo-deny interprets bare version strings as caret ranges
+    # (e.g., "0.35" matches ">=0.35.0, <0.36.0"). This is intentional
+    # here — ammonia floats its own transitive html5ever pin.
     { name = "html5ever", version = "0.35" },
     { name = "cssparser", version = "0.35" },
 ]
+# psl (via addr) uses a versioning scheme where the patch number
+# tracks the Public Suffix List snapshot date (e.g. 2.1.200). This
+# is legitimate but looks like a massive version bump to naive
+# pattern matching.
 
 [sources]
 unknown-registry = "deny"

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,211 @@
+# Audit Log
+
+rusty-imap-mcp maintains an append-only JSONL audit log at the path
+configured in `[audit].path`. Every tool invocation, authentication
+attempt, and process lifecycle event is recorded.
+
+## Format
+
+One JSON object per line (JSONL). Every record shares a common header:
+
+```json
+{
+  "seq": 42,
+  "ts": "2026-04-07T14:22:01.234Z",
+  "process_id": "01JX...",
+  "kind": "tool_start"
+}
+```
+
+| Field | Description |
+|---|---|
+| `seq` | Per-process monotonic sequence number, starting at 1 |
+| `ts` | RFC 3339 timestamp, millisecond precision, UTC |
+| `process_id` | ULID generated at process start, stable for the process lifetime |
+| `kind` | Record type discriminator |
+
+## Record types
+
+### `process_start`
+
+First record of every process invocation.
+
+| Field | Description |
+|---|---|
+| `version` | Semver of the running binary |
+| `git_commit` | Build-time git SHA (empty until wired) |
+| `posture` | Effective base posture at startup |
+| `config_path` | Absolute path of the loaded config file |
+| `config_hash_sha256` | SHA-256 hex of the config file contents at load time |
+| `previous_last_seq` | Last `seq` found in the file at startup (null if empty) |
+| `previous_process_id` | Process ID of the previous run (null if empty) |
+| `previous_file_inode` | Inode of the audit file as observed at open time |
+| `audit_file_inode_changed` | True if the inode differs from the prior `process_start`'s inode (tamper signal) |
+
+### `process_end`
+
+Best-effort record on SIGINT, SIGTERM, or stdin EOF. A hard crash
+leaves no `process_end` -- the last record will be whatever was most
+recently flushed.
+
+| Field | Description |
+|---|---|
+| `reason` | One of `signal_int`, `signal_term`, `eof`, `error` |
+| `total_tool_calls` | Number of tool calls dispatched in this process |
+
+### `auth`
+
+IMAP authentication attempt.
+
+| Field | Description |
+|---|---|
+| `result` | `success` or `failure` |
+| `host` | IMAP host attempted |
+| `port` | IMAP port attempted |
+| `username` | Login identity (never contains credentials) |
+| `tls_fingerprint_sha256` | Observed TLS certificate fingerprint (null if handshake did not complete) |
+| `fingerprint_match` | Whether observed fingerprint matched config (null if no pin configured) |
+| `error_code` | Stable error code on failure (e.g. `ERR_TLS`, `ERR_AUTH`); null on success |
+
+### `tool_start`
+
+Recorded before dispatch begins. If the process crashes mid-call, this
+record survives as a breadcrumb.
+
+| Field | Description |
+|---|---|
+| `tool` | Tool name (e.g. `fetch_message`) |
+| `posture_effective` | Effective posture at dispatch time |
+| `arguments_redacted` | Redacted arguments (untrusted content replaced with `"<redacted:length>"`, recipient addresses hashed, passwords never logged) |
+| `arguments_hash_sha256` | SHA-256 hex of the unredacted arguments for integrity |
+
+### `tool_end`
+
+Recorded after dispatch completes.
+
+| Field | Description |
+|---|---|
+| `start_seq` | `seq` of the paired `tool_start` record |
+| `tool` | Tool name (duplicated for self-contained log lines) |
+| `status` | `ok` or `error` |
+| `error_code` | Stable error code on failure; null on success |
+| `duration_ms` | Wall-clock duration in milliseconds |
+| `result_summary.message_ids_returned` | Message-ID values returned to the caller |
+| `result_summary.bytes_returned` | Approximate bytes returned (post-truncation) |
+| `result_summary.truncated` | Whether the result was truncated |
+| `result_summary.security_warnings_emitted` | Warning codes emitted (e.g. `LOOKALIKE_SENDER_MIXED_SCRIPT`) |
+| `provenance.window_seconds` | Configured provenance window |
+| `provenance.message_ids_recently_read` | Message IDs read by this process within the window |
+
+### `config`
+
+Config-related event. Declared for future use.
+
+| Field | Description |
+|---|---|
+| `path` | Config file path |
+| `hash_sha256` | SHA-256 hex of the config file contents |
+
+## File handling
+
+- **Permissions:** audit file is created with mode `0600`. Parent
+  directory is created with mode `0700` if missing.
+- **Exclusive lock:** the process acquires a non-blocking exclusive
+  advisory lock (`flock(LOCK_EX | LOCK_NB)`) on the audit file at
+  startup. A second process against the same path fails immediately
+  with `ERR_CONFIG`. The lock is held for the full process lifetime
+  and released on exit.
+- **Write discipline:** each record is one `write_all` + buffer flush.
+  `fsync` is called after `process_start`, `process_end`, `auth`, and
+  `config` records. `tool_start` and `tool_end` are flushed but not
+  fsync'd (a crash may lose a few trailing entries).
+- **Write failure:** fails the tool call with `ERR_INTERNAL` by
+  default. Set `audit.fail_open = true` to suppress write failures
+  and continue (not recommended -- audit records will be lost).
+
+## Rotation
+
+When the active file exceeds `audit.rotate_bytes` (default 10 MiB),
+rotation occurs under the exclusive lock:
+
+1. The active file is renamed (e.g. `audit.jsonl.1`)
+2. A new active file is created and locked
+3. Excess rotated files beyond `audit.rotate_keep` (default 5) are
+   deleted
+
+`rotate_keep` is a count-based cap. Under low write volumes a single
+rotated file may span a long time period. Operators needing time-based
+retention should configure external log rotation as well.
+
+Set `rotate_bytes = 0` to disable rotation entirely.
+
+## `audit merge` subcommand
+
+```
+rusty-imap-mcp audit merge [options] <path>
+```
+
+Reads the audit file with a shared lock and streams JSONL to stdout.
+Output is canonical JSON (re-serialized via `serde_json`) and can be
+piped to `jq`.
+
+### Filters
+
+| Flag | Description |
+|---|---|
+| `--since <RFC3339>` | Only records at or after this timestamp |
+| `--until <RFC3339>` | Only records at or before this timestamp |
+| `--tool <name>` | Only `tool_start`/`tool_end` records for this tool |
+| `--kind <kind>` | Only records of this kind (e.g. `auth`, `tool_end`) |
+| `--process <ulid>` | Only records from this process ID |
+
+Trailing malformed lines (from a mid-record crash) produce a stderr
+warning and are skipped.
+
+### Example
+
+```bash
+rusty-imap-mcp audit merge \
+  --since 2026-04-07T00:00:00Z \
+  --tool fetch_message \
+  ~/.local/state/rusty-imap-mcp/audit.jsonl \
+  | jq '.result_summary'
+```
+
+### File permissions for merged output
+
+`audit merge` writes to stdout. When redirected to a file, the output
+inherits the shell's umask, which is typically `0022` (producing
+world-readable `0644`). The source audit file is `0600`, so the merged
+output may have weaker permissions than expected.
+
+Recommended patterns:
+
+```bash
+# Set a tight umask in the same shell invocation (the && is required)
+umask 077 && rusty-imap-mcp audit merge ... > dump.jsonl
+
+# Preferred in scripts: atomic mode-set via install, no umask dependency
+rusty-imap-mcp audit merge ... \
+  | install -m 0600 /dev/stdin /target/dump.jsonl
+```
+
+## Startup self-check
+
+Before writing the first `process_start` record, the server:
+
+1. Verifies the audit file is writable (creates it if missing)
+2. Reads the last line of the existing file and extracts `seq` and
+   `process_id`, recording them as `previous_last_seq` and
+   `previous_process_id` in the new `process_start` (chains history
+   across restarts)
+3. Records the file's current inode. If the file was deleted and
+   recreated between runs, the inode differs and
+   `audit_file_inode_changed` is set to `true` as a tamper signal
+
+## What is not logged
+
+- Full message bodies or HTML
+- Passwords, tokens, keychain internals
+- Config file contents (only path + hash)
+- IMAP wire-level traffic (use `tracing` stderr logs for debugging)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,189 @@
+# Configuration
+
+rusty-imap-mcp uses a single TOML config file. All sections except `[imap]`
+and `[audit]` have defaults and can be omitted.
+
+## Config file location
+
+Resolution order:
+
+1. `--config <path>` CLI argument
+2. `RUSTY_IMAP_MCP_CONFIG` environment variable
+3. Platform default:
+   - Linux: `$XDG_CONFIG_HOME/rusty-imap-mcp/config.toml`
+     (falls back to `~/.config/rusty-imap-mcp/config.toml`)
+   - macOS: `~/Library/Application Support/rusty-imap-mcp/config.toml`
+
+## Minimal example
+
+```toml
+[imap]
+host = "127.0.0.1"
+port = 1143
+username = "alice@example.test"
+
+[audit]
+path = "/home/alice/.local/state/rusty-imap-mcp/audit.jsonl"
+```
+
+All other sections use defaults when omitted.
+
+## `[imap]` section
+
+IMAP connection settings. `host`, `port`, and `username` are required.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `host` | string | (required) | IMAP server hostname or IP |
+| `port` | u16 | (required) | IMAP server port (IMAPS) |
+| `username` | string | (required) | IMAP login identity |
+| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional (`"ab:cd:..."` or `"abcd..."`). Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. |
+| `command_timeout_seconds` | u32 | 30 | Per-command timeout for IMAP operations |
+| `connect_timeout_seconds` | u32 | 10 | TCP + TLS handshake + greeting + CAPABILITY probe deadline |
+
+## `[security]` section
+
+Controls which tools are available.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `posture` | string | `"draft-safe"` | Base posture: `"readonly"`, `"draft-safe"`, or `"full"`. See [postures.md](postures.md). |
+| `tools` | table | (empty) | Per-tool overrides. Keys are tool names, values are `"allow"` or `"deny"`. |
+
+### `[security.lookalike]` subsection
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | true | Enable look-alike detection on addresses, domains, links, and filenames |
+| `known_domains` | list of strings | `[]` | User-curated watchlist of protected domains (e.g. `["paypal.com"]`) |
+| `warn_on_any_non_ascii_domain` | bool | false | Warn on any non-ASCII domain, even if not in the watchlist |
+
+### Per-tool overrides
+
+Override the posture's default for individual tools. Use the tool's
+canonical name as the key:
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+mark_read = "deny"                # deny even though draft-safe allows it
+"search.advanced_query" = "allow" # allow even though draft-safe denies it
+```
+
+Valid tool names: `list_folders`, `search`, `search.advanced_query`,
+`fetch_message`, `fetch_message.include_html`, `list_attachments`,
+`download_attachment`, `mark_read`, `mark_unread`, `flag`, `unflag`,
+`move_message`, `create_draft`.
+
+Overrides referencing unknown or v2 tools (`delete_message`, `expunge`,
+`send_email`) are a startup error.
+
+## `[limits]` section
+
+Numeric limits for rate limiting, search, and size caps.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_search_results` | u32 | 200 | Default search result limit |
+| `max_search_results_cap` | u32 | 1000 | Hard ceiling on `max_search_results` |
+| `max_fetch_body_bytes` | u64 | 5,242,880 (5 MiB) | Max fetched body bytes per message. Bodies exceeding this are truncated. |
+| `max_attachment_bytes` | u64 | 26,214,400 (25 MiB) | Max attachment bytes. Attachments exceeding this are refused at download. |
+| `commands_per_second` | u32 | 10 | Rate limiter: tool calls per second |
+| `drafts_per_minute` | u32 | 5 | Separate rate limit for `create_draft` |
+| `circuit_breaker_error_threshold` | u32 | 5 | Error count within the window to trip the circuit breaker |
+| `circuit_breaker_window_seconds` | u32 | 30 | Sliding window for the circuit breaker error counter |
+
+## `[audit]` section
+
+Audit log file settings. `path` is required.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `path` | string | (required) | Path to the audit log file (JSONL) |
+| `rotate_bytes` | u64 | 10,485,760 (10 MiB) | Rotate when the file reaches this size. `0` disables rotation. |
+| `rotate_keep` | u32 | 5 | Number of rotated files to keep after rotation |
+| `provenance_window_seconds` | u32 | 60 | Provenance ring buffer window for tracking recently-read message IDs |
+| `fail_open` | bool | false | If true, continue on audit write failure (insecure). Default is false: audit write failure fails the tool call. |
+| `allowed_base_dir` | string | (platform default) | Containment base for `audit.path`. The path must resolve under this directory. Defaults to `$XDG_STATE_HOME/rusty-imap-mcp/` or platform equivalent. Set to `"/"` to disable containment (not recommended). |
+
+See [audit-log.md](audit-log.md) for the log format and record types.
+
+## `[attachments]` section
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `download_dir` | string | `""` | Directory for downloaded attachments. Empty string means a per-session temporary directory. |
+
+## Full example
+
+```toml
+[imap]
+host = "127.0.0.1"
+port = 1143
+username = "dave@proton.me"
+tls_fingerprint_sha256 = "ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89"
+command_timeout_seconds = 30
+connect_timeout_seconds = 10
+
+[security]
+posture = "draft-safe"
+
+[security.tools]
+# mark_read = "deny"
+
+[security.lookalike]
+enabled = true
+known_domains = ["paypal.com", "example.com"]
+warn_on_any_non_ascii_domain = false
+
+[limits]
+max_search_results = 200
+max_search_results_cap = 1000
+max_fetch_body_bytes = 5_242_880
+max_attachment_bytes = 26_214_400
+commands_per_second = 10
+drafts_per_minute = 5
+circuit_breaker_error_threshold = 5
+circuit_breaker_window_seconds = 30
+
+[audit]
+path = "/home/dave/.local/state/rusty-imap-mcp/audit.jsonl"
+rotate_bytes = 10_485_760
+rotate_keep = 5
+provenance_window_seconds = 60
+fail_open = false
+
+[attachments]
+download_dir = ""
+```
+
+## Credential resolution
+
+Passwords are never stored in the config file. Resolution order:
+
+1. **OS keychain** -- service `rusty-imap-mcp`, account
+   `<username>@<host>`. Store credentials with:
+   ```
+   rusty-imap-mcp login
+   ```
+2. **Environment variable** `RUSTY_IMAP_MCP_PASSWORD` -- fallback for
+   headless, container, or CI environments.
+3. **Error** -- if neither source has a value, the server exits with a
+   message directing the user to run `rusty-imap-mcp login` or set the
+   environment variable.
+
+The server never prompts interactively on stdio (stdio is the MCP
+transport). The `login` subcommand is the only interactive mode.
+
+## Validation
+
+The config is validated at startup. Validation errors are fatal. Checks
+include:
+
+- Posture name is one of `readonly`, `draft-safe`, `full`
+- Every tool override name exists in the v1 tool set
+- TLS fingerprint (if set) parses as 32 hex bytes
+- Numeric limits are positive
+- Unknown fields in any section are rejected (`deny_unknown_fields`)

--- a/docs/postures.md
+++ b/docs/postures.md
@@ -1,0 +1,112 @@
+# Security Postures
+
+rusty-imap-mcp uses three security postures to control which tools are
+available. The posture is set in the config file under `[security].posture`
+and defaults to `draft-safe`.
+
+## Posture values
+
+| Posture | Description |
+|---|---|
+| `readonly` | Read-only operations. No flag changes, no drafts, no moves. |
+| `draft-safe` | Read + safe mutations: flag changes, moves, and draft creation with `$PendingReview`. Default. |
+| `full` | Everything in `draft-safe` plus escape hatches: `search.advanced_query` and `fetch_message.include_html`. |
+
+## Tool matrix
+
+Each row is a dispatchable capability. Some MCP tools expose multiple
+gated capabilities (e.g. `search` has a separate `search.advanced_query`
+capability).
+
+| Capability | `readonly` | `draft-safe` | `full` |
+|---|---|---|---|
+| `list_folders` | allowed | allowed | allowed |
+| `search` | allowed | allowed | allowed |
+| `search.advanced_query` | **denied** | **denied** | allowed |
+| `fetch_message` | allowed | allowed | allowed |
+| `fetch_message.include_html` | **denied** | **denied** | allowed |
+| `list_attachments` | allowed | allowed | allowed |
+| `download_attachment` | allowed | allowed | allowed |
+| `mark_read` | **denied** | allowed | allowed |
+| `mark_unread` | **denied** | allowed | allowed |
+| `flag` | **denied** | allowed | allowed |
+| `unflag` | **denied** | allowed | allowed |
+| `move_message` | **denied** | allowed | allowed |
+| `create_draft` | **denied** | allowed | allowed |
+
+## Per-tool overrides
+
+The base posture can be adjusted per-tool in the config file:
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+mark_read = "deny"                # deny even though draft-safe allows it
+"search.advanced_query" = "allow" # allow even though draft-safe denies it
+```
+
+- `"allow"` grants the tool regardless of what the posture would deny.
+- `"deny"` blocks the tool regardless of what the posture would allow.
+- An override that matches the posture's default is a no-op (not an error).
+- Overrides referencing unknown tool names or v2 tools (`delete_message`,
+  `expunge`, `send_email`) cause a startup error.
+
+## Tool advertisement
+
+Tools denied by the effective matrix (posture + overrides) are **not
+advertised** via the MCP `list_tools` response. Denial is enforced at
+both discovery and dispatch (defense in depth).
+
+The `advertised` set is the list of tool names where the effective
+matrix resolves to `allowed`. For example, with `readonly` posture and
+no overrides, `list_tools` returns only: `list_folders`, `search`,
+`fetch_message`, `list_attachments`, `download_attachment`.
+
+## Escape hatches (full posture only)
+
+Two capabilities are restricted to the `full` posture by default:
+
+- **`search.advanced_query`** -- allows raw IMAP search queries
+  (e.g. `"OR FROM alice FROM bob"`). Bypasses the structured query
+  builder. Useful for queries the structured form cannot express, but
+  exposes the full IMAP SEARCH grammar.
+
+- **`fetch_message.include_html`** -- returns sanitized HTML alongside
+  the text body. The HTML is sanitized by `ammonia` with a conservative
+  allowlist, but still carries more attack surface than plain text.
+
+Both can be individually enabled in lower postures via per-tool
+overrides if the operator accepts the tradeoff.
+
+## `$PendingReview` flag
+
+In both `draft-safe` and `full` postures, `create_draft` appends
+messages to the Drafts folder with the `\Draft` flag and a
+`$PendingReview` keyword. This acts as a human-in-the-loop gate: the
+agent can compose a draft, but a human must review and send it from
+their mail client. The server never opens an SMTP connection in v1.
+
+## Config example
+
+```toml
+# Read-only posture for monitoring/analysis use cases
+[security]
+posture = "readonly"
+```
+
+```toml
+# Default posture (can be omitted entirely)
+[security]
+posture = "draft-safe"
+```
+
+```toml
+# Full posture with one tool locked down
+[security]
+posture = "full"
+
+[security.tools]
+create_draft = "deny"
+```

--- a/docs/proton-bridge-setup.md
+++ b/docs/proton-bridge-setup.md
@@ -1,0 +1,105 @@
+# Proton Bridge Setup
+
+rusty-imap-mcp's primary target is Proton Mail via
+[Proton Bridge](https://proton.me/mail/bridge), which exposes a local
+IMAP server on `127.0.0.1:1143` with a self-signed TLS certificate.
+
+## Prerequisites
+
+1. Install Proton Bridge from <https://proton.me/mail/bridge>
+2. Sign in and enable Bridge IMAP
+3. Note the bridge password (displayed in Bridge settings -- this is
+   not your Proton account password)
+
+## Capture the TLS fingerprint
+
+Proton Bridge uses a self-signed certificate. You must pin the
+certificate fingerprint in the config file so the server can verify it.
+
+```bash
+openssl s_client -connect 127.0.0.1:1143 < /dev/null 2>/dev/null \
+  | openssl x509 -outform DER \
+  | openssl dgst -sha256 -hex \
+  | awk '{print $2}'
+```
+
+This prints a 64-character hex string. Copy it into your config file.
+
+The fingerprint changes when Proton Bridge regenerates its certificate
+(e.g. after a Bridge update or reinstall). If the server fails to
+connect with `ERR_TLS`, recapture the fingerprint.
+
+## Store the credential
+
+```bash
+rusty-imap-mcp login
+```
+
+This prompts for the IMAP password interactively and stores it in the
+OS keychain under service `rusty-imap-mcp`, account
+`<username>@127.0.0.1`. Use the bridge password from step 3, not your
+Proton account password.
+
+Alternatively, set `RUSTY_IMAP_MCP_PASSWORD` for headless environments.
+
+## Config file
+
+```toml
+[imap]
+host = "127.0.0.1"
+port = 1143
+username = "dave@proton.me"
+tls_fingerprint_sha256 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[security]
+posture = "draft-safe"
+
+[audit]
+path = "/home/dave/.local/state/rusty-imap-mcp/audit.jsonl"
+```
+
+Replace `username` with your Proton email address and
+`tls_fingerprint_sha256` with the output from the openssl command above.
+
+## Known quirks
+
+### Self-signed certificate
+
+Proton Bridge generates a self-signed TLS certificate. Without
+`tls_fingerprint_sha256`, the server will reject the connection because
+the certificate is not in the system trust store. Fingerprint pinning
+is required.
+
+### Folder naming
+
+Proton Bridge maps Proton's label system to IMAP folders. Folder names
+may differ from what you see in the Proton web interface. Use
+`list_folders` to discover the actual IMAP folder names.
+
+Common mappings:
+- `INBOX` -- Inbox
+- `Drafts` -- Drafts
+- `Sent` -- Sent
+- `Trash` -- Trash
+- `Archive` -- Archive
+- `Spam` -- Spam
+- Labels appear as top-level folders under `Labels/`
+- Subfolders appear under `Folders/`
+
+### MOVE support
+
+Proton Bridge supports the IMAP MOVE extension. `move_message` uses
+MOVE directly rather than the COPY+STORE+EXPUNGE fallback.
+
+### Bridge password vs. account password
+
+The IMAP password is the bridge-specific password displayed in Proton
+Bridge settings, not your Proton account password. Using the wrong
+password results in `ERR_AUTH`.
+
+### Timeouts
+
+The default `connect_timeout_seconds` of 10 and
+`command_timeout_seconds` of 30 work well with Proton Bridge. If
+Bridge is slow to start or your mailbox is large, you may need to
+increase `command_timeout_seconds`.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,180 @@
+# Security Model
+
+## Threat model
+
+The primary adversary is a crafted email that, when read by an agent
+through this MCP server, attempts to induce the agent to take a harmful
+action: exfiltrate data, send mail on the attacker's behalf, modify
+mailbox state, or pivot to other tools.
+
+Secondary adversaries include a hostile IMAP server (MITM, malformed
+responses) and local malware with the user's file-system privileges.
+
+**The server does not trust:** email bodies, headers, sender addresses,
+display names, attachment filenames, link targets, or any
+server-provided content. All of these are treated as untrusted input
+that must be parsed, sanitized, tagged, and structurally separated from
+server-controlled metadata before being returned to an MCP client.
+
+**The server does trust:** its own configuration file, its own keychain
+entries, its own audit log, and (within limits defined by fingerprint
+pinning) the TLS identity of its configured IMAP server.
+
+## Defense layers
+
+### 1. Content pipeline
+
+Every byte from IMAP flows through the content pipeline
+(`rimap-content`) before reaching any tool response. The pipeline has
+zero IMAP dependencies -- it takes `&[u8]` in and emits typed `Content`
+structures out.
+
+**Pipeline stages:**
+
+1. **Parse** -- `mail-parser` decodes RFC 5322 into headers + body
+   parts. Malformed messages produce a structured error, not a panic.
+2. **Header extraction** -- Header names are ASCII-validated (control
+   chars in names indicate header smuggling and are rejected). Values
+   are decoded from RFC 2047 encoded-words, then processed through the
+   Unicode pipeline. CR/LF inside decoded header values is rejected
+   (header smuggling defense).
+3. **Mailing list detection** -- `List-Id` and `List-*` headers are
+   extracted before sanitization so the raw values survive for agent
+   filtering.
+4. **Body part selection** -- MIME tree walk preferring `text/plain`;
+   falls back to `text/html` through the HTML-to-text converter.
+5. **HTML to text conversion** -- Strips `<script>`, `<style>`,
+   `<iframe>`, `<form>`, and other dangerous elements. Strips elements
+   with hidden visibility (CSS `display:none`, `visibility:hidden`,
+   `opacity:0`, `font-size:0`, white-on-white color). Strips zero-width
+   and bidirectional override characters. Link handling detects
+   text/href domain mismatches and emits `link_warnings`.
+6. **Sanitized HTML** (only with `include_html=true` in `full` posture)
+   -- `ammonia` with a conservative allowlist: no scripts, no event
+   handlers, no external resources, no `data:` URIs except images
+   under 1 MiB.
+7. **Attachment metadata extraction** -- Filenames sanitized (path
+   separators stripped, leading dots stripped, Windows reserved names
+   prefixed, length truncated). No bytes are read at this stage.
+8. **Content tagging** -- The final output is wrapped in the `untrusted`
+   field, separate from `meta`.
+
+### 2. Unicode policy
+
+Every string leaving the content pipeline is:
+
+- Valid UTF-8
+- In NFKC form (collapses visually-equivalent forms for security)
+- Free of invisible/ambiguous codepoints (zero-width chars,
+  bidirectional overrides, C0/C1 controls except `\t` and `\n`,
+  unassigned/private-use codepoints)
+- Preserves legitimate scripts (CJK, Hebrew, Arabic, European
+  accents, emoji including ZWJ sequences)
+
+### 3. Response envelope
+
+Every tool response structurally separates three fields:
+
+- **`meta`** -- server-controlled metadata (folder names, UIDs, flags,
+  sizes). Trusted.
+- **`untrusted`** -- sanitized content derived from email data. Agents
+  and host LLMs should treat this as untrusted input.
+- **`security_warnings`** -- structured observations emitted by the
+  server's look-alike and sanitization layers. Trusted metadata (the
+  server's assessment, not email content).
+
+This structural separation means agents can apply different trust
+policies to different parts of the response without parsing conventions
+out of a flat string.
+
+### 4. Look-alike detection
+
+Detects and flags (never rejects) visual spoofing attempts on:
+
+- Sender addresses (mixed-script, confusable skeleton matching)
+- Display name vs. address mismatches
+  (`From: "support@paypal.com" <eve@evil.example>`)
+- Reply-To vs. From domain mismatches
+- Link href domain vs. link text mismatches
+- Attachment filename bidirectional tricks
+
+Body text prose is not scanned (false-positive rate on multilingual
+content is too high). All detection is local, deterministic, and
+rules-based -- no network lookups, no ML.
+
+Warning codes include `LOOKALIKE_SENDER_MIXED_SCRIPT`,
+`LOOKALIKE_SENDER_CONFUSABLE`, `LOOKALIKE_DISPLAY_NAME_SPOOFS_ADDRESS`,
+`LOOKALIKE_REPLY_TO_DOMAIN_MISMATCH`, `LOOKALIKE_LINK_DOMAIN_MISMATCH`,
+`LOOKALIKE_FILENAME_BIDI_EXTENSION`, and others.
+
+### 5. `$PendingReview` human-in-the-loop gate
+
+`create_draft` appends messages to the Drafts folder with `\Draft` and
+`$PendingReview` keywords. The server never opens an SMTP connection in
+v1. A human must review and send from their mail client. This prevents
+an agent from autonomously sending mail, even in the `full` posture.
+
+### 6. Posture-based authorization
+
+Three postures (`readonly`, `draft-safe`, `full`) control which tools
+are available. Tools denied by the active posture are not advertised via
+`list_tools` and are rejected at dispatch. See [postures.md](postures.md).
+
+### 7. Audit log
+
+Every tool invocation produces exactly two audit records (`tool_start`
++ `tool_end`), linked by a monotonic sequence number. The audit log
+tracks content provenance: a ring buffer of recently-read message IDs
+is snapshotted into every `tool_end` record, enabling post-hoc
+detection of suspicious read-then-draft sequences.
+
+The audit file is exclusively locked for the process lifetime. Write
+failures fail the tool call by default (`fail_open = false`). See
+[audit-log.md](audit-log.md).
+
+### 8. Rate limiting
+
+- Global rate limiter: `commands_per_second` (default 10/sec) with a
+  burst of 20.
+- Separate stricter limit for `create_draft`: `drafts_per_minute`
+  (default 5/min).
+- On exceed: waits up to 250ms, then fails with `ERR_RATE_LIMITED` and
+  a `retry_after_ms` hint.
+
+### 9. Circuit breaker
+
+Sliding-window count-based breaker protects against cascading failures:
+
+- **Closed** (normal): counts errors in the configured window (default
+  30s). At threshold (default 5 errors), transitions to Open.
+- **Open**: immediately fails with `ERR_CIRCUIT_OPEN` for a cooldown
+  period.
+- **Half-open**: allows one probe call. Success returns to Closed;
+  failure re-opens with a doubled cooldown (capped at 5 min).
+- Auth failures trip immediately (single failure opens for 60s).
+
+Errors that trip the breaker: `ConnectionLost`, `AuthFailure`,
+`Timeout`, `ProtocolError`, `TlsError`. User/policy errors
+(`NotFound`, `InvalidInput`, `PostureDenied`, `RateLimited`) do not
+trip it.
+
+### 10. TLS fingerprint pinning
+
+When `imap.tls_fingerprint_sha256` is set, the server verifies the
+IMAP server's TLS certificate fingerprint before any application data
+flows. A mismatch is a hard failure -- the server does not fall back
+to the system trust store when pinning is configured.
+
+## Dispatch chain
+
+Every tool call passes through all layers in order:
+
+```
+ToolCall -> input validation -> posture authorization -> circuit breaker
+         -> rate limiter -> audit start -> tool execution -> audit end
+         -> response
+```
+
+Any stage failing short-circuits to a structured error response and
+records an audit end entry. Failures before tool execution never reach
+the network.

--- a/docs/superpowers/plans/2026-04-10-sprint-5-phase1-handoff.md
+++ b/docs/superpowers/plans/2026-04-10-sprint-5-phase1-handoff.md
@@ -1,0 +1,204 @@
+# Sprint 5 Phase 1 → Phase 2 Handoff — Content Pipeline Remediation
+
+**Status:** Sprint 5 Phase 1 is complete on branch `feat/sprint-5`.
+**Parent spec:** [`2026-04-10-sprint-5-phase1-remediation-design.md`](../specs/2026-04-10-sprint-5-phase1-remediation-design.md)
+**Phase 1 plan:** [`2026-04-10-sprint-5-phase1.md`](./2026-04-10-sprint-5-phase1.md)
+**Sprint 4b → Sprint 5 handoff (prior):** [`2026-04-08-sprint-4b-to-5-handoff.md`](./2026-04-08-sprint-4b-to-5-handoff.md)
+**Mutants survivors:** [`../mutants-survivors.md`](../mutants-survivors.md)
+
+## What Phase 1 shipped
+
+Phase 1 closed 14 commits on `feat/sprint-5`, addressing warning semantics,
+Reply-To coverage, bypass fixes, ammonia hardening, build strictness, and
+supply-chain comment hygiene.
+
+### Warning semantics (#49)
+
+- **Renamed `HtmlHiddenContentStripped` → `HtmlHiddenContentDetected`.** The old
+  name implied hidden content was removed everywhere. In reality, hidden content
+  is stripped from `body_text` but may remain in `body_html` when the posture
+  allows HTML exposure. The new name reflects detection, not removal.
+- **Added `HtmlAnchorUnparsableHref` variant** (Informational severity). Fires
+  when an anchor's `href` can't be resolved via the Public Suffix List but the
+  anchor's visible text contains a URL-looking token (detected by `linkify`).
+  This makes "we checked and it's fine" distinguishable from "we couldn't
+  check." Phase 2 posture policy can filter on this variant.
+- **Pinned `HtmlLinkTextHrefMismatch` as raw-DOM (pre-ammonia) semantics** via
+  doc comment. An anchor stripped by ammonia may still produce this warning —
+  the warning signals the message's intent, not the sanitized output.
+- **Pinned `SecurityWarning::detail` as opaque/human-readable** via doc comment.
+  Consumers must not parse this field programmatically; use `code` and other
+  typed fields for dispatch.
+
+### Reply-To + address extraction (#50 items 1 and 3)
+
+- **`reply_to: Option<String>` added to `ContentMeta`.** Populated via
+  `first_address_string(message.reply_to(), ...)` in `extract_meta()`, which
+  includes the bidi-prestrip audit. Reply-To domains with bidi override
+  characters now emit `LookalikeHomographDomain` with `location = "header:reply_to"`.
+- **`header_domains: Vec<(String, String)>` added to `LookalikeInput`.** Built
+  at the `parse_message` boundary using structured `Addr.address` data rather
+  than rfind-based re-parsing of rendered display strings.
+- **`scan_header_domains()` rewritten** to iterate pre-extracted domains
+  (covers `from`, `to`, `cc`, and `reply_to`). Eliminates the Sprint 4b
+  finding 9 gap where Reply-To was invisible to the lookalike header pass.
+- **`collect_header_domains()` + `addr_domain()` helpers added** in `parse.rs`
+  at the structured-data boundary.
+
+### Bypass fixes (#51 items 2–5)
+
+- **CDATA text leak (#51.2).** html5ever/scraper parses `<![CDATA[` in HTML5
+  non-SVG context as a bogus comment. Inner content can leak as text nodes via
+  two paths: closed CDATA (text includes `]]>`) and unclosed CDATA (text node
+  follows the bogus comment with no `]]>` marker). Fixed with an `after_cdata`
+  flag in text extraction that suppresses text nodes following CDATA sections.
+  Both paths covered and tested.
+- **Double-extension filename heuristic (#51.3).** `detect_double_extension()`
+  checks for patterns like `invoice.pdf.exe` — penultimate extension is a
+  document type, final extension is an executable type. Emits
+  `LookalikeFilenameExtensionSpoof` with `reason=double_extension`. Two
+  constant slices (`DOCUMENT_EXTENSIONS`, `EXECUTABLE_EXTENSIONS`) define the
+  type sets.
+- **PSL silent-skip (#51.4).** `detect_mismatches()` now emits
+  `HtmlAnchorUnparsableHref` when an href can't be PSL-resolved but anchor
+  text contains a URL token. Return type changed from `(hits, overflow)` to
+  `(hits, overflow, unparsable_hrefs)`.
+- **Off-screen threshold (#51.5).** Lowered from -1000px to -100px (catches
+  evasion via `left: -999px`). Added `transform: translate` pattern detection
+  via `parse_translate_px()`. `StyleHints` gains `transform_offset_px: Option<f64>`.
+
+### Ammonia hardening (#52 items 1–2)
+
+- **Explicit `rm_tags()` call** with 20 tags including `details` and `summary`
+  (new removals — collapsed `<details>` content is invisible to humans but
+  visible to LLMs reading HTML tokens). Other tags pinned: `iframe`, `object`,
+  `embed`, `meta`, `base`, `link`, `form`, `input`, `button`, `textarea`,
+  `svg`, `math`, `frame`, `frameset`, `noframes`, `applet`.
+- **Explicit `strip_comments(true)`** to pin comment-stripping behavior against
+  upstream ammonia drift.
+
+### Charset proptest (#52 item 3)
+
+- **New `proptest_charset.rs`** — 10,000 cases of arbitrary charset parameter
+  strings in `Content-Type` headers, asserting that `parse_message` always
+  produces valid UTF-8 output or a structured `ContentError`, never a panic.
+
+### `build.rs` strictness (#53 item 3)
+
+- **Malformed target rows now `panic!`** instead of `eprintln!` + `continue`.
+  A malformed row is a build-time data integrity failure, not a warning.
+- **Floor raised from >5000 to >=6200.** Unicode 16.0 produces ~6355 entries;
+  the tighter floor catches silent format drift that drops more than ~2.5% of
+  entries.
+
+### Supply-chain comment hygiene (#54)
+
+- **M1:** 4 missing ICU4X proc-macros added to R10 provenance block in root
+  `Cargo.toml` (`yoke-derive`, `zerofrom-derive`, `zerovec-derive`,
+  `displaydoc`).
+- **M2:** `idna` comment rewritten to document the actual ICU4X baseline and
+  the ~20 transitive crates it introduces.
+- **M3:** `phf` default-features comment clarified — our direct declaration
+  disables defaults; `phf_macros` still enters the graph transitively via
+  `cssparser`.
+- **L1:** Caret-range semantics documented in `deny.toml` `skip-tree` entries.
+- **L2:** Unicode-DFS-2016 license TODO added to `crates/rimap-content/Cargo.toml`
+  for the vendored `confusables.txt`.
+- **L3:** `NOTICE` file created at `crates/rimap-content/data/NOTICE` with
+  Unicode attribution.
+- **L4:** PSL version pattern (patch-as-snapshot-date) documented in `deny.toml`.
+- **L5:** `check-forbidden-macros.sh` regex tightened to
+  `(^|/)crates/[^/]+/build\.rs$` so only workspace crate build scripts are
+  exempted.
+
+## Test totals
+
+- `just ci` green: **459 tests, 0 failures**
+- Wall-clock: **~10.7s test execution** (total `just ci` ~2m 20s with linters)
+- **25 corpus fixtures** (up from 22), **25 insta snapshots**
+- **9 proptest properties** at 10,000 cases each (up from 8):
+  - `proptest_charset.rs`: 1 new property
+  - `proptest_html_lookalike.rs`: 3 from Sprint 4b
+  - `properties.rs`: 5 from Sprint 4a
+- **New unit tests:** ammonia tag denial (18 tags), HTML comments, off-screen
+  threshold variants (−999px, −50px, translateX, small translateX), CDATA both
+  closed and unclosed, double-extension positive and negative, Reply-To
+  extraction, Reply-To bidi prestrip, Reply-To lookalike (mixed script), PSL
+  unparsable href
+
+## Deferred items
+
+- **Mutants rerun (#53 item 4).** The ~76-minute `cargo mutants --package rimap-content`
+  run should be done before the Phase 1 PR merges to verify the library kill
+  rate reached ≥85% after Phase 1's test additions. The Sprint 4b number was
+  83.9% (library-only) / 77.5% (whole-crate including `epvme_runner`).
+- **Authentication-Results parser (#50 item 2).** New module for parsing
+  `Authentication-Results:` headers (DKIM, SPF, DMARC pass/fail). Deferred to
+  Phase 2 or later. No partial scaffolding was added.
+- **rfc822 recursion (#51.1).** Deferred since Sprint 4a. Nested HTML bodies
+  inside `message/rfc822` attachments are not processed. `MAX_MIME_DEPTH` only
+  applies to the outer walk.
+- **`spawn_blocking` (#53 item 1).** `parse_message` is CPU-bound (~2ms per
+  message on warm cache). The async wrapper belongs in `rimap-server`, which
+  lands in Phase 2. No change to the synchronous `rimap-content` API.
+- **`epvme_runner` integration tests (#53 item 2).** 44 of the Sprint 4b
+  surviving mutants were in `src/bin/epvme_runner.rs`. Phase 2 should add
+  integration tests for `collect_eml_files` and `run_dataset` over a small
+  fixture directory.
+
+## API findings
+
+- **`mail_parser::Message::reply_to()`** returns `Option<&Address<'_>>`, the
+  same shape as `from()`. `first_address_string` works directly without
+  special-casing.
+- **html5ever CDATA in HTML5 non-SVG context.** The parser treats `<![CDATA[`
+  as a bogus comment that terminates at the first `>`. Inner content leaks as
+  text nodes via two distinct paths: (1) closed CDATA — the text includes the
+  `]]>` literal; (2) unclosed CDATA — a text node follows the bogus comment
+  with no `]]>` marker. Both paths are now suppressed by the `after_cdata`
+  flag.
+- **`ammonia::Builder::rm_tags` is a no-op for tags ammonia already strips.**
+  The explicit call is intentional — it pins behavior against upstream
+  allowlist changes. A future ammonia version that adds `details` to its
+  allowlist would silently expose content without our explicit removal.
+
+## Phase 2 prerequisites
+
+1. **`ContentMeta.reply_to` is populated.** Phase 2 tool handlers can expose it
+   in `fetch_message` and `search_messages` responses without any further
+   `rimap-content` changes.
+2. **`HtmlAnchorUnparsableHref` is wired.** Phase 2 posture policy can filter
+   on it. The Informational severity means it does not block message delivery
+   by default.
+3. **`body_html` sanitization is hardened** (ammonia explicit tag list + CDATA
+   suppression + off-screen threshold + comment stripping). Phase 2
+   `fetch_message` with `include_html=true` builds on a solid foundation.
+4. **Address extraction uses structured data.** Phase 2 can trust that lookalike
+   warnings reflect actual `Addr.address` values at every header domain, not
+   re-parsed display strings. Reply-To is now a first-class source.
+5. **`spawn_blocking` wrapper.** Phase 2 adds the async shim in `rimap-server`
+   wrapping the synchronous `rimap_content::parse_message`. The `rimap-content`
+   API remains `fn parse_message(raw: &[u8]) -> Result<Content, ContentError>`
+   — no change required.
+
+## Gotchas and non-obvious constraints
+
+- **`after_cdata` flag is stateful across the text-node walk.** The flag is set
+  when a bogus-comment node whose data starts with `[CDATA[` is encountered, and
+  cleared after the following text node is suppressed. This is load-bearing for
+  the unclosed CDATA path — do not refactor it into a stateless predicate.
+- **`detect_double_extension` requires ≥3 dot-separated segments.** A filename
+  like `invoice.exe` has only 2 segments and does not fire. This is intentional:
+  the heuristic targets the specific `visible.doc.exe` camouflage pattern.
+- **`rm_tags` order in `build_ammonia_builder` does not matter.** ammonia applies
+  the removal set regardless of declaration order. The 20-entry list is for
+  documentation — future maintainers should not infer semantic ordering.
+- **Off-screen transform detection parses the minimum (most negative) pixel
+  value found.** `translate(-500px, 0)` extracts −500 from the first argument
+  only; `0` (no `px` suffix) is not parsed as a pixel value. This is the
+  conservative safe direction: false positives are harmless, false negatives
+  (missed detections) are the risk.
+- **`just ci` wall-clock is ~2m 20s** (including `cargo deny check`, `typos`,
+  and linters). The proptest at 10,000 × 9 properties dominates test time. The
+  `[profile.dev.package."*"] opt-level = 3` workspace setting from Sprint 4b
+  Task 18 is load-bearing — do not remove it.

--- a/docs/superpowers/plans/2026-04-10-sprint-5-phase1.md
+++ b/docs/superpowers/plans/2026-04-10-sprint-5-phase1.md
@@ -1,0 +1,1863 @@
+# Sprint 5 Phase 1 — Content Pipeline Remediation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out Sprint 4b remediation items against `rimap-content` — warning semantics, ammonia hardening, bypass fixes, Reply-To gaps, address extraction consistency, build.rs strictness, and supply-chain comment hygiene.
+
+**Architecture:** Bottom-up by file. Warning types land first (output.rs), then ammonia hardening + bypass fixes (html.rs), then parse-layer changes (parse.rs), then lookalike changes (lookalike.rs), then verification and comment hygiene. Each task produces a compilable, testable commit.
+
+**Tech Stack:** Rust 2024 edition, MSRV 1.88. `scraper`, `ammonia`, `linkify`, `addr`, `idna`, `unicode-script`, `phf`, `mail-parser`, `proptest`, `insta`. Workspace clippy with `unwrap_used = deny`, `panic = deny`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-10-sprint-5-phase1-remediation-design.md`](../specs/2026-04-10-sprint-5-phase1-remediation-design.md)
+
+**Worktree:** `/Users/dave/src/rusty-imap-mcp-sprint5` on branch `feat/sprint-5`
+
+---
+
+### Task 1: Rename `HtmlHiddenContentStripped` → `HtmlHiddenContentDetected`
+
+**Files:**
+- Modify: `crates/rimap-content/src/output.rs`
+- Modify: `crates/rimap-content/src/html.rs`
+- Modify: `crates/rimap-content/tests/injection_corpus.rs`
+- Modify: `crates/rimap-content/tests/snapshots.rs` (snapshot regen only)
+- Modify: all `tests/injection-corpus/*/expected.json` that reference `html_hidden_content_stripped`
+
+- [ ] **Step 1: Rename the variant in `output.rs`**
+
+In `crates/rimap-content/src/output.rs`, rename the variant and update its doc comment:
+
+```rust
+    /// HTML content contained hidden elements (e.g. `display:none`,
+    /// `visibility:hidden`, `opacity:0`, off-screen positioning,
+    /// zero font size, or background-color-matching text). Hidden
+    /// content is stripped from `body_text` but may remain in
+    /// `body_html` when the posture allows HTML exposure.
+    HtmlHiddenContentDetected,
+```
+
+Update the `severity()` match arm: change `WarningCode::HtmlHiddenContentStripped` → `WarningCode::HtmlHiddenContentDetected` in the Adversarial arm.
+
+Update every test in the `mod tests` block that references `HtmlHiddenContentStripped` to use `HtmlHiddenContentDetected`. There are four occurrences:
+- `severity_classifies_known_variants` (line 331)
+- `new_warning_variants_serialize_snake_case` (lines 372-374)
+
+- [ ] **Step 2: Update `html.rs` emission sites**
+
+In `crates/rimap-content/src/html.rs`, replace all `WarningCode::HtmlHiddenContentStripped` with `WarningCode::HtmlHiddenContentDetected`. There are two emission sites:
+- `process()` line 557 (per-hit warnings)
+- `process()` line 564 (overflow summary warning)
+
+Update all tests in `html.rs` that reference the old variant. Search for `HtmlHiddenContentStripped`:
+- `process_detects_display_none_in_body` (line 858)
+- `process_hidden_hit_cap_summarizes_overflow` (line 879)
+
+- [ ] **Step 3: Update corpus harness**
+
+In `crates/rimap-content/tests/injection_corpus.rs`, update `warning_code_to_label`:
+```rust
+        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
+```
+
+Update every `expected.json` that references `html_hidden_content_stripped`. Check:
+```bash
+rg -l 'html_hidden_content_stripped' tests/injection-corpus/
+```
+Change each `"html_hidden_content_stripped"` to `"html_hidden_content_detected"`.
+
+- [ ] **Step 4: Regenerate snapshots**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --test snapshots -- --ignored 2>/dev/null; cargo insta review --accept
+```
+
+Or if `insta` is not installed as a CLI:
+```bash
+INSTA_UPDATE=always cargo test --package rimap-content --test snapshots
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all tests pass. The snapshot test will show diffs for every fixture that emits `html_hidden_content_detected` (the old `_stripped` label).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/output.rs crates/rimap-content/src/html.rs \
+  crates/rimap-content/tests/injection_corpus.rs \
+  crates/rimap-content/tests/snapshots/ \
+  tests/injection-corpus/
+git commit -m "refactor(content): rename HtmlHiddenContentStripped → HtmlHiddenContentDetected
+
+The old name implied hidden content was removed everywhere. In reality
+it is stripped from body_text but may remain in body_html. The new name
+reflects detection, not removal.
+
+Closes part of #49 item 1.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add `HtmlAnchorUnparsableHref` variant + doc comments
+
+**Files:**
+- Modify: `crates/rimap-content/src/output.rs`
+- Modify: `crates/rimap-content/tests/injection_corpus.rs`
+
+- [ ] **Step 1: Add the variant to `WarningCode`**
+
+In `crates/rimap-content/src/output.rs`, add after `HtmlRemoteImageStripped`:
+
+```rust
+    /// An HTML anchor's `href` could not be resolved to a registrable
+    /// domain via the Public Suffix List, but the anchor's visible text
+    /// contained a URL-looking token (detected by `linkify`). This
+    /// distinguishes "we checked and it's fine" from "we couldn't
+    /// check." Consumers should treat the anchor with suspicion.
+    HtmlAnchorUnparsableHref,
+```
+
+Add it to the `severity()` match in the `Informational` arm:
+
+```rust
+            WarningCode::ParseBodyTruncated
+            | WarningCode::HtmlStyleStripped
+            | WarningCode::HtmlRemoteImageStripped
+            | WarningCode::HtmlAnchorUnparsableHref
+            | WarningCode::LookalikeIdnPunycode => WarningSeverity::Informational,
+```
+
+- [ ] **Step 2: Add doc comments for semantic pinning**
+
+On `HtmlLinkTextHrefMismatch`, update the doc comment:
+
+```rust
+    /// An HTML anchor's visible text contained a URL-looking token
+    /// whose registrable domain differs from the anchor's `href`
+    /// registrable domain.
+    ///
+    /// Reflects the original message content (pre-ammonia), not the
+    /// sanitized `body_html`. An anchor stripped by ammonia may still
+    /// produce this warning — the warning signals the message's
+    /// intent, not the sanitized output.
+    HtmlLinkTextHrefMismatch,
+```
+
+On `SecurityWarning::detail`, update the doc comment:
+
+```rust
+    /// Human-readable context string. Consumers MUST NOT parse this
+    /// field programmatically — use `code` and other typed fields for
+    /// dispatch. Format may change without notice.
+    ///
+    /// `None` when no additional detail is available.
+    pub detail: Option<String>,
+```
+
+- [ ] **Step 3: Add test for new variant serialization**
+
+In the `mod tests` block at the bottom of `output.rs`, add to the `new_warning_variants_serialize_snake_case` test array:
+
+```rust
+            (
+                WarningCode::HtmlAnchorUnparsableHref,
+                "html_anchor_unparsable_href",
+            ),
+```
+
+Add to `severity_classifies_known_variants`:
+
+```rust
+        assert_eq!(
+            WarningCode::HtmlAnchorUnparsableHref.severity(),
+            WarningSeverity::Informational
+        );
+```
+
+- [ ] **Step 4: Update corpus harness**
+
+In `crates/rimap-content/tests/injection_corpus.rs`, add to `warning_code_to_label`:
+
+```rust
+        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/output.rs crates/rimap-content/tests/injection_corpus.rs
+git commit -m "feat(content): add HtmlAnchorUnparsableHref variant + semantic doc comments
+
+New Informational variant for anchors whose href can't be resolved via
+PSL but whose visible text looks like a URL. Also pins
+HtmlLinkTextHrefMismatch as raw-DOM semantics and detail as opaque.
+
+Closes #49 items 2-4.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add `reply_to` to `ContentMeta`
+
+**Files:**
+- Modify: `crates/rimap-content/src/output.rs`
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-content/src/output.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn content_meta_has_reply_to_field() {
+        let meta = ContentMeta {
+            reply_to: Some("reply@example.com".to_string()),
+            ..ContentMeta::default()
+        };
+        assert_eq!(meta.reply_to.as_deref(), Some("reply@example.com"));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- output::tests::content_meta_has_reply_to_field
+```
+
+Expected: FAIL — `reply_to` field does not exist.
+
+- [ ] **Step 3: Add the field**
+
+In `ContentMeta`, after `cc`:
+
+```rust
+    /// Parsed `Reply-To:` header, sanitized. `None` if absent.
+    pub reply_to: Option<String>,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- output::tests::content_meta_has_reply_to_field
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate snapshots (reply_to will appear as null in JSON)**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+INSTA_UPDATE=always cargo test --package rimap-content --test snapshots
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/output.rs crates/rimap-content/tests/snapshots/
+git commit -m "feat(content): add reply_to field to ContentMeta
+
+Preparation for Reply-To lookalike and bidi-prestrip audit coverage.
+
+Part of #50 item 1.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Ammonia hardening — explicit tag denial + strip_comments
+
+**Files:**
+- Modify: `crates/rimap-content/src/html.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+In `crates/rimap-content/src/html.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn sanitize_drops_iframe_and_details() {
+        let tags = [
+            "iframe", "object", "embed", "meta", "base", "link",
+            "form", "input", "button", "textarea", "svg", "math",
+            "frame", "frameset", "noframes", "applet",
+            "details", "summary",
+        ];
+        for tag in tags {
+            let input = format!(
+                "<html><body><{tag}>hidden content</{tag}></body></html>"
+            );
+            let result = process(input.as_bytes(), None)
+                .expect("process should succeed");
+            assert!(
+                !result.body_html.contains(&format!("<{tag}")),
+                "tag <{tag}> should be stripped from body_html, got: {}",
+                result.body_html
+            );
+        }
+    }
+
+    #[test]
+    fn body_html_has_no_html_comments() {
+        let input = b"<html><body><!-- secret comment --><p>visible</p></body></html>";
+        let result = process(input, None).expect("process should succeed");
+        assert!(
+            !result.body_html.contains("<!--"),
+            "HTML comments should be stripped, got: {}",
+            result.body_html
+        );
+        assert!(
+            !result.body_html.contains("secret comment"),
+            "comment content should be stripped, got: {}",
+            result.body_html
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify the `details`/`summary` test fails**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::sanitize_drops_iframe_and_details
+```
+
+Expected: FAIL on `details` or `summary` (ammonia allows them by default). The `strip_comments` test likely passes already (ammonia defaults to stripping comments) but we want to pin it.
+
+- [ ] **Step 3: Update `build_ammonia_builder`**
+
+In `crates/rimap-content/src/html.rs`, replace `build_ammonia_builder`:
+
+```rust
+fn build_ammonia_builder() -> Builder<'static> {
+    let mut builder = Builder::default();
+    let schemes: HashSet<&'static str> =
+        ["http", "https", "mailto", "tel"].into_iter().collect();
+    builder.url_schemes(schemes);
+    builder.rm_tag_attributes("img", &["src", "srcset"]);
+    builder.add_tag_attributes("img", &["alt", "width", "height"]);
+    // Pin tag removals against ammonia default drift. details/summary
+    // are explicitly removed: collapsed content is invisible to humans
+    // but visible to LLMs reading HTML tokens.
+    builder.rm_tags(&[
+        "script", "style", "iframe", "object", "embed", "meta",
+        "base", "link", "form", "input", "button", "textarea",
+        "svg", "math", "frame", "frameset", "noframes", "applet",
+        "details", "summary",
+    ]);
+    builder.strip_comments(true);
+    builder
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::sanitize_drops_iframe_and_details
+cargo test --package rimap-content --lib -- html::tests::body_html_has_no_html_comments
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Run full rimap-content tests + regenerate snapshots**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+INSTA_UPDATE=always cargo test --package rimap-content
+```
+
+Expected: all pass. Some snapshots may change if `<details>` appeared in any corpus fixture's body_html output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/html.rs crates/rimap-content/tests/snapshots/
+git commit -m "fix(content): explicit ammonia tag denial list + strip_comments
+
+Pin script/style/iframe/object/embed/meta/base/link/form/input/button/
+textarea/svg/math/frame/frameset/noframes/applet/details/summary removal
+against ammonia default drift. Explicitly set strip_comments(true).
+
+Closes #52 items 1-2.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Off-screen threshold loosening + transform detection
+
+**Files:**
+- Modify: `crates/rimap-content/src/html.rs`
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-content/src/html.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn classify_offscreen_minus_999_fires() {
+        assert_eq!(
+            classify_inline_style("position: absolute; left: -999px"),
+            Some(HiddenMethod::OffScreen)
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_minus_50_does_not_fire() {
+        assert_eq!(
+            classify_inline_style("position: absolute; left: -50px"),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_transform_translate() {
+        assert_eq!(
+            classify_inline_style(
+                "position: absolute; transform: translateX(-9999px)"
+            ),
+            Some(HiddenMethod::OffScreen)
+        );
+        assert_eq!(
+            classify_inline_style(
+                "position: fixed; transform: translate(-500px, 0)"
+            ),
+            Some(HiddenMethod::OffScreen)
+        );
+    }
+
+    #[test]
+    fn classify_offscreen_transform_small_value_no_fire() {
+        assert_eq!(
+            classify_inline_style(
+                "position: absolute; transform: translateX(-50px)"
+            ),
+            None
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::classify_offscreen_minus_999_fires
+```
+
+Expected: FAIL (current threshold is -1000).
+
+- [ ] **Step 3: Update `StyleHints` and `is_offscreen`**
+
+In `crates/rimap-content/src/html.rs`, update `StyleHints` to add a `transform` field:
+
+```rust
+struct StyleHints {
+    position: Option<String>,
+    left_px: Option<f64>,
+    top_px: Option<f64>,
+    color: Option<String>,
+    bg_color: Option<String>,
+    transform_offset_px: Option<f64>,
+}
+```
+
+Update `StyleHints::record` to parse `transform`:
+
+```rust
+    fn record(&mut self, prop: &str, val: &str) {
+        match prop {
+            "position" => self.position = Some(val.to_string()),
+            "left" => self.left_px = parse_px(val),
+            "top" => self.top_px = parse_px(val),
+            "color" => self.color = Some(val.to_string()),
+            "background-color" => self.bg_color = Some(val.to_string()),
+            "transform" => self.transform_offset_px = parse_translate_px(val),
+            _ => {}
+        }
+    }
+```
+
+Update `is_offscreen` to use the new threshold and transform:
+
+```rust
+    fn is_offscreen(&self) -> bool {
+        let positioned = matches!(
+            self.position.as_deref(),
+            Some("absolute" | "fixed")
+        );
+        if !positioned {
+            return false;
+        }
+        let off_left = self.left_px.is_some_and(|v| v < -100.0);
+        let off_top = self.top_px.is_some_and(|v| v < -100.0);
+        let off_transform = self
+            .transform_offset_px
+            .is_some_and(|v| v < -100.0);
+        off_left || off_top || off_transform
+    }
+```
+
+Add a `parse_translate_px` function near `parse_px`:
+
+```rust
+/// Parse a `transform: translate*(-Npx)` value and return the most
+/// negative pixel offset found, or `None` if no translate pattern
+/// matches. Handles `translateX(-9999px)`, `translateY(-500px)`,
+/// and `translate(-500px, 0)`.
+fn parse_translate_px(val: &str) -> Option<f64> {
+    let mut min: Option<f64> = None;
+    // Match patterns: translateX(-Npx), translateY(-Npx),
+    // translate(-Npx ...).
+    for part in val.split(|c: char| c == '(' || c == ',' || c == ')') {
+        let trimmed = part.trim();
+        if let Some(px_val) = parse_px(trimmed) {
+            match min {
+                Some(current) if px_val < current => min = Some(px_val),
+                None => min = Some(px_val),
+                _ => {}
+            }
+        }
+    }
+    min
+}
+```
+
+- [ ] **Step 4: Update the existing off-screen test threshold**
+
+The existing test `classify_offscreen_absolute` asserts `-9999px` and `-5000px` — both still pass with the new threshold. No change needed. Verify:
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::classify_offscreen
+```
+
+Expected: all offscreen tests pass.
+
+- [ ] **Step 5: Run full rimap-content tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/html.rs
+git commit -m "fix(content): loosen off-screen threshold to -100px + transform detection
+
+Catches evasion via left:-999px and transform:translateX(-9999px).
+Small negative values (legitimate border tricks) are not flagged.
+
+Part of #51 item 5.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: PSL silent-skip → `HtmlAnchorUnparsableHref` emission
+
+**Files:**
+- Modify: `crates/rimap-content/src/html.rs`
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-content/src/html.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn mismatch_emits_unparsable_href_for_psl_failure() {
+        // href uses a single-label host (no dot) that PSL can't resolve,
+        // but the visible text looks like a domain (has a dot, linkify
+        // picks it up).
+        let input = br#"<html><body>
+            <a href="https://evilserver/phish">Visit paypal.com now</a>
+        </body></html>"#;
+        let result = process(input, None).expect("ok");
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| matches!(
+                    w.code,
+                    crate::output::WarningCode::HtmlAnchorUnparsableHref
+                )),
+            "expected HtmlAnchorUnparsableHref, got {:?}",
+            result.warnings
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::mismatch_emits_unparsable_href_for_psl_failure
+```
+
+Expected: FAIL — currently the anchor is silently skipped.
+
+- [ ] **Step 3: Update `detect_mismatches` to emit the warning**
+
+In `detect_mismatches()` (around line 338-371), change the `extract_registrable_domain(href)` None case. Currently when `href_domain` is `None`, the loop does `continue`. Instead, check if the anchor text contains a URL:
+
+Replace the current block:
+```rust
+        let Some(href_domain) = extract_registrable_domain(href) else {
+            continue;
+        };
+```
+
+With:
+```rust
+        let href_domain = match extract_registrable_domain(href) {
+            Some(d) => d,
+            None => {
+                // href couldn't be resolved via PSL. If the anchor text
+                // looks like a URL, emit an informational warning so
+                // the absence of HtmlLinkTextHrefMismatch is
+                // distinguishable from "we couldn't check."
+                let mut text: String =
+                    anchor.text().collect::<Vec<&str>>().join(" ");
+                if text.len() > MAX_ANCHOR_TEXT_SCAN {
+                    text.truncate(MAX_ANCHOR_TEXT_SCAN);
+                }
+                let has_url_text = finder
+                    .links(&text)
+                    .any(|l| l.kind() == &linkify::LinkKind::Url);
+                if has_url_text && hits.len() < MAX_MISMATCH_HITS {
+                    unparsable_hrefs.push((
+                        href.to_string(),
+                        text.trim().to_string(),
+                    ));
+                }
+                continue;
+            }
+        };
+```
+
+This requires adding a `unparsable_hrefs` accumulator. Change the function signature to return it:
+
+Actually, to keep the return type stable, add the unparsable hrefs to a separate return. Change the function:
+
+```rust
+fn detect_mismatches(
+    document: &Html,
+) -> (Vec<MismatchHit>, usize, Vec<(String, String)>) {
+```
+
+Add `let mut unparsable_hrefs: Vec<(String, String)> = Vec::new();` at the top, and return `(hits, overflow, unparsable_hrefs)`.
+
+Update the call site in `process()` to destructure and emit warnings:
+
+```rust
+    let (mismatches, mismatch_overflow, unparsable_hrefs) =
+        detect_mismatches(&document);
+    // ... existing mismatch warning emission ...
+    for (href, text) in &unparsable_hrefs {
+        warnings.push(SecurityWarning {
+            code: crate::output::WarningCode::HtmlAnchorUnparsableHref,
+            detail: Some(format!("href={href},text={text}")),
+            location: Some("body_html:anchor".to_string()),
+        });
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests::mismatch_emits_unparsable_href
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/html.rs
+git commit -m "fix(content): emit HtmlAnchorUnparsableHref for PSL-unresolvable hrefs
+
+When an anchor's href can't be resolved via the Public Suffix List but
+the visible text contains a URL token, emit an Informational warning
+instead of silently skipping. Distinguishes 'checked, fine' from
+'couldn't check.'
+
+Closes #51 item 4.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: CDATA text leak fix
+
+**Files:**
+- Modify: `crates/rimap-content/src/html.rs`
+- Modify: `tests/injection-corpus/html-tokenizer-divergence/expected.json`
+
+- [ ] **Step 1: Investigate the CDATA behavior**
+
+Before writing the fix, validate what scraper does with CDATA. Run:
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- html::tests 2>&1 | head -30
+```
+
+Read the existing `html-tokenizer-divergence/input.eml` to understand the current fixture content. The handoff says CDATA was intentionally omitted from the fixture. We need to understand scraper's behavior to craft the right fix.
+
+Write a diagnostic test (temporary) to see what scraper does:
+
+```rust
+    #[test]
+    fn debug_cdata_scraper_behavior() {
+        let html = r#"<html><body><![CDATA[<script>alert("cdata-bypass")</script>]]></body></html>"#;
+        let result = process(html.as_bytes(), None).expect("ok");
+        eprintln!("body_text: {:?}", result.body_text);
+        eprintln!("body_html: {:?}", result.body_html);
+        // This test is diagnostic — check stderr output to determine
+        // whether the JS source leaks into body_text.
+    }
+```
+
+Run it with `-- --nocapture` to see output. Based on the output, determine the fix approach.
+
+- [ ] **Step 2: Implement the fix**
+
+Per the handoff, the JS source text survives as a text node in `body_text`. The fix in `collect_visible_text` / `walk_element` depends on how scraper represents the CDATA content. If it appears as a text child of an element that scraper treats as a comment or special node, the fix may be to check for script-like content in text nodes.
+
+The most robust approach: in `push_text`, or in the text-node handler in `collect_visible_text`, skip text content that looks like it leaked from a CDATA section. Alternatively, check if the parent element or sibling context indicates CDATA provenance.
+
+**Note to implementer:** the exact fix depends on the diagnostic test output from Step 1. The handoff says "one-liner" — likely the scraper parse turns CDATA into a comment node that the text walker incorrectly treats as text, or the walker needs to skip a specific node type.
+
+- [ ] **Step 3: Update the corpus fixture**
+
+In `tests/injection-corpus/html-tokenizer-divergence/input.eml`, add a CDATA section to the HTML body. If the input.eml already has one that was commented out, uncomment it. If not, add it to the HTML body part:
+
+```
+<![CDATA[<script>alert("cdata-bypass")</script>]]>
+```
+
+Update `tests/injection-corpus/html-tokenizer-divergence/expected.json` — the `must_not_contain` already includes `alert("cdata-bypass")`, so no change needed there.
+
+- [ ] **Step 4: Run tests + regenerate snapshots**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+INSTA_UPDATE=always cargo test --package rimap-content
+```
+
+Expected: all pass, including the tokenizer-divergence fixture.
+
+- [ ] **Step 5: Remove the diagnostic test**
+
+Delete the `debug_cdata_scraper_behavior` test added in Step 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/html.rs \
+  tests/injection-corpus/html-tokenizer-divergence/ \
+  crates/rimap-content/tests/snapshots/
+git commit -m "fix(content): prevent CDATA JS source from leaking into body_text
+
+Scraper/html5ever parses CDATA sections such that inner script content
+survives as text nodes. Skip these during visible-text extraction.
+
+Closes #51 item 2.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Double-extension filename heuristic
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse.rs`
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-content/src/parse.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn double_extension_pdf_exe_fires_spoof_warning() {
+        let eml = b"From: test@example.com\r\n\
+            Subject: invoice\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: multipart/mixed; boundary=\"bound\"\r\n\
+            \r\n\
+            --bound\r\n\
+            Content-Type: text/plain\r\n\
+            \r\n\
+            See attached.\r\n\
+            --bound\r\n\
+            Content-Type: application/octet-stream\r\n\
+            Content-Disposition: attachment; filename=\"invoice.pdf.exe\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            AAAA\r\n\
+            --bound--\r\n";
+        let content = parse_message(eml).expect("should parse");
+        assert!(
+            content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeFilenameExtensionSpoof
+                    && w.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("double_extension"))
+            }),
+            "expected LookalikeFilenameExtensionSpoof with double_extension, \
+             got {:?}",
+            content.security_warnings
+        );
+    }
+
+    #[test]
+    fn single_extension_does_not_fire_double_extension() {
+        let eml = b"From: test@example.com\r\n\
+            Subject: file\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: multipart/mixed; boundary=\"bound\"\r\n\
+            \r\n\
+            --bound\r\n\
+            Content-Type: text/plain\r\n\
+            \r\n\
+            See attached.\r\n\
+            --bound\r\n\
+            Content-Type: application/pdf\r\n\
+            Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            AAAA\r\n\
+            --bound--\r\n";
+        let content = parse_message(eml).expect("should parse");
+        assert!(
+            !content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeFilenameExtensionSpoof
+                    && w.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("double_extension"))
+            }),
+            "single extension should not fire double_extension spoof"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- parse::tests::double_extension_pdf_exe_fires
+```
+
+Expected: FAIL — double extension check doesn't exist yet.
+
+- [ ] **Step 3: Implement `detect_double_extension`**
+
+Add a helper function in `parse.rs` near `contains_bidi_override`:
+
+```rust
+/// Document-type extensions that commonly appear as the penultimate
+/// extension in a double-extension spoof (e.g. `invoice.pdf.exe`).
+const DOCUMENT_EXTENSIONS: &[&str] = &[
+    "pdf", "doc", "docx", "xls", "xlsx", "png", "jpg", "jpeg",
+    "gif", "txt", "csv", "rtf",
+];
+
+/// Executable-type extensions that commonly appear as the final
+/// extension in a double-extension spoof.
+const EXECUTABLE_EXTENSIONS: &[&str] = &[
+    "exe", "dll", "bat", "cmd", "ps1", "vbs", "js", "scr", "msi",
+    "app", "dmg", "sh", "com", "pif", "jar", "lnk",
+];
+
+/// Check for a double-extension spoof pattern like `file.pdf.exe`.
+/// Returns `Some((penultimate, final))` if the filename has 3+
+/// dot-separated segments where the penultimate is a document type
+/// and the final is an executable type.
+fn detect_double_extension(name: &str) -> Option<(String, String)> {
+    let segments: Vec<&str> = name.split('.').collect();
+    if segments.len() < 3 {
+        return None;
+    }
+    let penultimate = segments[segments.len() - 2].to_ascii_lowercase();
+    let final_ext = segments[segments.len() - 1].to_ascii_lowercase();
+    if DOCUMENT_EXTENSIONS.contains(&penultimate.as_str())
+        && EXECUTABLE_EXTENSIONS.contains(&final_ext.as_str())
+    {
+        Some((penultimate, final_ext))
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 4: Wire into `build_attachment_meta`**
+
+In `build_attachment_meta`, after the existing bidi-override check (line ~734) and before the `unicode::sanitize` call, add the double-extension check:
+
+```rust
+        if let Some((penult, final_ext)) = detect_double_extension(name) {
+            warnings.push(SecurityWarning {
+                code: WarningCode::LookalikeFilenameExtensionSpoof,
+                detail: Some(format!(
+                    "reason=double_extension,visible=.{penult},\
+                     declared=.{penult}.{final_ext}"
+                )),
+                location: Some(format!("attachment[{idx}]:filename")),
+            });
+        }
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- parse::tests::double_extension
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 6: Run full tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/parse.rs
+git commit -m "feat(content): detect double-extension filename spoofs
+
+Detect patterns like invoice.pdf.exe where the penultimate extension
+is a document type and the final extension is an executable type.
+Emits LookalikeFilenameExtensionSpoof with reason=double_extension.
+
+Closes #51 item 3.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Populate Reply-To in `extract_meta` + bidi audit
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse.rs`
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-content/src/parse.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn reply_to_extracted_into_meta() {
+        let eml = b"From: sender@example.com\r\n\
+            Reply-To: reply@different.com\r\n\
+            To: recipient@example.com\r\n\
+            Subject: test\r\n\
+            \r\n\
+            body\r\n";
+        let content = parse_message(eml).expect("should parse");
+        assert_eq!(
+            content.meta.reply_to.as_deref(),
+            Some("reply@different.com")
+        );
+    }
+
+    #[test]
+    fn reply_to_bidi_override_emits_warning() {
+        // Reply-To domain with a bidi override character.
+        let eml = format!(
+            "From: sender@example.com\r\n\
+             Reply-To: attacker@evil\u{202E}.com\r\n\
+             To: recipient@example.com\r\n\
+             Subject: test\r\n\
+             \r\n\
+             body\r\n"
+        );
+        let content = parse_message(eml.as_bytes()).expect("should parse");
+        assert!(
+            content.security_warnings.iter().any(|w| {
+                w.code == WarningCode::LookalikeHomographDomain
+                    && w.location.as_deref() == Some("header:reply_to")
+            }),
+            "expected LookalikeHomographDomain on reply_to, got {:?}",
+            content.security_warnings
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- parse::tests::reply_to_extracted
+```
+
+Expected: FAIL — `reply_to` is not populated.
+
+- [ ] **Step 3: Populate Reply-To in `extract_meta`**
+
+In `extract_meta()`, add after the `cc` line (around line 125):
+
+```rust
+    let reply_to = first_address_string(
+        message.reply_to(),
+        "header:reply_to",
+        warnings,
+    );
+```
+
+Add to the `ContentMeta` struct literal (around line 138):
+
+```rust
+        reply_to,
+```
+
+Note: `first_address_string` already calls `audit_addr_domain_bidi` internally (line 194), so the bidi audit for Reply-To is automatically wired by using this function.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- parse::tests::reply_to
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Regenerate snapshots + run full tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+INSTA_UPDATE=always cargo test --package rimap-content
+```
+
+Expected: all pass. Snapshots may change to include `reply_to` values.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/parse.rs crates/rimap-content/tests/snapshots/
+git commit -m "feat(content): populate Reply-To in ContentMeta with bidi audit
+
+Extract Reply-To via first_address_string, which includes the
+addr-domain bidi-prestrip audit. Reply-To domains with bidi overrides
+now emit LookalikeHomographDomain.
+
+Closes #50 item 1.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Address extraction consistency + Reply-To lookalike pass
+
+**Files:**
+- Modify: `crates/rimap-content/src/lookalike.rs`
+- Modify: `crates/rimap-content/src/parse.rs`
+
+- [ ] **Step 1: Write failing test for Reply-To lookalike**
+
+In `crates/rimap-content/src/lookalike.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn audit_flags_mixed_script_reply_to_domain() {
+        let mut meta = empty_meta();
+        meta.from = Some("legit@example.com".to_string());
+        meta.reply_to =
+            Some("support@p\u{0430}ypal.com".to_string());
+        let warnings = run_audit(&meta, "", &[]);
+        let reply_to_warnings: Vec<_> = warnings
+            .iter()
+            .filter(|w| {
+                w.code == WarningCode::LookalikeMixedScript
+                    && w.location.as_deref() == Some("header:reply_to")
+            })
+            .collect();
+        assert_eq!(
+            reply_to_warnings.len(),
+            1,
+            "expected one mixed-script hit on reply_to, got {warnings:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --lib -- lookalike::tests::audit_flags_mixed_script_reply_to
+```
+
+Expected: FAIL — `scan_header_domains` doesn't check `reply_to`.
+
+- [ ] **Step 3: Add `header_domains` to `LookalikeInput`**
+
+In `crates/rimap-content/src/lookalike.rs`, update `LookalikeInput`:
+
+```rust
+pub(crate) struct LookalikeInput<'a> {
+    /// Header-derived metadata (from, subject, list-id, …).
+    pub meta: &'a ContentMeta,
+    /// Sanitized plain-text body, used for body-URL scanning.
+    pub body_text: &'a str,
+    /// Anchor hrefs collected from the sanitized HTML body.
+    pub anchor_hrefs: &'a [String],
+    /// Pre-extracted header address domains with their locations.
+    /// Built at the `parse_message` boundary using structured
+    /// `Addr.address` data rather than re-parsing rendered strings.
+    pub header_domains: Vec<(String, String)>,
+}
+```
+
+- [ ] **Step 4: Rewrite `scan_header_domains` to use `header_domains`**
+
+```rust
+fn scan_header_domains(
+    input: &LookalikeInput<'_>,
+    out: &mut Vec<SecurityWarning>,
+) {
+    for (domain, location) in &input.header_domains {
+        emit_classification(domain, location, out);
+    }
+}
+```
+
+Update the call in `audit()`:
+```rust
+    scan_header_domains(input, &mut out);
+```
+
+- [ ] **Step 5: Build `header_domains` in `parse_message`**
+
+In `crates/rimap-content/src/parse.rs`, add a helper to extract domains from structured addresses:
+
+```rust
+/// Extract domains from structured `Addr` values for lookalike
+/// scanning. Uses `addr.address` directly rather than re-parsing
+/// rendered display strings.
+fn collect_header_domains(
+    message: &Message<'_>,
+) -> Vec<(String, String)> {
+    let mut domains = Vec::new();
+    if let Some(address) = message.from() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:from".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.to() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:to".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.cc() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((domain, "header:cc".to_string()));
+            }
+        }
+    }
+    if let Some(address) = message.reply_to() {
+        for addr in address.iter() {
+            if let Some(domain) = addr_domain(addr) {
+                domains.push((
+                    domain,
+                    "header:reply_to".to_string(),
+                ));
+            }
+        }
+    }
+    domains
+}
+
+/// Extract the domain from a structured `Addr` via `addr.address`.
+fn addr_domain(addr: &mail_parser::Addr<'_>) -> Option<String> {
+    let email = addr.address.as_deref()?;
+    let (_local, domain) = email.rsplit_once('@')?;
+    let trimmed = domain.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+```
+
+Update the `lookalike::audit` call in `parse_message`:
+
+```rust
+    let header_domains = collect_header_domains(&message);
+    let lookalike_warnings = lookalike::audit(&lookalike::LookalikeInput {
+        meta: &content.meta,
+        body_text: &content.untrusted.body_text,
+        anchor_hrefs: &html_anchor_hrefs,
+        header_domains,
+    });
+```
+
+- [ ] **Step 6: Update test helpers in `lookalike.rs`**
+
+Update the `run_audit` helper in `lookalike::tests`:
+
+```rust
+    fn run_audit(
+        meta: &ContentMeta,
+        body_text: &str,
+        anchor_hrefs: &[String],
+    ) -> Vec<SecurityWarning> {
+        // For tests, build header_domains from meta fields to keep
+        // existing test patterns working.
+        let mut header_domains = Vec::new();
+        if let Some(from) = meta.from.as_deref() {
+            if let Some(domain) = extract_domain_from_address(from) {
+                header_domains.push((domain, "header:from".to_string()));
+            }
+        }
+        for addr in &meta.to {
+            if let Some(domain) = extract_domain_from_address(addr) {
+                header_domains.push((domain, "header:to".to_string()));
+            }
+        }
+        for addr in &meta.cc {
+            if let Some(domain) = extract_domain_from_address(addr) {
+                header_domains.push((domain, "header:cc".to_string()));
+            }
+        }
+        if let Some(reply_to) = meta.reply_to.as_deref() {
+            if let Some(domain) = extract_domain_from_address(reply_to) {
+                header_domains.push((
+                    domain,
+                    "header:reply_to".to_string(),
+                ));
+            }
+        }
+        audit(&LookalikeInput {
+            meta,
+            body_text,
+            anchor_hrefs,
+            header_domains,
+        })
+    }
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass including the new Reply-To test.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/src/lookalike.rs crates/rimap-content/src/parse.rs
+git commit -m "feat(content): address extraction consistency + Reply-To lookalike pass
+
+Replace rfind-based domain extraction in scan_header_domains with
+pre-extracted domains from structured Addr.address at the parse
+boundary. Adds Reply-To as a fourth header domain source.
+
+Closes #50 item 3.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Corpus fixtures — offscreen evasion, unparsable href, Reply-To
+
+**Files:**
+- Create: `tests/injection-corpus/html-offscreen-evasion/input.eml`
+- Create: `tests/injection-corpus/html-offscreen-evasion/expected.json`
+- Create: `tests/injection-corpus/html-anchor-unparsable-href/input.eml`
+- Create: `tests/injection-corpus/html-anchor-unparsable-href/expected.json`
+- Create: `tests/injection-corpus/lookalike-reply-to-mismatch/input.eml`
+- Create: `tests/injection-corpus/lookalike-reply-to-mismatch/expected.json`
+- Modify: `crates/rimap-content/tests/snapshots.rs`
+
+- [ ] **Step 1: Create `html-offscreen-evasion` fixture**
+
+Create `tests/injection-corpus/html-offscreen-evasion/input.eml` (CRLF line endings):
+
+```
+From: attacker@evil.example
+To: victim@example.com
+Subject: Offscreen evasion test
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body>
+<p>Please review the attached document.</p>
+<div style="position: absolute; left: -999px">HIDDEN BY LEFT OFFSET</div>
+<div style="position: fixed; transform: translateX(-9999px)">HIDDEN BY TRANSFORM</div>
+</body></html>
+```
+
+Create `tests/injection-corpus/html-offscreen-evasion/expected.json`:
+
+```json
+{
+  "description": "Off-screen evasion via left:-999px (below old -1000px threshold) and transform:translateX(-9999px). Both must trigger HtmlHiddenContentDetected.",
+  "expect": "ok",
+  "must_contain": [
+    "Please review the attached document."
+  ],
+  "must_not_contain": [
+    "HIDDEN BY LEFT OFFSET",
+    "HIDDEN BY TRANSFORM"
+  ],
+  "warning_codes": [
+    "html_hidden_content_detected"
+  ],
+  "forbidden_warning_codes": []
+}
+```
+
+- [ ] **Step 2: Create `html-anchor-unparsable-href` fixture**
+
+Create `tests/injection-corpus/html-anchor-unparsable-href/input.eml` (CRLF line endings):
+
+```
+From: phisher@evil.example
+To: victim@example.com
+Subject: Unparsable href test
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body>
+<p>Click to verify your account:</p>
+<a href="https://evilserver/phishing-page">Visit paypal.com to verify</a>
+</body></html>
+```
+
+Create `tests/injection-corpus/html-anchor-unparsable-href/expected.json`:
+
+```json
+{
+  "description": "Anchor href uses a single-label host (no dot, PSL fails) but visible text contains paypal.com. HtmlAnchorUnparsableHref must fire.",
+  "expect": "ok",
+  "must_contain": [
+    "Click to verify your account:"
+  ],
+  "must_not_contain": [],
+  "warning_codes": [
+    "html_anchor_unparsable_href"
+  ],
+  "forbidden_warning_codes": []
+}
+```
+
+- [ ] **Step 3: Create `lookalike-reply-to-mismatch` fixture**
+
+Create `tests/injection-corpus/lookalike-reply-to-mismatch/input.eml` (CRLF line endings). Uses a Cyrillic 'а' (U+0430) in the Reply-To domain:
+
+```
+From: support@paypal.com
+Reply-To: =?utf-8?B?c3VwcG9ydEBw0LB5cGFsLmNvbQ==?=
+To: victim@example.com
+Subject: Account verification required
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Please verify your account by replying to this email.
+```
+
+Note: the base64 `c3VwcG9ydEBw0LB5cGFsLmNvbQ==` decodes to `support@pаypal.com` (with Cyrillic а).
+
+**Important:** Verify the base64 encoding is correct before committing. Generate it:
+```bash
+echo -n 'support@p\xd0\xb0ypal.com' | base64
+```
+
+Create `tests/injection-corpus/lookalike-reply-to-mismatch/expected.json`:
+
+```json
+{
+  "description": "Reply-To uses a Cyrillic homograph of paypal.com (Latin+Cyrillic mixed script). LookalikeMixedScript must fire on header:reply_to.",
+  "expect": "ok",
+  "must_contain": [
+    "Please verify your account"
+  ],
+  "must_not_contain": [],
+  "warning_codes": [
+    "lookalike_mixed_script"
+  ],
+  "forbidden_warning_codes": []
+}
+```
+
+- [ ] **Step 4: Add snapshot test functions**
+
+In `crates/rimap-content/tests/snapshots.rs`, add:
+
+```rust
+#[test]
+fn snapshot_html_offscreen_evasion() {
+    snapshot_one("html-offscreen-evasion");
+}
+
+#[test]
+fn snapshot_html_anchor_unparsable_href() {
+    snapshot_one("html-anchor-unparsable-href");
+}
+
+#[test]
+fn snapshot_lookalike_reply_to_mismatch() {
+    snapshot_one("lookalike-reply-to-mismatch");
+}
+```
+
+Also update the `warning_code_to_label` in `snapshots.rs` if it has a matching function (check — it may use serde instead).
+
+- [ ] **Step 5: Run tests + generate initial snapshots**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+INSTA_UPDATE=always cargo test --package rimap-content
+```
+
+Expected: all pass. New snapshots created for the three fixtures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add tests/injection-corpus/html-offscreen-evasion/ \
+  tests/injection-corpus/html-anchor-unparsable-href/ \
+  tests/injection-corpus/lookalike-reply-to-mismatch/ \
+  crates/rimap-content/tests/snapshots.rs \
+  crates/rimap-content/tests/snapshots/
+git commit -m "test(content): add corpus fixtures for offscreen evasion, unparsable href, Reply-To
+
+Three new adversarial corpus fixtures with insta snapshots:
+- html-offscreen-evasion: left:-999px + translateX(-9999px)
+- html-anchor-unparsable-href: PSL-unresolvable href with brand text
+- lookalike-reply-to-mismatch: Cyrillic homograph in Reply-To domain
+
+Part of #51 items 4-5 and #50 item 1.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: `build.rs` strictness
+
+**Files:**
+- Modify: `crates/rimap-content/build.rs`
+
+- [ ] **Step 1: Tighten the floor and fail on malformed rows**
+
+In `crates/rimap-content/build.rs`, replace the `eprintln!` + `continue` for malformed targets (around line 60-65):
+
+```rust
+        let Some(target_string) = parse_codepoint_sequence(tgt) else {
+            panic!(
+                "build: malformed target at line {}: {raw_line}\n\
+                 Bump EXPECTED_MIN and re-audit when regenerating \
+                 from a new Unicode version.",
+                lineno + 1
+            );
+        };
+```
+
+Replace the floor assertion at the bottom (around line 98-103):
+
+```rust
+    // Unicode 16.0 produces ~6355 MA rows. This floor catches silent
+    // format drift that drops more than ~2.5% of entries. Bump this
+    // value and re-audit when regenerating from a new Unicode version.
+    assert!(
+        seen.len() >= 6200,
+        "build: suspiciously small confusables map ({} entries, \
+         expected >= 6200) — is data/confusables.txt the right file?",
+        seen.len()
+    );
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo build --package rimap-content
+```
+
+Expected: builds successfully, `eprintln` output shows ~6355 entries.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/build.rs
+git commit -m "fix(content): tighten build.rs confusables row floor to 6200 + fail on malformed
+
+Any malformed target row now panics the build instead of silently
+skipping. Floor raised from >5000 to >=6200 (Unicode 16.0 has ~6355).
+
+Closes #53 item 3.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Charset proptest
+
+**Files:**
+- Create: `crates/rimap-content/tests/proptest_charset.rs`
+
+- [ ] **Step 1: Write the proptest**
+
+Create `crates/rimap-content/tests/proptest_charset.rs`:
+
+```rust
+//! Proptest property: arbitrary charset parameter strings passed to
+//! `parse_message` always produce either a valid `Content` with UTF-8
+//! `body_text` or a structured `ContentError` — never a panic.
+//!
+//! Runs at 10,000 cases.
+
+use proptest::prelude::*;
+use rimap_content::parse_message;
+
+fn config() -> ProptestConfig {
+    ProptestConfig {
+        cases: 10_000,
+        max_shrink_iters: 10_000,
+        ..ProptestConfig::default()
+    }
+}
+
+proptest! {
+    #![proptest_config(config())]
+
+    #[test]
+    fn charset_parameter_produces_valid_utf8_or_error(
+        charset in "[a-zA-Z0-9_:. -]{0,40}"
+    ) {
+        let eml = format!(
+            "From: test@example.com\r\n\
+             Subject: charset test\r\n\
+             MIME-Version: 1.0\r\n\
+             Content-Type: text/plain; charset=\"{charset}\"\r\n\
+             \r\n\
+             Hello world\r\n"
+        );
+        match parse_message(eml.as_bytes()) {
+            Ok(content) => {
+                // body_text must be valid UTF-8 (it's a String, so
+                // this is guaranteed by construction, but we verify
+                // the content is non-panicking and reasonable).
+                let _ = content.untrusted.body_text.len();
+            }
+            Err(_) => {
+                // Structured error is acceptable.
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the proptest**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content --test proptest_charset -- --nocapture
+```
+
+Expected: 10,000 cases pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add crates/rimap-content/tests/proptest_charset.rs
+git commit -m "test(content): add charset parameter proptest (10k cases)
+
+Arbitrary charset strings in Content-Type must produce valid UTF-8
+output or a structured error, never a panic.
+
+Closes #52 item 3.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Supply-chain comment hygiene (#54)
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root)
+- Modify: `deny.toml`
+- Modify: `crates/rimap-content/Cargo.toml`
+- Create: `crates/rimap-content/data/NOTICE`
+- Modify: `scripts/check-forbidden-macros.sh`
+
+- [ ] **Step 1: M1 — Add missing proc-macros to R10 provenance block**
+
+In the root `Cargo.toml`, find the R10 provenance comment block (around the proc-macro enumeration, search for `phf_macros` or `derive_more-impl`). After the existing list, add:
+
+```
+# - yoke-derive 0.8.2 (unicode-org via ICU4X, pulled through idna_adapter)
+# - zerofrom-derive 0.1.7 (unicode-org via ICU4X, pulled through idna_adapter)
+# - zerovec-derive 0.11.3 (unicode-org via ICU4X, pulled through idna_adapter)
+# - displaydoc 0.2.5 (unicode-org via ICU4X, pulled through idna_adapter)
+```
+
+- [ ] **Step 2: M2 — Rewrite `idna` line comment**
+
+Find the `idna = "1.1.0"` line (line 118) and replace its comment block:
+
+```toml
+# First url/idna entry in the workspace. idna 1.x replaced in-crate
+# Unicode tables with the ICU4X provider stack, pulling ~20 new
+# transitive crates (icu_collections, icu_locale_core, icu_normalizer,
+# icu_normalizer_data, icu_properties, icu_properties_data,
+# icu_provider, idna_adapter, litemap, potential_utf, tinystr,
+# writeable, yoke*, zerofrom*, zerotrie, zerovec*, utf8_iter,
+# displaydoc). Accepted because ICU4X is the unicode-org canonical
+# path; re-audit on any minor bump of the idna or icu_* family.
+idna = "1.1.0"
+```
+
+- [ ] **Step 3: M3 — Rewrite `phf` default-features comment**
+
+Find the `phf` line (line 152) and update the nearby comment to note:
+
+```toml
+# Our direct phf declaration disables defaults; phf_macros still
+# enters the graph transitively via cssparser, which is acknowledged
+# in the proc-macro enumeration above.
+phf = { version = "0.13.1", default-features = false }
+```
+
+- [ ] **Step 4: L1 — Add caret-range comment to deny.toml skip-tree**
+
+In `deny.toml`, before the `html5ever` skip-tree entry (around line 111), add:
+
+```toml
+    # NOTE: cargo-deny interprets bare version strings as caret ranges
+    # (e.g., "0.35" matches ">=0.35.0, <0.36.0"). This is intentional
+    # here — ammonia floats its own transitive html5ever pin.
+```
+
+- [ ] **Step 5: L2 — Add Unicode-DFS-2016 TODO to rimap-content Cargo.toml**
+
+In `crates/rimap-content/Cargo.toml`, near the `license.workspace = true` line, add a comment:
+
+```toml
+# TODO: data/confusables.txt is licensed under Unicode-DFS-2016. If
+# this crate is ever published to crates.io, update the license field
+# to reflect the vendored data and add "Unicode-DFS-2016" to the
+# workspace deny.toml allow list.
+```
+
+- [ ] **Step 6: L3 — Create NOTICE file**
+
+Check the root NOTICE for the attribution text, then create `crates/rimap-content/data/NOTICE`:
+
+```
+Unicode Character Database — confusables.txt
+Copyright (c) 1991-2024 Unicode, Inc. All rights reserved.
+
+Licensed under the Unicode License v3 (Unicode-DFS-2016).
+Full text: https://www.unicode.org/license.txt
+
+Vendored from Unicode TR39 (Unicode 16.0).
+```
+
+- [ ] **Step 7: L4 — Add psl version pattern note**
+
+In `deny.toml`, add a comment near the bottom or in the `[bans]` section:
+
+```toml
+# psl (via addr) uses a versioning scheme where the patch number
+# tracks the Public Suffix List snapshot date (e.g. 2.1.200). This
+# is legitimate but looks like a massive version bump to naive
+# pattern matching.
+```
+
+- [ ] **Step 8: L5 — Tighten check-forbidden-macros.sh regex**
+
+In `scripts/check-forbidden-macros.sh`, change line ~14:
+
+From:
+```bash
+    grep -vE '(^|/)build\.rs$' ||
+```
+
+To:
+```bash
+    grep -vE '(^|/)crates/[^/]+/build\.rs$' ||
+```
+
+- [ ] **Step 9: Verify build + tests**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo test --package rimap-content
+cargo deny check
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add Cargo.toml deny.toml crates/rimap-content/Cargo.toml \
+  crates/rimap-content/data/NOTICE scripts/check-forbidden-macros.sh
+git commit -m "chore: supply-chain comment hygiene from Sprint 4b review
+
+M1: add 4 missing ICU4X proc-macros to R10 provenance block
+M2: rewrite idna line comment to reflect actual baseline
+M3: clarify phf_macros transitive entry via cssparser
+L1: document caret-range semantics in deny.toml skip-tree
+L2: add Unicode-DFS-2016 license TODO for vendored confusables.txt
+L3: create rimap-content/data/NOTICE with Unicode attribution
+L4: document psl version pattern
+L5: tighten check-forbidden-macros.sh build.rs exemption regex
+
+Closes #54.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Mutants rerun + verification pass
+
+**Files:**
+- Modify: `docs/superpowers/mutants-survivors.md`
+
+- [ ] **Step 1: Run just ci to verify everything is green**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+just ci
+```
+
+Expected: all green in ~2m 20s.
+
+- [ ] **Step 2: Run mutants (long — ~76 min)**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+cargo mutants --package rimap-content --timeout 120
+```
+
+Expected: library kill rate >= 85%. Record the exact numbers.
+
+- [ ] **Step 3: Update mutants-survivors.md**
+
+Update `docs/superpowers/mutants-survivors.md` with:
+- Sprint 5 Phase 1 run date
+- Library kill rate
+- Whole-crate kill rate
+- New survivor list (if any new easy kills, add targeted tests in a follow-up)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add docs/superpowers/mutants-survivors.md
+git commit -m "docs(content): update mutants-survivors.md with Sprint 5 Phase 1 numbers
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: Sprint 5 Phase 1 handoff doc
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-10-sprint-5-phase1-handoff.md`
+
+- [ ] **Step 1: Write handoff document**
+
+Summarize what Phase 1 shipped: warning renames, new variants, ammonia hardening, bypass fixes (CDATA, double-extension, PSL skip, off-screen threshold), Reply-To plumbing, address extraction consistency, build.rs strictness, supply-chain comments, mutants verification. List test totals. Note any API findings or gotchas. State Phase 2 prerequisites.
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp-sprint5
+git add docs/superpowers/plans/2026-04-10-sprint-5-phase1-handoff.md
+git commit -m "docs(sprint-5): Phase 1 handoff to Phase 2
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-04-12-sprint-5-phase2a-imap-mutations.md
+++ b/docs/superpowers/plans/2026-04-12-sprint-5-phase2a-imap-mutations.md
@@ -1,0 +1,1179 @@
+# Sprint 5 Phase 2a — IMAP Mutations + `spawn_blocking`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add STORE, MOVE, and APPEND operations to `rimap-imap` and a `spawn_blocking` wrapper for `parse_message` in `rimap-server`.
+
+**Architecture:** Three new ops modules in `rimap-imap` (`store`, `move_msg`, `append`) following the existing pattern of free functions taking `&mut ImapSession`, with public methods on `Connection` providing timeout + reconnect wrapping. New types (`FlagAction`, `MoveResult`, `AppendResult`) in `types.rs`. A thin async wrapper in `rimap-server` for the CPU-bound content parser.
+
+**Tech Stack:** `async-imap 0.11` (STORE, COPY, MOVE, APPEND), `tokio::task::spawn_blocking`, existing Dovecot container harness for integration tests.
+
+**Spec:** [`../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md`](../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md) §2
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `crates/rimap-imap/src/types.rs` | Add `FlagAction`, `MoveResult`, `AppendResult` types |
+| `crates/rimap-imap/src/error.rs` | Add `BatchTooLarge` variant |
+| `crates/rimap-imap/src/ops/store.rs` | New: UID STORE free function |
+| `crates/rimap-imap/src/ops/move_msg.rs` | New: UID MOVE / COPY+DELETE free functions |
+| `crates/rimap-imap/src/ops/append.rs` | New: APPEND free function |
+| `crates/rimap-imap/src/ops/mod.rs` | Wire new modules |
+| `crates/rimap-imap/src/connection.rs` | Add `store_flags`, `move_messages`, `append_message` methods |
+| `crates/rimap-imap/src/lib.rs` | Re-export new public types |
+| `crates/rimap-imap/tests/integration/dovecot.rs` | Integration tests for STORE, MOVE, APPEND |
+| `crates/rimap-server/src/content.rs` | New: `parse_message_async` wrapper |
+| `crates/rimap-server/src/main.rs` | Wire `content` module |
+
+---
+
+### Task 1: Add `FlagAction` and `BatchTooLarge` to types/error
+
+**Files:**
+- Modify: `crates/rimap-imap/src/types.rs`
+- Modify: `crates/rimap-imap/src/error.rs`
+- Modify: `crates/rimap-imap/src/connection.rs` (update exhaustive match)
+
+- [ ] **Step 1: Add `FlagAction` enum to `types.rs`**
+
+Add after the `Flag` enum (after line 136):
+
+```rust
+/// Whether to add or remove flags in a STORE command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagAction {
+    /// `+FLAGS` — add the given flags.
+    Add,
+    /// `-FLAGS` — remove the given flags.
+    Remove,
+}
+```
+
+- [ ] **Step 2: Add `BatchTooLarge` variant to `error.rs`**
+
+Add a new variant to the `Error` enum (after the `Audit` variant, before the closing `}`):
+
+```rust
+    /// Caller passed more UIDs than the per-command batch limit.
+    #[error("ERR_BATCH_TOO_LARGE: {count} UIDs exceeds limit of {limit}")]
+    BatchTooLarge {
+        /// Number of UIDs the caller provided.
+        count: usize,
+        /// Maximum UIDs allowed per command.
+        limit: usize,
+    },
+```
+
+- [ ] **Step 3: Update the `From<Error> for RimapError` impl in `error.rs`**
+
+Add the new variant to the match in the `From` impl:
+
+```rust
+            Error::BatchTooLarge { .. } => ErrorCode::InvalidInput,
+```
+
+- [ ] **Step 4: Update the exhaustive match in `connection.rs` `fetch_body`**
+
+In `connection.rs`, the `should_invalidate` match (around line 523) lists every `Error` variant explicitly. Add `Error::BatchTooLarge { .. }` to the false arm alongside `Error::InvalidInput { .. }`:
+
+```rust
+            Err(
+                Error::Tls { .. }
+                | Error::TlsHandshake(_)
+                | Error::Connect(_)
+                | Error::Timeout { .. }
+                | Error::Auth { .. }
+                | Error::Protocol(_)
+                | Error::InvalidInput { .. }
+                | Error::BatchTooLarge { .. }
+                | Error::Audit { .. },
+            )
+            | Ok(_) => false,
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile, no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-imap/src/types.rs crates/rimap-imap/src/error.rs crates/rimap-imap/src/connection.rs
+git commit -m "feat(imap): add FlagAction enum and BatchTooLarge error variant"
+```
+
+---
+
+### Task 2: Implement STORE op
+
+**Files:**
+- Create: `crates/rimap-imap/src/ops/store.rs`
+- Modify: `crates/rimap-imap/src/ops/mod.rs`
+
+- [ ] **Step 1: Create `ops/store.rs` with the store function**
+
+```rust
+//! UID STORE: add or remove flags on messages by UID.
+
+use futures_util::TryStreamExt;
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::types::{Flag, FlagAction, Uid};
+
+/// Maximum UIDs per STORE command. Enforced defensively; callers
+/// should clamp before calling.
+const MAX_BATCH: usize = 100;
+
+/// Add or remove `flags` on `uids` in the currently selected folder.
+///
+/// Returns the UIDs the server confirmed as updated. The server may
+/// silently skip non-existent UIDs, so the returned vec can be shorter
+/// than `uids`.
+///
+/// # Errors
+///
+/// Returns `Error::BatchTooLarge` if `uids.len() > MAX_BATCH`.
+/// Propagates `Error::Protocol` from async-imap on IMAP failures.
+pub async fn store(
+    session: &mut ImapSession,
+    uids: &[Uid],
+    flags: &[Flag],
+    action: FlagAction,
+) -> Result<Vec<Uid>, Error> {
+    if uids.len() > MAX_BATCH {
+        return Err(Error::BatchTooLarge {
+            count: uids.len(),
+            limit: MAX_BATCH,
+        });
+    }
+    if uids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let uid_set = uid_set_string(uids);
+    let flag_str = flags_string(flags);
+    let query = match action {
+        FlagAction::Add => format!("+FLAGS ({flag_str})"),
+        FlagAction::Remove => format!("-FLAGS ({flag_str})"),
+    };
+
+    let fetches = session
+        .uid_store(&uid_set, &query)
+        .await
+        .map_err(Error::Protocol)?;
+
+    let items: Vec<_> = fetches
+        .try_collect()
+        .await
+        .map_err(Error::Protocol)?;
+
+    let mut updated = Vec::with_capacity(items.len());
+    for item in &items {
+        if let Some(uid_val) = item.uid {
+            if let Some(uid) = Uid::new(uid_val) {
+                updated.push(uid);
+            }
+        }
+    }
+
+    Ok(updated)
+}
+
+/// Format UIDs as a comma-separated set for IMAP commands.
+fn uid_set_string(uids: &[Uid]) -> String {
+    let mut s = String::new();
+    for (i, uid) in uids.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&uid.get().to_string());
+    }
+    s
+}
+
+/// Format flags as space-separated IMAP flag atoms.
+fn flags_string(flags: &[Flag]) -> String {
+    let mut s = String::new();
+    for (i, flag) in flags.iter().enumerate() {
+        if i > 0 {
+            s.push(' ');
+        }
+        match flag {
+            Flag::Seen => s.push_str("\\Seen"),
+            Flag::Answered => s.push_str("\\Answered"),
+            Flag::Flagged => s.push_str("\\Flagged"),
+            Flag::Deleted => s.push_str("\\Deleted"),
+            Flag::Draft => s.push_str("\\Draft"),
+            Flag::Recent => s.push_str("\\Recent"),
+            Flag::Keyword(k) => s.push_str(k),
+        }
+    }
+    s
+}
+```
+
+- [ ] **Step 2: Wire the module in `ops/mod.rs`**
+
+Add to `crates/rimap-imap/src/ops/mod.rs`:
+
+```rust
+pub mod store;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/store.rs crates/rimap-imap/src/ops/mod.rs
+git commit -m "feat(imap): implement UID STORE op for flag manipulation"
+```
+
+---
+
+### Task 3: Add `store_flags` method to `Connection`
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs`
+
+- [ ] **Step 1: Add `store_flags` method**
+
+Add after the `fetch_body` method (after line 541), following the existing pattern of timeout + invalidate-on-connection-lost:
+
+```rust
+    /// `UID STORE` — add or remove flags on messages.
+    ///
+    /// Batch limit: ≤100 UIDs. Returns the UIDs the server confirmed.
+    ///
+    /// # Errors
+    /// Returns `Error::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn store_flags(
+        &self,
+        folder: &str,
+        uids: &[crate::types::Uid],
+        flags: &[crate::types::Flag],
+        action: crate::types::FlagAction,
+    ) -> Result<Vec<crate::types::Uid>, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("store", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            // SELECT the folder first so STORE targets the right mailbox.
+            crate::ops::folders::select(session, folder, false).await?;
+            crate::ops::store::store(session, uids, flags, action).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/src/connection.rs
+git commit -m "feat(imap): add store_flags method to Connection"
+```
+
+---
+
+### Task 4: Implement MOVE op
+
+**Files:**
+- Create: `crates/rimap-imap/src/ops/move_msg.rs`
+- Modify: `crates/rimap-imap/src/ops/mod.rs`
+- Modify: `crates/rimap-imap/src/types.rs`
+
+- [ ] **Step 1: Add `MoveResult` to `types.rs`**
+
+Add after the `FlagAction` enum:
+
+```rust
+/// Result of moving a single message. `new_uid` is `None` when the
+/// server lacks UIDPLUS or when using the COPY+DELETE fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveResult {
+    /// UID in the source folder (before the move).
+    pub old_uid: Uid,
+    /// UID in the destination folder (after the move). `None` if the
+    /// server does not report it (no UIDPLUS, or COPY+DELETE fallback).
+    pub new_uid: Option<Uid>,
+}
+```
+
+- [ ] **Step 2: Create `ops/move_msg.rs`**
+
+```rust
+//! UID MOVE with COPY+DELETE fallback for servers without the MOVE
+//! extension (RFC 6851).
+
+use futures_util::TryStreamExt;
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::ops::store;
+use crate::types::{Flag, FlagAction, MoveResult, Uid};
+
+/// Maximum UIDs per MOVE command.
+const MAX_BATCH: usize = 100;
+
+/// Move `uids` from the currently selected folder to `dest_folder`.
+///
+/// Tries the MOVE extension first. If the server lacks MOVE capability,
+/// falls back to COPY + STORE \Deleted + EXPUNGE.
+///
+/// The MOVE extension path is atomic; the fallback is not — if the
+/// EXPUNGE fails after COPY+STORE, duplicates may exist. This is
+/// documented in the tool response.
+///
+/// # Errors
+///
+/// Returns `Error::BatchTooLarge` if `uids.len() > MAX_BATCH`.
+/// Propagates `Error::Protocol` from async-imap on IMAP failures.
+pub async fn move_messages(
+    session: &mut ImapSession,
+    dest_folder: &str,
+    uids: &[Uid],
+) -> Result<Vec<MoveResult>, Error> {
+    if uids.len() > MAX_BATCH {
+        return Err(Error::BatchTooLarge {
+            count: uids.len(),
+            limit: MAX_BATCH,
+        });
+    }
+    if uids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let uid_set = store::uid_set_string(uids);
+
+    // Try MOVE first; fall back to COPY+DELETE if the server rejects it.
+    let move_result = session
+        .uid_mv(&uid_set, dest_folder)
+        .await;
+
+    match move_result {
+        Ok(()) => {
+            // MOVE succeeded. async-imap's uid_mv returns () — no
+            // UIDPLUS data is exposed. Report new_uid as None.
+            Ok(uids
+                .iter()
+                .map(|&uid| MoveResult {
+                    old_uid: uid,
+                    new_uid: None,
+                })
+                .collect())
+        }
+        Err(e) => {
+            // Check if the error is "unknown command" or similar,
+            // indicating MOVE is unsupported. Otherwise propagate.
+            let msg = e.to_string();
+            if msg.contains("BAD")
+                || msg.contains("unknown command")
+                || msg.contains("not supported")
+            {
+                copy_delete_fallback(session, dest_folder, uids)
+                    .await
+            } else {
+                Err(Error::Protocol(e))
+            }
+        }
+    }
+}
+
+/// Fallback: COPY + STORE \Deleted + EXPUNGE. Not atomic.
+async fn copy_delete_fallback(
+    session: &mut ImapSession,
+    dest_folder: &str,
+    uids: &[Uid],
+) -> Result<Vec<MoveResult>, Error> {
+    let uid_set = store::uid_set_string(uids);
+
+    // Step 1: COPY to destination.
+    session
+        .uid_copy(&uid_set, dest_folder)
+        .await
+        .map_err(Error::Protocol)?;
+
+    // Step 2: STORE +FLAGS \Deleted on the originals.
+    store::store(
+        session,
+        uids,
+        &[Flag::Deleted],
+        FlagAction::Add,
+    )
+    .await?;
+
+    // Step 3: EXPUNGE to remove deleted messages. The stream yields
+    // sequence numbers of expunged messages; we drain it to completion.
+    let expunge_stream = session.expunge().await.map_err(Error::Protocol)?;
+    let _: Vec<_> = expunge_stream
+        .try_collect()
+        .await
+        .map_err(Error::Protocol)?;
+
+    Ok(uids
+        .iter()
+        .map(|&uid| MoveResult {
+            old_uid: uid,
+            new_uid: None,
+        })
+        .collect())
+}
+```
+
+- [ ] **Step 3: Make `uid_set_string` pub(crate) in `ops/store.rs`**
+
+In `crates/rimap-imap/src/ops/store.rs`, change:
+
+```rust
+fn uid_set_string(uids: &[Uid]) -> String {
+```
+
+to:
+
+```rust
+pub(crate) fn uid_set_string(uids: &[Uid]) -> String {
+```
+
+- [ ] **Step 4: Wire the module in `ops/mod.rs`**
+
+Add to `crates/rimap-imap/src/ops/mod.rs`:
+
+```rust
+pub mod move_msg;
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/move_msg.rs crates/rimap-imap/src/ops/mod.rs \
+  crates/rimap-imap/src/ops/store.rs crates/rimap-imap/src/types.rs
+git commit -m "feat(imap): implement UID MOVE op with COPY+DELETE fallback"
+```
+
+---
+
+### Task 5: Add `move_messages` method to `Connection`
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs`
+
+- [ ] **Step 1: Add `move_messages` method**
+
+Add after the `store_flags` method:
+
+```rust
+    /// Move messages from `source_folder` to `dest_folder`.
+    ///
+    /// Uses the IMAP MOVE extension (RFC 6851) when available; falls
+    /// back to COPY + STORE \Deleted + EXPUNGE when the server lacks
+    /// MOVE support. The fallback is not atomic.
+    ///
+    /// Batch limit: ≤100 UIDs.
+    ///
+    /// # Errors
+    /// Returns `Error::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn move_messages(
+        &self,
+        source_folder: &str,
+        dest_folder: &str,
+        uids: &[crate::types::Uid],
+    ) -> Result<Vec<crate::types::MoveResult>, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("move", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            // SELECT the source folder so MOVE/COPY targets the right mailbox.
+            crate::ops::folders::select(session, source_folder, false).await?;
+            crate::ops::move_msg::move_messages(session, dest_folder, uids).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/src/connection.rs
+git commit -m "feat(imap): add move_messages method to Connection"
+```
+
+---
+
+### Task 6: Implement APPEND op
+
+**Files:**
+- Create: `crates/rimap-imap/src/ops/append.rs`
+- Modify: `crates/rimap-imap/src/ops/mod.rs`
+- Modify: `crates/rimap-imap/src/types.rs`
+
+- [ ] **Step 1: Add `AppendResult` to `types.rs`**
+
+Add after the `MoveResult` struct:
+
+```rust
+/// Result of appending a message to a mailbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendResult {
+    /// UID assigned by the server. `None` if the server lacks UIDPLUS.
+    /// async-imap 0.11's `append()` does not expose the APPENDUID
+    /// response code, so this is always `None` for now.
+    pub uid: Option<Uid>,
+}
+```
+
+- [ ] **Step 2: Create `ops/append.rs`**
+
+```rust
+//! IMAP APPEND: upload a message to a mailbox.
+
+use crate::connection::ImapSession;
+use crate::error::Error;
+use crate::types::{AppendResult, Flag};
+
+/// Append a raw RFC 5322 message to `folder` with the given flags and
+/// keywords.
+///
+/// Keywords are IMAP keyword atoms (e.g. `"$PendingReview"`). They are
+/// appended to the flags string alongside system flags.
+///
+/// # Errors
+///
+/// Propagates `Error::Protocol` from async-imap on IMAP failures.
+pub async fn append(
+    session: &mut ImapSession,
+    folder: &str,
+    message: &[u8],
+    flags: &[Flag],
+    keywords: &[&str],
+) -> Result<AppendResult, Error> {
+    let flag_str = build_flags_string(flags, keywords);
+    let flags_arg = if flag_str.is_empty() {
+        None
+    } else {
+        Some(format!("({flag_str})"))
+    };
+
+    session
+        .append(folder, flags_arg.as_deref(), None, message)
+        .await
+        .map_err(Error::Protocol)?;
+
+    // async-imap 0.11's append() returns () — it does not parse the
+    // APPENDUID response code. UID is always None until upstream
+    // support or a post-APPEND STATUS+SEARCH workaround.
+    Ok(AppendResult { uid: None })
+}
+
+/// Build a space-separated flags + keywords string for the APPEND
+/// command.
+fn build_flags_string(flags: &[Flag], keywords: &[&str]) -> String {
+    use crate::ops::store::flags_string;
+
+    let mut s = flags_string(flags);
+    for kw in keywords {
+        if !s.is_empty() {
+            s.push(' ');
+        }
+        s.push_str(kw);
+    }
+    s
+}
+```
+
+- [ ] **Step 3: Make `flags_string` pub(crate) in `ops/store.rs`**
+
+In `crates/rimap-imap/src/ops/store.rs`, change:
+
+```rust
+fn flags_string(flags: &[Flag]) -> String {
+```
+
+to:
+
+```rust
+pub(crate) fn flags_string(flags: &[Flag]) -> String {
+```
+
+- [ ] **Step 4: Wire the module in `ops/mod.rs`**
+
+Add to `crates/rimap-imap/src/ops/mod.rs`:
+
+```rust
+pub mod append;
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/append.rs crates/rimap-imap/src/ops/mod.rs \
+  crates/rimap-imap/src/ops/store.rs crates/rimap-imap/src/types.rs
+git commit -m "feat(imap): implement APPEND op for message upload"
+```
+
+---
+
+### Task 7: Add `append_message` method to `Connection`
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs`
+
+- [ ] **Step 1: Add `append_message` method**
+
+Add after the `move_messages` method:
+
+```rust
+    /// `APPEND` a raw RFC 5322 message to `folder` with the given flags
+    /// and keywords.
+    ///
+    /// Does NOT select the folder first — APPEND targets a named mailbox
+    /// directly per RFC 3501 §6.3.11.
+    ///
+    /// # Errors
+    /// Propagates timeout, connection-lost, or protocol errors.
+    pub async fn append_message(
+        &self,
+        folder: &str,
+        message: &[u8],
+        flags: &[crate::types::Flag],
+        keywords: &[&str],
+    ) -> Result<crate::types::AppendResult, Error> {
+        let dur = self.inner.cfg.command_timeout;
+        let result = crate::time::with_timeout("append", dur, async {
+            let mut guard = self.session().await?;
+            let session = guard
+                .as_mut()
+                .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            crate::ops::append::append(session, folder, message, flags, keywords).await
+        })
+        .await;
+        if let Err(Error::ConnectionLost) = &result {
+            self.invalidate().await;
+        }
+        result
+    }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/src/connection.rs
+git commit -m "feat(imap): add append_message method to Connection"
+```
+
+---
+
+### Task 8: Update `lib.rs` exports
+
+**Files:**
+- Modify: `crates/rimap-imap/src/lib.rs`
+
+- [ ] **Step 1: Re-export new public types**
+
+The new types (`FlagAction`, `MoveResult`, `AppendResult`) are already public in `types.rs`, which is `pub mod types` in `lib.rs`. Users access them via `rimap_imap::types::FlagAction` etc. No additional re-exports needed at the crate root unless the existing pattern re-exports them.
+
+Check: the existing `lib.rs` only re-exports `Connection`, `ConnectionConfig`, `AuthFailure`, `Error`. The types module is public, so users access types directly. No changes needed.
+
+Run: `cargo check --package rimap-imap`
+Expected: clean compile.
+
+- [ ] **Step 2: Commit (skip if no changes)**
+
+No commit needed — this is a verification step.
+
+---
+
+### Task 9: Integration tests for STORE
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/dovecot.rs`
+- Modify: `crates/rimap-imap/tests/integration/support/fixtures.rs`
+
+- [ ] **Step 1: Add a fixture helper to seed a test message**
+
+Read `crates/rimap-imap/tests/integration/support/fixtures.rs` first to understand the existing fixture pattern. Then add a helper that creates a minimal RFC 5322 message for seeding via APPEND:
+
+```rust
+/// Minimal RFC 5322 message for test seeding.
+pub fn minimal_rfc5322(subject: &str) -> Vec<u8> {
+    format!(
+        "From: test@example.com\r\n\
+         To: recipient@example.com\r\n\
+         Subject: {subject}\r\n\
+         Date: Sat, 12 Apr 2026 12:00:00 +0000\r\n\
+         Message-ID: <test-{subject}@example.com>\r\n\
+         \r\n\
+         Test body for {subject}.\r\n"
+    )
+    .into_bytes()
+}
+```
+
+- [ ] **Step 2: Write STORE integration tests**
+
+Add to `dovecot.rs`:
+
+```rust
+#[tokio::test]
+async fn case_12_store_add_seen_flag() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message via APPEND.
+    let msg = support::fixtures::minimal_rfc5322("store-seen");
+    h.connection
+        .append_message("INBOX", &msg, &[], &[])
+        .await
+        .unwrap();
+
+    // Search for it.
+    let uids = h.connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("store-seen".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "seeded message not found");
+    let uid = uids[0];
+
+    // Add \Seen flag.
+    let updated = h.connection
+        .store_flags(
+            "INBOX",
+            &[uid],
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Add,
+        )
+        .await
+        .unwrap();
+    assert!(updated.contains(&uid));
+
+    // Verify the flag is set.
+    let fetched = h.connection
+        .fetch(
+            "INBOX",
+            &[uid],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(flags.contains(&rimap_imap::types::Flag::Seen));
+}
+
+#[tokio::test]
+async fn case_13_store_remove_seen_flag() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message with \Seen.
+    let msg = support::fixtures::minimal_rfc5322("store-unseen");
+    h.connection
+        .append_message("INBOX", &msg, &[rimap_imap::types::Flag::Seen], &[])
+        .await
+        .unwrap();
+
+    let uids = h.connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("store-unseen".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty());
+    let uid = uids[0];
+
+    // Remove \Seen flag.
+    let updated = h.connection
+        .store_flags(
+            "INBOX",
+            &[uid],
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Remove,
+        )
+        .await
+        .unwrap();
+    assert!(updated.contains(&uid));
+
+    // Verify the flag is removed.
+    let fetched = h.connection
+        .fetch(
+            "INBOX",
+            &[uid],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(!flags.contains(&rimap_imap::types::Flag::Seen));
+}
+
+#[tokio::test]
+async fn case_14_store_batch_too_large() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Create 101 fake UIDs.
+    let uids: Vec<rimap_imap::types::Uid> = (1..=101)
+        .map(|n| rimap_imap::types::Uid::new(n).unwrap())
+        .collect();
+
+    let result = h.connection
+        .store_flags(
+            "INBOX",
+            &uids,
+            &[rimap_imap::types::Flag::Seen],
+            rimap_imap::types::FlagAction::Add,
+        )
+        .await;
+
+    match result {
+        Err(rimap_imap::error::Error::BatchTooLarge { count: 101, limit: 100 }) => {}
+        other => panic!("expected BatchTooLarge, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 3: Run tests (skip if no Docker)**
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo test --package rimap-imap --test integration -- case_12 case_13 case_14`
+Expected: all three pass (with Docker) or skip silently (without).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/dovecot.rs \
+  crates/rimap-imap/tests/integration/support/fixtures.rs
+git commit -m "test(imap): integration tests for STORE flag operations"
+```
+
+---
+
+### Task 10: Integration tests for MOVE and APPEND
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/dovecot.rs`
+
+- [ ] **Step 1: Write APPEND integration test**
+
+```rust
+#[tokio::test]
+async fn case_15_append_message_to_inbox() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    let msg = support::fixtures::minimal_rfc5322("append-test");
+    let result = h.connection
+        .append_message(
+            "INBOX",
+            &msg,
+            &[rimap_imap::types::Flag::Draft],
+            &["$PendingReview"],
+        )
+        .await
+        .unwrap();
+
+    // async-imap doesn't expose APPENDUID, so uid is None.
+    assert_eq!(result.uid, None);
+
+    // Verify the message is in INBOX by searching for it.
+    let uids = h.connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("append-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "appended message not found");
+
+    // Verify it has the \Draft flag.
+    let fetched = h.connection
+        .fetch(
+            "INBOX",
+            &[uids[0]],
+            rimap_imap::types::FetchSpec {
+                flags: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let flags = fetched[0].flags.as_ref().unwrap();
+    assert!(flags.contains(&rimap_imap::types::Flag::Draft));
+}
+```
+
+- [ ] **Step 2: Write MOVE integration test**
+
+```rust
+#[tokio::test]
+async fn case_16_move_message_between_folders() {
+    let Some(h) = boot(PinChoice::Correct) else {
+        return;
+    };
+
+    // Seed a message in INBOX.
+    let msg = support::fixtures::minimal_rfc5322("move-test");
+    h.connection
+        .append_message("INBOX", &msg, &[], &[])
+        .await
+        .unwrap();
+
+    let uids = h.connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("move-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(!uids.is_empty(), "seeded message not found");
+    let uid = uids[0];
+
+    // Move to Archive (seeded in Dovecot entrypoint.sh).
+    let results = h.connection
+        .move_messages("INBOX", "Archive", &[uid])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].old_uid, uid);
+
+    // Verify the message is gone from INBOX.
+    let after_uids = h.connection
+        .search(
+            "INBOX",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("move-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(
+        after_uids.is_empty(),
+        "message should be gone from INBOX after move"
+    );
+
+    // Verify the message is in Archive.
+    let archive_uids = h.connection
+        .search(
+            "Archive",
+            rimap_imap::types::SearchQuery::Structured(
+                rimap_imap::types::StructuredQuery {
+                    subject: Some("move-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !archive_uids.is_empty(),
+        "message should be in Archive after move"
+    );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo test --package rimap-imap --test integration -- case_15 case_16`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/dovecot.rs
+git commit -m "test(imap): integration tests for APPEND and MOVE operations"
+```
+
+---
+
+### Task 11: `parse_message_async` wrapper in `rimap-server`
+
+**Files:**
+- Create: `crates/rimap-server/src/content.rs`
+- Modify: `crates/rimap-server/src/main.rs`
+
+- [ ] **Step 1: Create `content.rs`**
+
+```rust
+//! Async wrapper for the synchronous `rimap_content::parse_message`.
+
+use rimap_content::{Content, ContentError, parse_message};
+
+/// Run `parse_message` on the blocking threadpool to avoid starving
+/// the tokio runtime. `parse_message` is CPU-bound (~2ms per message).
+///
+/// # Errors
+///
+/// Returns `ContentError` from the inner call, or
+/// `ContentError::Malformed` if the blocking task panicked.
+pub async fn parse_message_async(
+    raw: Vec<u8>,
+) -> Result<Content, ContentError> {
+    tokio::task::spawn_blocking(move || parse_message(&raw))
+        .await
+        .unwrap_or_else(|e| {
+            Err(ContentError::Malformed {
+                reason: format!("spawn_blocking panicked: {e}"),
+            })
+        })
+}
+```
+
+Note: `ContentError` has three variants: `Malformed`, `LimitExceeded`,
+`Decoding`. A `JoinError` (task panicked) maps to `Malformed` since the
+message could not be processed. Phase 2b may add an `Internal` variant
+if needed for other server-side errors.
+
+- [ ] **Step 3: Wire the module in `main.rs`**
+
+Add to `crates/rimap-server/src/main.rs` (in the module declarations):
+
+```rust
+mod content;
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check --package rimap-server`
+Expected: clean compile. If `ContentError` lacks an `Internal` variant, adjust step 1.
+
+- [ ] **Step 5: Write a unit test**
+
+Add to the bottom of `content.rs`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parse_message_async_matches_sync() {
+        let raw = b"From: test@example.com\r\n\
+                     Subject: async test\r\n\
+                     \r\n\
+                     Body.\r\n"
+            .to_vec();
+
+        let sync_result = parse_message(&raw).unwrap();
+        let async_result = parse_message_async(raw).await.unwrap();
+
+        assert_eq!(sync_result.meta.subject, async_result.meta.subject);
+        assert_eq!(
+            sync_result.untrusted.body_text,
+            async_result.untrusted.body_text
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run the test**
+
+Run: `cargo test --package rimap-server -- content::tests`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/content.rs crates/rimap-server/src/main.rs
+git commit -m "feat(server): add parse_message_async spawn_blocking wrapper"
+```
+
+---
+
+### Task 12: Run `just ci` and verify
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CI suite**
+
+Run: `just ci`
+Expected: all tests pass, no warnings, `cargo deny check` clean.
+
+- [ ] **Step 2: Verify test count increased**
+
+The workspace test count should have increased from 459 (Phase 1 end) by the new unit + integration tests added in this phase.
+
+- [ ] **Step 3: Commit any fixups if needed**
+
+If `just ci` reveals issues (e.g., formatting, clippy warnings), fix and commit with `fix:` prefix.

--- a/docs/superpowers/plans/2026-04-12-sprint-5-phase2b-mcp-server.md
+++ b/docs/superpowers/plans/2026-04-12-sprint-5-phase2b-mcp-server.md
@@ -1,0 +1,1013 @@
+# Sprint 5 Phase 2b — MCP Server Wiring + Tool Handlers
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the rmcp MCP server with stdio transport, a posture-driven tool dispatch chain, and 9 v1 tool handlers (all except `create_draft`).
+
+**Architecture:** `ImapMcpServer` struct holds config, IMAP connection, authz matrix, rate limiter, circuit breaker, audit writer, and download dir. Tool dispatch follows a shared pipeline: authz → breaker → rate limit → audit ToolStart → execute → audit ToolEnd → response envelope. Each tool handler is a method on the server struct, registered via rmcp's `#[tool]` macro. Tools denied by posture are not registered (not advertised in `list_tools`).
+
+**Tech Stack:** `rmcp 1.4` (stdio MCP server), `schemars 1.0` (input JSON Schema), `infer 0.19` (MIME sniffing), `sha2 0.11` (attachment hashing), `rimap-imap` (IMAP ops from Phase 2a), `rimap-authz` (posture matrix, rate limiter, circuit breaker), `rimap-audit` (ToolStart/ToolEnd records).
+
+**Spec:** [`../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md`](../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md) §3
+
+**Phase 2a handoff:** STORE, MOVE, APPEND ops and `parse_message_async` are implemented and tested.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `Cargo.toml` (root) | Add `rmcp`, `schemars`, `infer` to workspace deps |
+| `crates/rimap-server/Cargo.toml` | Add dep references |
+| `deny.toml` | Entries for new crates |
+| `crates/rimap-server/src/main.rs` | Wire MCP server mode (replace placeholder) |
+| `crates/rimap-server/src/server.rs` | `ImapMcpServer` struct, `ServerHandler` impl |
+| `crates/rimap-server/src/dispatch.rs` | Shared dispatch pipeline (authz → breaker → rate limit → audit) |
+| `crates/rimap-server/src/error.rs` | `RimapError` → rmcp `ErrorData` mapping |
+| `crates/rimap-server/src/response.rs` | `meta`/`untrusted`/`security_warnings` envelope types |
+| `crates/rimap-server/src/download.rs` | Attachment download sandboxing (tempdir, path validation, MIME sniff, SHA256) |
+| `crates/rimap-server/src/tools/mod.rs` | Tool handler module, input/output types |
+| `crates/rimap-server/src/tools/list_folders.rs` | `list_folders` tool handler |
+| `crates/rimap-server/src/tools/search.rs` | `search` tool handler |
+| `crates/rimap-server/src/tools/fetch_message.rs` | `fetch_message` tool handler |
+| `crates/rimap-server/src/tools/list_attachments.rs` | `list_attachments` tool handler |
+| `crates/rimap-server/src/tools/download_attachment.rs` | `download_attachment` tool handler |
+| `crates/rimap-server/src/tools/flags.rs` | `mark_read`, `mark_unread`, `flag`, `unflag` handlers |
+| `crates/rimap-server/src/tools/move_message.rs` | `move_message` tool handler |
+
+---
+
+### Task 1: Add workspace dependencies
+
+**Files:**
+- Modify: `Cargo.toml` (root)
+- Modify: `crates/rimap-server/Cargo.toml`
+- Modify: `deny.toml`
+
+- [ ] **Step 1: Add dependencies to root `Cargo.toml`**
+
+Read `Cargo.toml` root, then add to `[workspace.dependencies]`:
+
+```toml
+rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
+schemars = "1.0"
+infer = "0.19"
+```
+
+Note: `sha2` is already in the workspace deps.
+
+- [ ] **Step 2: Add to `crates/rimap-server/Cargo.toml`**
+
+Add under `[dependencies]`:
+
+```toml
+rmcp = { workspace = true }
+schemars = { workspace = true }
+infer = { workspace = true }
+rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
+```
+
+Note: `rimap-imap` is not yet a dependency of rimap-server — add it.
+
+- [ ] **Step 3: Update `deny.toml`**
+
+Read the existing `deny.toml` to understand the format. Add `skip-tree` entries if rmcp pulls duplicate transitive crates (likely for `http`, `hyper`, etc. from disabled features — verify with `cargo deny check` output). Add license exceptions if needed.
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo check --package rimap-server && cargo deny check`
+Expected: compiles, deny check passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "chore(server): add rmcp, schemars, infer workspace dependencies"
+```
+
+---
+
+### Task 2: Response envelope types
+
+**Files:**
+- Create: `crates/rimap-server/src/response.rs`
+
+- [ ] **Step 1: Create response types**
+
+The MCP tool response envelope has three top-level fields: `meta`, `untrusted`, `security_warnings`. Tools return JSON content via rmcp. Define the envelope:
+
+```rust
+//! Response envelope types for MCP tool responses.
+//!
+//! Every tool returns a JSON object with three top-level fields:
+//! `meta` (trusted server metadata), `untrusted` (sanitized email
+//! content), and `security_warnings` (structured observations).
+
+use serde::Serialize;
+
+/// Top-level tool response envelope.
+#[derive(Debug, Serialize)]
+pub struct ToolResponse {
+    /// Server-controlled metadata. Trusted.
+    pub meta: serde_json::Value,
+    /// Sanitized content derived from email data. Untrusted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub untrusted: Option<serde_json::Value>,
+    /// Structured security observations. Trusted metadata.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security_warnings: Vec<serde_json::Value>,
+}
+```
+
+Use `serde_json::Value` for flexibility — tool handlers construct the specific shapes. This avoids a proliferation of per-tool output structs while keeping the envelope consistent.
+
+- [ ] **Step 2: Wire module**
+
+Add `mod response;` to `main.rs`.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo check --package rimap-server`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(server): add ToolResponse envelope types"
+```
+
+---
+
+### Task 3: Error mapping (RimapError → rmcp ErrorData)
+
+**Files:**
+- Create: `crates/rimap-server/src/error.rs`
+
+- [ ] **Step 1: Create error mapping module**
+
+Map `rimap_core::RimapError` to rmcp's `ErrorData`:
+
+```rust
+//! Map `RimapError` to rmcp `ErrorData` for MCP tool error responses.
+
+use rimap_core::{ErrorCode, RimapError};
+use rmcp::model::ErrorData;
+
+/// Convert a `RimapError` into an rmcp `ErrorData`.
+pub fn to_mcp_error(err: &RimapError) -> ErrorData {
+    let code = err.code();
+    let message = err.to_string();
+
+    // Map ErrorCode to appropriate rmcp error codes.
+    // rmcp uses JSON-RPC error codes (-32xxx) plus custom ranges.
+    match code {
+        ErrorCode::InvalidInput => {
+            ErrorData::invalid_params(message, None)
+        }
+        ErrorCode::PostureDenied => {
+            ErrorData::new(-32001, message, None)
+        }
+        ErrorCode::RateLimited => {
+            ErrorData::new(-32002, message, None)
+        }
+        ErrorCode::CircuitOpen => {
+            ErrorData::new(-32003, message, None)
+        }
+        ErrorCode::NotFound => {
+            ErrorData::new(-32004, message, None)
+        }
+        ErrorCode::ImapProtocol
+        | ErrorCode::Tls
+        | ErrorCode::Auth
+        | ErrorCode::ConnectionLost
+        | ErrorCode::Timeout => {
+            ErrorData::internal_error(message, None)
+        }
+        ErrorCode::AttachmentTooLarge => {
+            ErrorData::new(-32005, message, None)
+        }
+        ErrorCode::Config | ErrorCode::Internal => {
+            ErrorData::internal_error(message, None)
+        }
+    }
+}
+```
+
+Note: read rmcp's `ErrorData` API first to verify the constructor signatures. The above uses `ErrorData::new(code, message, data)`, `ErrorData::invalid_params(message, data)`, and `ErrorData::internal_error(message, data)`. Verify these exist.
+
+- [ ] **Step 2: Wire module**
+
+Add `mod error;` to `main.rs`. Note: this will conflict with the existing error handling via `anyhow`. The `error.rs` module is for MCP error mapping, not the server's own errors. Use a descriptive module name if needed (e.g., `mcp_error.rs`).
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo check --package rimap-server`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(server): add RimapError to MCP ErrorData mapping"
+```
+
+---
+
+### Task 4: Dispatch pipeline
+
+**Files:**
+- Create: `crates/rimap-server/src/dispatch.rs`
+
+- [ ] **Step 1: Create the dispatch wrapper**
+
+The dispatch pipeline runs before and after every tool handler:
+
+```rust
+//! Shared tool dispatch pipeline.
+//!
+//! Every tool handler passes through this pipeline:
+//! 1. Authz (posture matrix check)
+//! 2. Circuit breaker
+//! 3. Rate limiter
+//! 4. Audit ToolStart
+//! 5. Execute handler
+//! 6. Audit ToolEnd
+//! 7. Format response
+
+use rimap_audit::AuditWriter;
+use rimap_audit::record::{ToolEnd, ToolStart, ToolStatus};
+use rimap_authz::breaker::CircuitBreaker;
+use rimap_authz::guard::AuthzGuard;
+use rimap_authz::matrix::EffectiveMatrix;
+use rimap_authz::rate_limit::Governor;
+use rimap_core::RimapError;
+use rimap_core::tool::ToolName;
+
+use crate::response::ToolResponse;
+
+/// Run the pre-call guard chain: posture → breaker → rate limit.
+///
+/// Returns `Ok(())` if all guards pass, or `Err(RimapError)` with
+/// the first failure.
+pub fn pre_call_guards(
+    matrix: &EffectiveMatrix,
+    breaker: &CircuitBreaker<impl rimap_authz::breaker::Clock>,
+    governor: &Governor,
+    tool: ToolName,
+) -> Result<(), RimapError> {
+    matrix.check(tool)?;
+    breaker.pre_call()?;
+    governor.check(tool)?;
+    Ok(())
+}
+```
+
+Note: read the actual `AuthzGuard`, `EffectiveMatrix`, `Governor`, and `CircuitBreaker` APIs to verify the method signatures. The above is a sketch — adapt to match the real types.
+
+The audit ToolStart/ToolEnd records should be written by the server's call_tool method, not in this module. This module provides the guard chain.
+
+- [ ] **Step 2: Wire module**
+
+Add `mod dispatch;` to `main.rs`.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo check --package rimap-server`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(server): add pre-call dispatch guard chain"
+```
+
+---
+
+### Task 5: `ImapMcpServer` struct and `ServerHandler` impl
+
+**Files:**
+- Create: `crates/rimap-server/src/server.rs`
+
+This is the core of Phase 2b. The server struct holds all shared state, and the `ServerHandler` trait impl wires rmcp.
+
+- [ ] **Step 1: Define `ImapMcpServer`**
+
+```rust
+//! MCP server core: state, tool registration, and request dispatch.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rimap_audit::AuditWriter;
+use rimap_authz::breaker::CircuitBreaker;
+use rimap_authz::matrix::EffectiveMatrix;
+use rimap_authz::rate_limit::Governor;
+use rimap_config::validate::ValidatedConfig;
+use rimap_imap::Connection;
+use tokio::sync::Mutex;
+
+/// Shared MCP server state.
+pub struct ImapMcpServer {
+    pub(crate) config: ValidatedConfig,
+    pub(crate) imap: Connection,
+    pub(crate) matrix: EffectiveMatrix,
+    pub(crate) governor: Governor,
+    pub(crate) breaker: CircuitBreaker<rimap_authz::breaker::SystemClock>,
+    pub(crate) audit: AuditWriter,
+    pub(crate) download_dir: PathBuf,
+}
+```
+
+- [ ] **Step 2: Implement `ServerHandler`**
+
+The `ServerHandler` trait requires `get_info`, `list_tools`, and `call_tool`. For `list_tools`, only advertise tools the posture matrix allows. For `call_tool`, run the dispatch pipeline (guards → audit → execute → audit → response).
+
+Read the rmcp `ServerHandler` trait definition first. The `call_tool` implementation should:
+1. Parse the tool name from `request.name`
+2. Run `dispatch::pre_call_guards`
+3. Write `ToolStart` audit record
+4. Match on tool name and dispatch to the handler
+5. On success: write `ToolEnd` with success, return the response
+6. On error: write `ToolEnd` with error, return the MCP error
+7. On breaker/rate-limit failure: report to breaker, return error
+
+For `list_tools`, use `matrix.advertised()` to get allowed tool names, then build `Tool` objects with the tool name, description, and input schema. The input schema comes from `schemars` — each tool's input struct derives `JsonSchema`.
+
+Note: rmcp's `#[tool_router]` macro auto-registers all tools. Since we need posture-driven selective registration, we may need to implement `call_tool` manually instead of using the macro. Read the rmcp API to determine if `ToolRouter` supports filtering, or if we need manual dispatch.
+
+**Alternative approach (likely simpler):** Implement `call_tool` manually with a match on tool name, and `list_tools` manually using `matrix.advertised()`. This avoids fighting the macro system for dynamic registration.
+
+- [ ] **Step 3: Wire module and update `main.rs`**
+
+Add `mod server;` to `main.rs`. Replace the placeholder error in the server mode branch with actual server startup:
+
+```rust
+// Server mode: build and start MCP server.
+let config_path = resolve_cli_config_path(&cli)?;
+let raw = load_from_path(&config_path)
+    .with_context(|| format!("loading config {}", config_path.display()))?;
+let validated = validate(raw).context("validating config")?;
+let audit = audit_init::init_audit_writer(&validated, &config_path)?;
+
+// Build server components
+let matrix = EffectiveMatrix::from_validated(&validated);
+let governor = Governor::new(
+    validated.config.limits.commands_per_second,
+    validated.config.limits.drafts_per_minute,
+)?;
+let breaker = CircuitBreaker::new(SystemClock, BreakerConfig::default());
+
+// Connect to IMAP
+let conn_cfg = /* build ConnectionConfig from validated */;
+let imap = Connection::new(conn_cfg, audit.clone(), credentials);
+
+// Resolve download dir
+let download_dir = if validated.config.attachments.download_dir.is_empty() {
+    tempfile::tempdir()?.into_path()
+} else {
+    PathBuf::from(&validated.config.attachments.download_dir)
+};
+
+let server = ImapMcpServer {
+    config: validated,
+    imap,
+    matrix,
+    governor,
+    breaker,
+    audit,
+    download_dir,
+};
+
+// Start stdio MCP server
+let rt = tokio::runtime::Runtime::new()?;
+rt.block_on(async {
+    let (stdin, stdout) = rmcp::transport::io::stdio();
+    rmcp::service::serve_server(server, (stdin, stdout)).await
+})?;
+```
+
+Note: `main` is currently sync. Either make it `#[tokio::main] async fn main()` or use `rt.block_on`. Read the current `main.rs` and adapt — it currently uses a sync `fn main() -> ExitCode` pattern. The tokio runtime is already a dependency.
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo check --package rimap-server`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(server): add ImapMcpServer struct and ServerHandler impl"
+```
+
+---
+
+### Task 6: `list_folders` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/mod.rs`
+- Create: `crates/rimap-server/src/tools/list_folders.rs`
+
+- [ ] **Step 1: Create `tools/mod.rs`**
+
+```rust
+//! MCP tool handlers. Each module implements one v1 tool.
+
+pub mod list_folders;
+```
+
+- [ ] **Step 2: Implement `list_folders` handler**
+
+```rust
+//! `list_folders` tool handler.
+
+use serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
+
+use crate::server::ImapMcpServer;
+use crate::response::ToolResponse;
+
+/// Input for `list_folders`. No parameters required.
+#[derive(Debug, Deserialize, JsonSchema, Default)]
+pub struct ListFoldersInput {}
+
+/// A single folder in the response.
+#[derive(Debug, Serialize)]
+struct FolderEntry {
+    name: String,
+    delimiter: Option<char>,
+    flags: Vec<String>,
+    exists: Option<u32>,
+    unseen: Option<u32>,
+    uid_validity: Option<u32>,
+}
+
+/// Execute the `list_folders` tool.
+pub async fn handle(
+    server: &ImapMcpServer,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let folders = server.imap.list_folders("*").await?;
+
+    let mut entries = Vec::with_capacity(folders.len());
+    for folder in &folders {
+        // Get STATUS for each folder
+        let status = server.imap
+            .status(
+                &folder.name,
+                rimap_imap::types::StatusItems::all(),
+            )
+            .await?;
+
+        entries.push(FolderEntry {
+            name: folder.name.clone(),
+            delimiter: folder.delimiter,
+            flags: folder.attributes.clone(),
+            exists: status.messages,
+            unseen: status.unseen,
+            uid_validity: status.uid_validity,
+        });
+    }
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folders": serde_json::to_value(&entries)?,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+```
+
+Note: `serde_json::to_value` returns `Result` — handle the error by mapping to `RimapError::Internal`. Folder names should go through unicode sanitization per the spec — use `rimap_content::unicode::sanitize` if the function is public, or defer to Phase 2d cleanup.
+
+- [ ] **Step 3: Wire module and add `tools` to `main.rs`**
+
+Add `mod tools;` to `main.rs`.
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo check --package rimap-server`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(server): implement list_folders tool handler"
+```
+
+---
+
+### Task 7: `search` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/search.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement `search` handler**
+
+Input struct with all fields from spec §5 `search`:
+- `folder` (required)
+- `from`, `to`, `cc`, `subject`, `body` (optional substring match)
+- `since`, `before` (optional ISO dates)
+- `seen`, `flagged`, `has_attachment` (optional booleans)
+- `advanced_query` (optional raw IMAP SEARCH — requires `full` posture, guarded by `SearchAdvanced` tool check)
+- `limit` (optional, default 100, max capped)
+- `offset` (optional, default 0)
+
+The handler:
+1. Build `StructuredQuery` from input fields
+2. If `advanced_query` is present, check `matrix.check(ToolName::SearchAdvanced)` — return `ERR_POSTURE_DENIED` if denied
+3. IMAP SEARCH → UIDs
+4. FETCH ENVELOPE + FLAGS + SIZE for matched UIDs (paginated)
+5. Header-only sanitization via `parse_message_async` or lighter weight header extraction
+6. Return response with `meta.total_matched`, `meta.truncated`, `untrusted.messages[]`
+
+Note: search returns headers only, never body content. The handler should use FETCH ENVELOPE (already implemented in rimap-imap) rather than fetching full BODY[] and parsing. The lookalike scan on headers is deferred — it requires fetching the full message for `parse_message`, which is expensive for search results. Start with just ENVELOPE data, formatted into the response.
+
+- [ ] **Step 2: Wire in `tools/mod.rs`**
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(server): implement search tool handler"
+```
+
+---
+
+### Task 8: `fetch_message` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/fetch_message.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement `fetch_message` handler**
+
+Input: `folder`, `uid`, `include_html` (optional bool), `max_body_bytes` (optional usize).
+
+The handler:
+1. If `include_html=true`, check `matrix.check(ToolName::FetchMessageHtml)` — return `ERR_POSTURE_DENIED` if denied
+2. IMAP FETCH BODY[] via `server.imap.fetch_body(folder, uid)`
+3. `parse_message_async(raw)` → `Content`
+4. Build response from `Content`: meta (folder, uid, message_id, size), untrusted (headers, common_headers, body_text, body_html if allowed, attachments), security_warnings
+5. If `max_body_bytes` is set, truncate `body_text` and `body_html` and set `meta.truncated = true`
+
+This is the most complex handler because it uses the full content pipeline.
+
+- [ ] **Step 2: Wire and commit**
+
+```bash
+git commit -m "feat(server): implement fetch_message tool handler"
+```
+
+---
+
+### Task 9: `list_attachments` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/list_attachments.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement `list_attachments` handler**
+
+Input: `folder`, `uid`.
+
+The handler:
+1. IMAP FETCH BODYSTRUCTURE via `server.imap.fetch(folder, &[uid], FetchSpec { bodystructure: true, .. })`
+2. Walk the `BodyStructure` tree to extract attachment metadata (part_id, filename, mime_type, size)
+3. Filenames through `rimap_content::parse::sanitize_filename` if public, otherwise sanitize in-place
+4. Return response with `untrusted.attachments[]`
+
+- [ ] **Step 2: Wire and commit**
+
+```bash
+git commit -m "feat(server): implement list_attachments tool handler"
+```
+
+---
+
+### Task 10: Attachment download sandboxing
+
+**Files:**
+- Create: `crates/rimap-server/src/download.rs`
+
+- [ ] **Step 1: Implement download sandboxing**
+
+```rust
+//! Attachment download sandboxing: path validation, filename
+//! de-duplication, MIME sniffing, and SHA-256 hashing.
+
+use std::path::{Path, PathBuf};
+
+use rimap_core::RimapError;
+
+/// Resolve and validate the destination path for an attachment download.
+///
+/// If `dest_dir` is provided, canonicalize it and verify it starts
+/// with `allowed_root`. If not provided, use `fallback_dir`.
+///
+/// Returns `Err(RimapError)` on path traversal attempts.
+pub fn resolve_dest_dir(
+    dest_dir: Option<&str>,
+    allowed_root: &Path,
+    fallback_dir: &Path,
+) -> Result<PathBuf, RimapError> {
+    // ...
+}
+
+/// Write `data` to `dir/filename`, de-duplicating on collision.
+/// Returns the final path.
+pub fn write_attachment(
+    dir: &Path,
+    filename: &str,
+    data: &[u8],
+) -> Result<PathBuf, RimapError> {
+    // De-duplicate: try filename, then filename_1, filename_2, etc.
+    // ...
+}
+
+/// MIME-sniff `data` and return the detected type.
+pub fn sniff_mime(data: &[u8]) -> Option<String> {
+    infer::get(data).map(|t| t.mime_type().to_string())
+}
+
+/// SHA-256 hash of `data`, returned as lowercase hex.
+pub fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(data);
+    hex::encode(hash)
+}
+```
+
+- [ ] **Step 2: Add unit tests**
+
+Test `resolve_dest_dir` with:
+- Valid path within allowed root
+- Path traversal attempt (`../../../etc/passwd`)
+- No dest_dir provided (returns fallback)
+
+Test `write_attachment` with:
+- Normal write
+- Collision de-duplication
+
+Test `sha256_hex` with a known hash.
+
+- [ ] **Step 3: Wire module**
+
+Add `mod download;` to `main.rs`.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+git commit -m "feat(server): add attachment download sandboxing"
+```
+
+---
+
+### Task 11: `download_attachment` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/download_attachment.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement `download_attachment` handler**
+
+Input: `folder`, `uid`, `part_id`, `dest_dir` (optional).
+
+The handler:
+1. Resolve destination via `download::resolve_dest_dir`
+2. FETCH BODY[part_id] — this requires a new method or using `fetch_body` with a part specifier. Check if rimap-imap supports fetching individual parts. If not, fetch the full BODY[] and extract the part via rimap-content's MIME walk.
+3. Get filename from BODYSTRUCTURE metadata → `sanitize_filename`
+4. `download::write_attachment` to write to disk
+5. `download::sniff_mime` for MIME detection
+6. `download::sha256_hex` for integrity hash
+7. Return meta (path, size, sha256, mime_type_declared, mime_type_sniffed) + untrusted (filename_original)
+
+Note: FETCH BODY[part_id] is not yet implemented in rimap-imap. Options:
+a) Add a `fetch_part(folder, uid, part_id)` method to rimap-imap
+b) Fetch the full BODY[] and extract the part in the handler
+
+Option (a) is preferred for efficiency. If time-constrained, option (b) works since the body is already capped by `max_fetch_body_bytes`.
+
+- [ ] **Step 2: Wire and commit**
+
+```bash
+git commit -m "feat(server): implement download_attachment tool handler"
+```
+
+---
+
+### Task 12: Flag tool handlers (mark_read, mark_unread, flag, unflag)
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/flags.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement flag handlers**
+
+All four share the same pattern:
+
+```rust
+//! Flag mutation tool handlers: mark_read, mark_unread, flag, unflag.
+
+use serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
+
+use rimap_imap::types::{Flag, FlagAction};
+
+use crate::server::ImapMcpServer;
+use crate::response::ToolResponse;
+
+/// Input for flag mutation tools. Accepts a single UID or a batch.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FlagInput {
+    /// Target folder.
+    pub folder: String,
+    /// Single UID (mutually exclusive with `uids`).
+    pub uid: Option<u32>,
+    /// Batch of UIDs (≤100).
+    pub uids: Option<Vec<u32>>,
+}
+
+pub async fn handle_mark_read(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    handle_flag(server, input, &[Flag::Seen], FlagAction::Add).await
+}
+
+pub async fn handle_mark_unread(
+    server: &ImapMcpServer,
+    input: FlagInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    handle_flag(server, input, &[Flag::Seen], FlagAction::Remove).await
+}
+
+pub async fn handle_flag(
+    server: &ImapMcpServer,
+    input: FlagInput,
+    flags: &[Flag],
+    action: FlagAction,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uids = resolve_uids(&input)?;
+    let updated = server.imap
+        .store_flags(&input.folder, &uids, flags, action)
+        .await?;
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uids_updated": updated.iter()
+                .map(|u| u.get())
+                .collect::<Vec<_>>(),
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Resolve `uid` or `uids` from input to a Vec<Uid>.
+fn resolve_uids(input: &FlagInput) -> Result<Vec<rimap_imap::types::Uid>, rimap_core::RimapError> {
+    match (&input.uid, &input.uids) {
+        (Some(uid), None) => {
+            let u = rimap_imap::types::Uid::new(*uid)
+                .ok_or_else(|| rimap_core::RimapError::Internal(
+                    "UID must be non-zero".into()
+                ))?;
+            Ok(vec![u])
+        }
+        (None, Some(uids)) => {
+            let mut result = Vec::with_capacity(uids.len());
+            for &uid in uids {
+                let u = rimap_imap::types::Uid::new(uid)
+                    .ok_or_else(|| rimap_core::RimapError::Internal(
+                        "UID must be non-zero".into()
+                    ))?;
+                result.push(u);
+            }
+            Ok(result)
+        }
+        (Some(_), Some(_)) => Err(rimap_core::RimapError::Internal(
+            "provide uid or uids, not both".into(),
+        )),
+        (None, None) => Err(rimap_core::RimapError::Internal(
+            "provide uid or uids".into(),
+        )),
+    }
+}
+```
+
+- [ ] **Step 2: Wire in `tools/mod.rs`**
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(server): implement flag mutation tool handlers"
+```
+
+---
+
+### Task 13: `move_message` tool handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/move_message.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Implement `move_message` handler**
+
+Input: `source_folder`, `dest_folder`, `uid` or `uids` (≤100).
+
+Reuse `resolve_uids` from `flags.rs` (move it to `tools/mod.rs` or a shared module).
+
+```rust
+pub async fn handle(
+    server: &ImapMcpServer,
+    input: MoveInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let results = server.imap
+        .move_messages(&input.source_folder, &input.dest_folder, &uids)
+        .await?;
+
+    let moves: Vec<_> = results.iter().map(|r| {
+        serde_json::json!({
+            "old_uid": r.old_uid.get(),
+            "new_uid": r.new_uid.map(|u| u.get()),
+        })
+    }).collect();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "source_folder": input.source_folder,
+            "dest_folder": input.dest_folder,
+            "moves": moves,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+```
+
+- [ ] **Step 2: Wire and commit**
+
+```bash
+git commit -m "feat(server): implement move_message tool handler"
+```
+
+---
+
+### Task 14: Wire tool dispatch in `ServerHandler::call_tool`
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs`
+
+- [ ] **Step 1: Implement the `call_tool` dispatch**
+
+In the `ServerHandler` impl, `call_tool` matches on the tool name and dispatches to the handler:
+
+```rust
+async fn call_tool(
+    &self,
+    request: CallToolRequestParams,
+    context: RequestContext<RoleServer>,
+) -> Result<CallToolResult, McpError> {
+    let tool_name = ToolName::from_str(&request.name)
+        .map_err(|e| McpError::from(
+            ErrorData::invalid_params(e.to_string(), None)
+        ))?;
+
+    // Pre-call guards
+    if let Err(e) = dispatch::pre_call_guards(
+        &self.matrix, &self.breaker, &self.governor, tool_name,
+    ) {
+        self.breaker.on_failure(FailureReason::Authz);
+        return Err(McpError::from(error::to_mcp_error(&e)));
+    }
+
+    // Parse arguments
+    let args = request.arguments.unwrap_or_default();
+
+    // Dispatch to handler
+    let result = match tool_name {
+        ToolName::ListFolders => {
+            tools::list_folders::handle(self).await
+        }
+        ToolName::Search | ToolName::SearchAdvanced => {
+            let input = serde_json::from_value(
+                serde_json::Value::Object(args)
+            ).map_err(/* ... */)?;
+            tools::search::handle(self, input).await
+        }
+        ToolName::FetchMessage | ToolName::FetchMessageHtml => {
+            let input = serde_json::from_value(
+                serde_json::Value::Object(args)
+            ).map_err(/* ... */)?;
+            tools::fetch_message::handle(self, input).await
+        }
+        // ... etc for all tools
+        ToolName::CreateDraft => {
+            // Phase 2c — should not be registered
+            return Err(McpError::from(
+                ErrorData::internal_error("not implemented", None)
+            ));
+        }
+    };
+
+    match result {
+        Ok(response) => {
+            self.breaker.on_success();
+            let json = serde_json::to_string(&response)
+                .map_err(/* ... */)?;
+            Ok(CallToolResult::text_content(json, None))
+        }
+        Err(e) => {
+            self.breaker.on_failure(FailureReason::Imap);
+            Err(McpError::from(error::to_mcp_error(&e)))
+        }
+    }
+}
+```
+
+Note: this is a sketch. The exact rmcp types (`CallToolRequestParams`, `CallToolResult`, `McpError`, `RequestContext`) need to be verified against the actual rmcp API. Read the rmcp source to confirm.
+
+- [ ] **Step 2: Implement `list_tools`**
+
+```rust
+async fn list_tools(
+    &self,
+    _request: Option<PaginatedRequestParams>,
+    _context: RequestContext<RoleServer>,
+) -> Result<ListToolsResult, McpError> {
+    let allowed = self.matrix.advertised();
+    let tools: Vec<Tool> = allowed.iter()
+        .filter_map(|tn| tool_definition(*tn))
+        .collect();
+    Ok(ListToolsResult::with_all_items(tools))
+}
+```
+
+Where `tool_definition(tn)` returns a `Tool` with name, description, and input schema. The input schemas come from `schemars` — each tool's input struct can generate its schema via `schemars::schema_for!(InputType)`.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(server): wire tool dispatch in ServerHandler::call_tool"
+```
+
+---
+
+### Task 15: Update `main.rs` for MCP server mode
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+- [ ] **Step 1: Replace the placeholder error with actual server startup**
+
+The current `main.rs` server mode branch returns `Err("MCP server mode is not implemented")`. Replace it with the actual startup sequence from Task 5's outline.
+
+Key decisions:
+- Make `fn main()` stay sync, use `tokio::runtime::Runtime::new()?.block_on(...)` for the MCP server
+- OR make `main` async with `#[tokio::main]` — this is simpler but changes the existing pattern
+- Write `ProcessStart` audit record at startup, `ProcessEnd` at shutdown
+
+- [ ] **Step 2: Handle shutdown gracefully**
+
+On stdin close (MCP client disconnect), write `ProcessEnd` audit record and clean up tempdir if session-created.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(server): wire MCP server startup in main.rs"
+```
+
+---
+
+### Task 16: Run `just ci` and verify
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CI suite**
+
+Run: `just ci`
+Expected: all tests pass, no warnings, `cargo deny check` clean.
+
+- [ ] **Step 2: Commit any fixups**
+
+Fix formatting, clippy, or deny issues. Commit with `fix:` prefix.
+
+---
+
+## Notes for implementers
+
+### rmcp API patterns
+
+- `ServerHandler` trait requires `get_info()`, `list_tools()`, `call_tool()`
+- `CallToolResult::text_content(text, None)` for text responses
+- `ErrorData::invalid_params(msg, None)` for input errors
+- `ErrorData::internal_error(msg, None)` for server errors
+- `rmcp::transport::io::stdio()` returns `(stdin, stdout)` for stdio transport
+- `rmcp::service::serve_server(handler, transport)` starts the server
+
+### Posture-driven registration
+
+The key design choice is that tools denied by posture are NOT advertised. `list_tools` only returns tools for which `matrix.check(tool).is_ok()`. Sub-capabilities (`SearchAdvanced`, `FetchMessageHtml`) are checked at call time, not at registration time — the parent tool (`Search`, `FetchMessage`) is registered, and the sub-capability is guarded inside the handler.
+
+### `serde_json::Value` vs typed responses
+
+Use `serde_json::Value` for response construction to avoid a proliferation of output structs. The `ToolResponse` envelope wraps `meta`, `untrusted`, and `security_warnings` as `Value` / `Vec<Value>`. This keeps the code DRY while maintaining the spec's three-field structure.
+
+### Audit records
+
+`ToolStart` and `ToolEnd` records use the existing `rimap_audit::record` types. The `ToolStart` record includes the tool name and redacted arguments. The `ToolEnd` record includes the paired `ToolStart` seq, tool name, status (success/error), and provenance snapshot. Read `crates/rimap-audit/src/record.rs` for exact field shapes.

--- a/docs/superpowers/plans/2026-04-12-sprint-5-phase2c-create-draft.md
+++ b/docs/superpowers/plans/2026-04-12-sprint-5-phase2c-create-draft.md
@@ -1,0 +1,92 @@
+# Sprint 5 Phase 2c — `create_draft` Tool Handler
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `create_draft` MCP tool handler using `mail-builder` for RFC 5322 message construction, with threading header resolution, `$PendingReview` keyword, and draft-specific rate limiting.
+
+**Architecture:** The handler constructs an RFC 5322 message via `mail-builder`, optionally fetches threading headers from a referenced message, and APPENDs to the Drafts folder with `\Draft` flag and `$PendingReview` keyword. The draft rate limiter (already in `rimap-authz::Governor`) provides a separate bucket from the global rate limit.
+
+**Tech Stack:** `mail-builder 0.4` (RFC 5322 construction), `rimap-imap` APPEND op (from Phase 2a), `rimap-authz::Governor` draft bucket.
+
+**Spec:** [`../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md`](../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md) §4
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `Cargo.toml` (root) | Add `mail-builder` to workspace deps |
+| `crates/rimap-server/Cargo.toml` | Add dep reference |
+| `deny.toml` | Entry for `mail-builder`, `gethostname` if needed |
+| `crates/rimap-server/src/tools/create_draft.rs` | `create_draft` handler |
+| `crates/rimap-server/src/tools/mod.rs` | Wire module |
+| `crates/rimap-server/src/server.rs` | Replace placeholder dispatch |
+
+---
+
+### Task 1: Add `mail-builder` dependency
+
+**Files:**
+- Modify: `Cargo.toml` (root)
+- Modify: `crates/rimap-server/Cargo.toml`
+
+- [ ] **Step 1:** Add to `[workspace.dependencies]` in root Cargo.toml:
+```toml
+mail-builder = "0.4"
+```
+
+- [ ] **Step 2:** Add to `crates/rimap-server/Cargo.toml` under `[dependencies]`:
+```toml
+mail-builder = { workspace = true }
+```
+
+- [ ] **Step 3:** Run `cargo check --package rimap-server && cargo deny check`
+
+- [ ] **Step 4:** Commit:
+```bash
+git commit -m "chore(server): add mail-builder workspace dependency"
+```
+
+---
+
+### Task 2: Implement `create_draft` handler
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/create_draft.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+The handler:
+1. Parse input (to, cc, bcc, subject, body_text, in_reply_to_uid, in_reply_to_folder)
+2. If `in_reply_to_uid` is set, fetch the referenced message's Message-ID and References headers
+3. Construct RFC 5322 message via `mail_builder::MessageBuilder`
+4. APPEND to Drafts folder with `\Draft` flag and `$PendingReview` keyword
+5. Return meta with folder, uid, message_id, keywords
+
+Threading resolution:
+- Fetch the referenced message via `server.imap.fetch_body(folder, uid)`
+- Parse with `mail_parser` to extract Message-ID and References headers
+- Set `In-Reply-To` and `References` on the new message
+
+The "from" address comes from the config — `server.config.config.imap.username` as the email address (or a dedicated `email_address` config field if it exists).
+
+---
+
+### Task 3: Wire dispatch and test
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs`
+- Modify: `crates/rimap-server/src/tools/create_draft.rs` (add tests)
+
+Replace the `CreateDraft` placeholder in `dispatch_tool` with the real handler. Add unit tests:
+- Draft construction round-trips through `mail-parser`
+- Threading headers are set correctly when `in_reply_to_uid` is provided
+- Rate limit enforcement (6th draft in one minute returns error)
+
+---
+
+### Task 4: Run `just ci` and verify
+
+- [ ] Run `just ci`
+- [ ] Verify all tests pass
+- [ ] Commit any fixups

--- a/docs/superpowers/plans/2026-04-12-sprint-5-phase2d-e2e-docs.md
+++ b/docs/superpowers/plans/2026-04-12-sprint-5-phase2d-e2e-docs.md
@@ -1,0 +1,61 @@
+# Sprint 5 Phase 2d — End-to-End Tests, Documentation, Cleanup
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate the full MCP server with a scripted Dovecot smoke test, publish v0.1.0 documentation, clean up deferred items (epvme_runner tests, mutants rerun), and tag `v0.1.0`.
+
+**Architecture:** The e2e test starts the MCP server in-process against the Dovecot container, sends MCP tool requests, and validates responses including audit log assertions. Documentation describes existing behavior from code and specs.
+
+**Spec:** [`../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md`](../specs/2026-04-12-sprint-5-phase2-mcp-server-design.md) §5
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `crates/rimap-server/tests/e2e_dovecot.rs` | Full-session MCP smoke test |
+| `docs/configuration.md` | Config file format, all fields, defaults |
+| `docs/postures.md` | Three postures, tool matrix, overrides |
+| `docs/security-model.md` | Threat model, sanitization, audit, $PendingReview |
+| `docs/proton-bridge-setup.md` | Bridge install, fingerprint capture, config |
+| `docs/audit-log.md` | JSONL schema, record types, rotation, merge |
+| `crates/rimap-content/tests/epvme_integration.rs` | epvme_runner integration tests |
+
+---
+
+### Task 1: End-to-end smoke test
+
+Write a Dovecot-backed integration test that exercises the full MCP tool chain. Gated behind `RIMAP_REQUIRE_DOCKER=1`.
+
+### Task 2: Documentation — configuration.md
+
+Config file format, all fields with defaults, env var overrides, credential resolution.
+
+### Task 3: Documentation — postures.md
+
+Three postures, the tool matrix, per-tool overrides, list_tools behavior.
+
+### Task 4: Documentation — security-model.md
+
+Threat model summary, sanitization pipeline, lookalike detection, audit log, $PendingReview.
+
+### Task 5: Documentation — proton-bridge-setup.md
+
+Bridge install, TLS fingerprint capture, config example, known quirks.
+
+### Task 6: Documentation — audit-log.md
+
+JSONL schema, record types, rotation, `audit merge`, operator notes.
+
+### Task 7: epvme_runner integration tests
+
+Tests for `collect_eml_files` and `run_dataset` over fixture directory.
+
+### Task 8: Mutants rerun
+
+Run `cargo mutants --package rimap-content --timeout 120`, update docs.
+
+### Task 9: Final CI verification and v0.1.0 readiness
+
+Run `just ci`, verify all exit criteria, prepare for tag.

--- a/docs/superpowers/specs/2026-04-10-sprint-5-phase1-remediation-design.md
+++ b/docs/superpowers/specs/2026-04-10-sprint-5-phase1-remediation-design.md
@@ -1,0 +1,381 @@
+# Sprint 5 Phase 1 — Content Pipeline Remediation Design
+
+**Status:** Approved 2026-04-10
+**Parent spec:** [`2026-04-07-rusty-imap-mcp-design.md`](2026-04-07-rusty-imap-mcp-design.md) §Sprint 5
+**Sprint 4b handoff:** [`../plans/2026-04-08-sprint-4b-to-5-handoff.md`](../plans/2026-04-08-sprint-4b-to-5-handoff.md)
+**Branch:** `feat/sprint-5`
+
+## 1. Scope and Strategy
+
+Sprint 5 is a two-phase sprint:
+
+- **Phase 1** (this spec): Close out high-priority Sprint 4b remediation
+  items against `rimap-content`. Fixes warning semantics, bypass classes,
+  Reply-To gaps, ammonia hardening, and supply-chain comment hygiene.
+- **Phase 2** (separate spec): MCP server wiring (`rimap-server` tool
+  handlers, IMAP STORE/MOVE/APPEND, `spawn_blocking`, end-to-end tests).
+
+### Issues addressed
+
+| Issue | Items included | Items deferred |
+|-------|---------------|----------------|
+| #49 (posture + warning semantics) | All 4 items | — |
+| #50 (Reply-To + Auth-Results gaps) | Items 1, 3 (Reply-To, addr consistency) | Item 2 (Authentication-Results parser) |
+| #51 (bypass classes) | Items 2–5 (CDATA, double-ext, PSL skip, off-screen) | Item 1 (rfc822 recursion) |
+| #52 (ammonia + charset hardening) | All 3 items | — |
+| #53 (operational readiness) | Items 3, 4 (build.rs, mutants rerun) | Items 1, 2 (spawn_blocking, epvme tests → Phase 2) |
+| #54 (supply-chain comment hygiene) | All items | — |
+
+### Deferred to Phase 2 or later
+
+- **Authentication-Results parser** (#50 item 2) — New module, new config
+  surface, not load-bearing for Phase 2 tool handlers.
+- **`message/rfc822` recursion** (#51 item 1) — Largest single item,
+  deferred since Sprint 4a. High value but high complexity; requires its
+  own design spec.
+- **`spawn_blocking` for `parse_message`** (#53 item 1) — Needed in
+  `rimap-server`, lands naturally in Phase 2.
+- **`epvme_runner` integration tests** (#53 item 2) — Phase 2 cleanup.
+
+### Approach
+
+Bottom-up by file to minimize merge conflicts:
+
+1. Warning semantics layer (`output.rs`)
+2. Ammonia hardening (`html.rs` — defensive)
+3. Bypass fixes (`html.rs` + `parse.rs`)
+4. Reply-To + address extraction (`parse.rs` + `lookalike.rs`)
+5. Hardening & verification (build.rs, proptest, mutants, comments)
+
+## 2. Warning Semantics Layer
+
+File: `crates/rimap-content/src/output.rs`
+
+### 2.1 Rename `HtmlHiddenContentStripped` → `HtmlHiddenContentDetected`
+
+The current name implies the payload is removed everywhere. In reality,
+hidden content is stripped from `body_text` but remains in `body_html`
+(by design — posture rules decide exposure). Rename the variant to
+reflect detection, not removal.
+
+Update the `severity()` match arm. All 22 insta snapshots regenerate.
+
+### 2.2 Add `HtmlAnchorUnparsableHref` variant
+
+New variant with severity `Informational`. Fires when
+`extract_registrable_domain()` returns `None` for an anchor href whose
+visible text looks like a URL/domain. Distinguishes "we checked and
+it's fine" from "we couldn't check."
+
+### 2.3 Document `HtmlLinkTextHrefMismatch` raw-DOM semantics
+
+Add doc comment on the variant:
+
+> Reflects the original message content, not the sanitized `body_html`.
+> An anchor stripped by ammonia may still produce this warning. This is
+> intentional — the warning is a signal about the message's intent,
+> not about the sanitized output.
+
+No code change beyond the comment. Detection stays pre-ammonia.
+
+### 2.4 Pin `detail` as opaque
+
+Add doc comment on `SecurityWarning::detail`:
+
+> Human-readable context string. Consumers MUST NOT parse this field
+> programmatically — use `code` and other typed fields for dispatch.
+> Format may change without notice.
+
+No structural change. If Phase 2 tool handlers need structured warning
+data, add typed fields to `SecurityWarning` incrementally.
+
+## 3. Ammonia Hardening
+
+File: `crates/rimap-content/src/html.rs`
+
+### 3.1 Explicit tag denial list
+
+In `build_ammonia_builder()`, call `Builder::rm_tags()` with: `script`,
+`style`, `iframe`, `object`, `embed`, `meta`, `base`, `link`, `form`,
+`input`, `button`, `textarea`, `svg`, `math`, `frame`, `frameset`,
+`noframes`, `applet`, `details`, `summary`.
+
+This pins behavior against ammonia default drift. The `details`/`summary`
+removal is new — collapsed content is invisible to humans glancing at
+rendered output but visible to LLMs reading HTML tokens.
+
+Test: `sanitize_drops_iframe_and_details` — pass each tag through
+`build_ammonia_builder().clean()`, assert stripped output.
+
+### 3.2 Explicit `strip_comments(true)`
+
+Call `.strip_comments(true)` in `build_ammonia_builder()`.
+
+Test: `body_html_has_no_html_comments` — verify `<!-- comment -->`
+is removed from sanitized output.
+
+## 4. Bypass Fixes
+
+### 4.1 CDATA text leak
+
+Files: `crates/rimap-content/src/html.rs` (`collect_visible_text` /
+`walk_element`)
+
+Sprint 4b's `html-tokenizer-divergence` fixture discovered that
+scraper/html5ever leaks JS source from CDATA sections into `body_text`
+as text nodes. The inner `<script>` tags are stripped but literal JS
+source survives.
+
+Fix: in `walk_element()`, skip text content that leaked through CDATA
+parsing. The exact mechanism depends on scraper's representation —
+validate in the worktree before implementing. The handoff characterizes
+this as a one-liner.
+
+Re-add CDATA payload to `html-tokenizer-divergence` fixture with
+`must_not_contain: ["alert(", "cdata-bypass"]`.
+
+### 4.2 PSL silent-skip → `HtmlAnchorUnparsableHref`
+
+File: `crates/rimap-content/src/html.rs` (`detect_mismatches`)
+
+In `detect_mismatches()`, when `extract_registrable_domain(href)`
+returns `None` but the existing `linkify` scan finds a URL in the
+anchor's visible text (i.e., the text looks like a clickable domain),
+emit `HtmlAnchorUnparsableHref` instead of silently skipping the
+anchor. This covers the case where an attacker crafts an href the PSL
+cannot resolve, paired with visible text pointing at a brand.
+
+Warning fields:
+- `code`: `HtmlAnchorUnparsableHref`
+- `detail`: `"href=<unparsable_url>,text=<visible_text>"`
+- `location`: `"body_html:anchor"`
+
+Corpus fixture: `html-anchor-unparsable-href` with an anchor whose
+href has an unresolvable PSL domain paired with brand-like visible text.
+
+### 4.3 Off-screen threshold loosening
+
+File: `crates/rimap-content/src/html.rs` (`detect_hidden`)
+
+Current: fires on `left <= -1000px` or `top <= -1000px` with
+`position: absolute|fixed`.
+
+Change to: fire on `left < -100px` or `top < -100px` (same position
+requirement). This catches `-999px` evasion while leaving small
+negative values (legitimate border tricks) alone.
+
+Add `transform: translate` pattern: parse inline `style` for
+`transform:` values matching `translate[XY]?\s*\(\s*-(\d+)` where the
+captured pixel value exceeds 100. Catches `translateX(-9999px)` and
+`translate(-500px, 0)`.
+
+Corpus fixture: `html-offscreen-evasion` with `left: -999px` and
+`transform: translateX(-9999px)` payloads, asserting
+`HtmlHiddenContentDetected`.
+
+### 4.4 Double-extension filename heuristic
+
+File: `crates/rimap-content/src/parse.rs` (`build_attachment_meta`)
+
+After the existing bidi-override check and before `sanitize_filename()`,
+add a double-extension check:
+
+1. Split filename on `.`
+2. If 3+ segments, extract penultimate and final extensions (lowercased)
+3. If penultimate is a document type AND final is an executable type,
+   emit `LookalikeFilenameExtensionSpoof`
+
+Document types: `pdf`, `doc`, `docx`, `xls`, `xlsx`, `png`, `jpg`,
+`jpeg`, `gif`, `txt`, `csv`, `rtf`.
+
+Executable types: `exe`, `dll`, `bat`, `cmd`, `ps1`, `vbs`, `js`,
+`scr`, `msi`, `app`, `dmg`, `sh`, `com`, `pif`, `jar`, `lnk`.
+
+Warning fields:
+- `code`: `LookalikeFilenameExtensionSpoof`
+- `detail`: `"reason=double_extension,visible=.<penultimate>,declared=.<penultimate>.<final>"`
+- `location`: `"attachment[<idx>]:filename"`
+
+The gap-pinning fixture at
+`tests/injection-corpus/attachment-double-extension/` currently asserts
+detector-absent behavior. When this detector lands, the snapshot diffs
+— that diff is the verification.
+
+## 5. Reply-To + Address Extraction
+
+### 5.1 Add `reply_to` to `ContentMeta`
+
+File: `crates/rimap-content/src/output.rs`
+
+Add `pub reply_to: Option<String>` to `ContentMeta`.
+
+### 5.2 Populate Reply-To in `extract_meta`
+
+File: `crates/rimap-content/src/parse.rs`
+
+In `extract_meta()`, populate `reply_to` via `first_address_string()`
+on `message.reply_to()`, matching the existing `from` pattern.
+
+### 5.3 Thread Reply-To through bidi audit
+
+File: `crates/rimap-content/src/parse.rs`
+
+In `parse_message()`, after the existing from/to/cc bidi audit calls,
+add a call for Reply-To: extract the first `Addr` from
+`message.reply_to()`, pass to `audit_addr_domain_bidi()` with
+`location = "header:reply_to"`.
+
+### 5.4 Add Reply-To pass in lookalike `scan_header_domains`
+
+File: `crates/rimap-content/src/lookalike.rs`
+
+Add a fourth block in `scan_header_domains()` after cc: extract domain
+from `meta.reply_to`, pass to `emit_classification()` with
+`location = "header:reply_to"`.
+
+### 5.5 Address extraction consistency
+
+Files: `crates/rimap-content/src/lookalike.rs`,
+`crates/rimap-content/src/parse.rs`
+
+Currently `extract_domain_from_address()` uses `rfind('@')` on the
+rendered string from `ContentMeta`. This can disagree with
+mail-parser's structured `Addr.address` on adversarial display-name
+attacks like `"Name <fake@x>" <real@y>`.
+
+Fix: add a field `header_domains: Vec<(String, String)>` to
+`LookalikeInput` — each entry is `(domain, location)`, pre-extracted
+at the `parse_message()` boundary using `addr.address` directly.
+`scan_header_domains()` iterates this vec instead of re-parsing
+`meta.from`/`to`/`cc`/`reply_to`.
+
+`extract_domain_from_address()` remains available for anchor-href and
+body-url passes in passes 2 and 3 of `audit()`.
+
+### 5.6 Corpus fixture
+
+Add `lookalike-reply-to-mismatch` with a Reply-To domain that triggers
+`LookalikeMixedScript` or `LookalikeIdnPunycode`.
+
+## 6. Hardening & Verification
+
+### 6.1 `build.rs` strictness
+
+File: `crates/rimap-content/build.rs`
+
+Two changes:
+
+1. **Fail on malformed rows.** Replace `eprintln!` + `continue` with
+   `panic!` on parse failure. Any skipped row becomes a build failure.
+   Add comment: "Bump EXPECTED_MIN and re-audit when regenerating from
+   a new Unicode version."
+2. **Tighten floor.** Change `assert!(seen.len() > 5000)` to
+   `assert!(seen.len() >= 6200)`. Unicode 16.0 produces ~6355 MA rows;
+   this catches silent format drift dropping more than ~2.5% of entries.
+
+### 6.2 Charset proptest
+
+File: new `crates/rimap-content/tests/proptest_charset.rs` (or appended
+to `proptest_html_lookalike.rs`)
+
+Property: generate arbitrary `Content-Type` charset parameter strings,
+construct a minimal `.eml` with that charset declaration, pass to
+`parse_message()`, assert the result is either
+`Err(ContentError::...)` or `Ok(Content)` where `body_text` is valid
+UTF-8. Run at 10k cases.
+
+### 6.3 Mutants rerun
+
+Run `cargo mutants --package rimap-content --timeout 120` early in the
+sprint. Confirm library kill rate >= 85%. Update
+`docs/superpowers/mutants-survivors.md` with measured numbers and new
+survivor list. If survivors reveal easy kills, add targeted tests.
+
+### 6.4 Supply-chain comment hygiene (#54)
+
+All items from issue #54. Zero code impact beyond comments, config
+annotations, and one shell script regex fix:
+
+- **M1:** Add 4 missing proc-macros (`yoke-derive`, `zerofrom-derive`,
+  `zerovec-derive`, `displaydoc`) to R10 provenance block in
+  `Cargo.toml`, identifying trust anchor as "unicode-org via ICU4X,
+  pulled through idna_adapter."
+- **M2:** Rewrite `idna` line comment: first `url`/`idna` entry in the
+  workspace, `idna 1.x` replaced in-crate Unicode tables with ICU4X
+  provider stack pulling ~20 new transitive crates. Accepted because
+  ICU4X is the unicode-org canonical path; re-audit on any minor bump.
+- **M3:** Rewrite `phf` default-features comment: our direct `phf`
+  declaration disables defaults; `phf_macros` still enters the graph
+  transitively via `cssparser`.
+- **L1:** Add comment to `deny.toml` skip-tree entries documenting
+  caret-range semantics.
+- **L2:** Add TODO comment in `crates/rimap-content/Cargo.toml` about
+  Unicode-DFS-2016 license for vendored `data/confusables.txt`.
+- **L3:** Create `crates/rimap-content/data/NOTICE` with Unicode
+  attribution matching root `NOTICE`.
+- **L4:** Add informational comment about `psl` version pattern
+  (patch tracks PSL snapshot date) in `deny.toml`.
+- **L5:** Tighten `scripts/check-forbidden-macros.sh` regex from
+  `(^|/)build\.rs$` to `(^|/)crates/[^/]+/build\.rs$`.
+
+## 7. Test Impact Summary
+
+### New corpus fixtures (4)
+
+| Fixture | Asserts |
+|---------|---------|
+| `html-anchor-unparsable-href` | `HtmlAnchorUnparsableHref` emitted |
+| `html-offscreen-evasion` | `HtmlHiddenContentDetected` on -999px and translateX |
+| `lookalike-reply-to-mismatch` | `LookalikeMixedScript` or `LookalikeIdnPunycode` on Reply-To |
+| (CDATA re-add to `html-tokenizer-divergence`) | `must_not_contain` for JS source |
+
+### Snapshot changes
+
+All 22 existing snapshots regenerate due to the
+`HtmlHiddenContentStripped` → `HtmlHiddenContentDetected` rename.
+The `attachment-double-extension` gap-pinning fixture snapshot diffs
+when the detector lands.
+
+### New unit tests
+
+| Test | File |
+|------|------|
+| `sanitize_drops_iframe_and_details` | `html.rs` |
+| `body_html_has_no_html_comments` | `html.rs` |
+
+### New proptest
+
+| Property | Cases | File |
+|----------|-------|------|
+| charset parameter → valid UTF-8 or error | 10,000 | `proptest_charset.rs` |
+
+## 8. Files Changed
+
+| File | Changes |
+|------|---------|
+| `crates/rimap-content/src/output.rs` | Rename variant, add variant, add `reply_to` field, doc comments |
+| `crates/rimap-content/src/html.rs` | Ammonia hardening, CDATA fix, PSL→warning, off-screen threshold, tests |
+| `crates/rimap-content/src/parse.rs` | Reply-To extraction, bidi audit, double-extension, header_domains for lookalike |
+| `crates/rimap-content/src/lookalike.rs` | Reply-To pass, `header_domains` on `LookalikeInput`, `scan_header_domains` rewrite |
+| `crates/rimap-content/build.rs` | Malformed-row panic, floor tightening |
+| `crates/rimap-content/tests/proptest_charset.rs` | New charset proptest |
+| `Cargo.toml` | Comment fixes (M1, M2, M3) |
+| `deny.toml` | Comment fixes (L1, L4) |
+| `crates/rimap-content/Cargo.toml` | Comment fix (L2) |
+| `crates/rimap-content/data/NOTICE` | New file (L3) |
+| `scripts/check-forbidden-macros.sh` | Regex tighten (L5) |
+| `docs/superpowers/mutants-survivors.md` | Updated numbers |
+| `tests/injection-corpus/` | 3 new fixtures + 1 fixture update |
+| `crates/rimap-content/tests/snapshots/` | 22+ snapshot regenerations |
+
+## 9. Out of Scope
+
+- Authentication-Results parser (#50 item 2)
+- `message/rfc822` recursion (#51 item 1)
+- `spawn_blocking` wiring (#53 item 1)
+- `epvme_runner` tests (#53 item 2)
+- `<style>` block class/id resolution (deferred since 4b)
+- Runtime-configurable limits (deferred since 4b)
+- Differential HTML oracle
+- cargo-fuzz harnesses
+- Phase 2 MCP server work

--- a/docs/superpowers/specs/2026-04-12-sprint-5-phase2-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-04-12-sprint-5-phase2-mcp-server-design.md
@@ -1,0 +1,679 @@
+# Sprint 5 Phase 2 — MCP Server, v1 Tool Surface, Draft-Safe Send
+
+**Status:** Approved 2026-04-12
+**Parent spec:** [`2026-04-07-rusty-imap-mcp-design.md`](2026-04-07-rusty-imap-mcp-design.md) §Sprint 5
+**Phase 1 handoff:** [`../plans/2026-04-10-sprint-5-phase1-handoff.md`](../plans/2026-04-10-sprint-5-phase1-handoff.md)
+**Branch:** `feat/sprint-5`
+
+## 1. Scope and Strategy
+
+Phase 2 wires the MCP server binary, implements all v1 tool handlers, adds
+IMAP mutation operations, and ships `v0.1.0`. It is decomposed into four
+sub-phases executed sequentially on `feat/sprint-5`:
+
+| Sub-phase | Scope | New deps |
+|-----------|-------|----------|
+| **2a** | IMAP mutations (STORE, MOVE, APPEND) + `spawn_blocking` | none |
+| **2b** | rmcp stdio transport, tool dispatch, 9 tool handlers, attachment sandboxing | `rmcp 1.4.0`, `infer`, `schemars 1.0` |
+| **2c** | `create_draft` handler: `mail-builder`, threading, `$PendingReview`, draft rate limit | `mail-builder 0.4.4` |
+| **2d** | End-to-end smoke test (Dovecot), 5 documentation files, `epvme_runner` tests, mutants rerun, `v0.1.0` tag |  none |
+
+### Issues addressed
+
+| Issue | Items included | Items deferred |
+|-------|---------------|----------------|
+| #8 (audit lifecycle glue) | ProcessStart/ProcessEnd in server startup/shutdown | — |
+| #53 item 1 (spawn_blocking) | Async wrapper in rimap-server | — |
+| #53 item 2 (epvme_runner tests) | Integration tests in 2d | — |
+
+### Deferred beyond Sprint 5
+
+- **#14, #18, #19** — security review tooling (post-v1)
+- **#32** — fetch_body backpressure (architectural, post-v1)
+- **#44, #45** — audit retention and backup exclusion (post-v1)
+- **#50 item 2** — Authentication-Results parser (needs own spec)
+- **#51 item 1** — `message/rfc822` recursion (needs own spec)
+
+## 2. Phase 2a — IMAP Mutations + `spawn_blocking`
+
+### 2.1 STORE (flag manipulation)
+
+File: `crates/rimap-imap/src/ops/store.rs` (new)
+
+```rust
+pub async fn store_flags(
+    &mut self,
+    folder: &str,
+    uids: &[MessageUid],
+    flags: &[Flag],
+    action: FlagAction,  // Add | Remove
+) -> Result<Vec<MessageUid>, ImapError>;
+```
+
+- Uses UID STORE, not sequence numbers.
+- Batch-bounded: `rimap-imap` enforces ≤100 UIDs defensively. Returns
+  `ImapError::BatchTooLarge` if exceeded.
+- Returns the UIDs that were actually updated (IMAP server may silently
+  skip non-existent UIDs).
+
+Four tool-level operations map to this:
+
+| Tool | Flags | Action |
+|------|-------|--------|
+| `mark_read` | `\Seen` | Add |
+| `mark_unread` | `\Seen` | Remove |
+| `flag` | `\Flagged` | Add |
+| `unflag` | `\Flagged` | Remove |
+
+### 2.2 MOVE
+
+File: `crates/rimap-imap/src/ops/move_msg.rs` (new)
+
+```rust
+pub async fn move_messages(
+    &mut self,
+    source_folder: &str,
+    dest_folder: &str,
+    uids: &[MessageUid],
+) -> Result<Vec<MoveResult>, ImapError>;
+
+pub struct MoveResult {
+    pub old_uid: MessageUid,
+    pub new_uid: Option<MessageUid>,  // None without UIDPLUS
+}
+```
+
+- Capability-check `MOVE` extension first.
+- Fallback: `COPY` + `STORE +FLAGS \Deleted` + `EXPUNGE` when MOVE is
+  absent. The fallback is not atomic — this is documented in the error
+  type and the `move_message` tool response.
+- Same ≤100 UID batch cap.
+
+### 2.3 APPEND (for drafts)
+
+File: `crates/rimap-imap/src/ops/append.rs` (new)
+
+```rust
+pub async fn append_message(
+    &mut self,
+    folder: &str,
+    message: &[u8],
+    flags: &[Flag],
+    keywords: &[&str],
+) -> Result<AppendResult, ImapError>;
+
+pub struct AppendResult {
+    pub uid: Option<MessageUid>,  // requires UIDPLUS
+}
+```
+
+- Takes raw RFC 5322 bytes (from `mail-builder` in Phase 2c).
+- Sets flags and keywords in the APPEND command.
+- Returns assigned UID if server supports UIDPLUS.
+
+### 2.4 `spawn_blocking` wrapper
+
+File: `crates/rimap-server/src/content.rs` (new)
+
+```rust
+pub async fn parse_message_async(
+    raw: &[u8],
+) -> Result<Content, ContentError> {
+    let raw = raw.to_vec();
+    tokio::task::spawn_blocking(move || {
+        rimap_content::parse_message(&raw)
+    }).await?
+}
+```
+
+- `parse_message` is CPU-bound (~2ms). `spawn_blocking` prevents it from
+  blocking the tokio runtime under concurrent MCP requests.
+- `JoinError` from `spawn_blocking` maps to `ContentError::Internal`.
+
+### 2.5 Testing (Phase 2a)
+
+- Integration tests against Dovecot container harness for each STORE
+  operation (add/remove `\Seen`, add/remove `\Flagged`).
+- Integration test for MOVE (with MOVE capability).
+- Integration test for MOVE fallback (COPY+DELETE path). Test by mocking
+  the capability response or configuring Dovecot without MOVE.
+- Integration test for APPEND: append a raw message to INBOX, verify it
+  appears with correct flags.
+- Batch cap enforcement: verify `BatchTooLarge` on 101 UIDs.
+- Unit test for `parse_message_async`: verify same result as sync call.
+
+## 3. Phase 2b — MCP Server Wiring + Tool Handlers
+
+### 3.1 New dependencies
+
+Add to `[workspace.dependencies]` in root `Cargo.toml`:
+
+```toml
+rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
+schemars = "1.0"
+infer = "0.19"
+sha2 = "0.11"
+```
+
+- `rmcp`: MCP server framework. Edition 2024, deps align with workspace
+  (`thiserror 2`, `tokio 1`, `serde 1`, `futures 0.3`).
+- `schemars`: JSON Schema generation for tool input structs. Used by rmcp
+  for `list_tools` schema advertisement.
+- `infer`: MIME type sniffing for `download_attachment`.
+- `sha2`: SHA-256 hashing for downloaded attachments.
+
+Update `deny.toml` with entries for all new crates. `cargo deny check`
+must pass.
+
+### 3.2 Server structure
+
+File: `crates/rimap-server/src/server.rs` (new)
+
+```rust
+struct ImapMcpServer {
+    config: Config,
+    imap: ImapClient,
+    matrix: EffectiveMatrix,
+    rate_limiter: RateLimiter,
+    breaker: CircuitBreaker,
+    audit: AuditWriter,
+    download_dir: PathBuf,  // resolved at startup
+}
+```
+
+### 3.3 Startup sequence
+
+In `main.rs`, when no subcommand is given (MCP server mode):
+
+1. Load and validate config.
+2. Initialize `AuditWriter` — write `ProcessStart` record (#8).
+3. Resolve `download_dir`: use configured `attachments.download_dir` if
+   set, otherwise create a per-session tempdir.
+4. Authenticate to IMAP server (TLS + login).
+5. Build `EffectiveMatrix` from config posture + per-tool overrides.
+6. Build `RateLimiter` and `CircuitBreaker` from config limits.
+7. Register tools: iterate `ToolName` variants, check
+   `matrix.allows(posture, tool)`, register only allowed tools with rmcp.
+8. Start rmcp stdio transport, serve until stdin closes.
+9. On shutdown: write `ProcessEnd` audit record, flush audit, clean up
+   tempdir if session-created.
+
+### 3.4 Tool dispatch chain
+
+File: `crates/rimap-server/src/dispatch.rs` (new)
+
+Every tool handler passes through a shared dispatch wrapper:
+
+```rust
+async fn dispatch<F, Fut, T>(
+    &self,
+    tool: ToolName,
+    args: &serde_json::Value,
+    f: F,
+) -> Result<ToolResponse, McpError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, ToolError>>,
+    T: Serialize,
+```
+
+Pipeline:
+
+1. **Authz** — verify `matrix.allows(posture, tool)` (defense-in-depth;
+   tool shouldn't be registered if denied, but check anyway).
+2. **Circuit breaker** — check breaker state. Auth failures trip
+   immediately. IMAP errors tracked in sliding window.
+3. **Rate limiter** — check global bucket. Draft-specific bucket checked
+   only for `create_draft` (Phase 2c).
+4. **Audit ToolStart** — write record with redacted args per config
+   policy.
+5. **Execute** — call the inner function.
+6. **Audit ToolEnd** — write record with outcome (success or error code).
+7. **Format response** — wrap result in the `meta` / `untrusted` /
+   `security_warnings` envelope.
+
+### 3.5 Response envelope
+
+Every tool response follows the design spec §5 structure:
+
+```json
+{
+  "meta": { },
+  "untrusted": { },
+  "security_warnings": [ ]
+}
+```
+
+- `meta`: server-controlled metadata. Trusted.
+- `untrusted`: sanitized content from email. Agents treat as untrusted.
+- `security_warnings`: structured observations from the sanitization and
+  lookalike layers. Trusted metadata.
+
+Tools that produce no untrusted content (e.g., flag mutations) omit the
+`untrusted` field or return it empty.
+
+### 3.6 Input validation via `schemars`
+
+Each tool's input struct derives `JsonSchema` via `schemars 1.0`:
+
+```rust
+#[derive(Deserialize, JsonSchema)]
+struct FetchMessageInput {
+    folder: String,
+    uid: u32,
+    include_html: Option<bool>,
+    max_body_bytes: Option<usize>,
+}
+```
+
+rmcp uses these schemas for `list_tools` advertisement and automatic
+input shape validation. Field-level semantic validation (e.g., folder
+name not empty, uid > 0) is done in the handler.
+
+### 3.7 Tool handler details
+
+#### `list_folders`
+
+- IMAP: LIST + STATUS (existing `rimap-imap` ops).
+- Content: folder names through `rimap_content::unicode::sanitize` (NFKC,
+  control char strip).
+- Response: `meta.folders[]` with `name`, `delimiter`, `flags`, `exists`,
+  `unseen`, `uid_validity`.
+
+#### `search`
+
+- Input: structured fields (from, to, subject, since, before, etc.) plus
+  `advanced_query` (full posture only — guarded by matrix check on
+  `search.advanced_query`).
+- IMAP: build SEARCH command from structured fields. FETCH ENVELOPE +
+  FLAGS + RFC822.SIZE for matched UIDs, paginated by `limit`/`offset`.
+- Content: header-only sanitization (NFKC, control char strip, lookalike
+  scan on From/To/Cc/Reply-To).
+- Response: `meta.total_matched`, `meta.truncated`,
+  `untrusted.messages[]`, `security_warnings[]`.
+- Search results include headers only — never body content.
+
+#### `fetch_message`
+
+- Input: `folder`, `uid`, `include_html` (optional), `max_body_bytes`
+  (optional).
+- `include_html=true` rejected unless matrix allows
+  `fetch_message.include_html`. Returns `ERR_FORBIDDEN` if denied.
+- IMAP: FETCH BODY[] for full raw message.
+- Content: `parse_message_async` → full `Content` struct.
+- Response: `meta` (folder, uid, message_id, size_bytes, truncated),
+  `untrusted` (headers, common_headers, mailing_list, body_text,
+  body_html_sanitized if allowed, attachments, link_warnings),
+  `security_warnings`.
+- `max_body_bytes` truncates `body_text` and `body_html_sanitized` on a
+  grapheme boundary. Sets `meta.truncated = true`.
+
+#### `list_attachments`
+
+- IMAP: FETCH BODYSTRUCTURE (existing `rimap-imap` op).
+- Content: attachment metadata from MIME structure walk. Filenames through
+  `sanitize_filename`.
+- Response: `meta`, `untrusted.attachments[]` (part_id,
+  filename_sanitized, mime_type, size_bytes), `security_warnings`.
+
+#### `download_attachment`
+
+- Input: `folder`, `uid`, `part_id`, `dest_dir` (optional).
+- Resolve destination:
+  1. If `dest_dir` provided: canonicalize, verify it starts with
+     configured `attachments.download_dir`. Reject path traversal with
+     `ERR_INVALID_PARAMS`.
+  2. If not provided: use session tempdir (created lazily on first
+     download, cleaned on server shutdown).
+- IMAP: FETCH BODY[part_id] for raw part bytes.
+- Filename: from MIME metadata → `rimap_content::sanitize_filename`.
+- De-duplicate on collision: append `_1`, `_2`, etc.
+- Write bytes to disk.
+- MIME sniff via `infer` on the written bytes.
+- SHA-256 hash via `sha2`.
+- Response: `meta.path`, `meta.size_bytes`, `meta.sha256`,
+  `meta.mime_type_declared`, `meta.mime_type_sniffed`,
+  `untrusted.filename_original`, `security_warnings`.
+
+#### `mark_read` / `mark_unread` / `flag` / `unflag`
+
+- Input: `folder`, `uid` or `uids` (≤100).
+- IMAP: `store_flags` from Phase 2a.
+- Response: `meta.folder`, `meta.uids_updated[]`.
+- No `untrusted` or `security_warnings` — pure metadata operations.
+
+#### `move_message`
+
+- Input: `source_folder`, `dest_folder`, `uid` or `uids` (≤100).
+- IMAP: `move_messages` from Phase 2a.
+- Response: `meta.source_folder`, `meta.dest_folder`,
+  `meta.moves[].old_uid`, `meta.moves[].new_uid`.
+- No `untrusted` or `security_warnings`.
+
+### 3.8 Error mapping
+
+Tool errors map to stable MCP error codes from the design spec §9:
+
+| Domain | Code |
+|--------|------|
+| Input validation | `ERR_INVALID_PARAMS` |
+| Authz denied | `ERR_FORBIDDEN` |
+| Rate limited | `ERR_RATE_LIMITED` |
+| Breaker open | `ERR_UNAVAILABLE` |
+| IMAP failure | `ERR_IMAP` |
+| TLS failure | `ERR_TLS` |
+| Content parse | `ERR_CONTENT` |
+| Internal | `ERR_INTERNAL` |
+
+Each error includes a human-readable `message` field. No email content
+leaks into error messages.
+
+### 3.9 Testing (Phase 2b)
+
+- Unit tests for the dispatch wrapper: mock IMAP client, verify audit
+  records written, verify error mapping for each error domain.
+- Unit tests per handler: mock IMAP responses → verify JSON response
+  structure matches spec.
+- Integration test: start MCP server in-process with Dovecot backend,
+  send tool requests, verify responses.
+- `cargo deny check` passes with all new dependencies.
+
+## 4. Phase 2c — `create_draft`
+
+### 4.1 New dependency
+
+Add to `[workspace.dependencies]`:
+
+```toml
+mail-builder = "0.4"
+```
+
+Same author/org as `mail-parser` (Stalwart Labs). Single runtime
+dependency (`gethostname`). Apache-2.0 OR MIT. Update `deny.toml`.
+
+### 4.2 Draft construction
+
+File: `crates/rimap-server/src/tools/create_draft.rs` (new)
+
+Input:
+
+```rust
+#[derive(Deserialize, JsonSchema)]
+struct CreateDraftInput {
+    to: Vec<Address>,
+    cc: Option<Vec<Address>>,
+    bcc: Option<Vec<Address>>,
+    subject: String,
+    body_text: String,
+    in_reply_to_uid: Option<u32>,
+    in_reply_to_folder: Option<String>,  // defaults to INBOX
+}
+```
+
+### 4.3 Threading header resolution
+
+When `in_reply_to_uid` is provided:
+
+1. FETCH the referenced message's `Message-ID` and `References` headers
+   from `in_reply_to_folder` (default INBOX).
+2. Set `In-Reply-To: <fetched-message-id>`.
+3. Set `References: <fetched-references> <fetched-message-id>` (appending
+   per RFC 5322 §3.6.4).
+4. If the fetch fails (message deleted, folder inaccessible), return
+   `ERR_INVALID_PARAMS` with detail explaining the referenced message
+   was not found. Do not silently drop threading.
+
+### 4.4 Message construction
+
+```rust
+let msg = MessageBuilder::new()
+    .from(config.email_address())
+    .to(input.to)
+    .cc(input.cc)
+    .bcc(input.bcc)
+    .subject(&input.subject)
+    .in_reply_to(referenced_message_id)
+    .references(references_chain)
+    .text_body(&input.body_text)
+    .write_to_vec()?;
+```
+
+- `Message-ID` auto-generated by `mail-builder` (uses hostname via
+  `gethostname`).
+- `Date` auto-generated.
+- Body is plain text only — no HTML composition in v1.
+
+### 4.5 IMAP APPEND
+
+```rust
+let result = imap.append_message(
+    &config.drafts_folder(),  // default "Drafts"
+    &msg,
+    &[Flag::Draft],
+    &["$PendingReview"],
+).await?;
+```
+
+- `\Draft` flag marks it as a draft.
+- `$PendingReview` keyword is the safety signal — agents and humans can
+  filter on this to find AI-created drafts awaiting review before manual
+  send.
+- Drafts folder name from config (default `"Drafts"`; Gmail uses
+  `"[Gmail]/Drafts"`, configurable).
+
+### 4.6 Rate limiting
+
+`create_draft` has its own rate limit bucket separate from the global one:
+
+- Config: `limits.drafts_per_minute` (default 5/min).
+- Enforced by the existing `RateLimiter` in `rimap-authz` which already
+  has a draft-specific bucket.
+- Exceeding the limit returns `ERR_RATE_LIMITED` with `retry_after_ms`.
+
+### 4.7 Response
+
+```json
+{
+  "meta": {
+    "folder": "Drafts",
+    "uid": 12345,
+    "message_id": "<generated-id@hostname>",
+    "keywords": ["$PendingReview"]
+  }
+}
+```
+
+- No `untrusted` block — the server constructed this content, it is
+  trusted.
+- No `security_warnings` — no adversarial input to scan.
+- `uid` is `null` if server lacks UIDPLUS.
+
+### 4.8 Audit
+
+- `ToolStart` logs: recipient addresses (redacted per config policy),
+  subject (redacted per config policy), `in_reply_to_uid` if present.
+  Body is NOT logged (too large; the draft is retrievable from the
+  mailbox).
+- `ToolEnd` logs: assigned UID and `message_id`.
+
+### 4.9 Testing (Phase 2c)
+
+- Unit test: construct a draft with threading headers, round-trip the raw
+  RFC 5322 bytes through `mail-parser`, verify expected headers present.
+- Unit test: `in_reply_to_uid` pointing to non-existent message returns
+  `ERR_INVALID_PARAMS`.
+- Unit test: rate limit enforcement — 6th draft in one minute returns
+  `ERR_RATE_LIMITED`.
+- Integration test (Dovecot): create draft → IMAP SELECT Drafts → verify
+  message exists with `\Draft` flag and `$PendingReview` keyword, verify
+  threading headers when `in_reply_to_uid` was provided.
+
+## 5. Phase 2d — End-to-End Tests, Documentation, Cleanup
+
+### 5.1 End-to-end smoke test (Dovecot)
+
+File: `tests/e2e_dovecot.rs` (or `crates/rimap-server/tests/e2e.rs`)
+
+A single scripted session against the Dovecot container harness:
+
+1. Start MCP server, authenticate to Dovecot.
+2. `list_folders` — verify INBOX and Drafts present.
+3. Seed a test message via IMAP APPEND (with attachment).
+4. `search` — search by From, verify hit.
+5. `fetch_message` — fetch seeded message, verify
+   `meta`/`untrusted`/`security_warnings` structure.
+6. `list_attachments` — verify attachment metadata.
+7. `download_attachment` — download, verify SHA256 and MIME sniff result.
+8. `flag` — flag the message, verify flags updated.
+9. `mark_read` — mark read, verify `\Seen` flag.
+10. `create_draft` — reply draft with `in_reply_to_uid`, verify threading.
+11. Fetch from Drafts — confirm `\Draft`, `$PendingReview`, threading
+    headers.
+12. `move_message` — move original to a test folder.
+13. `mark_unread` — mark unread in new location.
+
+**Audit log assertions:** after the session, read the audit JSONL:
+- `ProcessStart` record at the beginning.
+- `ToolStart`/`ToolEnd` record pairs for every tool invocation.
+- Redacted fields match config policy.
+- No `ToolEnd` records with error status.
+
+**Test gating:** behind `RIMAP_REQUIRE_DOCKER=1`. Skipped silently when
+no container runtime is available.
+
+**Proton Bridge:** manual validation only. Not automated.
+
+### 5.2 Documentation
+
+All under `docs/`:
+
+| File | Content |
+|------|---------|
+| `configuration.md` | Config file format, all fields with defaults, env var overrides, credential resolution (keyring, env, file) |
+| `postures.md` | Three postures (readonly, draft-safe, full), tool matrix, per-tool overrides, `list_tools` behavior |
+| `security-model.md` | Threat model summary, sanitization pipeline, lookalike detection, audit log as forensic record, `$PendingReview` gate |
+| `proton-bridge-setup.md` | Bridge install, TLS fingerprint capture walkthrough, config example, known quirks |
+| `audit-log.md` | JSONL schema, record types, rotation config, `audit merge` reference, operator notes on file permissions |
+
+These describe existing behavior. Written from the code and specs.
+
+### 5.3 `epvme_runner` integration tests
+
+Address the 44 surviving mutants from Sprint 4b in
+`src/bin/epvme_runner.rs`:
+
+- Add integration tests for `collect_eml_files` and `run_dataset` over a
+  small fixture directory (2-3 `.eml` files).
+- Verify correct output format, error handling on missing directory, and
+  fixture count reporting.
+
+### 5.4 Mutants rerun
+
+- Run `cargo mutants --package rimap-content --timeout 120`.
+- Confirm library kill rate ≥ 85% (up from 83.9% after Phase 1).
+- Update `docs/superpowers/mutants-survivors.md` with measured numbers.
+- If survivors reveal easy kills, add targeted tests.
+
+### 5.5 `v0.1.0` tag
+
+After all sub-phases merge to `main` and CI is green:
+
+1. Tag `v0.1.0` on `main`.
+2. Verify binary runs as MCP server against Claude Code / Claude Desktop.
+
+## 6. New Dependencies Summary
+
+| Crate | Version | Sub-phase | Purpose |
+|-------|---------|-----------|---------|
+| `rmcp` | 1.4 | 2b | MCP server framework (stdio transport, tool macros) |
+| `schemars` | 1.0 | 2b | JSON Schema for tool input structs |
+| `infer` | 0.19 | 2b | MIME type sniffing for attachment downloads |
+| `sha2` | 0.11 | 2b | SHA-256 hashing for attachment downloads |
+| `mail-builder` | 0.4 | 2c | RFC 5322 message construction for drafts |
+
+All require `deny.toml` updates. `cargo deny check` must pass before
+each sub-phase merges.
+
+## 7. Files Changed (by sub-phase)
+
+### Phase 2a
+
+| File | Changes |
+|------|---------|
+| `crates/rimap-imap/src/ops/store.rs` | New: STORE flag manipulation |
+| `crates/rimap-imap/src/ops/move_msg.rs` | New: MOVE with COPY+DELETE fallback |
+| `crates/rimap-imap/src/ops/append.rs` | New: APPEND for drafts |
+| `crates/rimap-imap/src/ops/mod.rs` | Wire new modules |
+| `crates/rimap-imap/src/types.rs` | `FlagAction`, `MoveResult`, `AppendResult` types |
+| `crates/rimap-imap/src/error.rs` | `BatchTooLarge` variant |
+| `crates/rimap-server/src/content.rs` | New: `parse_message_async` wrapper |
+
+### Phase 2b
+
+| File | Changes |
+|------|---------|
+| `Cargo.toml` | Add `rmcp`, `schemars`, `infer`, `sha2` to workspace deps |
+| `crates/rimap-server/Cargo.toml` | Add dep references |
+| `deny.toml` | Entries for new crates |
+| `crates/rimap-server/src/main.rs` | MCP server mode startup/shutdown |
+| `crates/rimap-server/src/server.rs` | New: `ImapMcpServer` struct |
+| `crates/rimap-server/src/dispatch.rs` | New: dispatch wrapper (authz → breaker → rate limit → audit → execute) |
+| `crates/rimap-server/src/tools/mod.rs` | New: tool handler module |
+| `crates/rimap-server/src/tools/list_folders.rs` | New |
+| `crates/rimap-server/src/tools/search.rs` | New |
+| `crates/rimap-server/src/tools/fetch_message.rs` | New |
+| `crates/rimap-server/src/tools/list_attachments.rs` | New |
+| `crates/rimap-server/src/tools/download_attachment.rs` | New |
+| `crates/rimap-server/src/tools/mark_read.rs` | New |
+| `crates/rimap-server/src/tools/mark_unread.rs` | New |
+| `crates/rimap-server/src/tools/flag.rs` | New |
+| `crates/rimap-server/src/tools/unflag.rs` | New |
+| `crates/rimap-server/src/tools/move_message.rs` | New |
+| `crates/rimap-server/src/download.rs` | New: attachment download sandboxing |
+
+### Phase 2c
+
+| File | Changes |
+|------|---------|
+| `Cargo.toml` | Add `mail-builder` to workspace deps |
+| `crates/rimap-server/Cargo.toml` | Add dep reference |
+| `deny.toml` | Entry for `mail-builder`, `gethostname` |
+| `crates/rimap-server/src/tools/create_draft.rs` | New: draft construction + threading |
+
+### Phase 2d
+
+| File | Changes |
+|------|---------|
+| `tests/e2e_dovecot.rs` | New: full-session smoke test |
+| `docs/configuration.md` | New |
+| `docs/postures.md` | New |
+| `docs/security-model.md` | New |
+| `docs/proton-bridge-setup.md` | New |
+| `docs/audit-log.md` | New |
+| `crates/rimap-content/tests/epvme_integration.rs` | New: epvme_runner tests |
+| `docs/superpowers/mutants-survivors.md` | Updated numbers |
+
+## 8. Exit Criteria (v0.1.0)
+
+All must be true before tagging:
+
+1. Binary runs as MCP server against Claude Code / Claude Desktop.
+2. Every v1 tool works against Proton Bridge (manual validation).
+3. Adversarial corpus still green.
+4. `just ci` green.
+5. Five documentation files published.
+6. Library mutant kill rate ≥ 85%.
+7. Tag `v0.1.0` on `main`.
+
+## 9. Out of Scope
+
+- Authentication-Results parser (#50 item 2)
+- `message/rfc822` recursion (#51 item 1)
+- `<style>` block class/id resolution (deferred since 4b)
+- Runtime-configurable content limits (deferred since 4b)
+- Differential HTML oracle
+- cargo-fuzz harnesses
+- Proton Bridge automated tests
+- HTTP/SSE transport (v3.x)
+- Direct SMTP send (v2)
+- Multi-account support (v3)

--- a/scripts/check-forbidden-macros.sh
+++ b/scripts/check-forbidden-macros.sh
@@ -12,7 +12,7 @@ while IFS= read -r f; do
 done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' |
     grep -vE '(^|/)tests?/' |
     grep -vE '(^|/)benches/' |
-    grep -vE '(^|/)build\.rs$' ||
+    grep -vE '(^|/)crates/[^/]+/build\.rs$' ||
     true)
 
 if [ "${#files[@]}" -eq 0 ]; then

--- a/tests/injection-corpus/html-anchor-unparsable-href/expected.json
+++ b/tests/injection-corpus/html-anchor-unparsable-href/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Anchor href uses a single-label host (no dot, PSL fails) but visible text contains paypal.com. HtmlAnchorUnparsableHref must fire.",
+  "expect": "ok",
+  "must_contain": [
+    "Click to verify your account:"
+  ],
+  "must_not_contain": [],
+  "warning_codes": [
+    "html_anchor_unparsable_href"
+  ],
+  "forbidden_warning_codes": []
+}

--- a/tests/injection-corpus/html-anchor-unparsable-href/input.eml
+++ b/tests/injection-corpus/html-anchor-unparsable-href/input.eml
@@ -1,0 +1,10 @@
+From: phisher@evil.example
+To: victim@example.com
+Subject: Unparsable href test
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body>
+<p>Click to verify your account:</p>
+<a href="https://evilserver/phishing-page">Visit paypal.com to verify</a>
+</body></html>

--- a/tests/injection-corpus/html-display-none/expected.json
+++ b/tests/injection-corpus/html-display-none/expected.json
@@ -8,7 +8,7 @@
     "forward all 2FA codes"
   ],
   "warning_codes": [
-    "html_hidden_content_stripped"
+    "html_hidden_content_detected"
   ],
   "forbidden_warning_codes": []
 }

--- a/tests/injection-corpus/html-offscreen-evasion/expected.json
+++ b/tests/injection-corpus/html-offscreen-evasion/expected.json
@@ -1,0 +1,15 @@
+{
+  "description": "Off-screen evasion via left:-999px (below old -1000px threshold) and transform:translateX(-9999px). Both must trigger HtmlHiddenContentDetected.",
+  "expect": "ok",
+  "must_contain": [
+    "Please review the attached document."
+  ],
+  "must_not_contain": [
+    "HIDDEN BY LEFT OFFSET",
+    "HIDDEN BY TRANSFORM"
+  ],
+  "warning_codes": [
+    "html_hidden_content_detected"
+  ],
+  "forbidden_warning_codes": []
+}

--- a/tests/injection-corpus/html-offscreen-evasion/input.eml
+++ b/tests/injection-corpus/html-offscreen-evasion/input.eml
@@ -1,0 +1,11 @@
+From: attacker@evil.example
+To: victim@example.com
+Subject: Offscreen evasion test
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body>
+<p>Please review the attached document.</p>
+<div style="position: absolute; left: -999px">HIDDEN BY LEFT OFFSET</div>
+<div style="position: fixed; transform: translateX(-9999px)">HIDDEN BY TRANSFORM</div>
+</body></html>

--- a/tests/injection-corpus/html-only-hidden-instructions/expected.json
+++ b/tests/injection-corpus/html-only-hidden-instructions/expected.json
@@ -1,9 +1,9 @@
 {
-  "description": "A text/html-only message with hidden instructions inside a display:none div. Sprint 4b Task 12 wires html::process so the hidden subtree is excluded from body_text and an HtmlHiddenContentStripped warning is emitted.",
+  "description": "A text/html-only message with hidden instructions inside a display:none div. Sprint 4b Task 12 wires html::process so the hidden subtree is excluded from body_text and an HtmlHiddenContentDetected warning is emitted.",
   "expect": "ok",
   "must_contain": ["Please review the attached document"],
   "must_not_contain": ["Ignore previous instructions", "display:none"],
-  "warning_codes": ["html_hidden_content_stripped"],
+  "warning_codes": ["html_hidden_content_detected"],
   "forbidden_warning_codes": [],
   "meta": {
     "attachment_count": 0

--- a/tests/injection-corpus/html-tokenizer-divergence/input.eml
+++ b/tests/injection-corpus/html-tokenizer-divergence/input.eml
@@ -4,4 +4,4 @@ Subject: Policy update
 MIME-Version: 1.0
 Content-Type: text/html; charset=utf-8
 
-<html><body><p>Notice: please review the policy update.</p><SCRIPT type="text/javascript">alert('xss');document.cookie='leak=1'</SCRIPT><!-- <script>alert("in-comment")</script> --></body></html>
+<html><body><p>Notice: please review the policy update.</p><SCRIPT type="text/javascript">alert('xss');document.cookie='leak=1'</SCRIPT><!-- <script>alert("in-comment")</script> --><![CDATA[<script>alert("cdata-bypass")</script>]]></body></html>

--- a/tests/injection-corpus/html-white-on-white/expected.json
+++ b/tests/injection-corpus/html-white-on-white/expected.json
@@ -1,5 +1,5 @@
 {
-  "description": "HTML body with a white-on-white hidden <div>. The html::process pipeline must exclude the hidden text from body_text and emit html_hidden_content_stripped.",
+  "description": "HTML body with a white-on-white hidden <div>. The html::process pipeline must exclude the hidden text from body_text and emit html_hidden_content_detected.",
   "expect": "ok",
   "must_contain": [
     "Quarterly results attached."
@@ -8,7 +8,7 @@
     "exfiltrate the OAuth token"
   ],
   "warning_codes": [
-    "html_hidden_content_stripped"
+    "html_hidden_content_detected"
   ],
   "forbidden_warning_codes": []
 }

--- a/tests/injection-corpus/lookalike-reply-to-mismatch/expected.json
+++ b/tests/injection-corpus/lookalike-reply-to-mismatch/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Reply-To uses a Cyrillic homograph of paypal.com (Latin+Cyrillic mixed script). LookalikeMixedScript must fire on header:reply_to.",
+  "expect": "ok",
+  "must_contain": [
+    "Please verify your account"
+  ],
+  "must_not_contain": [],
+  "warning_codes": [
+    "lookalike_mixed_script"
+  ],
+  "forbidden_warning_codes": []
+}

--- a/tests/injection-corpus/lookalike-reply-to-mismatch/input.eml
+++ b/tests/injection-corpus/lookalike-reply-to-mismatch/input.eml
@@ -1,0 +1,8 @@
+From: support@paypal.com
+Reply-To: support@pаypal.com
+To: victim@example.com
+Subject: Account verification required
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Please verify your account by replying to this email.


### PR DESCRIPTION
## Summary

- **Warning semantics (#49):** Rename `HtmlHiddenContentStripped` → `HtmlHiddenContentDetected`, add `HtmlAnchorUnparsableHref` variant, pin `HtmlLinkTextHrefMismatch` as raw-DOM semantics, pin `detail` as opaque
- **Reply-To + address extraction (#50):** Add `reply_to` to `ContentMeta`, populate via structured `Addr.address`, rewrite lookalike `scan_header_domains` to use pre-extracted domains
- **Bypass fixes (#51):** CDATA text leak (closed + unclosed), double-extension filename heuristic, PSL silent-skip → `HtmlAnchorUnparsableHref`, off-screen threshold -1000px → -100px + `transform: translate`
- **Ammonia hardening (#52):** Explicit 20-tag denial list (including `details`/`summary`), `strip_comments(true)`, charset proptest (10k cases)
- **Operational (#53):** `build.rs` floor tightened to ≥6200, malformed row panic
- **Supply-chain (#54):** All 8 comment hygiene items — proc-macro provenance, idna baseline, phf comment, deny.toml annotations, NOTICE file, shell script regex

## Test plan

- [ ] `just ci` green (459 tests, 0 failures)
- [ ] 25 corpus fixtures (3 new: offscreen evasion, unparsable href, Reply-To mismatch)
- [ ] 25 insta snapshots regenerated
- [ ] 9 proptest properties at 10k cases (1 new: charset parameter)
- [ ] `cargo deny check` clean
- [ ] Run `cargo mutants --package rimap-content --timeout 120` to verify kill rate ≥85%

Closes #49, #52, #54. Partially addresses #50 (items 1, 3), #51 (items 2-5), #53 (items 3-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)