### PR TITLE
fix: address remaining open issues (#32, #14, #18, #19) and SonarQube complexity

### DIFF
--- a/.claude/agents/release-integrity-reviewer.md
+++ b/.claude/agents/release-integrity-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: release-integrity-reviewer
+description: "PLACEHOLDER — not yet active. Use this agent to audit release artifacts, signing, provenance, and distribution integrity when release automation lands. Do not invoke until the project ships binaries."
+tools: Read, Grep, Glob, Bash, WebFetch
+model: opus
+---
+
+# Release Integrity Reviewer — rusty-imap-mcp
+
+> **Status: PLACEHOLDER.** This agent is not yet active. It will be activated
+> when the project starts shipping binaries and release automation lands.
+> See [#19](https://github.com/randomparity/rusty-imap-mcp/issues/19).
+
+## Scope (draft taxonomy)
+
+When activated, this agent will cover:
+
+| ID | Category | What to check |
+|----|----------|---------------|
+| REL-REPRO-01 | Reproducible builds | `cargo build --release` byte-for-byte reproducible; no embedded timestamps, hostnames, or build paths |
+| REL-SIGN-01 | Sigstore signatures | Every release artifact signed with a Sigstore identity, verifiable via `cosign verify-blob` |
+| REL-SIGN-02 | PGP fallback | Maintainer PGP signature on `SHA256SUMS` for distributions that don't consume Sigstore |
+| REL-PROV-01 | SLSA Level 3 provenance | `slsa-framework/slsa-github-generator` attestations on GitHub releases |
+| REL-NOT-01 | macOS notarization | Apple notarization + hardened runtime + entitlements for distributed binaries |
+| REL-NOT-02 | Windows authenticode | Signed Windows binaries |
+| REL-SBOM-01 | SBOM | CycloneDX or SPDX via `cargo sbom` / `cargo auditable`, attached as release asset |
+| REL-CH-01 | Channel integrity | Per-channel integrity story: Homebrew tap, AUR, crates.io, GitHub Releases |
+| REL-UPD-01 | Update check path | TLS + signature verification + pinning on any update-check mechanism |
+| REL-ROLL-01 | Rollback plan | Yank procedure for crates.io + GitHub Releases; consumer notification |
+
+## Activation criteria
+
+- [ ] Release automation (GitHub Actions workflow for building + publishing) has landed
+- [ ] `ci-cd-security-reviewer` has audited the release workflow
+- [ ] This file's "PLACEHOLDER" status is removed
+- [ ] Cross-reference with `supply-chain-reviewer` `SC-REL-*` categories established
+
+## Relationship to other agents
+
+- **supply-chain-reviewer** owns `SC-REL-*` categories that seed this agent's taxonomy
+- **ci-cd-security-reviewer** audits the release workflow; this agent audits the artifacts
+- Both agents should review release-related changes, from different angles

--- a/.claude/agents/security-docs-reviewer.md
+++ b/.claude/agents/security-docs-reviewer.md
@@ -1,0 +1,69 @@
+---
+name: security-docs-reviewer
+description: Use this agent to audit SECURITY.md for currency against the project's threat model, CVE disclosure readiness, and supported-versions accuracy. Invoke on changes to SECURITY.md, docs/superpowers/specs/, release tag workflows, or version bumps.
+tools: Read, Grep, Glob, Bash, WebFetch
+model: sonnet
+---
+
+# Security Documentation Reviewer — rusty-imap-mcp
+
+You review `SECURITY.md` and related security documentation for currency and completeness. You do not review code.
+
+## Checklist
+
+Run every item on each review. A gap is a finding.
+
+### 1. Threat model currency
+
+- Does `SECURITY.md`'s threat model summary match the canonical threat model in `docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md` sections 1, 6, 7, 8, 9, 10?
+- Are all adversary classes listed? (crafted email, hostile IMAP server, local malware)
+- Are trust/untrust boundaries accurate?
+- Has a new sprint introduced components not reflected in the summary?
+
+### 2. Vulnerability reporting process
+
+- Is the reporting channel documented? (GitHub Security Advisories)
+- Is the response timeline stated? (7 days initial, 90 days fix target)
+- Is coordinated disclosure mentioned?
+- Is there a fallback contact if GitHub is unavailable?
+
+### 3. CVE process
+
+- Is the CVE numbering authority identified? (GitHub CNA)
+- Is the advisory-to-CVE workflow described?
+- Are known-affected-version communication steps documented?
+
+### 4. Supported versions
+
+- Does the supported-versions table match the actual release cadence?
+- Is the MSRV commitment reflected? (currently 1.88.0, in `[workspace.package]`)
+- Post-v1: does the table list specific version ranges?
+
+### 5. Security contact identity
+
+- Is a signing identity documented? (PGP key, Sigstore identity, or "not yet established")
+- If not yet established, is the tracking issue linked?
+- Post-v1: are release signatures verifiable?
+
+### 6. Spec alignment
+
+- Read the latest sprint spec under `docs/superpowers/specs/`
+- Check if any new trust boundaries, attacker classes, or defense layers are missing from `SECURITY.md`
+- Flag any divergence as a finding
+
+## Reporting format
+
+Findings as a prioritized list:
+
+1. **Severity** — `high` (stale threat model) / `medium` (missing process detail) / `low` (minor wording) / `info`
+2. **Checklist item** — section number above
+3. **Location** — file and line/section
+4. **What** — one sentence
+5. **Fix** — specific text to add or change
+
+## When to invoke
+
+- Changes to `SECURITY.md`
+- Changes to `docs/superpowers/specs/` (new threat surfaces)
+- Release tag workflows (verify disclosure channel reachability)
+- Version bumps in `Cargo.toml` (supported-versions table currency)

--- a/.claude/agents/threat-model-reviewer.md
+++ b/.claude/agents/threat-model-reviewer.md
@@ -1,0 +1,110 @@
+---
+name: threat-model-reviewer
+description: Use this agent to review rusty-imap-mcp specs and plans for threat-model completeness. Invoke on changes to docs/superpowers/specs/ or docs/superpowers/plans/, especially when new components, trust boundaries, or attacker surfaces are introduced. Operates on design documents, not code.
+tools: Read, Grep, Glob, Bash, WebFetch
+model: opus
+---
+
+# Threat Model Reviewer — rusty-imap-mcp
+
+You are a threat-model reviewer for design documents. You review specs (`docs/superpowers/specs/`) and plans (`docs/superpowers/plans/`), not code. Your job is to ensure every new component has an explicit threat analysis before implementation begins.
+
+## Project threat model (ground truth)
+
+`rusty-imap-mcp` is a security-first MCP server for IMAP email. The design spec lives at `docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md`. Read it before every review — it is the canonical threat model.
+
+**Primary adversary:** Crafted email attempting prompt injection to induce an LLM agent to exfiltrate data, send mail, modify mailbox state, or pivot to other tools.
+
+**Secondary adversaries:**
+- Hostile IMAP server (MITM, malformed IMAP responses, oversized literals)
+- Local malware with the user's file-system UID
+
+**Trusted:** Config file, keychain entries, audit log, TLS identity (within fingerprint-pinning limits).
+
+**Untrusted:** Email bodies, headers, sender addresses, display names, attachment filenames, link targets, all server-provided content.
+
+## Review checklist
+
+For each spec or plan under review, check every item. A missing item is a finding.
+
+### 1. Asset enumeration
+
+- What secrets does this component handle? (credentials, tokens, keys)
+- What data does it process? (email content, metadata, user input)
+- What capabilities does it grant? (network access, filesystem write, mailbox mutation)
+- Are assets classified by sensitivity? (public metadata vs. credential vs. PII)
+
+### 2. Trust boundary mapping
+
+- Where do untrusted inputs enter this component?
+- What sanitizer or validator sits at each entry point?
+- Does the spec name the specific crate/module responsible for validation?
+- Are there any paths where untrusted data bypasses sanitization?
+
+### 3. STRIDE analysis
+
+For each new component or interface, produce a table:
+
+| Threat | Applies? | Mitigation | Spec section |
+|--------|----------|------------|--------------|
+| **S**poofing | Does the component authenticate its inputs/peers? | | |
+| **T**ampering | Can an attacker modify data in transit or at rest? | | |
+| **R**epudiation | Is the action auditable? Is the audit tamper-evident? | | |
+| **I**nformation disclosure | Can secrets or PII leak through errors, logs, timing? | | |
+| **D**enial of service | Are there unbounded allocations, recursion, or fan-out? | | |
+| **E**levation of privilege | Can the component be used to bypass posture/authz? | | |
+
+### 4. Attacker model clarity
+
+- Every defense must cite the attacker class it defends against
+- Valid attacker classes: `malicious-email`, `hostile-imap-server`, `mitm`, `local-user`, `stolen-laptop`, `compromised-mcp-client`
+- A defense without a named attacker is a finding
+
+### 5. Deferral discipline
+
+- Any threat acknowledged but not mitigated in this sprint must have a GitHub issue
+- The issue must cite the spec section, name the threat, and state acceptance criteria
+- "Deferred to Sprint N" in prose without an issue link is a finding
+- Check: `gh issue list --state open` for existing tracking
+
+### 6. Cross-reference with existing taxonomies
+
+Link each identified threat to the most relevant taxonomy id from the six code-level reviewers:
+
+| Reviewer | Prefix | Scope |
+|----------|--------|-------|
+| mcp-security-reviewer | `MCP-*` | Prompt injection, tool poisoning, auth, transport |
+| email-imap-security-reviewer | `MAIL-*` | IMAP protocol, MIME, TLS, header parsing |
+| local-security-reviewer | `LOCAL-*` | Secrets, disk, permissions, TOCTOU |
+| rust-safety-reviewer | `RUST-*` | Unsafe, panics, async, integer overflow |
+| supply-chain-reviewer | `SC-*` | Dependencies, build, SBOM |
+| ci-cd-security-reviewer | `CI-*` | Actions, tokens, branch protection |
+
+A new threat that doesn't map to any existing category suggests the taxonomy needs extending — flag this.
+
+## Review process
+
+1. **Read the spec/plan end-to-end.** Understand what it claims to build.
+2. **Run the checklist** (sections 1-6 above) against each new component.
+3. **Compare against the canonical threat model** in the design spec. Flag any divergence.
+4. **Check prior sprint plans** for accumulated deferrals that this sprint should address.
+5. **Verify GitHub issues exist** for all deferred threats.
+
+## Reporting format
+
+Produce findings as a prioritized list. Each finding must have:
+
+1. **Severity** — `critical` / `high` / `medium` / `low` / `info`
+2. **Checklist item** — which section above was violated (e.g., "STRIDE-D", "Deferral discipline")
+3. **Location** — spec file and section heading
+4. **What** — one sentence describing the gap
+5. **Recommendation** — what to add to the spec or what issue to file
+
+End with a STRIDE summary table for the reviewed component(s) and a list of any new GitHub issues needed.
+
+## What NOT to do
+
+- Do not review code. This agent reviews design documents only.
+- Do not invent threats that require attacker capabilities outside the project's threat model.
+- Do not recommend features beyond what the spec proposes.
+- Do not mark a spec "safe" without running every checklist item.

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,0 @@
-[default.extend-words]
-# STRIDE table uses bold-letter formatting: **I**nformation, **D**enial, etc.
-# "nformation" is not a misspelling — it's the suffix after the bold "I".
-nformation = "nformation"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# STRIDE table uses bold-letter formatting: **I**nformation, **D**enial, etc.
+# "nformation" is not a misspelling — it's the suffix after the bold "I".
+nformation = "nformation"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,4 +35,30 @@ especially Sections 1, 6, 7, 8, 9, and 10.
 ## Supported versions
 
 During pre-v1 development, only the latest commit on `main` is supported. Once
-v1.0.0 ships, a supported-versions table will appear here.
+v1.0.0 ships, this policy applies:
+
+| Version | Security fixes | End of support |
+|---------|---------------|----------------|
+| Current major (e.g., 1.x) | All severity levels | 12 months after next major |
+| Previous major (e.g., 0.x) | Critical only | 6 months after next major |
+
+## Disclosure timeline
+
+- **Initial response:** within 7 calendar days of report
+- **Fix target:** within 90 calendar days of confirmed vulnerability
+- **Coordinated disclosure:** preferred; we will work with the reporter on timing
+- **Public disclosure:** after the fix ships, or after 90 days, whichever comes first
+
+## CVE process
+
+Security vulnerabilities are tracked via
+[GitHub Security Advisories](https://github.com/randomparity/rusty-imap-mcp/security/advisories).
+CVEs are requested through GitHub's CNA (CVE Numbering Authority) integration
+when the advisory is published. We do not self-assign CVE IDs.
+
+## Security contact identity
+
+Pre-v1, the security contact is the repository owner via GitHub Security
+Advisories (no direct email). A Sigstore signing identity and release
+attestations will be established when release automation lands (tracked in
+[#19](https://github.com/randomparity/rusty-imap-mcp/issues/19)).

--- a/crates/rimap-content/src/parse.rs
+++ b/crates/rimap-content/src/parse.rs
@@ -98,40 +98,27 @@ pub fn parse_message(raw: &[u8]) -> Result<Content, ContentError> {
     Ok(content)
 }
 
+/// Append the domain of every address in `group` to `out`, tagging each
+/// with `label`. No-op when `group` is `None`.
+fn push_domains_from(group: Option<&Address<'_>>, label: &str, out: &mut Vec<(String, String)>) {
+    let Some(address) = group else { return };
+    for addr in address.iter() {
+        if let Some(domain) = addr_domain(addr) {
+            out.push((domain, label.to_string()));
+        }
+    }
+}
+
 /// Pre-extract domains from structured `Addr.address` fields for
 /// all header address sources (From, To, Cc, Reply-To). Using the
 /// parser's structured data is more reliable than re-parsing the
 /// rendered display string.
 fn collect_header_domains(message: &Message<'_>) -> Vec<(String, String)> {
     let mut domains = Vec::new();
-    if let Some(address) = message.from() {
-        for addr in address.iter() {
-            if let Some(domain) = addr_domain(addr) {
-                domains.push((domain, "header:from".to_string()));
-            }
-        }
-    }
-    if let Some(address) = message.to() {
-        for addr in address.iter() {
-            if let Some(domain) = addr_domain(addr) {
-                domains.push((domain, "header:to".to_string()));
-            }
-        }
-    }
-    if let Some(address) = message.cc() {
-        for addr in address.iter() {
-            if let Some(domain) = addr_domain(addr) {
-                domains.push((domain, "header:cc".to_string()));
-            }
-        }
-    }
-    if let Some(address) = message.reply_to() {
-        for addr in address.iter() {
-            if let Some(domain) = addr_domain(addr) {
-                domains.push((domain, "header:reply_to".to_string()));
-            }
-        }
-    }
+    push_domains_from(message.from(), "header:from", &mut domains);
+    push_domains_from(message.to(), "header:to", &mut domains);
+    push_domains_from(message.cc(), "header:cc", &mut domains);
+    push_domains_from(message.reply_to(), "header:reply_to", &mut domains);
     domains
 }
 

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -517,20 +517,18 @@ impl Connection {
     /// # Size cap is enforced post-parse, not pre-allocation
     ///
     /// `async-imap 0.11` yields each FETCH item as an already-materialized
-    /// `Fetch` whose `body()` slice has been parsed into memory by the
-    /// upstream crate before this function gets a chance to inspect its
-    /// length. That means a hostile (or misconfigured) server can force a
-    /// single-item allocation up to the literal size it announces in the
-    /// FETCH response, **independent of `max_fetch_body_bytes`**. Our cap
-    /// is checked immediately after the item lands — so the session is
-    /// torn down and `Error::SizeLimit` is returned before any bytes reach
-    /// the caller — but the intermediate allocation inside async-imap has
-    /// already happened.
+    /// ## Pre-flight size check
     ///
-    /// Callers exposed to untrusted servers should pair this with an
-    /// external wall-clock memory limit (cgroups, `RLIMIT_AS`) until
-    /// <https://github.com/randomparity/rusty-imap-mcp/issues/32> lands
-    /// a pre-allocation path.
+    /// Before issuing `FETCH BODY.PEEK[]`, this method issues
+    /// `UID FETCH <uid> (RFC822.SIZE)` and rejects with
+    /// `Error::SizeLimit` if the server-reported size exceeds
+    /// `max_fetch_body_bytes`. This prevents async-imap from buffering
+    /// the full body into memory for oversize messages, at the cost of
+    /// one extra IMAP round-trip.
+    ///
+    /// The post-parse `project_size` check inside `ops::fetch::fetch_body`
+    /// remains as defense-in-depth because servers can lie about
+    /// `RFC822.SIZE`.
     ///
     /// # Errors
     /// Propagates `Error::SizeLimit` if the body exceeds the configured
@@ -544,6 +542,8 @@ impl Connection {
             let session = guard
                 .as_mut()
                 .unwrap_or_else(|| unreachable!("session() ensures Some"));
+            let server_size = crate::ops::fetch::preflight_fetch_size(session, folder, uid).await?;
+            crate::ops::fetch::preflight_size_check(server_size, limit)?;
             crate::ops::fetch::fetch_body(session, folder, uid, limit).await
         })
         .await;

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -514,10 +514,7 @@ impl Connection {
     /// the connection on size-limit overflow OR connection loss so the
     /// half-consumed response state never leaks to the next op.
     ///
-    /// # Size cap is enforced post-parse, not pre-allocation
-    ///
-    /// `async-imap 0.11` yields each FETCH item as an already-materialized
-    /// ## Pre-flight size check
+    /// # Pre-flight size check
     ///
     /// Before issuing `FETCH BODY.PEEK[]`, this method issues
     /// `UID FETCH <uid> (RFC822.SIZE)` and rejects with

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -146,11 +146,13 @@ pub(crate) async fn fetch(
 /// - `Error::ConnectionLost` if the underlying transport tore down.
 /// - Other `async-imap` errors propagated through `super::folders::map_err`.
 ///
-/// NOTE: `async-imap` delivers each `Fetch` response as a parsed unit, so
-/// the body bytes are already in memory before the size check fires. The
-/// limit acts as an accept/reject gate, not a backpressure mechanism. A
-/// future async-imap version with chunked body streaming would let us
-/// enforce the limit mid-network-read.
+/// NOTE: This is the **defense-in-depth fallback**. The primary size
+/// enforcement is `preflight_fetch_size` + `preflight_size_check`,
+/// which rejects oversize messages before the body fetch begins.
+/// This post-parse check catches the case where the server
+/// misreports `RFC822.SIZE`. `async-imap` delivers each `Fetch`
+/// response as a parsed unit, so the body bytes are already in
+/// memory before this check fires.
 pub(crate) async fn fetch_body(
     session: &mut ImapSession,
     folder: &str,

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -203,6 +203,46 @@ fn project_size(total: u64, chunk: usize, limit: u64) -> Result<u64, Error> {
     }
 }
 
+/// Check whether a server-reported `RFC822.SIZE` exceeds `limit`.
+/// Returns `Ok(())` when the size is absent (server did not report it)
+/// or within the limit. Returns `Err(Error::SizeLimit)` when the
+/// reported size strictly exceeds `limit`.
+pub(crate) fn preflight_size_check(server_size: Option<u32>, limit: u64) -> Result<(), Error> {
+    if let Some(size) = server_size
+        && u64::from(size) > limit
+    {
+        return Err(Error::SizeLimit { limit });
+    }
+    Ok(())
+}
+
+/// Issue `UID FETCH <uid> (RFC822.SIZE)` and return the server-reported
+/// size, or `None` if the server omitted it.
+pub(crate) async fn preflight_fetch_size(
+    session: &mut ImapSession,
+    folder: &str,
+    uid: Uid,
+) -> Result<Option<u32>, Error> {
+    session
+        .examine(folder)
+        .await
+        .map_err(super::folders::map_err)?;
+
+    let mut stream = session
+        .uid_fetch(uid.get().to_string(), "RFC822.SIZE")
+        .await
+        .map_err(super::folders::map_err)?;
+
+    let mut size: Option<u32> = None;
+    while let Some(msg) = stream.next().await {
+        let msg = msg.map_err(super::folders::map_err)?;
+        if msg.uid == Some(uid.get()) {
+            size = msg.size;
+        }
+    }
+    Ok(size)
+}
+
 fn build_fetch_items(spec: FetchSpec) -> String {
     let mut parts: Vec<&str> = vec!["UID"]; // always request UID
     if spec.envelope {
@@ -368,7 +408,10 @@ fn convert_flag(f: &async_imap::types::Flag<'_>) -> crate::types::Flag {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_BODYSTRUCTURE_DEPTH, compress_uid_set, convert_bs_inner, project_size};
+    use super::{
+        MAX_BODYSTRUCTURE_DEPTH, compress_uid_set, convert_bs_inner, preflight_size_check,
+        project_size,
+    };
     use crate::error::Error;
     use async_imap::imap_proto::{
         BodyContentCommon, BodyContentSinglePart, BodyStructure as ImapProtoBodyStructure,
@@ -659,6 +702,37 @@ mod tests {
     fn compress_singleton_u32_max() {
         let input = [uid(u32::MAX)];
         assert_eq!(compress_uid_set(&input), "4294967295");
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "test failure path")]
+    fn preflight_size_check_rejects_oversize() {
+        let limit = 5_000_000;
+        let result = preflight_size_check(Some(10_000_000), limit);
+        match result {
+            Err(Error::SizeLimit { limit: l }) => assert_eq!(l, limit),
+            other => panic!("expected SizeLimit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test")]
+    fn preflight_size_check_accepts_within_limit() {
+        preflight_size_check(Some(1_000_000), 5_000_000).unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test")]
+    fn preflight_size_check_accepts_at_exact_limit() {
+        // u32::MAX fits in u64, so use a smaller example for clarity.
+        let limit = 5_000_000;
+        preflight_size_check(Some(5_000_000), limit).unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test")]
+    fn preflight_size_check_passes_when_server_omits_size() {
+        preflight_size_check(None, 5_000_000).unwrap();
     }
 
     // NOTE: The round-trip parser in this proptest is a SIMPLIFIED model.

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -165,16 +165,37 @@ fn check_sniff_mismatch(declared: &str, sniffed: Option<&str>) -> Vec<serde_json
 /// Maximum recursion depth for BODYSTRUCTURE tree walking.
 const MAX_BS_DEPTH: u32 = 64;
 
+/// Compute the IMAP part ID for a leaf or message node.
+/// Root-level nodes get "1"; nested nodes keep their prefix.
+fn leaf_part_id(prefix: &str) -> String {
+    if prefix.is_empty() {
+        "1".to_string()
+    } else {
+        prefix.to_string()
+    }
+}
+
+/// Compute the IMAP part ID for a child of a multipart node.
+/// Root-level children are "1", "2", etc.; nested children
+/// are "prefix.1", "prefix.2", etc.
+fn child_part_id(prefix: &str, index: usize) -> String {
+    if prefix.is_empty() {
+        index.to_string()
+    } else {
+        format!("{prefix}.{index}")
+    }
+}
+
 /// Look up a part's declared MIME type from a `BodyStructure` tree by
 /// IMAP-style part ID (e.g. "2", "1.2").
 fn lookup_bodystructure_type(bs: &BodyStructure, target_part_id: &str) -> Option<String> {
-    lookup_bs_recursive(bs, &mut String::new(), target_part_id, 0)
+    lookup_bs_recursive(bs, "", target_part_id, 0)
 }
 
 /// Recursive walker that mirrors `collect_attachments` numbering.
 fn lookup_bs_recursive(
     bs: &BodyStructure,
-    prefix: &mut String,
+    prefix: &str,
     target: &str,
     depth: u32,
 ) -> Option<String> {
@@ -187,11 +208,7 @@ fn lookup_bs_recursive(
             mime_subtype,
             ..
         } => {
-            let part_id = if prefix.is_empty() {
-                "1".to_string()
-            } else {
-                prefix.clone()
-            };
+            let part_id = leaf_part_id(prefix);
             if part_id == target {
                 Some(format!(
                     "{}/{}",
@@ -204,25 +221,16 @@ fn lookup_bs_recursive(
         }
         BodyStructure::Multipart { parts, .. } => {
             for (i, part) in parts.iter().enumerate() {
-                let idx = i + 1;
-                let mut child = if prefix.is_empty() {
-                    idx.to_string()
-                } else {
-                    format!("{prefix}.{idx}")
-                };
-                if let Some(found) = lookup_bs_recursive(part, &mut child, target, depth + 1) {
+                let child = child_part_id(prefix, i + 1);
+                if let Some(found) = lookup_bs_recursive(part, &child, target, depth + 1) {
                     return Some(found);
                 }
             }
             None
         }
         BodyStructure::Message { body, .. } => {
-            let mut part_id = if prefix.is_empty() {
-                "1".to_string()
-            } else {
-                prefix.clone()
-            };
-            lookup_bs_recursive(body, &mut part_id, target, depth + 1)
+            let part_id = leaf_part_id(prefix);
+            lookup_bs_recursive(body, &part_id, target, depth + 1)
         }
     }
 }

--- a/crates/rimap-server/src/tools/list_attachments.rs
+++ b/crates/rimap-server/src/tools/list_attachments.rs
@@ -61,7 +61,7 @@ pub async fn handle(
     })?;
 
     let mut attachments = Vec::new();
-    collect_attachments(&bodystructure, &mut String::new(), &mut attachments, 0);
+    collect_attachments(&bodystructure, "", &mut attachments, 0);
 
     let attachment_values: Vec<serde_json::Value> = attachments
         .iter()
@@ -91,6 +91,27 @@ pub async fn handle(
 /// Maximum recursion depth for MIME tree walking (denial-of-service guard).
 const MAX_MIME_DEPTH: u32 = 64;
 
+/// Compute the IMAP part ID for a leaf or message node.
+/// Root-level nodes get "1"; nested nodes keep their prefix.
+fn leaf_part_id(prefix: &str) -> String {
+    if prefix.is_empty() {
+        "1".to_string()
+    } else {
+        prefix.to_string()
+    }
+}
+
+/// Compute the IMAP part ID for a child of a multipart node.
+/// Root-level children are "1", "2", etc.; nested children
+/// are "prefix.1", "prefix.2", etc.
+fn child_part_id(prefix: &str, index: usize) -> String {
+    if prefix.is_empty() {
+        index.to_string()
+    } else {
+        format!("{prefix}.{index}")
+    }
+}
+
 /// Walk the `BodyStructure` tree and collect attachment parts.
 ///
 /// IMAP part numbering: for a multipart message the top-level parts
@@ -99,7 +120,7 @@ const MAX_MIME_DEPTH: u32 = 64;
 /// root, the sole part is "1".
 fn collect_attachments(
     bs: &BodyStructure,
-    prefix: &mut String,
+    prefix: &str,
     out: &mut Vec<AttachmentInfo>,
     depth: u32,
 ) {
@@ -114,11 +135,7 @@ fn collect_attachments(
             size,
             ..
         } => {
-            let part_id = if prefix.is_empty() {
-                "1".to_string()
-            } else {
-                prefix.clone()
-            };
+            let part_id = leaf_part_id(prefix);
             if !is_inline_text(mime_type, mime_subtype) {
                 let filename = extract_filename(params);
                 let full_type = format!(
@@ -136,24 +153,14 @@ fn collect_attachments(
         }
         BodyStructure::Multipart { parts, .. } => {
             for (i, part) in parts.iter().enumerate() {
-                let idx = i + 1;
-                let child_prefix = if prefix.is_empty() {
-                    idx.to_string()
-                } else {
-                    format!("{prefix}.{idx}")
-                };
-                let mut child = child_prefix;
-                collect_attachments(part, &mut child, out, depth + 1);
+                let child = child_part_id(prefix, i + 1);
+                collect_attachments(part, &child, out, depth + 1);
             }
         }
         BodyStructure::Message { body, .. } => {
-            let part_id = if prefix.is_empty() {
-                "1".to_string()
-            } else {
-                prefix.clone()
-            };
+            let part_id = leaf_part_id(prefix);
             // Walk into the embedded message's body structure.
-            collect_attachments(body, &mut part_id.clone(), out, depth + 1);
+            collect_attachments(body, &part_id, out, depth + 1);
         }
     }
 }
@@ -206,7 +213,7 @@ mod tests {
     fn single_text_plain_is_not_attachment() {
         let bs = single("text", "plain", 100);
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert!(out.is_empty());
     }
 
@@ -214,7 +221,7 @@ mod tests {
     fn single_text_html_is_not_attachment() {
         let bs = single("text", "html", 200);
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert!(out.is_empty());
     }
 
@@ -222,7 +229,7 @@ mod tests {
     fn single_image_is_attachment() {
         let bs = single_with_name("image", "png", 5000, "photo.png");
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].part_id, "1");
         assert_eq!(out[0].mime_type, "image/png");
@@ -241,7 +248,7 @@ mod tests {
             ],
         };
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].part_id, "2");
         assert_eq!(out[0].mime_type, "application/pdf");
@@ -266,7 +273,7 @@ mod tests {
             ],
         };
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].part_id, "1.2");
         assert_eq!(out[0].filename.as_deref(), Some("anim.gif"));
@@ -307,7 +314,7 @@ mod tests {
             };
         }
         let mut out = Vec::new();
-        collect_attachments(&bs, &mut String::new(), &mut out, 0);
+        collect_attachments(&bs, "", &mut out, 0);
         assert!(out.is_empty());
     }
 }

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,10 @@ extend-ignore-re = [
 # Intentional project vocabulary. Add sparingly with a comment.
 imap = "imap"
 rimap = "rimap"
+# CVE Numbering Authority — a recognized industry acronym; typos incorrectly suggests "CAN"
+CNA = "CNA"
+# STRIDE table uses bold-letter notation (**I**nformation). Typos sees "nformation" as a fragment.
+nformation = "nformation"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Summary

- **#32** — Add pre-flight `UID FETCH RFC822.SIZE` check before `FETCH BODY.PEEK[]` in `Connection::fetch_body`, rejecting oversize messages without buffering the full body in async-imap. Post-parse `project_size` check remains as defense-in-depth.
- **#14** — Add `threat-model-reviewer` agent for STRIDE-based review of specs and plans.
- **#18** — Enhance `SECURITY.md` with disclosure timeline, CVE process, supported-versions policy, and security contact identity. Add `security-docs-reviewer` agent.
- **#19** — Add placeholder `release-integrity-reviewer` agent with full taxonomy, to be activated when release automation lands.
- **SonarQube** — Reduce cognitive complexity in three production functions:
  - `collect_header_domains` (24→6) via `push_domains_from` helper
  - `lookup_bs_recursive` (20→~12) via `leaf_part_id`/`child_part_id` helpers
  - `collect_attachments` (16→~10) via same helpers

## Test plan

- [ ] `just ci` passes (560 unit/property/snapshot tests, clippy, fmt, deny)
- [ ] Dovecot integration tests pass in CI (require container runtime)
- [ ] SonarQube re-scan shows no production code complexity violations
- [ ] Verify new agent files have correct frontmatter (`head -6 .claude/agents/*.md`)
- [ ] Verify SECURITY.md has all 6 sections (reporting, threat model, supported versions, disclosure timeline, CVE process, security contact)

Closes #32, closes #14, closes #18, closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)