### PR TITLE
fix: post-sprint 5 issue fixes (#56-#65, #44, #45, #8)

### DIFF
--- a/crates/rimap-audit/src/backup_exclude.rs
+++ b/crates/rimap-audit/src/backup_exclude.rs
@@ -1,0 +1,68 @@
+//! Exclude audit directories from macOS Time Machine backups.
+//!
+//! On macOS, calls `tmutil addexclusion -p <path>`. No-op on other
+//! platforms. Best-effort: logs a warning on failure.
+
+use std::path::Path;
+
+/// Exclude `path` from Time Machine backups (macOS only).
+/// Best-effort: logs a warning on failure, never propagates errors.
+pub fn exclude_from_backup(path: &Path) {
+    #[cfg(target_os = "macos")]
+    exclude_macos(path);
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = path;
+}
+
+#[cfg(target_os = "macos")]
+fn exclude_macos(path: &Path) {
+    match std::process::Command::new("tmutil")
+        .args(["addexclusion", "-p"])
+        .arg(path)
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            tracing::debug!(
+                path = %path.display(),
+                "excluded audit directory from Time Machine backups",
+            );
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!(
+                path = %path.display(),
+                status = %output.status,
+                stderr = %stderr.trim(),
+                "tmutil addexclusion failed; audit directory \
+                 may appear in Time Machine backups",
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to run tmutil; audit directory \
+                 may appear in Time Machine backups",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn exclude_from_backup_does_not_panic() {
+        exclude_from_backup(Path::new("/nonexistent/path"));
+    }
+
+    #[test]
+    fn exclude_from_backup_handles_tempdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        exclude_from_backup(tmp.path());
+    }
+}

--- a/crates/rimap-audit/src/backup_exclude.rs
+++ b/crates/rimap-audit/src/backup_exclude.rs
@@ -17,7 +17,7 @@ pub fn exclude_from_backup(path: &Path) {
 
 #[cfg(target_os = "macos")]
 fn exclude_macos(path: &Path) {
-    match std::process::Command::new("tmutil")
+    match std::process::Command::new("/usr/bin/tmutil")
         .args(["addexclusion", "-p"])
         .arg(path)
         .output()

--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+pub mod backup_exclude;
 pub mod error;
 pub(crate) mod fs_ext;
 pub mod ids;

--- a/crates/rimap-audit/src/rotation.rs
+++ b/crates/rimap-audit/src/rotation.rs
@@ -66,7 +66,11 @@ fn unique_rotated_path(active: &Path, now: OffsetDateTime) -> PathBuf {
 /// # Errors
 /// Any I/O error during `rename`, `open`, or `try_lock_exclusive` surfaces as
 /// [`AuditError::Rotate`] with a descriptive `reason`.
-pub fn rotate_file(active: &Path, keep: u32) -> Result<(BufWriter<File>, u64), AuditError> {
+pub fn rotate_file(
+    active: &Path,
+    keep: u32,
+    retention_seconds: Option<u64>,
+) -> Result<(BufWriter<File>, u64), AuditError> {
     let dst = unique_rotated_path(active, OffsetDateTime::now_utc());
     std::fs::rename(active, &dst).map_err(|source| AuditError::Rotate {
         path: active.to_path_buf(),
@@ -106,7 +110,7 @@ pub fn rotate_file(active: &Path, keep: u32) -> Result<(BufWriter<File>, u64), A
 
     // Prune old rotated siblings best-effort. Failures here are logged
     // but never propagated — a stale file is not a write failure.
-    prune_rotated_siblings(active, keep);
+    prune_rotated_siblings(active, keep, retention_seconds);
 
     Ok((BufWriter::new(new_file), 0))
 }
@@ -114,7 +118,7 @@ pub fn rotate_file(active: &Path, keep: u32) -> Result<(BufWriter<File>, u64), A
 /// Enumerate sibling files matching `<active_filename>.*`, sort by mtime
 /// descending, and delete all but the `keep` newest. `keep == 0` deletes
 /// every rotated sibling.
-fn prune_rotated_siblings(active: &Path, keep: u32) {
+fn prune_rotated_siblings(active: &Path, keep: u32, retention_seconds: Option<u64>) {
     let parent = match active.parent() {
         Some(p) if !p.as_os_str().is_empty() => p,
         _ => return,
@@ -173,8 +177,18 @@ fn prune_rotated_siblings(active: &Path, keep: u32) {
     siblings.sort_by(|a, b| b.0.cmp(&a.0));
 
     let keep_usize = usize::try_from(keep).unwrap_or(usize::MAX);
-    for (_, path) in siblings.into_iter().skip(keep_usize) {
-        if let Err(err) = std::fs::remove_file(&path) {
+    let cutoff = retention_seconds.map(|secs| {
+        std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(secs))
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+
+    for (idx, (mtime, path)) in siblings.into_iter().enumerate() {
+        let beyond_count = idx >= keep_usize;
+        let beyond_time = cutoff.is_some_and(|c| mtime < c);
+        if (beyond_count || beyond_time)
+            && let Err(err) = std::fs::remove_file(&path)
+        {
             tracing::warn!(
                 path = %path.display(),
                 error = %err,
@@ -241,7 +255,7 @@ mod tests {
 
         for _ in 0..7 {
             std::fs::write(&active, b"x\n").unwrap();
-            let (_buf, _len) = rotate_file(&active, 3).unwrap();
+            let (_buf, _len) = rotate_file(&active, 3, None).unwrap();
             sleep(Duration::from_millis(2));
         }
 
@@ -267,7 +281,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let active = dir.path().join("audit.jsonl");
         std::fs::write(&active, b"x\n").unwrap();
-        let (_buf, _len) = rotate_file(&active, 0).unwrap();
+        let (_buf, _len) = rotate_file(&active, 0, None).unwrap();
 
         let rotated = std::fs::read_dir(dir.path())
             .unwrap()
@@ -289,7 +303,7 @@ mod tests {
 
         // Create a real rotated sibling that should be kept.
         std::fs::write(&active, b"x\n").unwrap();
-        let (_buf, _len) = rotate_file(&active, 5).unwrap();
+        let (_buf, _len) = rotate_file(&active, 5, None).unwrap();
 
         // Plant a symlink whose name matches the rotated-sibling prefix.
         // Its target is an arbitrary file (here, /etc/hostname — any
@@ -303,7 +317,7 @@ mod tests {
         //   - keep the most recent real rotated file
         //   - skip the symlink entirely (not delete it and not rank it)
         std::fs::write(&active, b"y\n").unwrap();
-        let (_buf, _len) = rotate_file(&active, 1).unwrap();
+        let (_buf, _len) = rotate_file(&active, 1, None).unwrap();
 
         // The symlink must still exist — we never touched it.
         assert!(
@@ -329,5 +343,67 @@ mod tests {
             })
             .count();
         assert_eq!(real_rotated, 1, "expected exactly 1 real rotated sibling");
+    }
+
+    #[test]
+    fn prune_respects_retention_seconds() {
+        let dir = TempDir::new().unwrap();
+        let active = dir.path().join("audit.jsonl");
+
+        // Create two rotated siblings (milliseconds old).
+        std::fs::write(&active, b"x\n").unwrap();
+        let (_buf, _len) = rotate_file(&active, 10, None).unwrap();
+        sleep(Duration::from_millis(10));
+
+        std::fs::write(&active, b"y\n").unwrap();
+        let (_buf, _len) = rotate_file(&active, 10, None).unwrap();
+        sleep(Duration::from_millis(10));
+
+        // Both siblings are milliseconds old. Rotate with retention_seconds=0
+        // (raw function level — config validation rejects 0, but the function
+        // handles it). With retention 0, cutoff = now, so everything with
+        // mtime < now is expired.
+        std::fs::write(&active, b"z\n").unwrap();
+        let (_buf, _len) = rotate_file(&active, 10, Some(0)).unwrap();
+
+        let rotated = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("audit.jsonl."))
+            })
+            .count();
+        // The two older siblings should be expired by time. The newest one
+        // (just created by the third rotate_file) is racing with "now" so
+        // it may or may not survive. At most 1 should remain.
+        assert!(
+            rotated <= 1,
+            "expected at most 1 rotated sibling, got {rotated}"
+        );
+    }
+
+    #[test]
+    fn retention_none_preserves_count_only_behavior() {
+        let dir = TempDir::new().unwrap();
+        let active = dir.path().join("audit.jsonl");
+
+        for _ in 0..5 {
+            std::fs::write(&active, b"x\n").unwrap();
+            let (_buf, _len) = rotate_file(&active, 3, None).unwrap();
+            sleep(Duration::from_millis(2));
+        }
+
+        let rotated = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("audit.jsonl."))
+            })
+            .count();
+        assert_eq!(rotated, 3, "without retention_seconds, count-only applies");
     }
 }

--- a/crates/rimap-audit/src/writer.rs
+++ b/crates/rimap-audit/src/writer.rs
@@ -32,6 +32,10 @@ pub struct AuditOptions {
     /// `0` means "keep none — delete every rotated sibling immediately
     /// after rotation". The default at the config layer is 5.
     pub rotate_keep: u32,
+    /// Optional time-based retention in seconds. When set, rotated siblings
+    /// older than `now - retention_seconds` are pruned during rotation,
+    /// in addition to the count-based `rotate_keep` cap.
+    pub retention_seconds: Option<u64>,
     /// If `true`, write/flush/fsync failures inside `write_record` are
     /// logged via `tracing::error!` and converted to `Ok(())` so the
     /// surrounding tool call still succeeds. The default is `false`
@@ -53,6 +57,7 @@ pub struct AuditWriter {
     path: PathBuf,
     rotate_bytes: u64,
     rotate_keep: u32,
+    retention_seconds: Option<u64>,
     fail_open: bool,
     process_id: crate::ids::ProcessId,
     suppressed_failures: Arc<AtomicU64>,
@@ -125,6 +130,7 @@ impl AuditWriter {
             path: opts.path.clone(),
             rotate_bytes: opts.rotate_bytes,
             rotate_keep: opts.rotate_keep,
+            retention_seconds: opts.retention_seconds,
             fail_open: opts.fail_open,
             process_id: crate::ids::ProcessId::new_now(),
             suppressed_failures: Arc::new(AtomicU64::new(0)),
@@ -268,7 +274,8 @@ impl AuditWriter {
         // This prevents two clones of AuditWriter from both observing "needs
         // rotation" and racing on the rename.
         if self.rotate_bytes > 0 && guard.bytes_written >= self.rotate_bytes {
-            let (new_buf, new_len) = crate::rotation::rotate_file(&self.path, self.rotate_keep)?;
+            let (new_buf, new_len) =
+                crate::rotation::rotate_file(&self.path, self.rotate_keep, self.retention_seconds)?;
             guard.buf = new_buf;
             guard.bytes_written = new_len;
             tracing::info!(path = %self.path.display(), "audit file rotated");
@@ -484,6 +491,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -500,6 +508,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -508,6 +517,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -527,6 +537,7 @@ mod tests {
                 path: path.clone(),
                 rotate_bytes: 0,
                 rotate_keep: 0,
+                retention_seconds: None,
                 fail_open: false,
                 initial_seq: crate::ids::Seq::FIRST,
             })
@@ -537,6 +548,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -551,6 +563,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -570,6 +583,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -606,6 +620,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -640,6 +655,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 200,
             rotate_keep: 5,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -709,6 +725,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 200,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -731,6 +748,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -749,6 +767,7 @@ mod tests {
             path,
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -766,6 +785,7 @@ mod tests {
             path,
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -786,6 +806,7 @@ mod tests {
             path,
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq(42),
         })
@@ -804,6 +825,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -844,6 +866,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -886,6 +909,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })
@@ -929,6 +953,7 @@ mod tests {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: crate::ids::Seq::FIRST,
         })

--- a/crates/rimap-audit/src/writer.rs
+++ b/crates/rimap-audit/src/writer.rs
@@ -350,6 +350,33 @@ impl AuditWriter {
     }
 }
 
+impl AuditWriter {
+    /// Build a `process_end` record, allocate a seq, and write it.
+    /// Stamps the record with the writer's stable `process_id` and
+    /// `Timestamp::now()`. Returns the allocated `seq` on success.
+    ///
+    /// # Errors
+    /// Propagates any error from `allocate_seq` or `write_record`.
+    pub fn log_process_end(
+        &self,
+        reason: crate::record::ProcessEndReason,
+        total_tool_calls: u64,
+    ) -> Result<crate::ids::Seq, AuditError> {
+        let seq = self.allocate_seq()?;
+        let record = crate::record::AuditRecord {
+            seq,
+            ts: crate::ids::Timestamp::now(),
+            process_id: self.process_id,
+            payload: crate::record::Payload::ProcessEnd(crate::record::ProcessEnd {
+                reason,
+                total_tool_calls,
+            }),
+        };
+        self.write_record(&record)?;
+        Ok(seq)
+    }
+}
+
 /// Inputs to [`AuditWriter::log_process_start`]. Caller computes the
 /// inode-tamper signal by passing the trailing state from
 /// [`crate::self_check::read_trailing_state`] (run before `open`) and the
@@ -940,6 +967,61 @@ mod tests {
         assert_eq!(v["previous_process_id"], prior_pid.to_string());
         assert_eq!(v["previous_file_inode"], 8888);
         assert_eq!(v["audit_file_inode_changed"], true);
+    }
+
+    #[test]
+    fn log_process_end_writes_valid_record() {
+        use crate::record::ProcessEndReason;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = AuditWriter::open(&AuditOptions {
+            path: path.clone(),
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: crate::ids::Seq::FIRST,
+        })
+        .unwrap();
+
+        let seq = writer.log_process_end(ProcessEndReason::Eof, 42).unwrap();
+        assert_eq!(seq, crate::ids::Seq::FIRST);
+        drop(writer);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(v["kind"], "process_end");
+        assert_eq!(v["reason"], "eof");
+        assert_eq!(v["total_tool_calls"], 42);
+    }
+
+    #[test]
+    fn log_process_end_uses_writer_process_id() {
+        use crate::record::ProcessEndReason;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = AuditWriter::open(&AuditOptions {
+            path: path.clone(),
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: crate::ids::Seq::FIRST,
+        })
+        .unwrap();
+        let pid = writer.process_id();
+
+        writer
+            .log_process_end(ProcessEndReason::SignalTerm, 7)
+            .unwrap();
+        drop(writer);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+        assert_eq!(v["process_id"], pid.to_string());
+        assert_eq!(v["reason"], "signal_term");
     }
 
     #[test]

--- a/crates/rimap-audit/tests/concurrent_lock.rs
+++ b/crates/rimap-audit/tests/concurrent_lock.rs
@@ -15,6 +15,7 @@ fn concurrent_open_fails_fast_with_locked() {
         path: path.clone(),
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })
@@ -24,6 +25,7 @@ fn concurrent_open_fails_fast_with_locked() {
         path: path.clone(),
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })
@@ -43,6 +45,7 @@ fn lock_released_after_drop_allows_reopen() {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: rimap_audit::Seq::FIRST,
         })
@@ -52,6 +55,7 @@ fn lock_released_after_drop_allows_reopen() {
         path,
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })

--- a/crates/rimap-audit/tests/fail_open.rs
+++ b/crates/rimap-audit/tests/fail_open.rs
@@ -42,6 +42,7 @@ fn fail_open_false_propagates_rotation_failure() {
         path: path.clone(),
         rotate_bytes: 10,
         rotate_keep: 5,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: Seq::FIRST,
     })
@@ -69,6 +70,7 @@ fn fail_open_true_suppresses_rotation_failure_and_counts_it() {
         path: path.clone(),
         rotate_bytes: 10,
         rotate_keep: 5,
+        retention_seconds: None,
         fail_open: true,
         initial_seq: Seq::FIRST,
     })

--- a/crates/rimap-audit/tests/rotation.rs
+++ b/crates/rimap-audit/tests/rotation.rs
@@ -35,6 +35,7 @@ fn writes_survive_multiple_rotations() {
         path: path.clone(),
         rotate_bytes: 300,
         rotate_keep: 50,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })
@@ -74,6 +75,7 @@ fn lock_persists_across_rotations() {
         path: path.clone(),
         rotate_bytes: 300,
         rotate_keep: 5,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })
@@ -86,6 +88,7 @@ fn lock_persists_across_rotations() {
         path: path.clone(),
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: rimap_audit::Seq::FIRST,
     })

--- a/crates/rimap-config/src/model.rs
+++ b/crates/rimap-config/src/model.rs
@@ -201,13 +201,20 @@ pub struct AuditConfig {
     #[serde(default = "default_rotate_bytes")]
     pub rotate_bytes: u64,
     /// Number of rotated files to keep on disk after a rotation. This is
-    /// a COUNT-based cap only. Under low write volumes a single rotated
-    /// file may represent months of audit history, so operators who need
-    /// a time-based retention floor should ALSO configure external log
-    /// rotation or wait for the in-crate time-based retention tracked
-    /// in issue #44 (LOCAL-PRI-01). Default: 5.
+    /// a count-based cap. For time-based expiry, also set
+    /// `retention_seconds`. A rotated file is kept only if it is among
+    /// the newest `rotate_keep` AND within the retention window.
+    /// Default: 5.
     #[serde(default = "default_rotate_keep")]
     pub rotate_keep: u32,
+    /// Optional time-based retention in seconds. When set, rotated siblings
+    /// whose mtime is older than `now - retention_seconds` are deleted during
+    /// pruning, in addition to the count-based `rotate_keep` cap. A file is
+    /// kept only if it is among the newest `rotate_keep` AND within the
+    /// retention window. `None` (the default) disables time-based expiry.
+    /// `Some(0)` is rejected at validation — use `None` instead.
+    #[serde(default)]
+    pub retention_seconds: Option<u64>,
     /// Provenance ring buffer window in seconds.
     #[serde(default = "default_provenance_window")]
     pub provenance_window_seconds: u32,

--- a/crates/rimap-config/src/model.rs
+++ b/crates/rimap-config/src/model.rs
@@ -130,6 +130,9 @@ pub struct LimitsConfig {
     /// Max attachment bytes.
     #[serde(default = "default_max_attach")]
     pub max_attachment_bytes: u64,
+    /// Max APPEND message bytes.
+    #[serde(default = "default_max_append")]
+    pub max_append_bytes: u64,
     /// Rate limiter: commands per second.
     #[serde(default = "default_cps")]
     pub commands_per_second: u32,
@@ -151,6 +154,7 @@ impl Default for LimitsConfig {
             max_search_results_cap: default_max_search_cap(),
             max_fetch_body_bytes: default_max_body(),
             max_attachment_bytes: default_max_attach(),
+            max_append_bytes: default_max_append(),
             commands_per_second: default_cps(),
             drafts_per_minute: default_drafts_per_min(),
             circuit_breaker_error_threshold: default_breaker_threshold(),
@@ -170,6 +174,9 @@ fn default_max_body() -> u64 {
 }
 fn default_max_attach() -> u64 {
     26_214_400
+}
+fn default_max_append() -> u64 {
+    10_485_760
 }
 fn default_cps() -> u32 {
     10

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -109,6 +109,12 @@ fn validate_limits(config: &Config) -> Result<(), ConfigError> {
             reason: "must be > 0".to_string(),
         });
     }
+    if limits.max_append_bytes == 0 {
+        return Err(ConfigError::InvalidLimit {
+            field: "limits.max_append_bytes",
+            reason: "must be > 0".to_string(),
+        });
+    }
     Ok(())
 }
 

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -37,6 +37,7 @@ pub struct ValidatedConfig {
 pub fn validate(config: Config) -> Result<ValidatedConfig, ConfigError> {
     let tls_fingerprint = parse_fingerprint(config.imap.tls_fingerprint_sha256.as_deref())?;
     validate_limits(&config)?;
+    validate_audit(&config)?;
     validate_paths(&config)?;
     let tool_overrides = resolve_tool_overrides(&config)?;
     Ok(ValidatedConfig {
@@ -54,6 +55,18 @@ fn parse_fingerprint(maybe_fp: Option<&str>) -> Result<Option<TlsFingerprint>, C
         reason: e.to_string(),
     })?;
     Ok(Some(fp))
+}
+
+fn validate_audit(config: &Config) -> Result<(), ConfigError> {
+    if config.audit.retention_seconds == Some(0) {
+        return Err(ConfigError::InvalidLimit {
+            field: "audit.retention_seconds",
+            reason: "must be > 0 (use None / omit the field to disable \
+                     time-based retention)"
+                .to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn validate_limits(config: &Config) -> Result<(), ConfigError> {
@@ -277,6 +290,7 @@ mod tests {
                 path: audit_dir.join("audit.jsonl"),
                 rotate_bytes: 10_485_760,
                 rotate_keep: 5,
+                retention_seconds: None,
                 provenance_window_seconds: 60,
                 fail_open: false,
                 allowed_base_dir: Some(audit_dir.to_path_buf()),
@@ -470,6 +484,29 @@ mod tests {
         cfg.audit.allowed_base_dir = Some(base.path().to_path_buf());
         let err = validate(cfg).unwrap_err();
         assert!(matches!(err, ConfigError::AuditPathOutsideBase { .. }));
+    }
+
+    #[test]
+    fn retention_seconds_zero_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = base_config(dir.path());
+        cfg.audit.retention_seconds = Some(0);
+        let err = validate(cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::InvalidLimit {
+                field: "audit.retention_seconds",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn retention_seconds_nonzero_passes() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = base_config(dir.path());
+        cfg.audit.retention_seconds = Some(3600);
+        validate(cfg).unwrap();
     }
 
     #[test]

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -52,6 +52,8 @@ pub struct ConnectionConfig {
     pub command_timeout: Duration,
     /// Hard cap on `FETCH BODY[]` byte count.
     pub max_fetch_body_bytes: u64,
+    /// Hard cap on `APPEND` message byte count.
+    pub max_append_bytes: u64,
 }
 
 /// Active IMAP session type alias. `async-imap` parameterizes over the
@@ -620,12 +622,13 @@ impl Connection {
         keywords: &[&str],
     ) -> Result<crate::types::AppendResult, Error> {
         let dur = self.inner.cfg.command_timeout;
+        let limit = self.inner.cfg.max_append_bytes;
         let result = crate::time::with_timeout("append", dur, async {
             let mut guard = self.session().await?;
             let session = guard
                 .as_mut()
                 .unwrap_or_else(|| unreachable!("session() ensures Some"));
-            crate::ops::append::append(session, folder, message, flags, keywords).await
+            crate::ops::append::append(session, folder, message, flags, keywords, limit).await
         })
         .await;
         if let Err(Error::ConnectionLost | Error::Timeout { .. }) = &result {

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -13,6 +13,7 @@
 //! `docs/architecture/audit-locking.md` (added in Task 17).
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_imap::Session;
@@ -73,6 +74,9 @@ struct ConnectionInner {
     /// `None` = never connected, or last command tore down the connection.
     /// `Some(_)` = live session ready for the next command.
     session: Mutex<Option<ImapSession>>,
+    /// Server advertised MOVE capability (RFC 6851) after login.
+    /// Reset to `false` on `invalidate()`.
+    has_move: AtomicBool,
 }
 
 impl std::fmt::Debug for Connection {
@@ -99,6 +103,7 @@ impl Connection {
                 audit,
                 credentials,
                 session: Mutex::new(None),
+                has_move: AtomicBool::new(false),
             }),
         }
     }
@@ -122,10 +127,17 @@ impl Connection {
         Ok(guard)
     }
 
+    /// Whether the server advertised the MOVE capability (RFC 6851).
+    #[must_use]
+    pub fn has_move_capability(&self) -> bool {
+        self.inner.has_move.load(Ordering::Relaxed)
+    }
+
     /// Drop any current session. Called by ops on connection-lost errors.
     pub(crate) async fn invalidate(&self) {
         let mut guard = self.inner.session.lock().await;
         *guard = None;
+        self.inner.has_move.store(false, Ordering::Relaxed);
     }
 
     /// The full connect/handshake/login/CAPABILITY flow. Emits exactly one
@@ -290,15 +302,33 @@ impl Connection {
             })?;
 
         // Attempt LOGIN. On NO response the server rejected the credentials.
-        match client.login(&cfg.username, &password).await {
-            Ok(session) => Ok(session),
-            Err((err, _client)) => match err {
-                async_imap::error::Error::No(_) => Err(Error::Auth {
-                    reason: AuthFailure::LoginRejected,
-                }),
-                other => Err(Error::Protocol(other)),
-            },
-        }
+        let mut session = match client.login(&cfg.username, &password).await {
+            Ok(session) => session,
+            Err((err, _client)) => {
+                return match err {
+                    async_imap::error::Error::No(_) => Err(Error::Auth {
+                        reason: AuthFailure::LoginRejected,
+                    }),
+                    other => Err(Error::Protocol(other)),
+                };
+            }
+        };
+
+        // Post-login: probe CAPABILITY for MOVE (RFC 6851).
+        let has_move = match session.capabilities().await {
+            Ok(caps) => caps.has_str("MOVE"),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "post-login CAPABILITY probe failed; \
+                     assuming no MOVE support",
+                );
+                false
+            }
+        };
+        self.inner.has_move.store(has_move, Ordering::Relaxed);
+
+        Ok(session)
     }
 
     /// Emit an `Auth` audit record. Runs `AuditWriter::log_auth` inside
@@ -575,9 +605,10 @@ impl Connection {
 
     /// Move messages from `source_folder` to `dest_folder`.
     ///
-    /// Uses IMAP MOVE extension (RFC 6851) when available; falls back
-    /// to COPY + STORE \Deleted + EXPUNGE otherwise. The fallback is
-    /// not atomic.
+    /// Uses IMAP MOVE extension (RFC 6851) when the server advertised
+    /// it; falls back to COPY + STORE \Deleted + EXPUNGE otherwise.
+    /// The fallback is not atomic — callers should inspect
+    /// `MoveOutcome::used_fallback` and surface a warning.
     ///
     /// Batch limit: 100 UIDs.
     ///
@@ -589,15 +620,16 @@ impl Connection {
         source_folder: &str,
         dest_folder: &str,
         uids: &[crate::types::Uid],
-    ) -> Result<Vec<crate::types::MoveResult>, Error> {
+    ) -> Result<crate::ops::move_msg::MoveOutcome, Error> {
         let dur = self.inner.cfg.command_timeout;
+        let has_move = self.has_move_capability();
         let result = crate::time::with_timeout("move", dur, async {
             let mut guard = self.session().await?;
             let session = guard
                 .as_mut()
                 .unwrap_or_else(|| unreachable!("session() ensures Some"));
             crate::ops::folders::select(session, source_folder, false).await?;
-            crate::ops::move_msg::move_messages(session, dest_folder, uids).await
+            crate::ops::move_msg::move_messages(session, dest_folder, uids, has_move).await
         })
         .await;
         if let Err(Error::ConnectionLost | Error::Timeout { .. }) = &result {

--- a/crates/rimap-imap/src/ops/append.rs
+++ b/crates/rimap-imap/src/ops/append.rs
@@ -39,7 +39,7 @@ pub async fn append(
 
 /// Reject messages exceeding the configured byte limit.
 fn check_append_size(message: &[u8], max_append_bytes: u64) -> Result<(), Error> {
-    let len = message.len() as u64;
+    let len = u64::try_from(message.len()).unwrap_or(u64::MAX);
     if len > max_append_bytes {
         return Err(Error::SizeLimit {
             limit: max_append_bytes,

--- a/crates/rimap-imap/src/ops/append.rs
+++ b/crates/rimap-imap/src/ops/append.rs
@@ -19,7 +19,9 @@ pub async fn append(
     message: &[u8],
     flags: &[Flag],
     keywords: &[&str],
+    max_append_bytes: u64,
 ) -> Result<AppendResult, Error> {
+    check_append_size(message, max_append_bytes)?;
     let flag_str = build_flags_string(flags, keywords)?;
     let flags_arg = if flag_str.is_empty() {
         None
@@ -33,6 +35,17 @@ pub async fn append(
         .map_err(super::folders::map_err)?;
 
     Ok(AppendResult { uid: None })
+}
+
+/// Reject messages exceeding the configured byte limit.
+fn check_append_size(message: &[u8], max_append_bytes: u64) -> Result<(), Error> {
+    let len = message.len() as u64;
+    if len > max_append_bytes {
+        return Err(Error::SizeLimit {
+            limit: max_append_bytes,
+        });
+    }
+    Ok(())
 }
 
 /// Build the combined flags string from system flags and keywords.
@@ -56,8 +69,27 @@ fn build_flags_string(flags: &[Flag], keywords: &[&str]) -> Result<String, Error
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::panic, reason = "tests")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn append_rejects_oversized_message() {
+        let limit: u64 = 100;
+        let message = vec![b'X'; 101];
+        let result = super::check_append_size(&message, limit);
+        match result {
+            Err(Error::SizeLimit { limit: l }) => assert_eq!(l, 100),
+            other => panic!("expected SizeLimit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_accepts_message_at_limit() {
+        let limit: u64 = 100;
+        let message = vec![b'X'; 100];
+        assert!(super::check_append_size(&message, limit).is_ok());
+    }
 
     #[test]
     fn build_flags_string_rejects_bad_keyword() {

--- a/crates/rimap-imap/src/ops/move_msg.rs
+++ b/crates/rimap-imap/src/ops/move_msg.rs
@@ -11,11 +11,25 @@ use crate::types::{Flag, FlagAction, MoveResult, Uid};
 /// Maximum UIDs per MOVE command.
 const MAX_BATCH: usize = 100;
 
+/// Outcome of a `move_messages` call.
+#[derive(Debug)]
+pub struct MoveOutcome {
+    /// Per-UID results.
+    pub results: Vec<MoveResult>,
+    /// `true` when the non-atomic COPY+DELETE+EXPUNGE fallback was used
+    /// instead of the atomic UID MOVE command. Callers should surface a
+    /// security warning when this is `true`.
+    pub used_fallback: bool,
+}
+
 /// Move `uids` from the currently selected folder to `dest_folder`.
 ///
-/// Tries `UID MOVE` first (RFC 6851). If the server rejects the
-/// command (BAD / unknown / not supported), falls back to
-/// COPY + STORE \Deleted + EXPUNGE.
+/// When `has_move` is `true` the server advertised the MOVE capability
+/// and UID MOVE is used directly. A BAD response in this case is
+/// propagated as an error (the server lied about its capabilities).
+///
+/// When `has_move` is `false` the COPY+DELETE fallback is used
+/// immediately without attempting UID MOVE.
 ///
 /// # Errors
 ///
@@ -25,7 +39,8 @@ pub async fn move_messages(
     session: &mut ImapSession,
     dest_folder: &str,
     uids: &[Uid],
-) -> Result<Vec<MoveResult>, Error> {
+    has_move: bool,
+) -> Result<MoveOutcome, Error> {
     if uids.len() > MAX_BATCH {
         return Err(Error::BatchTooLarge {
             count: uids.len(),
@@ -33,17 +48,28 @@ pub async fn move_messages(
         });
     }
     if uids.is_empty() {
-        return Ok(Vec::new());
+        return Ok(MoveOutcome {
+            results: Vec::new(),
+            used_fallback: false,
+        });
+    }
+
+    if !has_move {
+        let results = copy_delete_fallback(session, dest_folder, uids).await?;
+        return Ok(MoveOutcome {
+            results,
+            used_fallback: true,
+        });
     }
 
     let uid_set = store::uid_set_string(uids);
-
-    // Try MOVE first; fall back to COPY+DELETE if the server rejects it.
     let move_result = session.uid_mv(&uid_set, dest_folder).await;
 
     match move_result {
-        Ok(()) => Ok(build_results(uids)),
-        Err(e) if is_move_unsupported(&e) => copy_delete_fallback(session, dest_folder, uids).await,
+        Ok(()) => Ok(MoveOutcome {
+            results: build_results(uids),
+            used_fallback: false,
+        }),
         Err(e) => Err(super::folders::map_err(e)),
     }
 }
@@ -80,23 +106,6 @@ async fn copy_delete_fallback(
     }
 
     Ok(build_results(uids))
-}
-
-/// Check whether the async-imap error indicates that the MOVE command
-/// is not supported by the server (BAD response, "unknown command",
-/// "not supported").
-fn is_move_unsupported(err: &async_imap::error::Error) -> bool {
-    match err {
-        async_imap::error::Error::Bad(_) => true,
-        async_imap::error::Error::No(msg) => {
-            let lower = msg.to_ascii_lowercase();
-            lower.contains("unknown command") || lower.contains("not supported")
-        }
-        // async_imap::error::Error is #[non_exhaustive], so the
-        // wildcard is required. All other known variants (Io,
-        // ConnectionLost, Parse, Validate, Append) are real failures.
-        _ => false,
-    }
 }
 
 /// Build `MoveResult` entries with `new_uid: None` (async-imap does

--- a/crates/rimap-imap/src/ops/move_msg.rs
+++ b/crates/rimap-imap/src/ops/move_msg.rs
@@ -13,6 +13,7 @@ const MAX_BATCH: usize = 100;
 
 /// Outcome of a `move_messages` call.
 #[derive(Debug)]
+#[must_use = "check used_fallback for security warnings"]
 pub struct MoveOutcome {
     /// Per-UID results.
     pub results: Vec<MoveResult>,

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -542,13 +542,13 @@ async fn case_16_move_message_between_folders() {
     let uid = uids[0];
 
     // Move to Archive (seeded in Dovecot entrypoint.sh).
-    let results = h
+    let outcome = h
         .connection
         .move_messages("INBOX", "Archive", &[uid])
         .await
         .unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].old_uid, uid);
+    assert_eq!(outcome.results.len(), 1);
+    assert_eq!(outcome.results[0].old_uid, uid);
 
     // Verify the message is gone from INBOX.
     let after_uids = h

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -133,6 +133,7 @@ async fn case_04_login_rejected_emits_audit() {
         connect_timeout: Duration::from_secs(10),
         command_timeout: Duration::from_secs(10),
         max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
     };
     let creds: Arc<dyn CredentialStore> = Arc::new(WrongPass);
     // Reuse h.audit so the rejected-auth record lands in the same file
@@ -264,6 +265,7 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
         connect_timeout: Duration::from_secs(10),
         command_timeout: Duration::from_secs(10),
         max_fetch_body_bytes: 10,
+        max_append_bytes: 10_485_760,
     };
     let creds: Arc<dyn CredentialStore> = Arc::new(support::container::StaticCreds(
         DovecotHarness::password().to_string(),

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -73,6 +73,7 @@ fn build_connection(cfg: &ProtonConfig) -> Connection {
         connect_timeout: Duration::from_secs(15),
         command_timeout: Duration::from_secs(60),
         max_fetch_body_bytes: 26_214_400,
+        max_append_bytes: 10_485_760,
     };
     let creds: Arc<dyn CredentialStore> = Arc::new(EnvCreds(cfg.pass.clone()));
     Connection::new(conn_cfg, audit, creds)

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -61,6 +61,7 @@ fn build_connection(cfg: &ProtonConfig) -> Connection {
         path: dir.path().join("audit.jsonl"),
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: Seq::FIRST,
     })

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -508,6 +508,7 @@ impl ConnectedHarness {
             path: audit_path,
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: Seq::FIRST,
         })

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -529,6 +529,7 @@ impl ConnectedHarness {
             connect_timeout: std::time::Duration::from_secs(10),
             command_timeout: std::time::Duration::from_secs(10),
             max_fetch_body_bytes: 5_242_880,
+            max_append_bytes: 10_485_760,
         };
         let creds: Arc<dyn CredentialStore> =
             Arc::new(StaticCreds(DovecotHarness::password().to_string()));

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -25,6 +25,7 @@ pub fn init_audit_writer(
         path: audit_path.clone(),
         rotate_bytes: cfg.config.audit.rotate_bytes,
         rotate_keep: cfg.config.audit.rotate_keep,
+        retention_seconds: cfg.config.audit.retention_seconds,
         fail_open: cfg.config.audit.fail_open,
         initial_seq,
     })?;
@@ -143,6 +144,7 @@ allowed_base_dir = "{}"
                 path: audit_path.clone(),
                 rotate_bytes: 0,
                 rotate_keep: 0,
+                retention_seconds: None,
                 fail_open: false,
                 initial_seq: Seq::FIRST,
             })

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -130,6 +130,33 @@ allowed_base_dir = "{}"
     }
 
     #[test]
+    fn process_end_writes_after_start() {
+        use rimap_audit::ProcessEndReason;
+
+        let dir = TempDir::new().unwrap();
+        let config_path = write_config(&dir);
+        let raw = rimap_config::loader::load_from_path(&config_path).unwrap();
+        let validated = rimap_config::validate::validate(raw).unwrap();
+        let audit_path = validated.config.audit.path.clone();
+
+        {
+            let writer = init_audit_writer(&validated, &config_path).unwrap();
+            writer.log_process_end(ProcessEndReason::Eof, 0).unwrap();
+        }
+
+        let contents = std::fs::read_to_string(&audit_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["kind"], "process_start");
+
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["kind"], "process_end");
+        assert_eq!(second["seq"], 2);
+    }
+
+    #[test]
     fn seq_continues_from_trailing_state() {
         use rimap_audit::{
             AuditOptions, AuditRecord, AuditWriter, Payload, ProcessEnd, ProcessEndReason,

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -30,6 +30,10 @@ pub fn init_audit_writer(
         initial_seq,
     })?;
 
+    if let Some(parent) = writer.path().parent() {
+        rimap_audit::backup_exclude::exclude_from_backup(parent);
+    }
+
     let current = rimap_audit::current_inode(audit_path)?;
     let config_hash = compute_config_hash(config_file_path);
 

--- a/crates/rimap-server/src/content.rs
+++ b/crates/rimap-server/src/content.rs
@@ -1,6 +1,13 @@
 //! Async wrapper for the synchronous `rimap_content::parse_message`.
 
+use std::sync::LazyLock;
+
 use rimap_content::{Content, ContentError, parse_message};
+use tokio::sync::Semaphore;
+
+/// Limits concurrent `spawn_blocking` parse invocations to avoid
+/// saturating the blocking threadpool (default 512 threads).
+static PARSE_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
 
 /// Run `parse_message` on the blocking threadpool to avoid starving
 /// the tokio runtime. `parse_message` is CPU-bound (~2 ms per message).
@@ -10,6 +17,12 @@ use rimap_content::{Content, ContentError, parse_message};
 /// Returns `ContentError` from the inner call, or
 /// `ContentError::Malformed` if the blocking task panicked.
 pub async fn parse_message_async(raw: Vec<u8>) -> Result<Content, ContentError> {
+    let _permit = PARSE_SEMAPHORE
+        .acquire()
+        .await
+        .map_err(|_| ContentError::Malformed {
+            reason: "parse semaphore closed".into(),
+        })?;
     tokio::task::spawn_blocking(move || parse_message(&raw))
         .await
         .unwrap_or_else(|e| {

--- a/crates/rimap-server/src/download.rs
+++ b/crates/rimap-server/src/download.rs
@@ -95,6 +95,50 @@ pub fn write_attachment(dir: &Path, filename: &str, data: &[u8]) -> Result<PathB
     Ok(path)
 }
 
+/// Async wrapper around [`resolve_dest_dir`] that runs on a
+/// blocking thread.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` if the blocking task panics or
+/// if `resolve_dest_dir` itself fails.
+pub async fn resolve_dest_dir_async(
+    dest_dir: Option<String>,
+    allowed_root: PathBuf,
+    fallback_dir: PathBuf,
+) -> Result<PathBuf, RimapError> {
+    tokio::task::spawn_blocking(move || {
+        resolve_dest_dir(dest_dir.as_deref(), &allowed_root, &fallback_dir)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        Err(RimapError::Internal(format!(
+            "spawn_blocking panicked: {e}"
+        )))
+    })
+}
+
+/// Async wrapper around [`write_attachment`] that runs on a
+/// blocking thread.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` if the blocking task panics or
+/// if `write_attachment` itself fails.
+pub async fn write_attachment_async(
+    dir: PathBuf,
+    filename: String,
+    data: Vec<u8>,
+) -> Result<PathBuf, RimapError> {
+    tokio::task::spawn_blocking(move || write_attachment(&dir, &filename, &data))
+        .await
+        .unwrap_or_else(|e| {
+            Err(RimapError::Internal(format!(
+                "spawn_blocking panicked: {e}"
+            )))
+        })
+}
+
 /// MIME-sniff `data` using magic bytes.
 #[must_use]
 pub fn sniff_mime(data: &[u8]) -> Option<String> {

--- a/crates/rimap-server/src/dry_run.rs
+++ b/crates/rimap-server/src/dry_run.rs
@@ -40,6 +40,7 @@ pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
     let audit_path = validated.config.audit.path.clone();
     let rotate_bytes = validated.config.audit.rotate_bytes;
     let rotate_keep = validated.config.audit.rotate_keep;
+    let retention_seconds = validated.config.audit.retention_seconds;
     // dry-run is a one-shot diagnostic path that exits immediately after
     // printing the matrix. Chain-of-history continuation (trailing state) is
     // not useful here; Seq::FIRST is correct.
@@ -47,6 +48,7 @@ pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
         path: audit_path.clone(),
         rotate_bytes,
         rotate_keep,
+        retention_seconds,
         fail_open: validated.config.audit.fail_open,
         initial_seq: rimap_audit::Seq::FIRST,
     })
@@ -124,6 +126,7 @@ allowed_base_dir = "{}"
             path: audit_path,
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: rimap_audit::Seq::FIRST,
         })

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -299,6 +299,7 @@ fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection 
         connect_timeout: Duration::from_secs(10),
         command_timeout: Duration::from_secs(30),
         max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
     };
     let creds: Arc<dyn CredentialStore> = Arc::new(StaticCreds("testpass".into()));
     Connection::new(conn_cfg, audit.clone(), creds)

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -234,6 +234,7 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
         path: audit_dir.path().join("audit.jsonl"),
         rotate_bytes: 0,
         rotate_keep: 0,
+        retention_seconds: None,
         fail_open: false,
         initial_seq: Seq::FIRST,
     })
@@ -279,6 +280,7 @@ fn test_config(harness: &DovecotHarness, audit_dir: &TempDir) -> ValidatedConfig
                 path: audit_dir.path().join("audit.jsonl"),
                 rotate_bytes: 0,
                 rotate_keep: 0,
+                retention_seconds: None,
                 provenance_window_seconds: 60,
                 fail_open: false,
                 allowed_base_dir: Some(audit_dir.path().to_path_buf()),

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -106,6 +106,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     let imap = Connection::new(conn_cfg, audit.clone(), credentials);
     let download_dir = resolve_download_dir(&validated)?;
 
+    let audit_for_shutdown = audit.clone();
     let mcp_server = server::ImapMcpServer {
         config: validated,
         imap,
@@ -115,7 +116,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     };
 
     let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
-    rt.block_on(async {
+    let mcp_result: anyhow::Result<()> = rt.block_on(async {
         let transport = rmcp::transport::io::stdio();
         let service = Box::pin(rmcp::serve_server(mcp_server, transport))
             .await
@@ -123,9 +124,22 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         service
             .waiting()
             .await
-            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))
-    })?;
-    Ok(())
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+        Ok(())
+    });
+
+    // Best-effort process_end emission.
+    let reason = match &mcp_result {
+        Ok(()) => rimap_audit::ProcessEndReason::Eof,
+        Err(_) => rimap_audit::ProcessEndReason::Error,
+    };
+    // total_tool_calls is not tracked yet — use 0 as placeholder.
+    // A future PR can add an AtomicU64 counter to ImapMcpServer.
+    if let Err(e) = audit_for_shutdown.log_process_end(reason, 0) {
+        tracing::error!(error = %e, "failed to write process_end audit record");
+    }
+
+    mcp_result
 }
 
 /// Resolve the config file path from `--config` or the

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -165,6 +165,7 @@ fn build_connection_config(cfg: &ValidatedConfig) -> ConnectionConfig {
         connect_timeout: Duration::from_secs(u64::from(imap.connect_timeout_seconds)),
         command_timeout: Duration::from_secs(u64::from(imap.command_timeout_seconds)),
         max_fetch_body_bytes: cfg.config.limits.max_fetch_body_bytes,
+        max_append_bytes: cfg.config.limits.max_append_bytes,
     }
 }
 

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -135,8 +135,9 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     };
     // total_tool_calls is not tracked yet — use 0 as placeholder.
     // A future PR can add an AtomicU64 counter to ImapMcpServer.
-    if let Err(e) = audit_for_shutdown.log_process_end(reason, 0) {
-        tracing::error!(error = %e, "failed to write process_end audit record");
+    match audit_for_shutdown.log_process_end(reason, 0) {
+        Ok(seq) => tracing::info!(seq = %seq, "process_end audit record written"),
+        Err(e) => tracing::error!(error = %e, "failed to write process_end audit record"),
     }
 
     mcp_result

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -154,7 +154,12 @@ fn parse_args<T: serde::de::DeserializeOwned>(
 fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::Value> {
     let schema = schemars::schema_for!(T);
     match serde_json::to_value(schema) {
-        Ok(serde_json::Value::Object(map)) => map,
+        Ok(serde_json::Value::Object(mut map)) => {
+            // Strip Rust struct name to avoid leaking implementation
+            // details in the MCP list_tools response.
+            map.remove("title");
+            map
+        }
         _ => serde_json::Map::new(),
     }
 }

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -149,37 +149,87 @@ fn parse_args<T: serde::de::DeserializeOwned>(
         .map_err(|e| rimap_core::RimapError::Internal(format!("invalid arguments: {e}")))
 }
 
+/// Convert a `schemars::JsonSchema` type into a JSON object map
+/// suitable for an MCP tool's `inputSchema`.
+fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::Value> {
+    let schema = schemars::schema_for!(T);
+    match serde_json::to_value(schema) {
+        Ok(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    }
+}
+
 /// Build an rmcp `Tool` definition for a `ToolName`. Returns `None`
 /// for sub-capabilities that share an MCP tool name with a parent
 /// (e.g. `SearchAdvanced` and `FetchMessageHtml` are gated
 /// sub-capabilities, not separate MCP tools).
 fn tool_definition(name: ToolName) -> Option<Tool> {
-    let (tool_name, description): (&str, &str) = match name {
-        ToolName::ListFolders => ("list_folders", "List all IMAP folders"),
-        ToolName::Search => ("search", "Search messages with structured query"),
+    use crate::tools::{
+        create_draft::CreateDraftInput, download_attachment::DownloadAttachmentInput,
+        fetch_message::FetchMessageInput, flags::FlagInput, list_attachments::ListAttachmentsInput,
+        move_message::MoveInput, search::SearchInput,
+    };
+
+    let (tool_name, description, schema): (&str, &str, serde_json::Map<_, _>) = match name {
+        ToolName::ListFolders => (
+            "list_folders",
+            "List all IMAP folders",
+            serde_json::Map::new(),
+        ),
+        ToolName::Search => (
+            "search",
+            "Search messages with structured query",
+            schema_map::<SearchInput>(),
+        ),
         ToolName::SearchAdvanced | ToolName::FetchMessageHtml => return None,
-        ToolName::FetchMessage => ("fetch_message", "Fetch message metadata and text body"),
-        ToolName::ListAttachments => ("list_attachments", "List attachments on a message"),
+        ToolName::FetchMessage => (
+            "fetch_message",
+            "Fetch message metadata and text body",
+            schema_map::<FetchMessageInput>(),
+        ),
+        ToolName::ListAttachments => (
+            "list_attachments",
+            "List attachments on a message",
+            schema_map::<ListAttachmentsInput>(),
+        ),
         ToolName::DownloadAttachment => (
             "download_attachment",
             "Download an attachment to the sandbox directory",
+            schema_map::<DownloadAttachmentInput>(),
         ),
-        ToolName::MarkRead => ("mark_read", "Mark messages as read"),
-        ToolName::MarkUnread => ("mark_unread", "Mark messages as unread"),
-        ToolName::Flag => ("flag", "Add the flagged flag to messages"),
-        ToolName::Unflag => ("unflag", "Remove the flagged flag from messages"),
-        ToolName::MoveMessage => ("move_message", "Move messages to another folder"),
+        ToolName::MarkRead => (
+            "mark_read",
+            "Mark messages as read",
+            schema_map::<FlagInput>(),
+        ),
+        ToolName::MarkUnread => (
+            "mark_unread",
+            "Mark messages as unread",
+            schema_map::<FlagInput>(),
+        ),
+        ToolName::Flag => (
+            "flag",
+            "Add the flagged flag to messages",
+            schema_map::<FlagInput>(),
+        ),
+        ToolName::Unflag => (
+            "unflag",
+            "Remove the flagged flag from messages",
+            schema_map::<FlagInput>(),
+        ),
+        ToolName::MoveMessage => (
+            "move_message",
+            "Move messages to another folder",
+            schema_map::<MoveInput>(),
+        ),
         ToolName::CreateDraft => (
             "create_draft",
             "Create a draft email with $PendingReview flag",
+            schema_map::<CreateDraftInput>(),
         ),
     };
 
-    Some(Tool::new(
-        tool_name,
-        description,
-        Arc::new(serde_json::Map::new()),
-    ))
+    Some(Tool::new(tool_name, description, Arc::new(schema)))
 }
 
 #[cfg(test)]
@@ -210,6 +260,22 @@ mod tests {
             assert!(
                 def.name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
                 "tool name {} is not snake_case",
+                def.name,
+            );
+        }
+    }
+
+    #[test]
+    fn tool_definitions_have_non_empty_schemas() {
+        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+            // list_folders has no input — empty schema is expected.
+            if def.name == "list_folders" {
+                continue;
+            }
+            let schema = &def.input_schema;
+            assert!(
+                !schema.is_empty(),
+                "tool {} has empty input schema",
                 def.name,
             );
         }

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -215,6 +215,23 @@ fn single_address(addr: &AddressInput) -> Address<'_> {
     }
 }
 
+const MAX_REFERENCES: usize = 50;
+
+/// Truncate a References chain to at most `MAX_REFERENCES` entries,
+/// preserving the root (first) and most recent (last) entries.
+fn cap_references(mut refs: Vec<String>) -> Vec<String> {
+    if refs.len() <= MAX_REFERENCES {
+        return refs;
+    }
+    let root = refs.remove(0);
+    let keep_recent = MAX_REFERENCES - 1;
+    let start = refs.len().saturating_sub(keep_recent);
+    let mut result = Vec::with_capacity(MAX_REFERENCES);
+    result.push(root);
+    result.extend(refs.into_iter().skip(start));
+    result
+}
+
 /// Fetch the referenced message and set In-Reply-To / References.
 async fn apply_threading_headers<'a>(
     server: &ImapMcpServer,
@@ -262,6 +279,7 @@ async fn apply_threading_headers<'a>(
         _ => {}
     }
     ref_ids.push(msg_id);
+    let ref_ids = cap_references(ref_ids);
 
     let builder = builder.references(MessageId::new_list(ref_ids.into_iter()));
 
@@ -276,7 +294,7 @@ mod tests {
     use mail_builder::headers::message_id::MessageId;
 
     use super::{
-        AddressInput, CreateDraftInput, addresses_to_builder, sanitize_message_id,
+        AddressInput, CreateDraftInput, addresses_to_builder, cap_references, sanitize_message_id,
         validate_draft_input,
     };
 
@@ -560,5 +578,21 @@ mod tests {
             address: "bob@example.com".into(),
         }]);
         validate_draft_input(&input).unwrap();
+    }
+
+    #[test]
+    fn references_chain_capped_at_50() {
+        let refs: Vec<String> = (0..200).map(|i| format!("msg-{i}@example.com")).collect();
+        let capped = cap_references(refs);
+        assert_eq!(capped.len(), 50);
+        assert_eq!(capped[0], "msg-0@example.com");
+        assert_eq!(capped[49], "msg-199@example.com");
+    }
+
+    #[test]
+    fn references_chain_under_cap_unchanged() {
+        let refs: Vec<String> = (0..10).map(|i| format!("msg-{i}@example.com")).collect();
+        let capped = cap_references(refs);
+        assert_eq!(capped.len(), 10);
     }
 }

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -4,13 +4,14 @@
 use mail_builder::MessageBuilder;
 use mail_builder::headers::address::Address;
 use mail_builder::headers::message_id::MessageId;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::response::ToolResponse;
 use crate::server::ImapMcpServer;
 
 /// Input for `create_draft`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateDraftInput {
     /// Recipient addresses.
     pub to: Vec<AddressInput>,
@@ -29,7 +30,7 @@ pub struct CreateDraftInput {
 }
 
 /// An email address with optional display name.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AddressInput {
     /// Display name (optional).
     pub name: Option<String>,

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -133,7 +133,7 @@ fn validate_draft_input(input: &CreateDraftInput) -> Result<(), rimap_core::Rima
         return Err(rimap_core::RimapError::Authz {
             code: rimap_core::error::ErrorCode::InvalidInput,
             message: format!(
-                "subject too long ({} chars); max is {MAX_SUBJECT_LEN}",
+                "subject too long ({} bytes); max is {MAX_SUBJECT_LEN}",
                 input.subject.len()
             ),
         });

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -115,6 +115,40 @@ fn validate_draft_input(input: &CreateDraftInput) -> Result<(), rimap_core::Rima
             message: "at least one To recipient is required".into(),
         });
     }
+
+    let total_recipients = input.to.len()
+        + input.cc.as_ref().map_or(0, Vec::len)
+        + input.bcc.as_ref().map_or(0, Vec::len);
+    if total_recipients > MAX_RECIPIENTS {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: format!(
+                "too many recipients ({total_recipients}); \
+                 max is {MAX_RECIPIENTS}"
+            ),
+        });
+    }
+
+    if input.subject.len() > MAX_SUBJECT_LEN {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: format!(
+                "subject too long ({} chars); max is {MAX_SUBJECT_LEN}",
+                input.subject.len()
+            ),
+        });
+    }
+
+    if input.body_text.len() > MAX_BODY_BYTES {
+        return Err(rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::InvalidInput,
+            message: format!(
+                "body_text too large ({} bytes); max is {MAX_BODY_BYTES}",
+                input.body_text.len()
+            ),
+        });
+    }
+
     validate_addresses("To", &input.to)?;
     if let Some(cc) = &input.cc {
         validate_addresses("CC", cc)?;
@@ -214,6 +248,10 @@ fn single_address(addr: &AddressInput) -> Address<'_> {
         None => Address::new_address(None::<&str>, addr.address.as_str()),
     }
 }
+
+const MAX_RECIPIENTS: usize = 100;
+const MAX_SUBJECT_LEN: usize = 1000;
+const MAX_BODY_BYTES: usize = 1_048_576;
 
 const MAX_REFERENCES: usize = 50;
 
@@ -594,5 +632,99 @@ mod tests {
         let refs: Vec<String> = (0..10).map(|i| format!("msg-{i}@example.com")).collect();
         let capped = cap_references(refs);
         assert_eq!(capped.len(), 10);
+    }
+
+    #[test]
+    fn too_many_recipients_rejected() {
+        let addrs: Vec<AddressInput> = (0..101)
+            .map(|i| AddressInput {
+                name: None,
+                address: format!("user{i}@example.com"),
+            })
+            .collect();
+        let input = make_input(addrs);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn too_many_recipients_across_fields_rejected() {
+        let to: Vec<AddressInput> = (0..50)
+            .map(|i| AddressInput {
+                name: None,
+                address: format!("to{i}@example.com"),
+            })
+            .collect();
+        let cc: Vec<AddressInput> = (0..30)
+            .map(|i| AddressInput {
+                name: None,
+                address: format!("cc{i}@example.com"),
+            })
+            .collect();
+        let bcc: Vec<AddressInput> = (0..21)
+            .map(|i| AddressInput {
+                name: None,
+                address: format!("bcc{i}@example.com"),
+            })
+            .collect();
+        let mut input = make_input(to);
+        input.cc = Some(cc);
+        input.bcc = Some(bcc);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn exactly_max_recipients_accepted() {
+        let addrs: Vec<AddressInput> = (0..100)
+            .map(|i| AddressInput {
+                name: None,
+                address: format!("user{i}@example.com"),
+            })
+            .collect();
+        let input = make_input(addrs);
+        validate_draft_input(&input).unwrap();
+    }
+
+    #[test]
+    fn subject_too_long_rejected() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.subject = "x".repeat(1001);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn subject_at_max_accepted() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.subject = "x".repeat(1000);
+        validate_draft_input(&input).unwrap();
+    }
+
+    #[test]
+    fn body_too_large_rejected() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.body_text = "x".repeat(1_048_577);
+        let err = validate_draft_input(&input).unwrap_err();
+        assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn body_at_max_accepted() {
+        let mut input = make_input(vec![AddressInput {
+            name: None,
+            address: "ok@example.com".into(),
+        }]);
+        input.body_text = "x".repeat(1_048_576);
+        validate_draft_input(&input).unwrap();
     }
 }

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -1,7 +1,7 @@
 //! `download_attachment` tool handler.
 
 use mail_parser::MimeHeaders;
-use rimap_imap::types::Uid;
+use rimap_imap::types::{BodyStructure, FetchSpec, Uid};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -76,6 +76,22 @@ pub async fn handle(
 
     let path_str = path.to_string_lossy().to_string();
 
+    let mut security_warnings = Vec::new();
+
+    // Cross-validate: fetch BODYSTRUCTURE and compare its declared
+    // MIME type against what mail_parser reports. Best-effort — if
+    // the fetch or lookup fails we skip validation silently.
+    let spec = FetchSpec {
+        bodystructure: true,
+        ..FetchSpec::default()
+    };
+    if let Ok(msgs) = server.imap.fetch(&input.folder, &[uid], spec).await
+        && let Some(bs) = msgs.into_iter().next().and_then(|m| m.bodystructure)
+        && let Some(bs_type) = lookup_bodystructure_type(&bs, &input.part_id)
+    {
+        security_warnings.extend(cross_validate_mime_type(&bs_type, &declared_type));
+    }
+
     Ok(ToolResponse {
         meta: serde_json::json!({
             "folder": input.folder,
@@ -90,8 +106,89 @@ pub async fn handle(
         untrusted: Some(serde_json::json!({
             "filename_original": original_filename,
         })),
-        security_warnings: Vec::new(),
+        security_warnings,
     })
+}
+
+/// Compare BODYSTRUCTURE-declared MIME type against `mail_parser`'s type.
+///
+/// Returns a security warning if they disagree (case-insensitive).
+fn cross_validate_mime_type(bodystructure_type: &str, parser_type: &str) -> Vec<serde_json::Value> {
+    if bodystructure_type.eq_ignore_ascii_case(parser_type) {
+        return Vec::new();
+    }
+    vec![serde_json::json!({
+        "type": "mime_type_mismatch",
+        "bodystructure_type": bodystructure_type,
+        "parser_type": parser_type,
+        "message":
+            "BODYSTRUCTURE MIME type disagrees with parsed content type"
+    })]
+}
+
+/// Maximum recursion depth for BODYSTRUCTURE tree walking.
+const MAX_BS_DEPTH: u32 = 64;
+
+/// Look up a part's declared MIME type from a `BodyStructure` tree by
+/// IMAP-style part ID (e.g. "2", "1.2").
+fn lookup_bodystructure_type(bs: &BodyStructure, target_part_id: &str) -> Option<String> {
+    lookup_bs_recursive(bs, &mut String::new(), target_part_id, 0)
+}
+
+/// Recursive walker that mirrors `collect_attachments` numbering.
+fn lookup_bs_recursive(
+    bs: &BodyStructure,
+    prefix: &mut String,
+    target: &str,
+    depth: u32,
+) -> Option<String> {
+    if depth > MAX_BS_DEPTH {
+        return None;
+    }
+    match bs {
+        BodyStructure::Single {
+            mime_type,
+            mime_subtype,
+            ..
+        } => {
+            let part_id = if prefix.is_empty() {
+                "1".to_string()
+            } else {
+                prefix.clone()
+            };
+            if part_id == target {
+                Some(format!(
+                    "{}/{}",
+                    mime_type.to_lowercase(),
+                    mime_subtype.to_lowercase()
+                ))
+            } else {
+                None
+            }
+        }
+        BodyStructure::Multipart { parts, .. } => {
+            for (i, part) in parts.iter().enumerate() {
+                let idx = i + 1;
+                let mut child = if prefix.is_empty() {
+                    idx.to_string()
+                } else {
+                    format!("{prefix}.{idx}")
+                };
+                if let Some(found) = lookup_bs_recursive(part, &mut child, target, depth + 1) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        BodyStructure::Message { body, .. } => {
+            let mut part_id = if prefix.is_empty() {
+                "1".to_string()
+            } else {
+                prefix.clone()
+            };
+            lookup_bs_recursive(body, &mut part_id, target, depth + 1)
+        }
+    }
 }
 
 /// Find the MIME part matching `part_id` in a parsed message.
@@ -200,5 +297,100 @@ mod tests {
         let mut out = Vec::new();
         walk_parts(&msg, 0, "", &mut out, MAX_MIME_DEPTH + 1).unwrap();
         assert!(out.is_empty());
+    }
+
+    // -- cross_validate_mime_type ------------------------------------------
+
+    #[test]
+    fn cross_validate_catches_type_mismatch() {
+        let warnings = cross_validate_mime_type("image/png", "text/html");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].to_string().contains("mime_type_mismatch"));
+    }
+
+    #[test]
+    fn cross_validate_passes_on_match() {
+        let warnings = cross_validate_mime_type("image/png", "image/png");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn cross_validate_case_insensitive() {
+        let warnings = cross_validate_mime_type("IMAGE/PNG", "image/png");
+        assert!(warnings.is_empty());
+    }
+
+    // -- lookup_bodystructure_type ----------------------------------------
+
+    fn single(mt: &str, sub: &str) -> BodyStructure {
+        BodyStructure::Single {
+            mime_type: mt.to_string(),
+            mime_subtype: sub.to_string(),
+            params: Vec::new(),
+            encoding: "7bit".to_string(),
+            size: 100,
+        }
+    }
+
+    #[test]
+    fn lookup_single_part_message() {
+        let bs = single("image", "png");
+        let result = lookup_bodystructure_type(&bs, "1");
+        assert_eq!(result.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn lookup_multipart_by_id() {
+        let bs = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![single("text", "plain"), single("application", "pdf")],
+        };
+        assert_eq!(
+            lookup_bodystructure_type(&bs, "2").as_deref(),
+            Some("application/pdf")
+        );
+        assert_eq!(
+            lookup_bodystructure_type(&bs, "1").as_deref(),
+            Some("text/plain")
+        );
+    }
+
+    #[test]
+    fn lookup_nested_multipart() {
+        let inner = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![single("text", "plain"), single("image", "gif")],
+        };
+        let bs = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![inner, single("application", "zip")],
+        };
+        assert_eq!(
+            lookup_bodystructure_type(&bs, "1.2").as_deref(),
+            Some("image/gif")
+        );
+        assert_eq!(
+            lookup_bodystructure_type(&bs, "2").as_deref(),
+            Some("application/zip")
+        );
+    }
+
+    #[test]
+    fn lookup_missing_part_id_returns_none() {
+        let bs = single("text", "plain");
+        assert!(lookup_bodystructure_type(&bs, "99").is_none());
+    }
+
+    #[test]
+    fn lookup_respects_depth_limit() {
+        let mut bs = single("application", "pdf");
+        for _ in 0..70 {
+            bs = BodyStructure::Multipart {
+                subtype: "mixed".to_string(),
+                parts: vec![bs],
+            };
+        }
+        // The deeply nested part should be unreachable.
+        assert!(lookup_bodystructure_type(&bs, "1").is_none());
     }
 }

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -140,7 +140,7 @@ fn compute_part_ids(
         .ok_or_else(|| rimap_core::RimapError::Internal("message has no parts".into()))?;
 
     if root.is_multipart() {
-        walk_parts(msg, 0, "", &mut result)?;
+        walk_parts(msg, 0, "", &mut result, 0)?;
     } else {
         // Single-part message: the sole part is "1".
         result.push((0, "1".to_string()));
@@ -149,13 +149,20 @@ fn compute_part_ids(
     Ok(result)
 }
 
+/// Maximum recursion depth for MIME tree walking (denial-of-service guard).
+const MAX_MIME_DEPTH: u32 = 64;
+
 /// Recursively walk parts and assign IMAP-style IDs.
 fn walk_parts(
     msg: &mail_parser::Message<'_>,
     part_idx: usize,
     prefix: &str,
     out: &mut Vec<(usize, String)>,
+    depth: u32,
 ) -> Result<(), rimap_core::RimapError> {
+    if depth > MAX_MIME_DEPTH {
+        return Ok(());
+    }
     let part = msg.parts.get(part_idx).ok_or_else(|| {
         rimap_core::RimapError::Internal(format!("part index {part_idx} out of range"))
     })?;
@@ -168,7 +175,7 @@ fn walk_parts(
             } else {
                 format!("{prefix}.{num}")
             };
-            walk_parts(msg, child_idx as usize, &child_id, out)?;
+            walk_parts(msg, child_idx as usize, &child_id, out, depth + 1)?;
         }
     } else {
         let part_id = if prefix.is_empty() {
@@ -179,4 +186,19 @@ fn walk_parts(
         out.push((part_idx, part_id));
     }
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_parts_respects_depth_limit() {
+        let raw = b"From: a@b\r\nContent-Type: text/plain\r\n\r\nHi\r\n";
+        let msg = mail_parser::MessageParser::new().parse(raw).unwrap();
+        let mut out = Vec::new();
+        walk_parts(&msg, 0, "", &mut out, MAX_MIME_DEPTH + 1).unwrap();
+        assert!(out.is_empty());
+    }
 }

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -92,6 +92,12 @@ pub async fn handle(
         security_warnings.extend(cross_validate_mime_type(&bs_type, &declared_type));
     }
 
+    // Compare declared MIME type against magic-byte detection.
+    security_warnings.extend(check_sniff_mismatch(
+        &declared_type,
+        mime_sniffed.as_deref(),
+    ));
+
     Ok(ToolResponse {
         meta: serde_json::json!({
             "folder": input.folder,
@@ -123,6 +129,26 @@ fn cross_validate_mime_type(bodystructure_type: &str, parser_type: &str) -> Vec<
         "parser_type": parser_type,
         "message":
             "BODYSTRUCTURE MIME type disagrees with parsed content type"
+    })]
+}
+
+/// Compare declared MIME type against magic-byte-sniffed type.
+///
+/// Returns a security warning when they disagree. Returns nothing
+/// when sniffing produced no result (unknown magic bytes).
+fn check_sniff_mismatch(declared: &str, sniffed: Option<&str>) -> Vec<serde_json::Value> {
+    let Some(sniffed) = sniffed else {
+        return Vec::new();
+    };
+    if declared.eq_ignore_ascii_case(sniffed) {
+        return Vec::new();
+    }
+    vec![serde_json::json!({
+        "type": "mime_sniff_mismatch",
+        "mime_declared": declared,
+        "mime_sniffed": sniffed,
+        "message":
+            "declared MIME type disagrees with magic-byte detection"
     })]
 }
 
@@ -392,5 +418,32 @@ mod tests {
         }
         // The deeply nested part should be unreachable.
         assert!(lookup_bodystructure_type(&bs, "1").is_none());
+    }
+
+    // -- check_sniff_mismatch -----------------------------------------------
+
+    #[test]
+    fn sniff_mismatch_produces_warning() {
+        let warnings = check_sniff_mismatch("text/plain", Some("image/png"));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].to_string().contains("mime_sniff_mismatch"));
+    }
+
+    #[test]
+    fn sniff_match_produces_no_warning() {
+        let warnings = check_sniff_mismatch("image/png", Some("image/png"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn sniff_none_produces_no_warning() {
+        let warnings = check_sniff_mismatch("text/plain", None);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn sniff_mismatch_case_insensitive() {
+        let warnings = check_sniff_mismatch("IMAGE/PNG", Some("image/png"));
+        assert!(warnings.is_empty());
     }
 }

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -79,11 +79,10 @@ pub async fn handle(
 
     let safe_filename = original_filename.as_deref().unwrap_or("attachment");
 
-    let path = download::write_attachment_async(dest, safe_filename.to_string(), part_body.clone())
-        .await?;
     let size = part_body.len();
     let sha256 = download::sha256_hex(&part_body);
     let mime_sniffed = download::sniff_mime(&part_body);
+    let path = download::write_attachment_async(dest, safe_filename.to_string(), part_body).await?;
 
     let path_str = path.to_string_lossy().to_string();
 

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -49,27 +49,38 @@ pub async fn handle(
         });
     }
 
-    let dest = download::resolve_dest_dir(
-        input.dest_dir.as_deref(),
-        &server.download_dir,
-        &server.download_dir,
-    )?;
+    let dest = download::resolve_dest_dir_async(
+        input.dest_dir,
+        server.download_dir.clone(),
+        server.download_dir.clone(),
+    )
+    .await?;
 
     let raw = server.imap.fetch_body(&input.folder, uid).await?;
 
-    let parsed = mail_parser::MessageParser::new()
-        .parse(&raw)
-        .ok_or_else(|| {
-            rimap_core::RimapError::Internal(
-                "failed to parse message for attachment extraction".into(),
-            )
-        })?;
+    let parsed = tokio::task::spawn_blocking(move || {
+        mail_parser::MessageParser::new()
+            .parse(&raw)
+            .map(mail_parser::Message::into_owned)
+            .ok_or_else(|| {
+                rimap_core::RimapError::Internal(
+                    "failed to parse message for attachment extraction".into(),
+                )
+            })
+    })
+    .await
+    .unwrap_or_else(|e| {
+        Err(rimap_core::RimapError::Internal(format!(
+            "spawn_blocking panicked: {e}"
+        )))
+    })?;
 
     let (part_body, declared_type, original_filename) = find_part_by_id(&parsed, &input.part_id)?;
 
     let safe_filename = original_filename.as_deref().unwrap_or("attachment");
 
-    let path = download::write_attachment(&dest, safe_filename, &part_body)?;
+    let path = download::write_attachment_async(dest, safe_filename.to_string(), part_body.clone())
+        .await?;
     let size = part_body.len();
     let sha256 = download::sha256_hex(&part_body);
     let mime_sniffed = download::sniff_mime(&part_body);

--- a/crates/rimap-server/src/tools/flags.rs
+++ b/crates/rimap-server/src/tools/flags.rs
@@ -2,13 +2,14 @@
 //! `unflag`.
 
 use rimap_imap::types::{Flag, FlagAction, Uid};
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::response::ToolResponse;
 use crate::server::ImapMcpServer;
 
 /// Input for flag mutation tools.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct FlagInput {
     /// Target folder.
     pub folder: String,

--- a/crates/rimap-server/src/tools/list_attachments.rs
+++ b/crates/rimap-server/src/tools/list_attachments.rs
@@ -61,7 +61,7 @@ pub async fn handle(
     })?;
 
     let mut attachments = Vec::new();
-    collect_attachments(&bodystructure, &mut String::new(), &mut attachments);
+    collect_attachments(&bodystructure, &mut String::new(), &mut attachments, 0);
 
     let attachment_values: Vec<serde_json::Value> = attachments
         .iter()
@@ -88,13 +88,24 @@ pub async fn handle(
     })
 }
 
+/// Maximum recursion depth for MIME tree walking (denial-of-service guard).
+const MAX_MIME_DEPTH: u32 = 64;
+
 /// Walk the `BodyStructure` tree and collect attachment parts.
 ///
 /// IMAP part numbering: for a multipart message the top-level parts
 /// are "1", "2", "3", etc. Nested multipart sub-parts are "1.1",
 /// "1.2", etc. For a non-multipart (single-part) message at the
 /// root, the sole part is "1".
-fn collect_attachments(bs: &BodyStructure, prefix: &mut String, out: &mut Vec<AttachmentInfo>) {
+fn collect_attachments(
+    bs: &BodyStructure,
+    prefix: &mut String,
+    out: &mut Vec<AttachmentInfo>,
+    depth: u32,
+) {
+    if depth > MAX_MIME_DEPTH {
+        return;
+    }
     match bs {
         BodyStructure::Single {
             mime_type,
@@ -132,7 +143,7 @@ fn collect_attachments(bs: &BodyStructure, prefix: &mut String, out: &mut Vec<At
                     format!("{prefix}.{idx}")
                 };
                 let mut child = child_prefix;
-                collect_attachments(part, &mut child, out);
+                collect_attachments(part, &mut child, out, depth + 1);
             }
         }
         BodyStructure::Message { body, .. } => {
@@ -142,7 +153,7 @@ fn collect_attachments(bs: &BodyStructure, prefix: &mut String, out: &mut Vec<At
                 prefix.clone()
             };
             // Walk into the embedded message's body structure.
-            collect_attachments(body, &mut part_id.clone(), out);
+            collect_attachments(body, &mut part_id.clone(), out, depth + 1);
         }
     }
 }
@@ -195,7 +206,7 @@ mod tests {
     fn single_text_plain_is_not_attachment() {
         let bs = single("text", "plain", 100);
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out);
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
         assert!(out.is_empty());
     }
 
@@ -203,7 +214,7 @@ mod tests {
     fn single_text_html_is_not_attachment() {
         let bs = single("text", "html", 200);
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out);
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
         assert!(out.is_empty());
     }
 
@@ -211,7 +222,7 @@ mod tests {
     fn single_image_is_attachment() {
         let bs = single_with_name("image", "png", 5000, "photo.png");
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out);
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].part_id, "1");
         assert_eq!(out[0].mime_type, "image/png");
@@ -230,7 +241,7 @@ mod tests {
             ],
         };
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out);
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].part_id, "2");
         assert_eq!(out[0].mime_type, "application/pdf");
@@ -255,7 +266,7 @@ mod tests {
             ],
         };
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out);
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].part_id, "1.2");
         assert_eq!(out[0].filename.as_deref(), Some("anim.gif"));
@@ -284,5 +295,19 @@ mod tests {
     fn extract_filename_returns_none_when_absent() {
         let params = vec![("charset".to_string(), "utf-8".to_string())];
         assert_eq!(extract_filename(&params), None);
+    }
+
+    #[test]
+    fn deeply_nested_mime_respects_depth_limit() {
+        let mut bs = single("application", "pdf", 100);
+        for _ in 0..70 {
+            bs = BodyStructure::Multipart {
+                subtype: "mixed".to_string(),
+                parts: vec![bs],
+            };
+        }
+        let mut out = Vec::new();
+        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        assert!(out.is_empty());
     }
 }

--- a/crates/rimap-server/src/tools/move_message.rs
+++ b/crates/rimap-server/src/tools/move_message.rs
@@ -1,6 +1,7 @@
 //! `move_message` tool handler.
 
 use rimap_imap::types::Uid;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::response::ToolResponse;
@@ -8,7 +9,7 @@ use crate::server::ImapMcpServer;
 use crate::tools::flags::resolve_uids;
 
 /// Input for `move_message`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct MoveInput {
     /// Source folder.
     pub source_folder: String,

--- a/crates/rimap-server/src/tools/move_message.rs
+++ b/crates/rimap-server/src/tools/move_message.rs
@@ -26,12 +26,13 @@ pub async fn handle(
     input: MoveInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uids = resolve_uids(input.uid, input.uids)?;
-    let results = server
+    let outcome = server
         .imap
         .move_messages(&input.source_folder, &input.dest_folder, &uids)
         .await?;
 
-    let moves: Vec<serde_json::Value> = results
+    let moves: Vec<serde_json::Value> = outcome
+        .results
         .iter()
         .map(|r| {
             serde_json::json!({
@@ -41,6 +42,17 @@ pub async fn handle(
         })
         .collect();
 
+    let mut warnings = Vec::new();
+    if outcome.used_fallback {
+        warnings.push(serde_json::json!({
+            "type": "non_atomic_move",
+            "message": "Server lacks MOVE capability; \
+                used non-atomic COPY+DELETE+EXPUNGE fallback. \
+                Other messages with \\Deleted flag in the source \
+                folder may have been expunged.",
+        }));
+    }
+
     Ok(ToolResponse {
         meta: serde_json::json!({
             "source_folder": input.source_folder,
@@ -48,6 +60,6 @@ pub async fn handle(
             "moves": moves,
         }),
         untrusted: None,
-        security_warnings: Vec::new(),
+        security_warnings: warnings,
     })
 }

--- a/crates/rimap-server/tests/audit_merge.rs
+++ b/crates/rimap-server/tests/audit_merge.rs
@@ -37,6 +37,7 @@ fn audit_merge_round_trips_synthetic_log() {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: Seq::FIRST,
         })
@@ -97,6 +98,7 @@ fn audit_merge_filters_by_kind() {
             path: path.clone(),
             rotate_bytes: 0,
             rotate_keep: 0,
+            retention_seconds: None,
             fail_open: false,
             initial_seq: Seq::FIRST,
         })

--- a/docs/superpowers/plans/2026-04-12-issue-fixes-plan.md
+++ b/docs/superpowers/plans/2026-04-12-issue-fixes-plan.md
@@ -1,0 +1,1616 @@
+# Post-Sprint 5 Issue Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 14 actionable open issues grouped by subsystem, each group as an independent commit on branch `fix/post-sprint5-issues`.
+
+**Architecture:** Issues are grouped into 5 implementation groups ordered by dependency: (A) IMAP protocol safety, (B) server MIME safety, (C) server input validation & schemas, (D) server async safety, (E) audit enhancements. Three issues (#14, #18, #19) are deferred meta-issues for future security-review agents and are not implemented here.
+
+**Tech Stack:** Rust, async-imap, mail_parser, schemars, tokio, fs4, time
+
+**Deferred (not in scope):**
+- #14 — threat-model-reviewer agent (post-v1 tooling)
+- #18 — SECURITY.md hygiene reviewer (post-v1 tooling)
+- #19 — release integrity reviewer (post-v1 tooling)
+- #32 — fetch_body backpressure (async-imap 0.11 limitation, no fix path)
+
+---
+
+## Group A: IMAP Protocol Safety (#56, #57)
+
+### Task 1: Add `max_append_bytes` size cap to APPEND (#56)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs:40-55` (add field to `ConnectionConfig`)
+- Modify: `crates/rimap-imap/src/ops/append.rs` (add size check)
+- Modify: `crates/rimap-imap/src/error.rs` (reuse `SizeLimit` variant or add context)
+- Modify: `crates/rimap-config/src/model.rs` (add `max_append_bytes` to `LimitsConfig`)
+- Modify: `crates/rimap-config/src/validate.rs` (validate > 0)
+- Modify: `crates/rimap-server/src/bootstrap.rs` or wherever `ConnectionConfig` is built (wire config value)
+
+- [ ] **Step 1: Write the failing test in `ops/append.rs`**
+
+```rust
+#[test]
+fn append_rejects_oversized_message() {
+    // Directly test the size check logic
+    let limit: u64 = 100;
+    let message = vec![0u8; 200];
+    let result = check_append_size(message.len(), limit);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, Error::SizeLimit { .. }));
+}
+
+#[test]
+fn append_accepts_message_within_limit() {
+    let limit: u64 = 200;
+    let message = vec![0u8; 100];
+    let result = check_append_size(message.len(), limit);
+    assert!(result.is_ok());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-imap append_rejects_oversized`
+Expected: FAIL — `check_append_size` does not exist
+
+- [ ] **Step 3: Add `max_append_bytes` to `LimitsConfig`**
+
+In `crates/rimap-config/src/model.rs`, add to `LimitsConfig`:
+```rust
+/// Hard cap on APPEND message size in bytes.
+/// Default: 10 MB. Prevents prompt-injection-driven storage exhaustion.
+#[serde(default = "default_max_append")]
+pub max_append_bytes: u64,
+```
+
+Add the default function:
+```rust
+fn default_max_append() -> u64 {
+    10 * 1024 * 1024
+}
+```
+
+In `validate.rs`, add to `validate_limits()`:
+```rust
+if cfg.limits.max_append_bytes == 0 {
+    return Err(ConfigError::InvalidValue {
+        field: "limits.max_append_bytes".into(),
+        reason: "must be > 0".into(),
+    });
+}
+```
+
+- [ ] **Step 4: Add `max_append_bytes` field to `ConnectionConfig`**
+
+In `crates/rimap-imap/src/connection.rs`, add to `ConnectionConfig`:
+```rust
+/// Hard cap on APPEND message size in bytes.
+pub max_append_bytes: u64,
+```
+
+- [ ] **Step 5: Implement `check_append_size` and wire it into `append()`**
+
+In `crates/rimap-imap/src/ops/append.rs`:
+```rust
+/// Check that the message does not exceed the configured append size limit.
+fn check_append_size(len: usize, limit: u64) -> Result<(), Error> {
+    let len_u64 = u64::try_from(len).unwrap_or(u64::MAX);
+    if len_u64 > limit {
+        return Err(Error::SizeLimit { limit });
+    }
+    Ok(())
+}
+```
+
+Update the `append()` function signature to accept `max_append_bytes: u64` and call `check_append_size(message.len(), max_append_bytes)?;` at the top.
+
+- [ ] **Step 6: Wire `max_append_bytes` through `Connection::append_message`**
+
+Wherever `Connection::append_message` calls `ops::append::append`, pass `self.inner.cfg.max_append_bytes` as the limit parameter.
+
+Wire the config value into `ConnectionConfig` construction in `rimap-server` bootstrap code.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p rimap-imap append_rejects && cargo test -p rimap-imap append_accepts`
+Expected: PASS
+
+- [ ] **Step 8: Run `just ci` and fix any warnings**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/append.rs crates/rimap-imap/src/connection.rs \
+       crates/rimap-config/src/model.rs crates/rimap-config/src/validate.rs \
+       crates/rimap-server/src/
+git commit -m "fix(imap): add max_append_bytes size cap to APPEND (#56)"
+```
+
+---
+
+### Task 2: Check MOVE capability before UID MOVE (#57)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/ops/move_msg.rs` (capability check, remove `Error::No` arm)
+- Modify: `crates/rimap-imap/src/connection.rs` (expose capabilities post-login)
+
+The key changes:
+1. After login, query `session.capabilities()` and cache whether MOVE is supported.
+2. In `move_messages()`, accept a `has_move: bool` parameter.
+3. If MOVE absent, go straight to fallback. If present but UID MOVE returns BAD, propagate the error.
+4. Remove the `Error::No` arm from `is_move_unsupported`.
+5. Return a structured warning when fallback is used.
+
+- [ ] **Step 1: Write failing tests**
+
+In `crates/rimap-imap/src/ops/move_msg.rs` tests:
+```rust
+#[test]
+fn is_move_unsupported_only_matches_bad() {
+    // BAD should trigger fallback
+    let bad = async_imap::error::Error::Bad("unknown command".to_string());
+    assert!(is_move_unsupported(&bad));
+
+    // NO should NOT trigger fallback (server has MOVE but rejected it)
+    let no = async_imap::error::Error::No("unknown command".to_string());
+    assert!(!is_move_unsupported(&no));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-imap is_move_unsupported_only`
+Expected: FAIL — the `Error::No` arm currently returns `true`
+
+- [ ] **Step 3: Fix `is_move_unsupported` to only match `Error::Bad`**
+
+In `crates/rimap-imap/src/ops/move_msg.rs`, replace the function:
+```rust
+fn is_move_unsupported(err: &async_imap::error::Error) -> bool {
+    match err {
+        async_imap::error::Error::Bad(_) => true,
+        // async_imap::error::Error is #[non_exhaustive], so the
+        // wildcard is required.
+        _ => false,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rimap-imap is_move_unsupported_only`
+Expected: PASS
+
+- [ ] **Step 5: Add `has_move_capability` parameter to `move_messages`**
+
+Update `move_messages` signature:
+```rust
+pub async fn move_messages(
+    session: &mut ImapSession,
+    dest_folder: &str,
+    uids: &[Uid],
+    has_move: bool,
+) -> Result<(Vec<MoveResult>, bool), Error> {
+```
+
+The `bool` return indicates whether the non-atomic fallback was used.
+
+When `has_move` is `false`, skip UID MOVE and go directly to `copy_delete_fallback`. When `has_move` is `true` and UID MOVE returns BAD, propagate the error (don't fall back — the server is misbehaving).
+
+- [ ] **Step 6: Expose capability check on `Connection`**
+
+In `connection.rs`, after successful login, call `session.capabilities()` to check for MOVE. Store the result in `ConnectionInner` (add a `has_move: std::sync::atomic::AtomicBool` field or similar). Expose via `Connection::has_move_capability(&self) -> bool`.
+
+- [ ] **Step 7: Wire through `Connection::move_messages` and the server layer**
+
+Update `Connection::move_messages` to pass `self.has_move_capability()` to `ops::move_msg::move_messages`.
+
+Update `crates/rimap-server/src/tools/move_message.rs` to include a `security_warning` when fallback is used:
+```rust
+if used_fallback {
+    response.security_warnings.push(serde_json::json!({
+        "type": "non_atomic_move",
+        "message": "server lacks MOVE capability; used non-atomic COPY+DELETE fallback"
+    }));
+}
+```
+
+- [ ] **Step 8: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/move_msg.rs crates/rimap-imap/src/connection.rs \
+       crates/rimap-server/src/tools/move_message.rs
+git commit -m "fix(imap): check MOVE capability before UID MOVE (#57)"
+```
+
+---
+
+## Group B: Server MIME Safety (#60, #62, #63)
+
+### Task 3: Add recursion depth limit to MIME tree walkers (#60)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/list_attachments.rs` (add `depth` param to `collect_attachments`)
+- Modify: `crates/rimap-server/src/tools/download_attachment.rs` (add `depth` param to `walk_parts`)
+
+- [ ] **Step 1: Write failing tests for `list_attachments` depth limit**
+
+In `crates/rimap-server/src/tools/list_attachments.rs` tests:
+```rust
+/// Maximum recursion depth for MIME tree walking.
+const MAX_MIME_DEPTH: u32 = 64;
+
+#[test]
+fn deeply_nested_mime_respects_depth_limit() {
+    // Build a structure nested deeper than MAX_MIME_DEPTH.
+    let mut bs = single("application", "pdf", 100);
+    for _ in 0..70 {
+        bs = BodyStructure::Multipart {
+            subtype: "mixed".to_string(),
+            parts: vec![bs],
+        };
+    }
+    let mut out = Vec::new();
+    collect_attachments(&bs, &mut String::new(), &mut out, 0);
+    // The deep attachment should NOT be found (depth exceeded).
+    assert!(out.is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-server deeply_nested_mime`
+Expected: FAIL — `collect_attachments` doesn't accept a depth parameter (compile error)
+
+- [ ] **Step 3: Add depth parameter to `collect_attachments`**
+
+```rust
+/// Maximum recursion depth for MIME tree walking (DoS guard).
+const MAX_MIME_DEPTH: u32 = 64;
+
+fn collect_attachments(
+    bs: &BodyStructure,
+    prefix: &mut String,
+    out: &mut Vec<AttachmentInfo>,
+    depth: u32,
+) {
+    if depth > MAX_MIME_DEPTH {
+        return;
+    }
+    match bs {
+        BodyStructure::Single { .. } => { /* unchanged */ }
+        BodyStructure::Multipart { parts, .. } => {
+            for (i, part) in parts.iter().enumerate() {
+                let idx = i + 1;
+                let child_prefix = if prefix.is_empty() {
+                    idx.to_string()
+                } else {
+                    format!("{prefix}.{idx}")
+                };
+                let mut child = child_prefix;
+                collect_attachments(part, &mut child, out, depth + 1);
+            }
+        }
+        BodyStructure::Message { body, .. } => {
+            let part_id = if prefix.is_empty() {
+                "1".to_string()
+            } else {
+                prefix.clone()
+            };
+            collect_attachments(body, &mut part_id.clone(), out, depth + 1);
+        }
+    }
+}
+```
+
+Update the call site in `handle()`:
+```rust
+collect_attachments(&bodystructure, &mut String::new(), &mut attachments, 0);
+```
+
+Update all existing test calls to pass `0` as the depth argument.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p rimap-server list_attachments`
+Expected: PASS (all existing + new depth test)
+
+- [ ] **Step 5: Write failing test for `download_attachment` depth limit**
+
+In `crates/rimap-server/src/tools/download_attachment.rs`, add a test module and test:
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    const MAX_MIME_DEPTH: u32 = 64;
+
+    #[test]
+    fn walk_parts_respects_depth_limit() {
+        // Build a message with mail_parser won't help here since
+        // we test the function directly. Instead, test that
+        // walk_parts with depth > MAX_MIME_DEPTH returns empty.
+        // This is a structural guarantee test.
+        //
+        // The depth check is in walk_parts; we verify it returns
+        // early by calling with depth already at the limit.
+        let raw = b"From: a@b\r\nContent-Type: text/plain\r\n\r\nHi\r\n";
+        let msg = mail_parser::MessageParser::new().parse(raw).unwrap();
+        let mut out = Vec::new();
+        // Start at depth = MAX_MIME_DEPTH + 1 to verify early return.
+        walk_parts(&msg, 0, "", &mut out, MAX_MIME_DEPTH + 1).unwrap();
+        assert!(out.is_empty());
+    }
+}
+```
+
+- [ ] **Step 6: Add depth parameter to `walk_parts` and `compute_part_ids`**
+
+```rust
+const MAX_MIME_DEPTH: u32 = 64;
+
+fn compute_part_ids(
+    msg: &mail_parser::Message<'_>,
+) -> Result<Vec<(usize, String)>, rimap_core::RimapError> {
+    let mut result = Vec::new();
+    let root = msg.parts.first().ok_or_else(|| {
+        rimap_core::RimapError::Internal("message has no parts".into())
+    })?;
+    if root.is_multipart() {
+        walk_parts(msg, 0, "", &mut result, 0)?;
+    } else {
+        result.push((0, "1".to_string()));
+    }
+    Ok(result)
+}
+
+fn walk_parts(
+    msg: &mail_parser::Message<'_>,
+    part_idx: usize,
+    prefix: &str,
+    out: &mut Vec<(usize, String)>,
+    depth: u32,
+) -> Result<(), rimap_core::RimapError> {
+    if depth > MAX_MIME_DEPTH {
+        return Ok(());
+    }
+    // ... rest unchanged except recursive calls pass depth + 1
+}
+```
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cargo test -p rimap-server`
+Expected: PASS
+
+- [ ] **Step 8: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/list_attachments.rs \
+       crates/rimap-server/src/tools/download_attachment.rs
+git commit -m "fix(server): add recursion depth limit to MIME tree walkers (#60)"
+```
+
+---
+
+### Task 4: Unify MIME tree walking to single parser (#62)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/download_attachment.rs` (add cross-validation)
+
+Issue #62 identifies a parser differential risk: `list_attachments` walks IMAP BODYSTRUCTURE while `download_attachment` re-parses with `mail_parser`. Full unification would require rearchitecting both tools to use the same parser, which is a larger refactor. The pragmatic fix per the acceptance criteria's "OR" clause is to add a cross-validation step that compares the declared content-type from BODYSTRUCTURE against the actual content-type from `mail_parser`.
+
+- [ ] **Step 1: Write failing test for content-type cross-validation**
+
+In `download_attachment.rs` tests:
+```rust
+#[test]
+fn cross_validate_catches_type_mismatch() {
+    let declared = "image/png";
+    let actual = "text/html";
+    let warnings = cross_validate_mime_type(declared, actual);
+    assert_eq!(warnings.len(), 1);
+    assert!(
+        warnings[0].to_string().contains("mime_type_mismatch"),
+    );
+}
+
+#[test]
+fn cross_validate_passes_on_match() {
+    let warnings = cross_validate_mime_type("image/png", "image/png");
+    assert!(warnings.is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-server cross_validate`
+Expected: FAIL — function doesn't exist
+
+- [ ] **Step 3: Implement cross-validation helper**
+
+```rust
+/// Compare declared MIME type (from BODYSTRUCTURE) against actual
+/// type (from mail_parser). Returns security warnings on mismatch.
+fn cross_validate_mime_type(
+    declared: &str,
+    actual: &str,
+) -> Vec<serde_json::Value> {
+    if declared.eq_ignore_ascii_case(actual) {
+        return Vec::new();
+    }
+    vec![serde_json::json!({
+        "type": "mime_type_mismatch",
+        "declared": declared,
+        "actual": actual,
+        "message": "BODYSTRUCTURE type disagrees with parsed content type"
+    })]
+}
+```
+
+This function is called from `handle()` but requires fetching BODYSTRUCTURE alongside the body. Since the current `handle()` only fetches the body, we need to also fetch BODYSTRUCTURE for the target message and look up the part's declared type. If the BODYSTRUCTURE fetch fails or the part isn't found, skip validation (defense-in-depth, not blocking).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rimap-server cross_validate`
+Expected: PASS
+
+- [ ] **Step 5: Wire cross-validation into `handle()`**
+
+In `handle()`, after `find_part_by_id` returns `declared_type`, optionally fetch BODYSTRUCTURE and look up the part's declared type from the IMAP side. Compare and add any warnings to the response's `security_warnings`.
+
+This is best-effort: if BODYSTRUCTURE lookup fails, proceed without the warning.
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/download_attachment.rs
+git commit -m "fix(server): add MIME type cross-validation in download_attachment (#62)"
+```
+
+---
+
+### Task 5: Emit MIME type mismatch security warning (#63)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/download_attachment.rs:79-94` (add warning when sniffed != declared)
+
+- [ ] **Step 1: Write failing test**
+
+In `download_attachment.rs` tests:
+```rust
+#[test]
+fn sniff_mismatch_produces_warning() {
+    let declared = "text/plain";
+    let sniffed = Some("image/png".to_string());
+    let warnings = check_sniff_mismatch(declared, sniffed.as_deref());
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].to_string().contains("mime_sniff_mismatch"));
+}
+
+#[test]
+fn sniff_match_produces_no_warning() {
+    let warnings = check_sniff_mismatch(
+        "image/png",
+        Some("image/png").as_deref(),
+    );
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn sniff_none_produces_no_warning() {
+    let warnings = check_sniff_mismatch("text/plain", None);
+    assert!(warnings.is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-server sniff_mismatch`
+Expected: FAIL — function doesn't exist
+
+- [ ] **Step 3: Implement the sniff mismatch check**
+
+```rust
+/// Compare declared MIME type against magic-bytes-sniffed type.
+/// Returns a security warning when they disagree.
+fn check_sniff_mismatch(
+    declared: &str,
+    sniffed: Option<&str>,
+) -> Vec<serde_json::Value> {
+    let Some(sniffed) = sniffed else {
+        return Vec::new();
+    };
+    if declared.eq_ignore_ascii_case(sniffed) {
+        return Vec::new();
+    }
+    vec![serde_json::json!({
+        "type": "mime_sniff_mismatch",
+        "mime_declared": declared,
+        "mime_sniffed": sniffed,
+        "message": "declared MIME type disagrees with magic-byte detection"
+    })]
+}
+```
+
+- [ ] **Step 4: Wire into `handle()`**
+
+In `handle()`, after computing `mime_sniffed`, call:
+```rust
+let mut warnings = check_sniff_mismatch(&declared_type, mime_sniffed.as_deref());
+```
+
+Then set `security_warnings: warnings` in the response instead of `Vec::new()`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p rimap-server sniff_mismatch && cargo test -p rimap-server download_attachment`
+Expected: PASS
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/download_attachment.rs
+git commit -m "fix(server): emit MIME type mismatch security warning (#63)"
+```
+
+---
+
+## Group C: Server Input Validation & Schemas (#59, #64, #65)
+
+### Task 6: Add input schemas to tool definitions (#59)
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs:156-183` (use `schemars::schema_for!`)
+- Modify: `crates/rimap-server/src/tools/create_draft.rs` (add `JsonSchema` derive)
+- Modify: `crates/rimap-server/src/tools/flags.rs` (add `JsonSchema` derive)
+- Modify: `crates/rimap-server/src/tools/move_message.rs` (add `JsonSchema` derive)
+- Modify: `crates/rimap-server/Cargo.toml` (ensure `schemars` dependency)
+
+Currently `tool_definition()` creates tools with `Arc::new(serde_json::Map::new())` (empty schema). Input structs for some tools already derive `JsonSchema` but it's not wired in. The fix: generate schemas from each tool's input struct and use them.
+
+- [ ] **Step 1: Write a failing test that schemas are non-empty**
+
+In `crates/rimap-server/src/server.rs` tests:
+```rust
+#[test]
+fn tool_definitions_have_non_empty_schemas() {
+    for def in ToolName::all().into_iter().filter_map(tool_definition) {
+        let schema = &def.input_schema;
+        assert!(
+            !schema.is_empty(),
+            "tool {} has empty input schema",
+            def.name,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-server tool_definitions_have_non_empty`
+Expected: FAIL — all schemas are empty
+
+- [ ] **Step 3: Add `JsonSchema` derive to all input structs missing it**
+
+Add `use schemars::JsonSchema;` and `#[derive(JsonSchema)]` to:
+- `crates/rimap-server/src/tools/create_draft.rs`: `CreateDraftInput`, `AddressInput`
+- `crates/rimap-server/src/tools/flags.rs`: `FlagInput`
+- `crates/rimap-server/src/tools/move_message.rs`: `MoveInput`
+
+(`ListAttachmentsInput`, `DownloadAttachmentInput`, `SearchInput`, `FetchMessageInput` already have it.)
+
+`list_folders` has no input struct (takes no arguments) — use an empty object schema for it.
+
+- [ ] **Step 4: Update `tool_definition` to generate schemas**
+
+Replace the function body to return schemas per tool:
+
+```rust
+use schemars::schema_for;
+
+fn tool_definition(name: ToolName) -> Option<Tool> {
+    let (tool_name, description, schema) = match name {
+        ToolName::ListFolders => (
+            "list_folders",
+            "List all IMAP folders",
+            serde_json::Map::new(),
+        ),
+        ToolName::Search => (
+            "search",
+            "Search messages with structured query",
+            schema_map::<crate::tools::search::SearchInput>(),
+        ),
+        ToolName::SearchAdvanced | ToolName::FetchMessageHtml => return None,
+        ToolName::FetchMessage => (
+            "fetch_message",
+            "Fetch message metadata and text body",
+            schema_map::<crate::tools::fetch_message::FetchMessageInput>(),
+        ),
+        ToolName::ListAttachments => (
+            "list_attachments",
+            "List attachments on a message",
+            schema_map::<crate::tools::list_attachments::ListAttachmentsInput>(),
+        ),
+        ToolName::DownloadAttachment => (
+            "download_attachment",
+            "Download an attachment to the sandbox directory",
+            schema_map::<crate::tools::download_attachment::DownloadAttachmentInput>(),
+        ),
+        ToolName::MarkRead => (
+            "mark_read",
+            "Mark messages as read",
+            schema_map::<crate::tools::flags::FlagInput>(),
+        ),
+        ToolName::MarkUnread => (
+            "mark_unread",
+            "Mark messages as unread",
+            schema_map::<crate::tools::flags::FlagInput>(),
+        ),
+        ToolName::Flag => (
+            "flag",
+            "Add the flagged flag to messages",
+            schema_map::<crate::tools::flags::FlagInput>(),
+        ),
+        ToolName::Unflag => (
+            "unflag",
+            "Remove the flagged flag from messages",
+            schema_map::<crate::tools::flags::FlagInput>(),
+        ),
+        ToolName::MoveMessage => (
+            "move_message",
+            "Move messages to another folder",
+            schema_map::<crate::tools::move_message::MoveInput>(),
+        ),
+        ToolName::CreateDraft => (
+            "create_draft",
+            "Create a draft email with $PendingReview flag",
+            schema_map::<crate::tools::create_draft::CreateDraftInput>(),
+        ),
+    };
+
+    Some(Tool::new(tool_name, description, Arc::new(schema)))
+}
+
+/// Convert a `schemars` root schema into the `serde_json::Map`
+/// expected by rmcp's `Tool::new`.
+fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::Value> {
+    let schema = schema_for!(T);
+    match serde_json::to_value(schema) {
+        Ok(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p rimap-server tool_definition`
+Expected: PASS (all 4 tests including the new non-empty schema test)
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/server.rs crates/rimap-server/src/tools/
+git commit -m "feat(server): add input schemas to tool definitions (#59)"
+```
+
+---
+
+### Task 7: Cap References chain length in `create_draft` (#64)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/create_draft.rs:246-265` (truncate References)
+
+- [ ] **Step 1: Write failing test**
+
+In `create_draft.rs` tests:
+```rust
+#[test]
+fn references_chain_capped_at_50() {
+    let refs: Vec<String> = (0..200)
+        .map(|i| format!("msg-{i}@example.com"))
+        .collect();
+    let capped = cap_references(refs);
+    assert_eq!(capped.len(), 50);
+    // First entry is always the root (oldest).
+    assert_eq!(capped[0], "msg-0@example.com");
+    // Last entry is always the most recent.
+    assert_eq!(capped[49], "msg-199@example.com");
+}
+
+#[test]
+fn references_chain_under_cap_unchanged() {
+    let refs: Vec<String> = (0..10)
+        .map(|i| format!("msg-{i}@example.com"))
+        .collect();
+    let capped = cap_references(refs);
+    assert_eq!(capped.len(), 10);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-server references_chain_capped`
+Expected: FAIL — `cap_references` does not exist
+
+- [ ] **Step 3: Implement `cap_references`**
+
+```rust
+/// Maximum References chain length. Keeps root + most recent entries.
+const MAX_REFERENCES: usize = 50;
+
+/// Truncate a References chain to at most `MAX_REFERENCES` entries,
+/// preserving the root (first) and most recent (last) entries.
+fn cap_references(mut refs: Vec<String>) -> Vec<String> {
+    if refs.len() <= MAX_REFERENCES {
+        return refs;
+    }
+    // Keep the root entry + the (MAX_REFERENCES - 1) most recent.
+    let root = refs.remove(0);
+    let keep_recent = MAX_REFERENCES - 1;
+    let start = refs.len().saturating_sub(keep_recent);
+    let mut result = Vec::with_capacity(MAX_REFERENCES);
+    result.push(root);
+    result.extend(refs.into_iter().skip(start));
+    result
+}
+```
+
+- [ ] **Step 4: Wire into `apply_threading_headers`**
+
+After building `ref_ids` and before passing to `builder.references()`:
+```rust
+let ref_ids = cap_references(ref_ids);
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p rimap-server references_chain && cargo test -p rimap-server create_draft`
+Expected: PASS
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/create_draft.rs
+git commit -m "fix(server): cap References chain length to 50 in create_draft (#64)"
+```
+
+---
+
+### Task 8: Add input length bounds to `create_draft` (#65)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/create_draft.rs:110-137` (add length checks to `validate_draft_input`)
+
+- [ ] **Step 1: Write failing tests**
+
+In `create_draft.rs` tests:
+```rust
+#[test]
+fn too_many_recipients_rejected() {
+    let addrs: Vec<AddressInput> = (0..101)
+        .map(|i| AddressInput {
+            name: None,
+            address: format!("user{i}@example.com"),
+        })
+        .collect();
+    let input = make_input(addrs);
+    let err = validate_draft_input(&input).unwrap_err();
+    assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+}
+
+#[test]
+fn subject_too_long_rejected() {
+    let mut input = make_input(vec![AddressInput {
+        name: None,
+        address: "ok@example.com".into(),
+    }]);
+    input.subject = "x".repeat(1001);
+    let err = validate_draft_input(&input).unwrap_err();
+    assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+}
+
+#[test]
+fn body_too_large_rejected() {
+    let mut input = make_input(vec![AddressInput {
+        name: None,
+        address: "ok@example.com".into(),
+    }]);
+    input.body_text = "x".repeat(1_048_577); // 1 MB + 1
+    let err = validate_draft_input(&input).unwrap_err();
+    assert_eq!(err.code(), rimap_core::error::ErrorCode::InvalidInput);
+}
+```
+
+- [ ] **Step 2: Run test to verify they fail**
+
+Run: `cargo test -p rimap-server too_many_recipients && cargo test -p rimap-server subject_too_long && cargo test -p rimap-server body_too_large`
+Expected: FAIL — no length checks exist
+
+- [ ] **Step 3: Add length bounds to `validate_draft_input`**
+
+Add constants:
+```rust
+/// Max combined recipients (to + cc + bcc).
+const MAX_RECIPIENTS: usize = 100;
+/// Max subject length in characters.
+const MAX_SUBJECT_LEN: usize = 1000;
+/// Max body_text length in bytes (1 MB).
+const MAX_BODY_BYTES: usize = 1_048_576;
+```
+
+Add checks in `validate_draft_input` after the empty-to check:
+```rust
+let total_recipients = input.to.len()
+    + input.cc.as_ref().map_or(0, Vec::len)
+    + input.bcc.as_ref().map_or(0, Vec::len);
+if total_recipients > MAX_RECIPIENTS {
+    return Err(rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: format!(
+            "too many recipients ({total_recipients}); max is {MAX_RECIPIENTS}"
+        ),
+    });
+}
+
+if input.subject.len() > MAX_SUBJECT_LEN {
+    return Err(rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: format!(
+            "subject too long ({} chars); max is {MAX_SUBJECT_LEN}",
+            input.subject.len()
+        ),
+    });
+}
+
+if input.body_text.len() > MAX_BODY_BYTES {
+    return Err(rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: format!(
+            "body_text too large ({} bytes); max is {MAX_BODY_BYTES}",
+            input.body_text.len()
+        ),
+    });
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rimap-server create_draft`
+Expected: PASS (all existing + 3 new tests)
+
+- [ ] **Step 5: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/create_draft.rs
+git commit -m "fix(server): add input length bounds to create_draft (#65)"
+```
+
+---
+
+## Group D: Server Async Safety (#58, #61)
+
+### Task 9: Wrap blocking filesystem I/O in `spawn_blocking` (#61)
+
+**Files:**
+- Modify: `crates/rimap-server/src/download.rs` (wrap `write_attachment`, `resolve_dest_dir`)
+- Modify: `crates/rimap-server/src/tools/download_attachment.rs` (wrap `mail_parser` parsing, use async versions)
+
+- [ ] **Step 1: Create async wrappers for blocking operations**
+
+In `download.rs`, create async versions:
+```rust
+/// Async wrapper for `resolve_dest_dir` — runs on the blocking
+/// threadpool to avoid stalling the Tokio runtime on slow filesystems.
+pub async fn resolve_dest_dir_async(
+    dest_dir: Option<String>,
+    allowed_root: PathBuf,
+    fallback_dir: PathBuf,
+) -> Result<PathBuf, RimapError> {
+    tokio::task::spawn_blocking(move || {
+        resolve_dest_dir(dest_dir.as_deref(), &allowed_root, &fallback_dir)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        Err(RimapError::Internal(format!(
+            "spawn_blocking panicked: {e}"
+        )))
+    })
+}
+
+/// Async wrapper for `write_attachment`.
+pub async fn write_attachment_async(
+    dir: PathBuf,
+    filename: String,
+    data: Vec<u8>,
+) -> Result<PathBuf, RimapError> {
+    tokio::task::spawn_blocking(move || {
+        write_attachment(&dir, &filename, &data)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        Err(RimapError::Internal(format!(
+            "spawn_blocking panicked: {e}"
+        )))
+    })
+}
+```
+
+- [ ] **Step 2: Update `download_attachment::handle` to use async wrappers**
+
+Replace sync calls with async versions:
+```rust
+let dest = download::resolve_dest_dir_async(
+    input.dest_dir,
+    server.download_dir.clone(),
+    server.download_dir.clone(),
+).await?;
+```
+
+Wrap `mail_parser` parsing in `spawn_blocking`:
+```rust
+let parsed = tokio::task::spawn_blocking(move || {
+    mail_parser::MessageParser::new().parse(&raw)
+        .ok_or_else(|| {
+            rimap_core::RimapError::Internal(
+                "failed to parse message for attachment extraction".into(),
+            )
+        })
+        .map(|m| m.into_owned())
+}).await.unwrap_or_else(|e| {
+    Err(rimap_core::RimapError::Internal(
+        format!("spawn_blocking panicked: {e}"),
+    ))
+})?;
+```
+
+Replace `write_attachment` call:
+```rust
+let path = download::write_attachment_async(
+    dest,
+    safe_filename.to_string(),
+    part_body.clone(),
+).await?;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p rimap-server download`
+Expected: PASS
+
+- [ ] **Step 4: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/download.rs \
+       crates/rimap-server/src/tools/download_attachment.rs
+git commit -m "fix(server): wrap blocking filesystem I/O in spawn_blocking (#61)"
+```
+
+---
+
+### Task 10: Bound concurrent `spawn_blocking` parse invocations (#58)
+
+**Files:**
+- Modify: `crates/rimap-server/src/content.rs` (add semaphore)
+- Modify: `crates/rimap-server/src/server.rs` or module-level (own the semaphore)
+
+- [ ] **Step 1: Write failing test**
+
+In `content.rs` tests:
+```rust
+#[tokio::test]
+async fn concurrent_parses_are_bounded() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tokio::sync::Semaphore;
+
+    let semaphore = Arc::new(Semaphore::new(4));
+    let concurrent = Arc::new(AtomicU32::new(0));
+    let max_concurrent = Arc::new(AtomicU32::new(0));
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let sem = semaphore.clone();
+        let conc = concurrent.clone();
+        let max_c = max_concurrent.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.unwrap();
+            let val = conc.fetch_add(1, Ordering::SeqCst) + 1;
+            max_c.fetch_max(val, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            conc.fetch_sub(1, Ordering::SeqCst);
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    assert!(max_concurrent.load(Ordering::SeqCst) <= 4);
+}
+```
+
+- [ ] **Step 2: Add semaphore to `parse_message_async`**
+
+In `content.rs`:
+```rust
+use std::sync::LazyLock;
+use tokio::sync::Semaphore;
+
+/// Limits concurrent CPU-bound parse operations to avoid exhausting
+/// the blocking threadpool (Tokio default: 512 threads).
+static PARSE_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
+
+pub async fn parse_message_async(raw: Vec<u8>) -> Result<Content, ContentError> {
+    let _permit = PARSE_SEMAPHORE.acquire().await.map_err(|_| {
+        ContentError::Malformed {
+            reason: "parse semaphore closed".into(),
+        }
+    })?;
+    tokio::task::spawn_blocking(move || parse_message(&raw))
+        .await
+        .unwrap_or_else(|e| {
+            Err(ContentError::Malformed {
+                reason: format!("spawn_blocking panicked: {e}"),
+            })
+        })
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p rimap-server content`
+Expected: PASS
+
+- [ ] **Step 4: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/content.rs
+git commit -m "fix(server): bound concurrent spawn_blocking parse invocations (#58)"
+```
+
+---
+
+## Group E: Audit Enhancements (#44, #45, #8)
+
+### Task 11: Implement time-based retention alongside `rotate_keep` (#44)
+
+**Files:**
+- Modify: `crates/rimap-config/src/model.rs` (add `retention_seconds` to `AuditConfig`)
+- Modify: `crates/rimap-config/src/validate.rs` (validate non-zero if Some)
+- Modify: `crates/rimap-audit/src/rotation.rs` (mtime check in `prune_rotated_siblings`)
+
+- [ ] **Step 1: Write failing test for mtime-based pruning**
+
+In `crates/rimap-audit/src/rotation.rs` tests:
+```rust
+#[test]
+fn prune_respects_retention_seconds() {
+    let dir = TempDir::new().unwrap();
+    let active = dir.path().join("audit.jsonl");
+
+    // Create rotated siblings with old mtime.
+    std::fs::write(&active, b"x\n").unwrap();
+    let (_buf, _len) = rotate_file(&active, 10, None).unwrap();
+    sleep(Duration::from_millis(5));
+
+    // Make the rotated sibling "old" by setting retention to 0 seconds
+    // (prune everything older than now).
+    std::fs::write(&active, b"y\n").unwrap();
+    let (_buf, _len) = rotate_file(&active, 10, Some(0)).unwrap();
+
+    let rotated = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("audit.jsonl."))
+        })
+        .count();
+    // retention_seconds=0 means delete everything older than now,
+    // which is all rotated siblings.
+    assert_eq!(rotated, 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rimap-audit prune_respects_retention`
+Expected: FAIL — `rotate_file` doesn't accept retention parameter
+
+- [ ] **Step 3: Add `retention_seconds` to `AuditConfig`**
+
+In `model.rs`:
+```rust
+/// Time-based retention cutoff in seconds. Rotated files older than
+/// this are deleted regardless of `rotate_keep`. `None` = no
+/// time-based expiry (count-only, today's behavior).
+#[serde(default)]
+pub retention_seconds: Option<u64>,
+```
+
+In `validate.rs`, add:
+```rust
+if let Some(0) = cfg.audit.retention_seconds {
+    return Err(ConfigError::InvalidValue {
+        field: "audit.retention_seconds".into(),
+        reason: "must be > 0 or absent".into(),
+    });
+}
+```
+
+Wait — the issue says `retention_seconds = 0` should be treated as None or rejected. Let's reject it at validation. But the test uses `Some(0)` internally in the rotation code as "delete everything" for testing purposes. The config validation rejects 0 from user config, but the rotation function can still receive any value internally.
+
+Actually, re-reading the test: I should pass retention as a `Duration` or `Option<u64>` to `prune_rotated_siblings` directly in the test, not through config validation. The config validation rejects 0 from user input. The rotation function itself just uses the value.
+
+- [ ] **Step 4: Add retention parameter to `rotate_file` and `prune_rotated_siblings`**
+
+Update signatures:
+```rust
+pub fn rotate_file(
+    active: &Path,
+    keep: u32,
+    retention_seconds: Option<u64>,
+) -> Result<(BufWriter<File>, u64), AuditError> {
+    // ... existing code ...
+    prune_rotated_siblings(active, keep, retention_seconds);
+    Ok((BufWriter::new(new_file), 0))
+}
+```
+
+Update `prune_rotated_siblings`:
+```rust
+fn prune_rotated_siblings(active: &Path, keep: u32, retention_seconds: Option<u64>) {
+    // ... existing enumeration and sorting ...
+
+    let keep_usize = usize::try_from(keep).unwrap_or(usize::MAX);
+
+    // Two independent filters AND together:
+    // 1. Count-based: keep only the `keep` newest
+    // 2. Time-based: delete anything older than retention_seconds
+    let now = std::time::SystemTime::now();
+    let cutoff = retention_seconds.map(|secs| {
+        now.checked_sub(std::time::Duration::from_secs(secs))
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+
+    for (i, (mtime, path)) in siblings.into_iter().enumerate() {
+        let beyond_count = i >= keep_usize;
+        let beyond_age = cutoff.is_some_and(|c| mtime < c);
+        if beyond_count || beyond_age {
+            if let Err(err) = std::fs::remove_file(&path) {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "audit rotate: failed to delete stale rotated sibling",
+                );
+            }
+        }
+    }
+}
+```
+
+Update all existing callers of `rotate_file` and `prune_rotated_siblings` to pass the retention parameter (existing callers pass `None`).
+
+- [ ] **Step 5: Update existing tests**
+
+All existing `rotate_file` test calls get a `None` third parameter:
+```rust
+let (_buf, _len) = rotate_file(&active, 3, None).unwrap();
+```
+
+- [ ] **Step 6: Wire through `AuditWriter` and `AuditOptions`**
+
+Add `retention_seconds: Option<u64>` to `AuditOptions`. Pass it through to `rotate_file` calls in `writer.rs`.
+
+Wire from `rimap-server` bootstrap: read `config.audit.retention_seconds` and pass to `AuditOptions`.
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p rimap-audit rotation && cargo test -p rimap-config validate`
+Expected: PASS
+
+- [ ] **Step 8: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-config/src/model.rs crates/rimap-config/src/validate.rs \
+       crates/rimap-audit/src/rotation.rs crates/rimap-audit/src/writer.rs \
+       crates/rimap-server/src/
+git commit -m "feat(audit): implement time-based retention alongside rotate_keep (#44)"
+```
+
+---
+
+### Task 12: Exclude audit directory from macOS backups (#45)
+
+**Files:**
+- Create: `crates/rimap-audit/src/backup_exclude.rs`
+- Modify: `crates/rimap-audit/src/lib.rs` (add module)
+
+- [ ] **Step 1: Write the module with platform-gated implementation**
+
+Create `crates/rimap-audit/src/backup_exclude.rs`:
+
+```rust
+//! Exclude audit directories from macOS Time Machine backups.
+//!
+//! On macOS, sets `com.apple.metadata:com_apple_backup_excludeItem`
+//! xattr on the given path. No-op on other platforms.
+
+use std::path::Path;
+
+/// Exclude `path` from Time Machine backups (macOS only).
+/// Best-effort: logs a warning on failure but never propagates errors.
+pub fn exclude_from_backup(path: &Path) {
+    #[cfg(target_os = "macos")]
+    exclude_macos(path);
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = path;
+}
+
+#[cfg(target_os = "macos")]
+fn exclude_macos(path: &Path) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    // Binary plist encoding of boolean `true` — fixed bytes per
+    // Apple TN2206. This is the canonical representation used by
+    // `tmutil addexclusion -p`.
+    static BPLIST_TRUE: &[u8] = &[
+        0x62, 0x70, 0x6C, 0x69, 0x73, 0x74, 0x30, 0x30, // bplist00
+        0x09, // bool true
+        0x08, // offset table offset
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, // offset table
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // trailer
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09,
+    ];
+
+    let xattr_name = CString::new(
+        "com.apple.metadata:com_apple_backup_excludeItem"
+    ).expect("static CString");
+
+    let c_path = match CString::new(path.as_os_str().as_bytes()) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "backup_exclude: path contains null byte, skipping",
+            );
+            return;
+        }
+    };
+
+    // SAFETY: libc::setxattr with valid CString pointers and known-good
+    // buffer length. No memory is borrowed across the call boundary.
+    let ret = unsafe {
+        libc::setxattr(
+            c_path.as_ptr(),
+            xattr_name.as_ptr(),
+            BPLIST_TRUE.as_ptr().cast(),
+            BPLIST_TRUE.len(),
+            0, // position (unused for this xattr)
+            0, // options (0 = create or replace)
+        )
+    };
+
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "backup_exclude: failed to set Time Machine exclusion xattr",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclude_from_backup_does_not_panic_on_nonexistent_path() {
+        // Should be best-effort; no panic on missing path.
+        exclude_from_backup(Path::new("/nonexistent/path/audit"));
+    }
+
+    #[test]
+    fn exclude_from_backup_is_noop_on_non_macos() {
+        // On non-macOS, this is a no-op. Just verify it compiles
+        // and doesn't error.
+        let tmp = tempfile::tempdir().unwrap();
+        exclude_from_backup(tmp.path());
+    }
+}
+```
+
+- [ ] **Step 2: Register module in `lib.rs`**
+
+Add `pub mod backup_exclude;` to `crates/rimap-audit/src/lib.rs`.
+
+- [ ] **Step 3: Add `libc` dependency for macOS**
+
+In workspace `Cargo.toml`, add `libc` to workspace dependencies (if not already present).
+In `crates/rimap-audit/Cargo.toml`, add:
+```toml
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+```
+
+Note: `unsafe_code` is forbidden workspace-wide. The macOS-only `libc::setxattr` call requires an `unsafe` block. Add `#[cfg_attr(target_os = "macos", expect(unsafe_code, reason = "libc::setxattr for Time Machine exclusion"))]` or allow unsafe for that specific function. Check the workspace lint config — if `unsafe_code = "forbid"` is at workspace level, you'll need to override it for this one module:
+
+```rust
+#[cfg(target_os = "macos")]
+#[expect(unsafe_code, reason = "libc::setxattr for Time Machine exclusion")]
+fn exclude_macos(path: &Path) { ... }
+```
+
+Wait — `forbid` cannot be overridden with `expect`. If the workspace uses `forbid`, this needs discussion. Check if `unsafe_code` is `forbid` or `deny`. If `forbid`, the macOS xattr functionality will need to be implemented via the `xattr` crate (pure safe Rust wrapper) instead of `libc`. Adjust accordingly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rimap-audit backup_exclude`
+Expected: PASS
+
+- [ ] **Step 5: Wire into server startup**
+
+In `rimap-server` bootstrap (wherever `AuditWriter::open` is called), add after opening:
+```rust
+if let Some(parent) = audit_path.parent() {
+    rimap_audit::backup_exclude::exclude_from_backup(parent);
+}
+```
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-audit/src/backup_exclude.rs crates/rimap-audit/src/lib.rs \
+       crates/rimap-audit/Cargo.toml Cargo.toml crates/rimap-server/src/
+git commit -m "feat(audit): exclude audit directory from macOS backups (#45)"
+```
+
+---
+
+### Task 13: Server lifecycle glue — `process_start` / `process_end` (#8)
+
+**Files:**
+- Create: `crates/rimap-audit/src/lifecycle.rs`
+- Modify: `crates/rimap-audit/src/lib.rs` (add module export)
+- Modify: `crates/rimap-server/src/main.rs` or bootstrap module
+
+This task wires together the existing building blocks:
+- `AuditWriter::open` (lock + create)
+- `self_check::read_trailing_state` (previous run's state)
+- `self_check::current_inode` (this run's inode)
+- `record::ProcessStart` / `ProcessEnd` payloads
+
+- [ ] **Step 1: Write failing test for lifecycle start**
+
+In a new `crates/rimap-audit/src/lifecycle.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_process_writes_process_start_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+
+        let ctx = StartContext {
+            version: "0.1.0".into(),
+            git_commit: Some("abc1234".into()),
+            posture: "cautious".into(),
+            config_path: "/etc/rimap.toml".into(),
+            config_hash: "deadbeef".into(),
+        };
+
+        let opts = crate::writer::AuditOptions {
+            path: path.clone(),
+            rotate_bytes: 10_000_000,
+            rotate_keep: 5,
+            fail_open: false,
+            initial_seq: None,
+            retention_seconds: None,
+        };
+
+        let (writer, _handle) = start_process(opts, ctx).unwrap();
+        drop(writer);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("process_start"));
+    }
+}
+```
+
+- [ ] **Step 2: Implement `lifecycle.rs`**
+
+```rust
+//! Process lifecycle audit records.
+
+use crate::error::AuditError;
+use crate::writer::{AuditOptions, AuditWriter};
+
+/// Context for constructing a `ProcessStart` record.
+pub struct StartContext {
+    pub version: String,
+    pub git_commit: Option<String>,
+    pub posture: String,
+    pub config_path: String,
+    pub config_hash: String,
+}
+
+/// Handle returned by `start_process` for emitting `ProcessEnd`.
+pub struct ProcessHandle {
+    writer: AuditWriter,
+}
+
+impl ProcessHandle {
+    /// Emit a best-effort `ProcessEnd` record.
+    pub fn end_process(self, total_tool_calls: u64) {
+        // Best-effort: log but don't propagate errors.
+        let payload = crate::record::Payload::ProcessEnd(
+            crate::record::ProcessEnd { total_tool_calls },
+        );
+        if let Err(e) = self.writer.write_record(&payload) {
+            tracing::error!(
+                error = %e,
+                "failed to write process_end audit record",
+            );
+        }
+    }
+}
+
+/// Open the audit writer, run self-check, emit `ProcessStart`.
+pub fn start_process(
+    opts: AuditOptions,
+    ctx: StartContext,
+) -> Result<(AuditWriter, ProcessHandle), AuditError> {
+    let writer = AuditWriter::open(opts)?;
+
+    // Self-check: read trailing state from previous run.
+    let prev = crate::self_check::read_trailing_state(writer.path());
+    let current_inode = crate::self_check::current_inode(writer.path());
+    let inode_changed = match (&prev, &current_inode) {
+        (Ok(Some(state)), Ok(inode)) => {
+            state.file_inode != *inode
+        }
+        _ => false,
+    };
+
+    let start = crate::record::ProcessStart {
+        version: ctx.version,
+        git_commit: ctx.git_commit,
+        posture: ctx.posture,
+        config_path: ctx.config_path,
+        config_hash: ctx.config_hash,
+        previous_seq: prev.as_ref().ok().and_then(|s| {
+            s.as_ref().map(|s| s.seq)
+        }),
+        previous_process_id: prev.as_ref().ok().and_then(|s| {
+            s.as_ref().map(|s| s.process_id.clone())
+        }),
+        audit_file_inode_changed: inode_changed,
+    };
+
+    let payload = crate::record::Payload::ProcessStart(start);
+    writer.write_record(&payload)?;
+
+    let handle = ProcessHandle {
+        writer: writer.clone(),
+    };
+
+    Ok((writer, handle))
+}
+```
+
+Note: The exact field names and types for `ProcessStart`, `ProcessEnd`, `TrailingState` etc. depend on the existing `record.rs` and `self_check.rs` definitions. The implementer must read those files and adapt accordingly. The structure above is a guide — match the actual types.
+
+- [ ] **Step 3: Register module**
+
+Add `pub mod lifecycle;` to `crates/rimap-audit/src/lib.rs`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rimap-audit lifecycle`
+Expected: PASS
+
+- [ ] **Step 5: Wire into `rimap-server` main**
+
+In `main.rs` or the bootstrap module, replace direct `AuditWriter::open` with `lifecycle::start_process`. Store the `ProcessHandle` and call `end_process` on shutdown (via a signal handler or Drop guard).
+
+- [ ] **Step 6: Run `just ci`**
+
+Run: `just ci`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-audit/src/lifecycle.rs crates/rimap-audit/src/lib.rs \
+       crates/rimap-server/src/
+git commit -m "feat(audit): add server lifecycle glue for process_start/process_end (#8)"
+```
+
+---
+
+## Summary
+
+| Group | Issues | Commits | Focus |
+|-------|--------|---------|-------|
+| A | #56, #57 | 2 | IMAP protocol safety |
+| B | #60, #62, #63 | 3 | MIME tree safety |
+| C | #59, #64, #65 | 3 | Input validation & schemas |
+| D | #58, #61 | 2 | Async/blocking safety |
+| E | #44, #45, #8 | 3 | Audit enhancements |
+| **Total** | **14** | **13** | |
+
+**Not in scope (3 issues):** #14, #18, #19 (security-review agent meta-issues, post-v1), #32 (async-imap design limitation).
+
+**Branch:** `fix/post-sprint5-issues`
+
+**Execution order:** Tasks 1-13 in order. Groups A-B have no cross-dependencies so could be parallelized. Group C depends on A (schemas reference all input types). Group D is independent. Group E is independent but Task 11 must precede Task 12-13 (retention parameter flows through rotation).


### PR DESCRIPTION
## Summary

Addresses 14 open issues grouped into 5 implementation areas:

- **IMAP protocol safety** (#56, #57): APPEND size cap (`max_append_bytes`), MOVE capability pre-check replacing heuristic fallback
- **Server MIME safety** (#60, #62, #63): Recursion depth limit (64) on MIME tree walkers, BODYSTRUCTURE vs mail_parser cross-validation, magic-byte sniff mismatch warning
- **Input validation & schemas** (#59, #64, #65): JSON schemas wired into `list_tools`, References chain capped at 50, draft input length bounds (100 recipients, 1000-byte subject, 1MB body)
- **Async safety** (#58, #61): Parse semaphore (8 permits) bounds concurrent `spawn_blocking`, blocking FS I/O wrapped in `spawn_blocking`
- **Audit enhancements** (#44, #45, #8): Time-based retention alongside `rotate_keep`, macOS Time Machine backup exclusion, `process_end` lifecycle record on shutdown

Reviewed by 6 project security agents (code, Rust safety, MCP, IMAP, local, supply chain). All findings addressed or tracked as follow-up.

Closes #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, #44, #45, #8

## Test plan

- [ ] `just fmt-check && just lint && just deny` passes
- [ ] All unit tests pass (`cargo nextest run --workspace --exclude rimap-imap && cargo nextest run -p rimap-imap --lib`)
- [ ] Dovecot e2e tests pass (requires container: `just test-integration`)
- [ ] Verify `list_tools` response includes non-empty `inputSchema` objects
- [ ] Verify `download_attachment` emits `mime_sniff_mismatch` warning for a text/plain-declared PNG
- [ ] Verify `move_message` emits `non_atomic_move` warning on servers without MOVE capability
- [ ] Verify `create_draft` rejects >100 recipients, >1000-byte subject, >1MB body
- [ ] Verify audit log contains `process_start` and `process_end` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)