### PR TITLE
feat: sprint-3 + v1.0.0 release prep (56 commits)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,18 @@ jobs:
           subject-path: |
             artifacts/rusty-imap-mcp-*
             artifacts/SHA256SUMS.txt
+      - name: Extract release notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          awk "/^## \\[${VERSION}\\]/,/^## \\[[^\\]]+\\]/" CHANGELOG.md \
+            | head -n -1 > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "Warning: no release notes extracted for ${TAG}"
+            cp CHANGELOG.md RELEASE_NOTES.md
+          fi
+          head -20 RELEASE_NOTES.md
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -179,6 +191,6 @@ jobs:
           gh release create "$TAG_NAME" \
             --draft \
             --title "$TAG_NAME" \
-            --notes-file CHANGELOG.md \
+            --notes-file RELEASE_NOTES.md \
             artifacts/${{ env.BINARY_NAME }}-* \
             artifacts/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -164,6 +166,11 @@ jobs:
           cd artifacts
           sha256sum ${{ env.BINARY_NAME }}-* > SHA256SUMS.txt
           cat SHA256SUMS.txt
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: |
+            artifacts/rusty-imap-mcp-*
+            artifacts/SHA256SUMS.txt
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
         with:
           toolchain: stable
-      - run: cargo build --release --locked
+      - name: Install cargo-auditable
+        run: cargo install cargo-auditable --locked --version 0.7.4
+      - run: cargo auditable build --release --locked
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -51,6 +53,9 @@ jobs:
           targets: aarch64-unknown-linux-gnu
       - name: Install cross
         run: cargo install cross --locked --version 0.2.5
+      # TODO: embed SBOM via cargo-auditable for cross builds. Requires
+      # installing cargo-auditable inside the cross container (e.g. via a
+      # Cross.toml pre-build hook or custom image). Tracked as follow-up.
       - run: cross build --release --locked --target aarch64-unknown-linux-gnu
       - name: Rename binary
         run: cp target/aarch64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
@@ -71,7 +76,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
         with:
           toolchain: stable
-      - run: cargo build --release --locked
+      - name: Install cargo-auditable
+        run: cargo install cargo-auditable --locked --version 0.7.4
+      - run: cargo auditable build --release --locked
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-apple-darwin
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -98,7 +105,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             rust:1.88.0-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 \
-            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
+            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo install cargo-auditable --locked --version 0.7.4 && cargo auditable build --release --locked"
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -125,7 +132,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             rust:1.88.0-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 \
-            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
+            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo install cargo-auditable --locked --version 0.7.4 && cargo auditable build --release --locked"
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
       - build-linux-ppc64le
       - build-linux-s390x
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,12 @@ jobs:
         with:
           platforms: linux/ppc64le
       - name: Build in ppc64le container
+        # rust:1.88.0-bookworm as of 2026-04-13
         run: |
           docker run --rm --platform linux/ppc64le \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            rust:1.88.0-bookworm \
+            rust:1.88.0-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 \
             bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
@@ -118,11 +119,12 @@ jobs:
         with:
           platforms: linux/s390x
       - name: Build in s390x container
+        # rust:1.88.0-bookworm as of 2026-04-13
         run: |
           docker run --rm --platform linux/s390x \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            rust:1.88.0-bookworm \
+            rust:1.88.0-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 \
             bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
       - name: Rename binary
         run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  BINARY_NAME: rusty-imap-mcp
+
+jobs:
+  build-linux-x86_64:
+    name: build (x86_64-unknown-linux-gnu)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: stable
+      - run: cargo build --release --locked
+      - name: Rename binary
+        run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
+          path: ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
+
+  build-linux-aarch64:
+    name: build (aarch64-unknown-linux-gnu)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: stable
+          targets: aarch64-unknown-linux-gnu
+      - name: Install cross
+        run: cargo install cross --locked
+      - run: cross build --release --locked --target aarch64-unknown-linux-gnu
+      - name: Rename binary
+        run: cp target/aarch64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
+          path: ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
+
+  build-macos-aarch64:
+    name: build (aarch64-apple-darwin)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: stable
+      - run: cargo build --release --locked
+      - name: Rename binary
+        run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-apple-darwin
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.BINARY_NAME }}-aarch64-apple-darwin
+          path: ${{ env.BINARY_NAME }}-aarch64-apple-darwin
+
+  build-linux-ppc64le:
+    name: build (powerpc64le-unknown-linux-gnu)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+        with:
+          platforms: linux/ppc64le
+      - name: Build in ppc64le container
+        run: |
+          docker run --rm --platform linux/ppc64le \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            rust:1.88.0-bookworm \
+            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
+      - name: Rename binary
+        run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
+          path: ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
+
+  build-linux-s390x:
+    name: build (s390x-unknown-linux-gnu)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+        with:
+          platforms: linux/s390x
+      - name: Build in s390x container
+        run: |
+          docker run --rm --platform linux/s390x \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            rust:1.88.0-bookworm \
+            bash -c "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && cargo build --release --locked"
+      - name: Rename binary
+        run: cp target/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
+          path: ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
+
+  release:
+    name: Create GitHub Release
+    needs:
+      - build-linux-x86_64
+      - build-linux-aarch64
+      - build-macos-aarch64
+      - build-linux-ppc64le
+      - build-linux-s390x
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Generate SHA256 checksums
+        run: |
+          cd artifacts
+          sha256sum ${{ env.BINARY_NAME }}-* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --draft \
+            --title "$TAG_NAME" \
+            --notes-file CHANGELOG.md \
+            artifacts/${{ env.BINARY_NAME }}-* \
+            artifacts/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           toolchain: stable
           targets: aarch64-unknown-linux-gnu
       - name: Install cross
-        run: cargo install cross --locked
+        run: cargo install cross --locked --version 0.2.5
       - run: cross build --release --locked --target aarch64-unknown-linux-gnu
       - name: Rename binary
         run: cp target/aarch64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .idea/
 .vscode/
 *.swp
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,16 +19,20 @@ structural tagging (`meta` / `untrusted` / `security_warnings`), Unicode
 normalization, look-alike detection, content provenance tracking in the audit
 log, posture-based authorization, and rate limiting.
 
-**Source of truth:** the design specification lives at
-[`docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md`](docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md).
-Read it before making non-trivial changes. Sprint-by-sprint implementation
-plans live in [`docs/superpowers/plans/`](docs/superpowers/plans/).
+**Source of truth:** the design specifications live at
+[`docs/superpowers/specs/`](docs/superpowers/specs/): the v1 spec
+(`2026-04-07-rusty-imap-mcp-design.md`), v2 spec
+(`2026-04-12-v2-design.md`), and sprint 3 spec
+(`2026-04-13-sprint-3-design.md`). Read them before making non-trivial
+changes. Sprint-by-sprint implementation plans live in
+[`docs/superpowers/plans/`](docs/superpowers/plans/).
 
 ## Repository status
 
-The repo is under active pre-v1 development. Sprint 0 (scaffolding) landed on
-`main`. No feature code exists yet — the seven member crates under `crates/`
-are empty placeholders. Features land sprint by sprint against dedicated plans.
+v1.0.0 is feature-complete. The eight member crates under `crates/` implement
+22 posture-gated MCP tools + 2 infrastructure tools (24 `ToolName` variants),
+multi-account support, SMTP sending, an audit log, and a content pipeline with
+look-alike detection. Five platform targets are built via the release workflow.
 
 ## Development commands
 
@@ -86,6 +90,7 @@ crates/
 ├── rimap-content/   # MIME parse, Unicode, HTML→text, look-alike, sanitization
 ├── rimap-audit/     # append-only JSONL audit log with exclusive file locking
 ├── rimap-authz/     # posture matrix, rate limiter, circuit breaker
+├── rimap-smtp/      # lettre wrapper, SMTP connection, TLS
 └── rimap-server/    # rmcp server (bin), tool dispatch, main.rs
 ```
 
@@ -157,11 +162,12 @@ are the ones that trip people up or aren't obvious from the lint set.
 - **`prek` hooks run on every commit and push.** If a hook fails, fix the
   underlying issue — do not `--no-verify`. Do not `--amend` commits that have
   been pushed.
-- **PR workflow:** feature branch → push → PR against `main`. CI runs all six
+- **PR workflow:** feature branch -> push -> PR against `main`. CI runs all six
   status checks (`rustfmt`, `clippy`, `test (stable)`, `test (MSRV 1.88.0)`,
   `cargo-deny`, `zizmor self-check`), plus `SonarQube` for code quality. `main`
   has branch protection requiring the status checks strict (branch must be up
-  to date).
+  to date). A separate release workflow triggers on `v*` tags and builds
+  binaries for five platform targets.
 - **Never force-push to `main`.** Never amend commits that have been pushed.
   Never skip hooks.
 
@@ -175,10 +181,12 @@ Some changes deserve extra scrutiny. When touching:
   advisory lock. Never hold the lock across awaits. Never silently swallow
   write errors — audit failures must surface as `ERR_INTERNAL` tool errors by
   default.
-- **`rimap-authz` posture matrix:** additions to the tool set must update the
-  matrix in `rimap-core` first, then the matrix-driven tool advertisement in
-  `rimap-server`. Tools denied by the active posture must not be advertised via
-  `list_tools`.
+- **`rimap-authz` posture matrix:** the matrix has 22 tools x 4 postures
+  (readonly, draft-safe, full, destructive) plus 2 infrastructure tools
+  (use_account, list_accounts) that bypass posture checks. Additions to the
+  tool set must update the matrix in `rimap-core` first, then the
+  matrix-driven tool advertisement in `rimap-server`. Tools denied by the
+  active posture must not be advertised via `list_tools`.
 - **TLS fingerprint verifier** (`rimap-imap`): the custom `ServerCertVerifier`
   must reject on fingerprint mismatch *before* any application data flows.
   Never fall back to system trust on pinning failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,4 +174,40 @@ Pre-built binaries for five targets:
 - `justfile` with `just ci` as the local-CI equivalent
 - Dual MIT / Apache-2.0 license
 
+### Security Hardening (post-review)
+
+- Namespace MCP tool names per account (`<account>.<tool>`) in multi-account
+  configs to prevent cross-account posture bypass. Single-account configs
+  with the synthetic `"default"` account keep bare tool names.
+- Emit `tool_start` and `tool_end` audit records for every dispatch with
+  account attribution, redacted arguments, and duration metadata.
+- Populate `account` field on `Auth` audit records for multi-account
+  attribution of login events.
+- Wrap resolved credentials in `secrecy::SecretString` to limit in-memory
+  exposure of IMAP and SMTP passwords.
+- Redact IMAP/SMTP usernames from `anyhow` error contexts so they no longer
+  leak into tracing output.
+- Reject IMAP/SMTP usernames containing CR, LF, or NUL bytes at config load.
+- Rate-limit infrastructure tools (`use_account`, `list_accounts`) to
+  prevent session-state flip-flap attacks.
+- Validate account names via `AccountId::new` before echoing them in
+  MCP error messages to prevent reflected-content amplification.
+- Drop `posture` from `read_resource` body and `imap_host` from
+  `list_accounts` response to reduce attack-surface fingerprinting.
+- Require labels to be ASCII (RFC 3501 atom syntax) and reject `[`
+  consistently at both validator layers to prevent homograph/bidi spoofing.
+- Digest-pin the Rust Docker base image used for ppc64le/s390x release
+  builds to resist tag-repointing supply-chain attacks.
+- Pin `cross` version in release workflow.
+- Embed SBOMs in native release binaries via `cargo-auditable`.
+- Add SLSA build provenance attestation to release artifacts and
+  `SHA256SUMS.txt` via `actions/attest-build-provenance`.
+- Extract per-tag release notes from `CHANGELOG.md` rather than attaching
+  the entire changelog to every release.
+- Document GitHub tag protection and release environment setup.
+- Create per-process attachment tempdir with `0700` permissions on Unix
+  to close a symlink/TOCTOU race on shared `/tmp`.
+- Replace `Mutex<Option<AccountId>>` in the account registry with
+  `ArcSwapOption` to eliminate async-refactor footguns and mutex poisoning.
+
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,173 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-04-13
 
 ### Added
 
-- Initial design specification (`docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md`).
-- Sprint 0 scaffolding: cargo workspace, seven empty member crates, MSRV pin at
-  1.85.1, rustfmt/clippy/cargo-deny/typos configuration, justfile, prek
-  pre-commit hooks, SHA-pinned GitHub Actions CI, dual MIT/Apache-2.0 licensing.
+#### Multi-account support
+
+- Multiple IMAP/SMTP accounts in a single server process via `[[accounts]]`
+  config array with per-account posture, rate limits, and SMTP settings.
+- `use_account` tool to set the session-scoped default account.
+- `list_accounts` tool to enumerate configured accounts with posture and
+  SMTP status.
+- MCP resource discovery: `rimap://accounts/<name>` exposes account
+  metadata (host, posture, available tools) without credentials.
+- Account resolution: explicit `account` parameter > session default >
+  auto-select (single account) > error.
+- Full backward compatibility: existing single-account `[imap]` configs
+  work unchanged as a synthetic `"default"` account.
+
+#### MCP tools (22 posture-gated + 2 infrastructure)
+
+**Read operations (all postures):**
+
+- `list_folders` -- IMAP folder listing with message counts
+- `search` -- structured query builder (from, to, subject, date range)
+- `fetch_message` -- message fetch with text body extraction
+- `list_attachments` -- attachment metadata for a message
+- `download_attachment` -- download attachment by part index
+- `list_labels` -- list custom IMAP keyword flags on a message
+
+**Mutation operations (draft-safe and above):**
+
+- `mark_read` / `mark_unread` -- set or clear `\Seen` flag
+- `flag` / `unflag` -- set or clear `\Flagged` flag
+- `add_label` / `remove_label` -- add or remove custom IMAP keyword flags
+- `move_message` -- move message between folders
+- `create_draft` -- append to Drafts with `$PendingReview` keyword
+
+**Full posture operations:**
+
+- `search_advanced` -- raw IMAP SEARCH query passthrough
+- `fetch_message_html` -- sanitized HTML body alongside text
+- `send_email` -- SMTP send with Sent folder copy
+- `delete_message` -- flag `\Deleted` and move to Trash
+- `create_folder` / `rename_folder` -- IMAP folder management
+
+**Destructive posture operations:**
+
+- `expunge` -- permanently remove `\Deleted` messages (folder allowlist)
+- `delete_folder` -- permanently remove folder (folder allowlist +
+  protected folder check)
+
+**Infrastructure tools (always available):**
+
+- `use_account` -- switch active account context
+- `list_accounts` -- list configured accounts
+
+#### Security postures
+
+Four authorization tiers with per-tool overrides:
+
+| Posture | Scope |
+|---------|-------|
+| `readonly` | Read-only: list, search, fetch, download |
+| `draft-safe` | Read + safe mutations: flags, moves, drafts (default) |
+| `full` | All above + send, delete, folder management, HTML, advanced search |
+| `destructive` | All above + expunge, delete_folder |
+
+Tools denied by the active posture are not advertised via `list_tools`.
+Per-tool `"allow"` / `"deny"` overrides merge on top of the posture.
+
+#### Content pipeline
+
+- RFC 5322 / MIME parsing via `mail-parser`
+- Charset decoding via `encoding_rs`
+- NFKC Unicode normalization
+- Invisible/ambiguous codepoint stripping (zero-width chars, bidi
+  overrides, C0/C1 controls)
+- HTML-to-text conversion with hidden-content stripping (CSS
+  `display:none`, `visibility:hidden`, `opacity:0`, white-on-white)
+- Sanitized HTML output via `ammonia` (conservative allowlist)
+- Link text/href domain mismatch detection
+- Look-alike detection: mixed-script, confusable skeleton matching,
+  display-name spoofing, reply-to domain mismatch, filename bidi tricks
+- Attachment filename sanitization (path separators, leading dots,
+  Windows reserved names, length truncation)
+- Structured response envelope: `meta` (trusted), `untrusted`
+  (sanitized), `security_warnings` (server assessment)
+
+#### SMTP sending
+
+- `rimap-smtp` crate wrapping `lettre` with rustls TLS
+- STARTTLS (port 587), implicit TLS (port 465), and plaintext modes
+- Per-send connection lifecycle (no pooling)
+- Automatic Sent folder copy via IMAP APPEND after send
+- `sends_per_minute` rate limit (default 3)
+
+#### Audit log
+
+- Append-only JSONL audit log with exclusive OS advisory file lock
+- Every tool call produces `tool_start` + `tool_end` records linked by
+  sequence number
+- Content provenance ring buffer: recently-read message IDs snapshotted
+  into every `tool_end` record
+- Account name tagged on every record in multi-account configs
+- Size-based rotation with configurable count and time-based retention
+- `audit merge` subcommand with `--account` filter and `--since` /
+  `--until` time range
+- `fail_open = false` default: audit write failures fail the tool call
+
+#### Folder safety
+
+- `protected_folders` list (default: INBOX, Sent, Drafts, Trash) --
+  blocks rename and delete on protected folders
+- `expunge_folders` allowlist (default empty = deny all) -- required for
+  `expunge` and `delete_folder`
+- `create_folder` rejects names colliding with protected folders
+
+#### Rate limiting and circuit breaker
+
+- Token-bucket rate limiter: `commands_per_second` (default 10) with
+  burst of 20
+- Separate `drafts_per_minute` (default 5) and `sends_per_minute`
+  (default 3) limits
+- Sliding-window circuit breaker: closed > open > half-open state
+  machine
+- Auth failures trip immediately (single failure opens for 60s)
+- Exponential backoff cooldown (doubled per re-trip, capped at 5 min)
+
+#### TLS fingerprint pinning
+
+- SHA-256 certificate fingerprint pinning for self-signed certs (e.g.
+  Proton Bridge)
+- Verified before any application data flows
+- Hard failure on mismatch -- no fallback to system trust store when
+  pinning is configured
+
+#### Labels
+
+- IMAP keyword-based labels via `STORE +FLAGS` / `-FLAGS`
+- `add_label`, `remove_label`, `list_labels` tools
+- Label validation: max 256 bytes, IMAP atom charset, no system flag
+  namespace (`\` prefix rejected)
+
+#### Platform support
+
+Pre-built binaries for five targets:
+
+- `x86_64-unknown-linux-gnu` (native)
+- `aarch64-unknown-linux-gnu` (cross-compiled)
+- `aarch64-apple-darwin` (native macOS)
+- `powerpc64le-unknown-linux-gnu` (QEMU emulation)
+- `s390x-unknown-linux-gnu` (QEMU emulation)
+
+#### Development toolchain
+
+- Cargo workspace with 8 member crates
+- MSRV 1.88.0 (edition 2024), dev toolchain 1.94.0
+- SHA-pinned GitHub Actions CI (fmt, clippy, test, MSRV, cargo-deny,
+  zizmor, SonarQube)
+- Release workflow triggered on `v*` tags with SHA256 checksums
+- `prek` pre-commit hooks (fmt, clippy, shellcheck, actionlint, zizmor,
+  typos)
+- `cargo-deny` supply-chain audit (advisories, licenses, bans, sources)
+- `cargo-nextest` test runner
+- Property-based tests via `proptest`, snapshot tests via `insta`
+- Adversarial email injection corpus
+- `justfile` with `just ci` as the local-CI equivalent
+- Dual MIT / Apache-2.0 license
+
+## [Unreleased]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "keyring",
  "rimap-core",
  "rpassword",
+ "secrecy",
  "serde",
  "temp-env",
  "tempfile",
@@ -2174,6 +2175,7 @@ dependencies = [
  "rimap-config",
  "rimap-core",
  "rustls",
+ "secrecy",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -2207,6 +2209,7 @@ dependencies = [
  "rimap-smtp",
  "rmcp",
  "schemars",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -2424,6 +2427,15 @@ dependencies = [
  "precomputed-hash",
  "selectors",
  "tendril 0.5.0",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "governor",
  "hex",
  "infer",
  "lettre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2200,7 @@ name = "rimap-server"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert_cmd",
  "clap",
  "governor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rimap-audit"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "fs4",
  "hex",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-authz"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "governor",
  "nonzero_ext",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-config"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "directories",
  "keyring",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-content"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "addr",
  "ammonia",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-core"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "hex",
  "serde",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-imap"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "async-channel 2.5.0",
  "async-imap",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-server"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-smtp"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "lettre",
  "rimap-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ directories = "5.0"
 # Credentials
 keyring = { version = "3.6", features = ["apple-native", "linux-native-sync-persistent"] }
 rpassword = "7.3"
+secrecy = "0.10"
 
 # Authorization primitives
 governor = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ governor = "0.7"
 utf7-imap = "0.3.2"
 nonzero_ext = "0.3"
 parking_lot = "0.12"
+# Lock-free Arc swap for session-scoped mutable state. MIT OR Apache-2.0.
+arc-swap = "1"
 
 # Async runtime
 tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }

--- a/README.md
+++ b/README.md
@@ -1,47 +1,185 @@
 # rusty-imap-mcp
 
-A security-first [Model Context Protocol](https://modelcontextprotocol.io/) server
-for IMAP email, written in Rust. Primary target: Proton Mail via Proton Bridge.
-Compatible with standard IMAP servers (Dovecot, Cyrus, Gmail app password, etc.).
-
-**Status:** Sprint 0 — scaffolding only. No functionality yet. See
-[`docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md`](docs/superpowers/specs/2026-04-07-rusty-imap-mcp-design.md)
-for the full design.
+A security-first [Model Context Protocol](https://modelcontextprotocol.io/)
+server for IMAP email, written in Rust. Primary target: Proton Mail via
+Proton Bridge. Compatible with standard IMAP servers (Dovecot, Cyrus,
+Gmail via app password, etc.).
 
 ## Why
 
-LLM agents reading email are an attractive target for prompt injection. A single
-crafted message can contain hidden instructions that induce the agent to send mail,
-leak data, or pivot to other tools. `rusty-imap-mcp` is built around that threat:
-every byte of email content is treated as untrusted input, sanitized aggressively,
-tagged structurally, and accompanied by server-generated security warnings about
-look-alike domains, hidden content, and content provenance.
+LLM agents reading email are a target for prompt injection. A single
+crafted message can contain hidden instructions that induce the agent to
+send mail, leak data, or pivot to other tools. rusty-imap-mcp treats
+every byte of email content as untrusted input: aggressive sanitization,
+structural tagging, Unicode normalization, look-alike detection, content
+provenance tracking, and posture-based authorization.
+
+## Quick start
+
+1. Build from source (see below) or download a binary from the
+   [releases page](https://github.com/randomparity/rusty-imap-mcp/releases).
+
+2. Create a config file:
+
+   ```toml
+   [imap]
+   host = "127.0.0.1"
+   port = 1143
+   username = "you@proton.me"
+   tls_fingerprint_sha256 = "..."  # see docs/proton-bridge-setup.md
+
+   [audit]
+   path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
+   ```
+
+   Place it at `~/.config/rusty-imap-mcp/config.toml` (Linux) or
+   `~/Library/Application Support/rusty-imap-mcp/config.toml` (macOS).
+
+3. Store the IMAP password:
+
+   ```bash
+   rusty-imap-mcp login
+   ```
+
+4. Test the connection:
+
+   ```bash
+   rusty-imap-mcp --dry-run
+   ```
+
+5. Add to your MCP client (e.g. Claude Desktop):
+
+   ```json
+   {
+     "mcpServers": {
+       "email": {
+         "command": "rusty-imap-mcp"
+       }
+     }
+   }
+   ```
 
 ## Security postures
 
-Three presets with per-tool overrides:
+Four tiers control which tools are available. The default is
+`draft-safe`.
 
-- **`readonly`** — list, search, fetch, download. No mutations. Safest.
-- **`draft-safe`** (default) — read + flag + move + *create drafts* (appended to
-  Drafts with a `$PendingReview` keyword). **Never opens an SMTP connection.**
-- **`full`** — everything above plus advanced search, HTML bodies, and (in v2)
-  direct SMTP send, delete, and expunge.
+| Posture | Scope |
+|---------|-------|
+| `readonly` | List, search, fetch, download. No mutations. |
+| `draft-safe` | Read + flags, moves, labels, drafts with `$PendingReview`. No SMTP. Default. |
+| `full` | All above + send, delete, folder management, HTML bodies, advanced search. |
+| `destructive` | All above + expunge, delete_folder. |
 
-## Building
+Tools denied by the active posture are not advertised via `list_tools`
+and are rejected at dispatch. Per-tool `"allow"` / `"deny"` overrides
+are supported.
+
+See [docs/security-model.md](docs/security-model.md) for the full
+22-tool x 4-posture matrix and threat model.
+
+## Multi-account
+
+Multiple accounts are supported in a single server process:
+
+```toml
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "user@proton.me"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.fastmail.com"
+port = 993
+username = "me@fastmail.com"
+
+[accounts.security]
+posture = "readonly"
+
+[audit]
+path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
+```
+
+Agents discover accounts via MCP resources
+(`rimap://accounts/<name>`) and select them with the `use_account`
+tool or per-call `account` parameter. Each account has independent
+posture, rate limits, and circuit breaker.
+
+Existing single-account configs work unchanged.
+
+See [docs/multi-account.md](docs/multi-account.md).
+
+## MCP tools
+
+**22 posture-gated tools:**
+
+- **Read:** `list_folders`, `search`, `search_advanced`,
+  `fetch_message`, `fetch_message_html`, `list_attachments`,
+  `download_attachment`, `list_labels`
+- **Mutate:** `mark_read`, `mark_unread`, `flag`, `unflag`,
+  `add_label`, `remove_label`, `move_message`, `create_draft`
+- **Manage:** `send_email`, `delete_message`, `create_folder`,
+  `rename_folder`, `expunge`, `delete_folder`
+
+**2 infrastructure tools** (always available):
+`use_account`, `list_accounts`
+
+## Build from source
+
+```bash
+# Clone and build
+git clone https://github.com/randomparity/rusty-imap-mcp.git
+cd rusty-imap-mcp
+cargo build --release
+
+# Binary at target/release/rusty-imap-mcp
+```
+
+Requires Rust 1.88.0+ and `libdbus-1-dev` (Linux) or equivalent.
+
+### Development
 
 ```bash
 just setup    # install required tooling and pre-commit hooks
-just ci       # run the full local-CI equivalent
+just ci       # run the full local-CI equivalent (fmt, clippy, test, MSRV, deny, typos)
 ```
 
-Developer toolchain is pinned in `rust-toolchain.toml`. MSRV is 1.88.0, verified
-independently in CI.
+MSRV is 1.88.0, verified independently in CI. Dev toolchain is 1.94.0,
+pinned in `rust-toolchain.toml`.
+
+## Pre-built binaries
+
+Binaries are published for five targets on each
+[release](https://github.com/randomparity/rusty-imap-mcp/releases):
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `aarch64-apple-darwin`
+- `powerpc64le-unknown-linux-gnu`
+- `s390x-unknown-linux-gnu`
+
+SHA256 checksums are included with each release.
+
+## Documentation
+
+- [Configuration reference](docs/configuration.md)
+- [Multi-account support](docs/multi-account.md)
+- [Security model and posture matrix](docs/security-model.md)
+- [Proton Bridge setup](docs/proton-bridge-setup.md)
+- [Audit log format](docs/audit-log.md)
 
 ## License
 
-Dual-licensed under MIT OR Apache-2.0. See `LICENSE-MIT` and `LICENSE-APACHE`.
+Dual-licensed under MIT OR Apache-2.0. See `LICENSE-MIT` and
+`LICENSE-APACHE`.
 
 ## Security
 
-See [`SECURITY.md`](SECURITY.md) for responsible disclosure and the threat model
-summary.
+See [`SECURITY.md`](SECURITY.md) for responsible disclosure and the
+threat model summary.

--- a/crates/rimap-audit/Cargo.toml
+++ b/crates/rimap-audit/Cargo.toml
@@ -12,7 +12,7 @@ description = "Append-only JSONL audit log with exclusive file locking for rusty
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -19,8 +19,8 @@ pub use crate::ids::{ProcessId, Seq, Timestamp};
 pub use crate::provenance::ProvenanceBuffer;
 pub use crate::reader::{Filter, open_shared, stream_records};
 pub use crate::record::{
-    AuditRecord, Auth, AuthResult, ConfigEvent, Payload, ProcessEnd, ProcessEndReason,
-    ProcessStart, Provenance, ResultSummary, ToolEnd, ToolStart, ToolStatus,
+    AccountSummary, AuditRecord, Auth, AuthResult, ConfigEvent, Payload, ProcessEnd,
+    ProcessEndReason, ProcessStart, Provenance, ResultSummary, ToolEnd, ToolStart, ToolStatus,
 };
 pub use crate::redact::{
     FieldPolicy, RedactionSalt, RedactionSchema, Redactor, hash_arguments, schemas,

--- a/crates/rimap-audit/src/reader.rs
+++ b/crates/rimap-audit/src/reader.rs
@@ -25,6 +25,10 @@ pub struct Filter {
     pub kind: Option<String>,
     /// Required `process_id` (canonical ULID string).
     pub process: Option<String>,
+    /// If set, only records whose `account` field matches are returned.
+    /// Records without an account field (`process_start`, `process_end`,
+    /// `config`) pass through when this filter is set.
+    pub account: Option<String>,
 }
 
 impl Filter {
@@ -63,6 +67,20 @@ impl Filter {
             match got {
                 Some(name) if name == want => {}
                 Some(_) | None => return false,
+            }
+        }
+        if let Some(ref want) = self.account {
+            let got = match &record.payload {
+                Payload::Auth(a) => a.account.as_deref(),
+                Payload::ToolStart(t) => t.account.as_deref(),
+                Payload::ToolEnd(t) => t.account.as_deref(),
+                Payload::ProcessStart(_) | Payload::ProcessEnd(_) | Payload::Config(_) => None,
+            };
+            // Records that lack an account field pass through.
+            if let Some(name) = got
+                && name != want
+            {
+                return false;
             }
         }
         true
@@ -357,6 +375,7 @@ mod tests {
             ts: Timestamp::from_offset(datetime!(2026-04-07 14:22:01.000 UTC)),
             process_id: pid,
             payload: Payload::ToolStart(ToolStart {
+                account: None,
                 tool: "read_email".to_string(),
                 posture_effective: "draft-safe".to_string(),
                 arguments_redacted: serde_json::json!({}),

--- a/crates/rimap-audit/src/record.rs
+++ b/crates/rimap-audit/src/record.rs
@@ -25,6 +25,17 @@ pub enum ProcessEndReason {
     Error,
 }
 
+/// Per-account summary for multi-account `process_start` records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountSummary {
+    /// Account name from config.
+    pub name: String,
+    /// Effective posture for this account.
+    pub posture: String,
+    /// IMAP host for this account.
+    pub imap_host: String,
+}
+
 /// Payload of the `process_start` kind. Fields chosen to chain history across
 /// restarts (see spec §10 startup self-check).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,8 +45,12 @@ pub struct ProcessStart {
     /// Git commit SHA embedded at build (via `vergen` when wired in Sprint 5;
     /// populated as an empty string until then).
     pub git_commit: String,
-    /// Effective base posture at startup.
-    pub posture: String,
+    /// Effective base posture at startup (single-account mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub posture: Option<String>,
+    /// Per-account summaries (multi-account mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accounts: Option<Vec<AccountSummary>>,
     /// Absolute path of the loaded config file.
     pub config_path: PathBuf,
     /// SHA-256 of the config file contents at load time, hex-encoded.
@@ -91,6 +106,9 @@ pub enum AuthResult {
 /// Payload of the `auth` kind.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Auth {
+    /// Account name this auth attempt belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
     /// Outcome.
     pub result: AuthResult,
     /// IMAP host attempted.
@@ -120,6 +138,9 @@ pub struct Auth {
 /// crash mid-call still leaves a breadcrumb.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolStart {
+    /// Account name this tool call targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
     /// The v1 tool name as a string (matches `ToolName::as_str`).
     pub tool: String,
     /// Effective posture at dispatch time (after any config-override merge).
@@ -173,6 +194,9 @@ pub struct Provenance {
 /// Payload of the `tool_end` kind.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolEnd {
+    /// Account name this tool call targeted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
     /// `seq` of the paired `tool_start` record.
     pub start_seq: Seq,
     /// Tool name (duplicated from `tool_start` for self-contained log lines).
@@ -235,7 +259,8 @@ mod tests {
             payload: Payload::ProcessStart(ProcessStart {
                 version: "0.1.0".to_string(),
                 git_commit: String::new(),
-                posture: "draft-safe".to_string(),
+                posture: Some("draft-safe".to_string()),
+                accounts: None,
                 config_path: PathBuf::from("/tmp/config.toml"),
                 config_hash_sha256: "abcd".repeat(16),
                 previous_last_seq: None,
@@ -254,6 +279,7 @@ mod tests {
         assert_eq!(v["kind"], "process_start");
         assert_eq!(v["seq"], 1);
         assert_eq!(v["posture"], "draft-safe");
+        assert!(v["accounts"].is_null(), "accounts should be omitted");
         assert!(v["ts"].is_string());
         assert_eq!(v["previous_file_inode"], 12345);
         assert_eq!(v["audit_file_inode_changed"], false);
@@ -300,6 +326,7 @@ mod tests {
             ts: Timestamp::now(),
             process_id: ProcessId::new_now(),
             payload: Payload::Auth(crate::record::Auth {
+                account: None,
                 result: crate::record::AuthResult::Success,
                 host: "127.0.0.1".to_string(),
                 port: 1143,
@@ -336,6 +363,7 @@ mod tests {
             ts: Timestamp::now(),
             process_id: ProcessId::new_now(),
             payload: Payload::ToolStart(crate::record::ToolStart {
+                account: None,
                 tool: "fetch_message".to_string(),
                 posture_effective: "draft-safe".to_string(),
                 arguments_redacted: serde_json::json!({
@@ -362,6 +390,7 @@ mod tests {
             ts: Timestamp::now(),
             process_id: ProcessId::new_now(),
             payload: Payload::ToolEnd(crate::record::ToolEnd {
+                account: None,
                 start_seq: Seq(10),
                 tool: "fetch_message".to_string(),
                 status: crate::record::ToolStatus::Ok,

--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -207,6 +207,7 @@ pub fn schemas() -> Vec<RedactionSchema> {
     let mut out = read_tool_schemas();
     out.extend(write_tool_schemas());
     out.extend(v2_tool_schemas());
+    out.extend(label_tool_schemas());
     out
 }
 
@@ -439,6 +440,34 @@ fn v2_tool_schemas() -> Vec<RedactionSchema> {
                 ("token", Forbidden),
             ],
         ),
+    ]
+}
+
+/// Schemas for v3 label tools: `add_label`, `remove_label`,
+/// `list_labels`.
+fn label_tool_schemas() -> Vec<RedactionSchema> {
+    use FieldPolicy::Verbatim;
+
+    vec![
+        RedactionSchema::new(
+            "add_label",
+            &[
+                ("folder", Verbatim),
+                ("uid", Verbatim),
+                ("uids", Verbatim),
+                ("label", Verbatim),
+            ],
+        ),
+        RedactionSchema::new(
+            "remove_label",
+            &[
+                ("folder", Verbatim),
+                ("uid", Verbatim),
+                ("uids", Verbatim),
+                ("label", Verbatim),
+            ],
+        ),
+        RedactionSchema::new("list_labels", &[("folder", Verbatim), ("uid", Verbatim)]),
     ]
 }
 

--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -208,6 +208,7 @@ pub fn schemas() -> Vec<RedactionSchema> {
     out.extend(write_tool_schemas());
     out.extend(v2_tool_schemas());
     out.extend(label_tool_schemas());
+    out.extend(account_tool_schemas());
     out
 }
 
@@ -468,6 +469,17 @@ fn label_tool_schemas() -> Vec<RedactionSchema> {
             ],
         ),
         RedactionSchema::new("list_labels", &[("folder", Verbatim), ("uid", Verbatim)]),
+    ]
+}
+
+/// Schemas for infrastructure account tools: `use_account`,
+/// `list_accounts`.
+fn account_tool_schemas() -> Vec<RedactionSchema> {
+    use FieldPolicy::Verbatim;
+
+    vec![
+        RedactionSchema::new("use_account", &[("account", Verbatim)]),
+        RedactionSchema::new("list_accounts", &[]),
     ]
 }
 

--- a/crates/rimap-audit/src/writer.rs
+++ b/crates/rimap-audit/src/writer.rs
@@ -351,6 +351,79 @@ impl AuditWriter {
 }
 
 impl AuditWriter {
+    /// Build a `tool_start` record, allocate a seq, and write it. Returns
+    /// the allocated `seq` — the caller should retain this value and pass
+    /// it back to [`AuditWriter::log_tool_end`] as `start_seq` so the two
+    /// records can be paired.
+    ///
+    /// `tool_start` is NOT fsynced per existing policy; see [`needs_fsync`].
+    ///
+    /// # Errors
+    /// Propagates any error from `allocate_seq` or `write_record`.
+    pub fn log_tool_start(
+        &self,
+        tool: &str,
+        account: Option<&str>,
+        posture_effective: &str,
+        arguments_redacted: serde_json::Value,
+        arguments_hash_sha256: String,
+    ) -> Result<crate::ids::Seq, AuditError> {
+        let seq = self.allocate_seq()?;
+        let record = crate::record::AuditRecord {
+            seq,
+            ts: crate::ids::Timestamp::now(),
+            process_id: self.process_id,
+            payload: crate::record::Payload::ToolStart(crate::record::ToolStart {
+                account: account.map(str::to_string),
+                tool: tool.to_string(),
+                posture_effective: posture_effective.to_string(),
+                arguments_redacted,
+                arguments_hash_sha256,
+            }),
+        };
+        self.write_record(&record)?;
+        Ok(seq)
+    }
+
+    /// Build a `tool_end` record, allocate a seq, and write it. `start_seq`
+    /// must be the seq returned by the paired [`AuditWriter::log_tool_start`].
+    ///
+    /// `tool_end` is NOT fsynced per existing policy; see [`needs_fsync`].
+    ///
+    /// # Errors
+    /// Propagates any error from `allocate_seq` or `write_record`.
+    #[expect(clippy::too_many_arguments, reason = "record schema is fixed")]
+    pub fn log_tool_end(
+        &self,
+        start_seq: crate::ids::Seq,
+        tool: &str,
+        account: Option<&str>,
+        status: crate::record::ToolStatus,
+        error_code: Option<String>,
+        duration_ms: u64,
+        result_summary: crate::record::ResultSummary,
+        provenance: crate::record::Provenance,
+    ) -> Result<crate::ids::Seq, AuditError> {
+        let seq = self.allocate_seq()?;
+        let record = crate::record::AuditRecord {
+            seq,
+            ts: crate::ids::Timestamp::now(),
+            process_id: self.process_id,
+            payload: crate::record::Payload::ToolEnd(crate::record::ToolEnd {
+                account: account.map(str::to_string),
+                start_seq,
+                tool: tool.to_string(),
+                status,
+                error_code,
+                duration_ms,
+                result_summary,
+                provenance,
+            }),
+        };
+        self.write_record(&record)?;
+        Ok(seq)
+    }
+
     /// Build a `process_end` record, allocate a seq, and write it.
     /// Stamps the record with the writer's stable `process_id` and
     /// `Timestamp::now()`. Returns the allocated `seq` on success.

--- a/crates/rimap-audit/src/writer.rs
+++ b/crates/rimap-audit/src/writer.rs
@@ -388,8 +388,10 @@ pub struct ProcessStartInputs {
     /// Git commit SHA at build time. Empty string until `vergen` lands in
     /// Sprint 5.
     pub git_commit: String,
-    /// Effective base posture at startup.
-    pub posture: String,
+    /// Effective base posture at startup (single-account mode).
+    pub posture: Option<String>,
+    /// Per-account summaries (multi-account mode).
+    pub accounts: Option<Vec<crate::record::AccountSummary>>,
     /// Absolute path of the loaded config file.
     pub config_path: std::path::PathBuf,
     /// SHA-256 of the config file contents at load time, hex-encoded.
@@ -421,6 +423,7 @@ impl AuditWriter {
             version: inputs.version,
             git_commit: inputs.git_commit,
             posture: inputs.posture,
+            accounts: inputs.accounts,
             config_path: inputs.config_path,
             config_hash_sha256: inputs.config_hash_sha256,
             previous_last_seq: inputs.trailing.last_seq,
@@ -861,6 +864,7 @@ mod tests {
 
         let seq = writer
             .log_auth(Auth {
+                account: None,
                 result: AuthResult::Success,
                 host: "127.0.0.1".to_string(),
                 port: 993,
@@ -902,6 +906,7 @@ mod tests {
         let pid = writer.process_id();
 
         let make = || Auth {
+            account: None,
             result: AuthResult::Failure,
             host: "h".into(),
             port: 1,
@@ -947,7 +952,8 @@ mod tests {
         let inputs = ProcessStartInputs {
             version: "0.0.0".to_string(),
             git_commit: String::new(),
-            posture: "draft-safe".to_string(),
+            posture: Some("draft-safe".to_string()),
+            accounts: None,
             config_path: std::path::PathBuf::from("/tmp/config.toml"),
             config_hash_sha256: "ab".repeat(32),
             trailing: TrailingState {
@@ -1045,7 +1051,8 @@ mod tests {
         let inputs = ProcessStartInputs {
             version: "0.0.0".to_string(),
             git_commit: String::new(),
-            posture: "draft-safe".to_string(),
+            posture: Some("draft-safe".to_string()),
+            accounts: None,
             config_path: std::path::PathBuf::from("/tmp/c.toml"),
             config_hash_sha256: "00".repeat(32),
             trailing: TrailingState {

--- a/crates/rimap-authz/Cargo.toml
+++ b/crates/rimap-authz/Cargo.toml
@@ -12,8 +12,8 @@ description = "Posture-based authorization, rate limiting, and circuit breaker f
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
-rimap-config = { path = "../rimap-config", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-config = { path = "../rimap-config", version = "1.0.0" }
 thiserror = { workspace = true }
 governor = { workspace = true }
 nonzero_ext = { workspace = true }

--- a/crates/rimap-authz/src/matrix.rs
+++ b/crates/rimap-authz/src/matrix.rs
@@ -106,14 +106,18 @@ mod tests {
     use crate::matrix::{EffectiveMatrix, base_allows};
 
     #[test]
-    fn matrix_covers_every_tool_variant_exactly_once() {
+    fn matrix_covers_every_non_infrastructure_tool_variant() {
         use std::collections::BTreeSet;
         let mut seen = BTreeSet::new();
         for (tool, _) in POSTURE_MATRIX {
             assert!(seen.insert(tool), "duplicate row for {tool}");
         }
-        assert_eq!(seen.len(), ToolName::all().len());
-        for t in ToolName::all() {
+        let non_infra: Vec<_> = ToolName::all()
+            .into_iter()
+            .filter(|t| !t.is_infrastructure())
+            .collect();
+        assert_eq!(seen.len(), non_infra.len());
+        for t in non_infra {
             assert!(seen.contains(&t), "missing row for {t}");
         }
     }
@@ -168,7 +172,7 @@ mod tests {
             assert!(!base_allows(Posture::DraftSafe, *t), "{t} expected denied");
         }
         for t in ToolName::all() {
-            if denied.contains(&t) {
+            if denied.contains(&t) || t.is_infrastructure() {
                 continue;
             }
             assert!(base_allows(Posture::DraftSafe, t), "{t} expected allowed");
@@ -179,7 +183,12 @@ mod tests {
     fn base_full_allows_except_destructive() {
         let denied = [ToolName::Expunge, ToolName::DeleteFolder];
         for t in ToolName::all() {
-            if denied.contains(&t) {
+            if t.is_infrastructure() {
+                assert!(
+                    !base_allows(Posture::Full, t),
+                    "{t} infrastructure tool should not be in posture matrix"
+                );
+            } else if denied.contains(&t) {
                 assert!(
                     !base_allows(Posture::Full, t),
                     "{t} expected denied at full"
@@ -194,12 +203,19 @@ mod tests {
     }
 
     #[test]
-    fn base_destructive_allows_everything() {
+    fn base_destructive_allows_all_non_infrastructure() {
         for t in ToolName::all() {
-            assert!(
-                base_allows(Posture::Destructive, t),
-                "destructive should allow {t}"
-            );
+            if t.is_infrastructure() {
+                assert!(
+                    !base_allows(Posture::Destructive, t),
+                    "{t} infrastructure tool should not be in posture matrix"
+                );
+            } else {
+                assert!(
+                    base_allows(Posture::Destructive, t),
+                    "destructive should allow {t}"
+                );
+            }
         }
     }
 
@@ -269,7 +285,16 @@ mod tests {
         let m = EffectiveMatrix::build(Posture::Destructive, &BTreeMap::new());
         let rows: Vec<_> = m.rows().collect();
         assert_eq!(rows.len(), ToolName::all().len());
-        assert!(rows.iter().all(|(_, allowed)| *allowed));
+        for (tool, allowed) in &rows {
+            if tool.is_infrastructure() {
+                assert!(
+                    !allowed,
+                    "{tool} infrastructure tool should be denied in matrix"
+                );
+            } else {
+                assert!(allowed, "{tool} should be allowed at destructive");
+            }
+        }
     }
 
     #[test]

--- a/crates/rimap-authz/src/matrix.rs
+++ b/crates/rimap-authz/src/matrix.rs
@@ -126,6 +126,7 @@ mod tests {
             ToolName::FetchMessage,
             ToolName::ListAttachments,
             ToolName::DownloadAttachment,
+            ToolName::ListLabels,
         ] {
             assert!(base_allows(Posture::Readonly, t), "{t} should be allowed");
         }
@@ -136,6 +137,8 @@ mod tests {
             ToolName::MarkUnread,
             ToolName::Flag,
             ToolName::Unflag,
+            ToolName::AddLabel,
+            ToolName::RemoveLabel,
             ToolName::MoveMessage,
             ToolName::CreateDraft,
             ToolName::SendEmail,
@@ -256,6 +259,7 @@ mod tests {
                 ToolName::FetchMessage,
                 ToolName::ListAttachments,
                 ToolName::DownloadAttachment,
+                ToolName::ListLabels,
             ]
         );
     }

--- a/crates/rimap-authz/src/rate_limit.rs
+++ b/crates/rimap-authz/src/rate_limit.rs
@@ -83,6 +83,9 @@ impl Governor {
             | ToolName::MarkUnread
             | ToolName::Flag
             | ToolName::Unflag
+            | ToolName::AddLabel
+            | ToolName::RemoveLabel
+            | ToolName::ListLabels
             | ToolName::MoveMessage
             | ToolName::SendEmail
             | ToolName::DeleteMessage
@@ -110,6 +113,9 @@ impl Governor {
             | ToolName::MarkUnread
             | ToolName::Flag
             | ToolName::Unflag
+            | ToolName::AddLabel
+            | ToolName::RemoveLabel
+            | ToolName::ListLabels
             | ToolName::MoveMessage
             | ToolName::CreateDraft
             | ToolName::DeleteMessage

--- a/crates/rimap-authz/src/rate_limit.rs
+++ b/crates/rimap-authz/src/rate_limit.rs
@@ -92,7 +92,9 @@ impl Governor {
             | ToolName::Expunge
             | ToolName::CreateFolder
             | ToolName::RenameFolder
-            | ToolName::DeleteFolder => false,
+            | ToolName::DeleteFolder
+            | ToolName::UseAccount
+            | ToolName::ListAccounts => false,
         };
         if is_draft {
             self.drafts.check().map_err(|nu| AuthzError::RateLimited {
@@ -122,7 +124,9 @@ impl Governor {
             | ToolName::Expunge
             | ToolName::CreateFolder
             | ToolName::RenameFolder
-            | ToolName::DeleteFolder => false,
+            | ToolName::DeleteFolder
+            | ToolName::UseAccount
+            | ToolName::ListAccounts => false,
         };
         if is_send {
             self.sends.check().map_err(|nu| AuthzError::RateLimited {

--- a/crates/rimap-config/Cargo.toml
+++ b/crates/rimap-config/Cargo.toml
@@ -20,6 +20,7 @@ toml = { workspace = true }
 directories = { workspace = true }
 keyring = { workspace = true }
 rpassword = { workspace = true }
+secrecy = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rimap-config/Cargo.toml
+++ b/crates/rimap-config/Cargo.toml
@@ -12,7 +12,7 @@ description = "Configuration loading, validation, and credential resolution for 
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
 utf7-imap = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -5,6 +5,8 @@
 //!   2. Environment variable `RUSTY_IMAP_MCP_PASSWORD`.
 //!   3. Clear, actionable error naming both.
 
+use secrecy::{ExposeSecret, SecretString};
+
 use crate::error::ConfigError;
 
 /// Service name used for all keychain entries.
@@ -22,7 +24,7 @@ pub trait CredentialStore: Send + Sync {
     ///
     /// # Errors
     /// Returns `ConfigError::Keychain` on I/O or access errors.
-    fn get_password(&self, account: &str) -> Result<Option<String>, ConfigError>;
+    fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError>;
 
     /// Persist `password` for `account`, overwriting any existing entry.
     ///
@@ -51,17 +53,17 @@ pub fn resolve_credential(
     store: &dyn CredentialStore,
     username: &str,
     host: &str,
-) -> Result<String, ConfigError> {
+) -> Result<SecretString, ConfigError> {
     let account = account_key(username, host);
     if let Some(p) = store.get_password(&account)?
-        && !p.is_empty()
+        && !p.expose_secret().is_empty()
     {
         return Ok(p);
     }
     if let Ok(env) = std::env::var(PASSWORD_ENV_VAR)
         && !env.is_empty()
     {
-        return Ok(env);
+        return Ok(SecretString::from(env));
     }
     Err(ConfigError::NoCredential {
         account,
@@ -79,14 +81,14 @@ pub fn resolve_credential(
 pub struct KeyringStore;
 
 impl CredentialStore for KeyringStore {
-    fn get_password(&self, account: &str) -> Result<Option<String>, ConfigError> {
+    fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
         let entry =
             keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|e| ConfigError::Keychain {
                 account: account.to_string(),
                 source: Box::new(e),
             })?;
         match entry.get_password() {
-            Ok(p) => Ok(Some(p)),
+            Ok(p) => Ok(Some(SecretString::from(p))),
             Err(keyring::Error::NoEntry) => Ok(None),
             Err(e) => Err(ConfigError::Keychain {
                 account: account.to_string(),
@@ -116,6 +118,8 @@ impl CredentialStore for KeyringStore {
 mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
+
+    use secrecy::{ExposeSecret, SecretString};
 
     use crate::credential::{CredentialStore, PASSWORD_ENV_VAR, account_key, resolve_credential};
     use crate::error::ConfigError;
@@ -147,14 +151,20 @@ mod tests {
     }
 
     impl CredentialStore for MockStore {
-        fn get_password(&self, account: &str) -> Result<Option<String>, ConfigError> {
+        fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
             if self.fail_on_get {
                 return Err(ConfigError::Keychain {
                     account: account.to_string(),
                     source: "simulated failure".into(),
                 });
             }
-            Ok(self.entries.lock().unwrap().get(account).cloned())
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .get(account)
+                .cloned()
+                .map(SecretString::from))
         }
 
         fn set_password(&self, account: &str, password: &str) -> Result<(), ConfigError> {
@@ -179,7 +189,7 @@ mod tests {
         let store = MockStore::with(&[("alice@host", "from_keychain")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             let got = resolve_credential(&store, "alice", "host").unwrap();
-            assert_eq!(got, "from_keychain");
+            assert_eq!(got.expose_secret(), "from_keychain");
         });
     }
 
@@ -188,7 +198,7 @@ mod tests {
         let store = MockStore::default();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             let got = resolve_credential(&store, "alice", "host").unwrap();
-            assert_eq!(got, "from_env");
+            assert_eq!(got.expose_secret(), "from_env");
         });
     }
 
@@ -222,9 +232,18 @@ mod tests {
         let store = MockStore::with(&[("alice@host", "")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             assert_eq!(
-                resolve_credential(&store, "alice", "host").unwrap(),
+                resolve_credential(&store, "alice", "host")
+                    .unwrap()
+                    .expose_secret(),
                 "from_env"
             );
         });
+    }
+
+    #[test]
+    fn resolved_credential_debug_does_not_leak() {
+        let p = SecretString::from("hunter2".to_string());
+        let formatted = format!("{p:?}");
+        assert!(!formatted.contains("hunter2"));
     }
 }

--- a/crates/rimap-config/src/error.rs
+++ b/crates/rimap-config/src/error.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 
+use rimap_core::account::InvalidAccountName;
 use rimap_core::posture::UnknownPosture;
 use rimap_core::tool::ParseToolNameError;
 use thiserror::Error;
@@ -131,4 +132,23 @@ pub enum ConfigError {
         /// The configured SMTP host.
         host: String,
     },
+    /// Two accounts share the same name.
+    #[error("duplicate account name `{name}`")]
+    DuplicateAccountName {
+        /// The duplicated name.
+        name: String,
+    },
+    /// Config file contains both legacy `[imap]` and multi-account
+    /// `[[accounts]]` sections.
+    #[error(
+        "config contains both [imap] and [[accounts]]; \
+         use one format or the other, not both"
+    )]
+    MixedConfigFormat,
+    /// Account name failed validation.
+    #[error(transparent)]
+    InvalidAccountName(#[from] InvalidAccountName),
+    /// Multi-account config has an empty `[[accounts]]` array.
+    #[error("no accounts defined in [[accounts]] array")]
+    NoAccounts,
 }

--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::credential::{
     resolve_credential,
 };
 pub use crate::error::ConfigError;
-pub use crate::loader::{CONFIG_ENV_VAR, load_from_path, resolve_config_path};
+pub use crate::loader::{CONFIG_ENV_VAR, load_and_validate, load_from_path, resolve_config_path};
 pub use crate::login::{run_login, tty_prompt};
 pub use crate::model::{
     AttachmentsConfig, AuditConfig, Config, DefaultsConfig, ImapConfig, LimitsConfig,

--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -17,8 +17,12 @@ pub use crate::error::ConfigError;
 pub use crate::loader::{CONFIG_ENV_VAR, load_from_path, resolve_config_path};
 pub use crate::login::{run_login, tty_prompt};
 pub use crate::model::{
-    AttachmentsConfig, AuditConfig, Config, ImapConfig, LimitsConfig, LookalikeConfig,
-    SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
+    AttachmentsConfig, AuditConfig, Config, DefaultsConfig, ImapConfig, LimitsConfig,
+    LookalikeConfig, MultiAccountConfig, RawAccountConfig, SecurityConfig, SmtpConfig,
+    SmtpEncryption, Verdict,
 };
-pub use crate::validate::{ValidatedConfig, validate};
+pub use crate::validate::{
+    ValidatedAccountConfig, ValidatedConfig, ValidatedMultiConfig, validate,
+    validate_legacy_as_multi, validate_multi,
+};
 pub use rimap_core::tls::{FingerprintParseError, TlsFingerprint};

--- a/crates/rimap-config/src/loader.rs
+++ b/crates/rimap-config/src/loader.rs
@@ -13,7 +13,8 @@ use std::path::{Path, PathBuf};
 use directories::ProjectDirs;
 
 use crate::error::ConfigError;
-use crate::model::Config;
+use crate::model::{Config, MultiAccountConfig};
+use crate::validate::{ValidatedMultiConfig, validate_legacy_as_multi, validate_multi};
 
 /// Organization qualifiers for `directories::ProjectDirs`.
 const QUALIFIER: &str = "";
@@ -57,6 +58,55 @@ pub fn load_from_path(path: &Path) -> Result<Config, ConfigError> {
     })
 }
 
+/// Load a config file and validate it, producing a `ValidatedMultiConfig`.
+///
+/// Detects format by scanning for `[[accounts]]` (multi-account) vs `[imap]`
+/// (legacy). Both present is an error. Parses the appropriate struct and
+/// runs validation.
+///
+/// # Errors
+/// Returns `ConfigError` on read, parse, or validation failure.
+pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let has_accounts = contains_toml_key(&contents, "[[accounts]]");
+    let has_imap = contains_toml_key(&contents, "[imap]");
+
+    if has_accounts && has_imap {
+        return Err(ConfigError::MixedConfigFormat);
+    }
+
+    if has_accounts {
+        let config = toml::from_str::<MultiAccountConfig>(&contents).map_err(|source| {
+            ConfigError::Parse {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+        validate_multi(config)
+    } else {
+        let config = toml::from_str::<Config>(&contents).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        validate_legacy_as_multi(config)
+    }
+}
+
+/// Check whether a TOML key/header marker appears in the raw text.
+/// Matches only outside of strings by looking for lines that start with the
+/// pattern (after optional whitespace). This is intentionally simple — it
+/// does not parse TOML, but false positives are harmless (they would trigger
+/// a parse error, not silent misconfiguration).
+fn contains_toml_key(contents: &str, marker: &str) -> bool {
+    contents
+        .lines()
+        .any(|line| line.trim_start().starts_with(marker))
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
@@ -65,7 +115,10 @@ mod tests {
     use rimap_core::posture::Posture;
     use tempfile::TempDir;
 
-    use crate::loader::{CONFIG_ENV_VAR, load_from_path, resolve_config_path};
+    use rimap_core::account::AccountId;
+
+    use crate::error::ConfigError;
+    use crate::loader::{CONFIG_ENV_VAR, load_and_validate, load_from_path, resolve_config_path};
     use crate::model::Verdict;
 
     fn write_config(dir: &TempDir, name: &str, contents: &str) -> PathBuf {
@@ -165,5 +218,102 @@ search = "allow"
                 assert!(path.ends_with("config.toml"));
             }
         });
+    }
+
+    // -----------------------------------------------------------------------
+    // load_and_validate format detection tests
+    // -----------------------------------------------------------------------
+
+    fn legacy_toml(audit_dir: &std::path::Path) -> String {
+        format!(
+            r#"
+[imap]
+host = "127.0.0.1"
+port = 1143
+username = "alice@example.test"
+
+[audit]
+path = "{dir}/audit.jsonl"
+allowed_base_dir = "{dir}"
+"#,
+            dir = audit_dir.display(),
+        )
+    }
+
+    fn multi_toml(audit_dir: &std::path::Path) -> String {
+        format!(
+            r#"
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "imap.work.com"
+port = 993
+username = "alice@work.com"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.personal.com"
+port = 993
+username = "alice@personal.com"
+
+[audit]
+path = "{dir}/audit.jsonl"
+allowed_base_dir = "{dir}"
+"#,
+            dir = audit_dir.display(),
+        )
+    }
+
+    #[test]
+    fn load_and_validate_legacy_format() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "config.toml", &legacy_toml(dir.path()));
+        let v = load_and_validate(&path).unwrap();
+        assert_eq!(v.accounts.len(), 1);
+        assert!(v.accounts.contains_key(&AccountId::default_account()));
+    }
+
+    #[test]
+    fn load_and_validate_multi_format() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "config.toml", &multi_toml(dir.path()));
+        let v = load_and_validate(&path).unwrap();
+        assert_eq!(v.accounts.len(), 2);
+        assert!(v.accounts.contains_key(&AccountId::new("work").unwrap()));
+        assert!(
+            v.accounts
+                .contains_key(&AccountId::new("personal").unwrap())
+        );
+    }
+
+    #[test]
+    fn load_and_validate_mixed_format_rejected() {
+        let dir = TempDir::new().unwrap();
+        let mixed = format!(
+            r#"
+[imap]
+host = "127.0.0.1"
+port = 1143
+username = "alice@example.test"
+
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "imap.work.com"
+port = 993
+username = "alice@work.com"
+
+[audit]
+path = "{dir}/audit.jsonl"
+"#,
+            dir = dir.path().display(),
+        );
+        let path = write_config(&dir, "config.toml", &mixed);
+        let err = load_and_validate(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::MixedConfigFormat));
     }
 }

--- a/crates/rimap-config/src/loader.rs
+++ b/crates/rimap-config/src/loader.rs
@@ -72,10 +72,20 @@ pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigErro
         source,
     })?;
 
-    let has_accounts = contains_toml_key(&contents, "[[accounts]]");
-    let has_imap = contains_toml_key(&contents, "[imap]");
+    // Parse once into `toml::Table` to classify the format. A TOML document
+    // is always a table at the top level, so `toml::from_str::<Table>` will
+    // succeed for any syntactically valid TOML. Format-specific deserialization
+    // is a second pass below — still cheaper and more correct than a
+    // substring match over the raw text.
+    let table: toml::Table = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })?;
 
-    if has_accounts && has_imap {
+    let has_accounts = table.get("accounts").and_then(|v| v.as_array()).is_some();
+    let has_flat_imap = table.contains_key("imap");
+
+    if has_accounts && has_flat_imap {
         return Err(ConfigError::MixedConfigFormat);
     }
 
@@ -94,17 +104,6 @@ pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigErro
         })?;
         validate_legacy_as_multi(config)
     }
-}
-
-/// Check whether a TOML key/header marker appears in the raw text.
-/// Matches only outside of strings by looking for lines that start with the
-/// pattern (after optional whitespace). This is intentionally simple — it
-/// does not parse TOML, but false positives are harmless (they would trigger
-/// a parse error, not silent misconfiguration).
-fn contains_toml_key(contents: &str, marker: &str) -> bool {
-    contents
-        .lines()
-        .any(|line| line.trim_start().starts_with(marker))
 }
 
 #[cfg(test)]

--- a/crates/rimap-config/src/login.rs
+++ b/crates/rimap-config/src/login.rs
@@ -54,6 +54,8 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
 
+    use secrecy::{ExposeSecret, SecretString};
+
     use crate::credential::{CredentialStore, account_key};
     use crate::error::ConfigError;
     use crate::login::run_login;
@@ -64,8 +66,14 @@ mod tests {
     }
 
     impl CredentialStore for MockStore {
-        fn get_password(&self, account: &str) -> Result<Option<String>, ConfigError> {
-            Ok(self.entries.lock().unwrap().get(account).cloned())
+        fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .get(account)
+                .cloned()
+                .map(SecretString::from))
         }
         fn set_password(&self, account: &str, password: &str) -> Result<(), ConfigError> {
             self.entries
@@ -84,7 +92,7 @@ mod tests {
             .get_password(&account_key("alice", "host"))
             .unwrap()
             .unwrap();
-        assert_eq!(got, "hunter2");
+        assert_eq!(got.expose_secret(), "hunter2");
     }
 
     #[test]

--- a/crates/rimap-config/src/model.rs
+++ b/crates/rimap-config/src/model.rs
@@ -328,3 +328,54 @@ pub struct AttachmentsConfig {
     #[serde(default)]
     pub download_dir: String,
 }
+
+// ---------------------------------------------------------------------------
+// Multi-account config format
+// ---------------------------------------------------------------------------
+
+/// Multi-account configuration format with `[[accounts]]` array.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MultiAccountConfig {
+    /// Default security/limits inherited by accounts that omit them.
+    #[serde(default)]
+    pub defaults: DefaultsConfig,
+    /// One or more account definitions.
+    pub accounts: Vec<RawAccountConfig>,
+    /// Global audit log settings.
+    pub audit: AuditConfig,
+    /// Global attachment download settings.
+    #[serde(default)]
+    pub attachments: AttachmentsConfig,
+}
+
+/// `[defaults]` block — shared settings inherited by accounts.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DefaultsConfig {
+    /// Default security posture and overrides.
+    #[serde(default)]
+    pub security: SecurityConfig,
+    /// Default numeric limits.
+    #[serde(default)]
+    pub limits: LimitsConfig,
+}
+
+/// A single account entry in `[[accounts]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawAccountConfig {
+    /// Human-readable account name (validated as `AccountId`).
+    pub name: String,
+    /// IMAP connection settings (required per account).
+    pub imap: ImapConfig,
+    /// SMTP connection settings (optional per account).
+    #[serde(default)]
+    pub smtp: Option<SmtpConfig>,
+    /// Per-account security overrides; `None` inherits from `[defaults]`.
+    #[serde(default)]
+    pub security: Option<SecurityConfig>,
+    /// Per-account limit overrides; `None` inherits from `[defaults]`.
+    #[serde(default)]
+    pub limits: Option<LimitsConfig>,
+}

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -333,10 +333,6 @@ fn validate_paths_multi(
 /// Returns `$XDG_STATE_HOME/rusty-imap-mcp/` on platforms where
 /// `directories::ProjectDirs` resolves; returns `None` otherwise (which
 /// causes the containment check to fail with a clear error).
-/// Compute the default audit base when `audit.allowed_base_dir` is unset.
-/// Returns `$XDG_STATE_HOME/rusty-imap-mcp/` on platforms where
-/// `directories::ProjectDirs` resolves; returns `None` otherwise (which
-/// causes the containment check to fail with a clear error).
 ///
 /// ## macOS Time Machine caveat (LOCAL-PRI-06)
 ///

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -40,6 +40,10 @@ pub struct ValidatedConfig {
 /// Returns `ConfigError` on any validation failure.
 pub fn validate(config: Config) -> Result<ValidatedConfig, ConfigError> {
     let tls_fingerprint = parse_fingerprint(config.imap.tls_fingerprint_sha256.as_deref())?;
+    validate_imap_username(&config.imap.username)?;
+    if let Some(ref smtp) = config.smtp {
+        validate_smtp_username(&smtp.username)?;
+    }
     validate_limits(&config)?;
     validate_audit(&config)?;
     validate_paths(&config)?;
@@ -157,6 +161,10 @@ fn validate_account(
     limits: LimitsConfig,
 ) -> Result<ValidatedAccountConfig, ConfigError> {
     let tls_fingerprint = parse_fingerprint(imap.tls_fingerprint_sha256.as_deref())?;
+    validate_imap_username(&imap.username)?;
+    if let Some(ref smtp_cfg) = smtp {
+        validate_smtp_username(&smtp_cfg.username)?;
+    }
     validate_limits_fields(&limits)?;
     validate_folder_safety_fields(&security)?;
     let tool_overrides = resolve_tool_overrides_fields(&security)?;
@@ -172,6 +180,33 @@ fn validate_account(
         tool_overrides,
         tls_fingerprint,
     })
+}
+
+fn validate_imap_username(username: &str) -> Result<(), ConfigError> {
+    validate_username_field(username, "imap.username")
+}
+
+fn validate_smtp_username(username: &str) -> Result<(), ConfigError> {
+    validate_username_field(username, "smtp.username")
+}
+
+fn validate_username_field(username: &str, field: &'static str) -> Result<(), ConfigError> {
+    if username.is_empty() {
+        return Err(ConfigError::InvalidLimit {
+            field,
+            reason: "username must not be empty".to_string(),
+        });
+    }
+    if username
+        .chars()
+        .any(|c| c == '\r' || c == '\n' || c == '\0')
+    {
+        return Err(ConfigError::InvalidLimit {
+            field,
+            reason: "username must not contain CR, LF, or NUL".to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn parse_fingerprint(maybe_fp: Option<&str>) -> Result<Option<TlsFingerprint>, ConfigError> {
@@ -1087,5 +1122,67 @@ allowed_base_dir = "{}"
         let cfg = base_multi_config(dir.path(), vec![acct]);
         let err = validate_multi(cfg).unwrap_err();
         assert!(matches!(err, ConfigError::ConflictingFolders { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Username validation tests (CR/LF/NUL rejection)
+    // -----------------------------------------------------------------------
+
+    use crate::validate::{validate_imap_username, validate_smtp_username};
+
+    #[test]
+    fn username_with_crlf_rejected() {
+        assert!(validate_imap_username("a@b\r\nX-Injected: 1").is_err());
+    }
+
+    #[test]
+    fn username_with_cr_rejected() {
+        assert!(validate_imap_username("a@b\rX").is_err());
+    }
+
+    #[test]
+    fn username_with_lf_rejected() {
+        assert!(validate_imap_username("a@b\nX").is_err());
+    }
+
+    #[test]
+    fn username_with_null_rejected() {
+        assert!(validate_imap_username("a@b\0c").is_err());
+    }
+
+    #[test]
+    fn normal_username_accepted() {
+        assert!(validate_imap_username("user@example.com").is_ok());
+    }
+
+    #[test]
+    fn empty_username_rejected() {
+        assert!(validate_imap_username("").is_err());
+    }
+
+    #[test]
+    fn smtp_username_crlf_rejected() {
+        assert!(validate_smtp_username("a@b\r\nX-Injected: 1").is_err());
+    }
+
+    #[test]
+    fn smtp_username_normal_accepted() {
+        assert!(validate_smtp_username("user@example.com").is_ok());
+    }
+
+    #[test]
+    fn validate_multi_rejects_crlf_username() {
+        let dir = TempDir::new().unwrap();
+        let mut acct = raw_account("work");
+        acct.imap.username = "a@b\r\nX-Injected: 1".into();
+        let cfg = base_multi_config(dir.path(), vec![acct]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::InvalidLimit {
+                field: "imap.username",
+                ..
+            }
+        ));
     }
 }

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -12,11 +12,15 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use rimap_core::account::AccountId;
 use rimap_core::tls::TlsFingerprint;
 use rimap_core::tool::ToolName;
 
 use crate::error::ConfigError;
-use crate::model::{Config, SmtpEncryption, Verdict};
+use crate::model::{
+    AttachmentsConfig, AuditConfig, Config, ImapConfig, LimitsConfig, MultiAccountConfig,
+    SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
+};
 
 /// Validated config: a `Config` plus the resolved per-tool override map
 /// keyed by `ToolName`, plus the parsed TLS fingerprint (if any).
@@ -50,6 +54,126 @@ pub fn validate(config: Config) -> Result<ValidatedConfig, ConfigError> {
     })
 }
 
+/// Validated per-account config with resolved overrides and fingerprint.
+#[derive(Debug, Clone)]
+pub struct ValidatedAccountConfig {
+    /// Account identity.
+    pub id: AccountId,
+    /// IMAP connection settings.
+    pub imap: ImapConfig,
+    /// SMTP connection settings (if configured).
+    pub smtp: Option<SmtpConfig>,
+    /// Security posture and folder lists.
+    pub security: SecurityConfig,
+    /// Numeric limits.
+    pub limits: LimitsConfig,
+    /// Resolved per-tool overrides.
+    pub tool_overrides: BTreeMap<ToolName, Verdict>,
+    /// Parsed pinned TLS fingerprint.
+    pub tls_fingerprint: Option<TlsFingerprint>,
+}
+
+/// Validated multi-account config — the canonical output of config loading.
+#[derive(Debug, Clone)]
+pub struct ValidatedMultiConfig {
+    /// Per-account validated configs, keyed by account id.
+    pub accounts: BTreeMap<AccountId, ValidatedAccountConfig>,
+    /// Global audit log settings.
+    pub audit: AuditConfig,
+    /// Global attachment download settings.
+    pub attachments: AttachmentsConfig,
+}
+
+/// Validate a multi-account config.
+///
+/// # Errors
+/// Returns `ConfigError` on any validation failure.
+pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig, ConfigError> {
+    if config.accounts.is_empty() {
+        return Err(ConfigError::NoAccounts);
+    }
+
+    let mut accounts = BTreeMap::new();
+    for raw in config.accounts {
+        let id = AccountId::new(&raw.name)?;
+        if accounts.contains_key(&id) {
+            return Err(ConfigError::DuplicateAccountName { name: raw.name });
+        }
+
+        let security = raw
+            .security
+            .unwrap_or_else(|| config.defaults.security.clone());
+        let limits = raw.limits.unwrap_or_else(|| config.defaults.limits.clone());
+
+        let validated = validate_account(id.clone(), raw.imap, raw.smtp, security, limits)?;
+        accounts.insert(id, validated);
+    }
+
+    validate_audit_config(&config.audit)?;
+    validate_paths_multi(&config.audit, &config.attachments)?;
+
+    Ok(ValidatedMultiConfig {
+        accounts,
+        audit: config.audit,
+        attachments: config.attachments,
+    })
+}
+
+/// Convert a legacy flat config into a `ValidatedMultiConfig` with a
+/// single account named "default".
+///
+/// # Errors
+/// Returns `ConfigError` on any validation failure.
+pub fn validate_legacy_as_multi(config: Config) -> Result<ValidatedMultiConfig, ConfigError> {
+    let validated = validate(config)?;
+    let id = AccountId::default_account();
+
+    let account = ValidatedAccountConfig {
+        id: id.clone(),
+        imap: validated.config.imap,
+        smtp: validated.config.smtp,
+        security: validated.config.security,
+        limits: validated.config.limits,
+        tool_overrides: validated.tool_overrides,
+        tls_fingerprint: validated.tls_fingerprint,
+    };
+
+    let mut accounts = BTreeMap::new();
+    accounts.insert(id, account);
+
+    Ok(ValidatedMultiConfig {
+        accounts,
+        audit: validated.config.audit,
+        attachments: validated.config.attachments,
+    })
+}
+
+/// Validate a single account's worth of config fields.
+fn validate_account(
+    id: AccountId,
+    imap: ImapConfig,
+    smtp: Option<SmtpConfig>,
+    security: SecurityConfig,
+    limits: LimitsConfig,
+) -> Result<ValidatedAccountConfig, ConfigError> {
+    let tls_fingerprint = parse_fingerprint(imap.tls_fingerprint_sha256.as_deref())?;
+    validate_limits_fields(&limits)?;
+    validate_folder_safety_fields(&security)?;
+    let tool_overrides = resolve_tool_overrides_fields(&security)?;
+    validate_smtp_required_fields(&security, &tool_overrides, smtp.as_ref())?;
+    validate_smtp_encryption_fields(smtp.as_ref())?;
+
+    Ok(ValidatedAccountConfig {
+        id,
+        imap,
+        smtp,
+        security,
+        limits,
+        tool_overrides,
+        tls_fingerprint,
+    })
+}
+
 fn parse_fingerprint(maybe_fp: Option<&str>) -> Result<Option<TlsFingerprint>, ConfigError> {
     let Some(raw) = maybe_fp else {
         return Ok(None);
@@ -61,7 +185,11 @@ fn parse_fingerprint(maybe_fp: Option<&str>) -> Result<Option<TlsFingerprint>, C
 }
 
 fn validate_audit(config: &Config) -> Result<(), ConfigError> {
-    if config.audit.retention_seconds == Some(0) {
+    validate_audit_config(&config.audit)
+}
+
+fn validate_audit_config(audit: &AuditConfig) -> Result<(), ConfigError> {
+    if audit.retention_seconds == Some(0) {
         return Err(ConfigError::InvalidLimit {
             field: "audit.retention_seconds",
             reason: "must be > 0 (use None / omit the field to disable \
@@ -73,7 +201,10 @@ fn validate_audit(config: &Config) -> Result<(), ConfigError> {
 }
 
 fn validate_limits(config: &Config) -> Result<(), ConfigError> {
-    let limits = &config.limits;
+    validate_limits_fields(&config.limits)
+}
+
+fn validate_limits_fields(limits: &LimitsConfig) -> Result<(), ConfigError> {
     if limits.commands_per_second == 0 {
         return Err(ConfigError::InvalidLimit {
             field: "limits.commands_per_second",
@@ -141,18 +272,24 @@ fn validate_limits(config: &Config) -> Result<(), ConfigError> {
 }
 
 fn validate_paths(config: &Config) -> Result<(), ConfigError> {
-    let audit_parent = config
-        .audit
+    validate_paths_multi(&config.audit, &config.attachments)
+}
+
+fn validate_paths_multi(
+    audit: &AuditConfig,
+    attachments: &AttachmentsConfig,
+) -> Result<(), ConfigError> {
+    let audit_parent = audit
         .path
         .parent()
         .ok_or_else(|| ConfigError::PathNotWritable {
-            path: config.audit.path.clone(),
+            path: audit.path.clone(),
             reason: "audit path has no parent directory".to_string(),
         })?;
     require_writable_dir(audit_parent)?;
-    enforce_audit_containment(config)?;
-    if !config.attachments.download_dir.is_empty() {
-        require_writable_dir(Path::new(&config.attachments.download_dir))?;
+    enforce_audit_containment_fields(audit)?;
+    if !attachments.download_dir.is_empty() {
+        require_writable_dir(Path::new(&attachments.download_dir))?;
     }
     Ok(())
 }
@@ -192,8 +329,8 @@ fn default_audit_base() -> Option<PathBuf> {
 /// exist. The parent is canonicalized first (not the path itself, which
 /// may not exist yet), then joined with the file name to produce the
 /// canonical audit path.
-fn enforce_audit_containment(config: &Config) -> Result<(), ConfigError> {
-    let audit_path = &config.audit.path;
+fn enforce_audit_containment_fields(audit: &AuditConfig) -> Result<(), ConfigError> {
+    let audit_path = &audit.path;
     let parent = audit_path
         .parent()
         .ok_or_else(|| ConfigError::PathNotWritable {
@@ -212,8 +349,7 @@ fn enforce_audit_containment(config: &Config) -> Result<(), ConfigError> {
         })?;
     let canon_path = canon_parent.join(file_name);
 
-    let base = config
-        .audit
+    let base = audit
         .allowed_base_dir
         .clone()
         .or_else(default_audit_base)
@@ -262,15 +398,18 @@ fn require_writable_dir(dir: &Path) -> Result<(), ConfigError> {
 }
 
 fn validate_folder_safety(config: &Config) -> Result<(), ConfigError> {
-    let mut protected: Vec<String> = config
-        .security
+    validate_folder_safety_fields(&config.security)
+}
+
+fn validate_folder_safety_fields(security: &SecurityConfig) -> Result<(), ConfigError> {
+    let mut protected: Vec<String> = security
         .protected_folders
         .iter()
         .map(|f| utf7_imap::decode_utf7_imap(f.clone()).to_lowercase())
         .collect();
     protected.push("inbox".to_string());
 
-    for folder in &config.security.expunge_folders {
+    for folder in &security.expunge_folders {
         let norm = utf7_imap::decode_utf7_imap(folder.clone()).to_lowercase();
         if protected.contains(&norm) {
             return Err(ConfigError::ConflictingFolders {
@@ -285,14 +424,22 @@ fn validate_smtp_required(
     config: &Config,
     tool_overrides: &BTreeMap<ToolName, Verdict>,
 ) -> Result<(), ConfigError> {
-    let posture = config.security.posture;
+    validate_smtp_required_fields(&config.security, tool_overrides, config.smtp.as_ref())
+}
+
+fn validate_smtp_required_fields(
+    security: &SecurityConfig,
+    tool_overrides: &BTreeMap<ToolName, Verdict>,
+    smtp: Option<&SmtpConfig>,
+) -> Result<(), ConfigError> {
+    let posture = security.posture;
     let send_email_base = rimap_core::base_allows(posture, ToolName::SendEmail);
     let send_email_effective = match tool_overrides.get(&ToolName::SendEmail) {
         Some(Verdict::Allow) => true,
         Some(Verdict::Deny) => false,
         None => send_email_base,
     };
-    if send_email_effective && config.smtp.is_none() {
+    if send_email_effective && smtp.is_none() {
         return Err(ConfigError::SmtpRequired {
             posture: posture.to_string(),
         });
@@ -301,7 +448,11 @@ fn validate_smtp_required(
 }
 
 fn validate_smtp_encryption(config: &Config) -> Result<(), ConfigError> {
-    let Some(smtp) = &config.smtp else {
+    validate_smtp_encryption_fields(config.smtp.as_ref())
+}
+
+fn validate_smtp_encryption_fields(smtp: Option<&SmtpConfig>) -> Result<(), ConfigError> {
+    let Some(smtp) = smtp else {
         return Ok(());
     };
     if smtp.encryption == SmtpEncryption::None {
@@ -315,8 +466,14 @@ fn validate_smtp_encryption(config: &Config) -> Result<(), ConfigError> {
 }
 
 fn resolve_tool_overrides(config: &Config) -> Result<BTreeMap<ToolName, Verdict>, ConfigError> {
+    resolve_tool_overrides_fields(&config.security)
+}
+
+fn resolve_tool_overrides_fields(
+    security: &SecurityConfig,
+) -> Result<BTreeMap<ToolName, Verdict>, ConfigError> {
     let mut out = BTreeMap::new();
-    for (name, verdict) in &config.security.tools {
+    for (name, verdict) in &security.tools {
         let tool = ToolName::from_str(name)?;
         out.insert(tool, *verdict);
     }
@@ -744,5 +901,191 @@ path = "/tmp/audit.jsonl"
             !debug.contains("secret_user"),
             "Debug output must not contain username: {debug}",
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-account validation tests
+    // -----------------------------------------------------------------------
+
+    use crate::model::{DefaultsConfig, MultiAccountConfig, RawAccountConfig};
+    use crate::validate::{validate_legacy_as_multi, validate_multi};
+    use rimap_core::account::AccountId;
+
+    fn base_multi_config(
+        audit_dir: &std::path::Path,
+        accounts: Vec<RawAccountConfig>,
+    ) -> MultiAccountConfig {
+        MultiAccountConfig {
+            defaults: DefaultsConfig::default(),
+            accounts,
+            audit: AuditConfig {
+                path: audit_dir.join("audit.jsonl"),
+                rotate_bytes: 10_485_760,
+                rotate_keep: 5,
+                retention_seconds: None,
+                provenance_window_seconds: 60,
+                fail_open: false,
+                allowed_base_dir: Some(audit_dir.to_path_buf()),
+            },
+            attachments: AttachmentsConfig::default(),
+        }
+    }
+
+    fn raw_account(name: &str) -> RawAccountConfig {
+        RawAccountConfig {
+            name: name.to_string(),
+            imap: ImapConfig {
+                host: "127.0.0.1".into(),
+                port: 1143,
+                username: format!("{name}@example.test"),
+                tls_fingerprint_sha256: None,
+                command_timeout_seconds: 30,
+                connect_timeout_seconds: 10,
+            },
+            smtp: None,
+            security: None,
+            limits: None,
+        }
+    }
+
+    #[test]
+    fn multi_two_accounts_parsed() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(
+            dir.path(),
+            vec![raw_account("work"), raw_account("personal")],
+        );
+        let v = validate_multi(cfg).unwrap();
+        assert_eq!(v.accounts.len(), 2);
+        assert!(v.accounts.contains_key(&AccountId::new("work").unwrap()));
+        assert!(
+            v.accounts
+                .contains_key(&AccountId::new("personal").unwrap())
+        );
+    }
+
+    #[test]
+    fn multi_toml_two_accounts() {
+        let dir = TempDir::new().unwrap();
+        let toml_str = format!(
+            r#"
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "imap.work.com"
+port = 993
+username = "alice@work.com"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.personal.com"
+port = 993
+username = "alice@personal.com"
+
+[audit]
+path = "{}/audit.jsonl"
+allowed_base_dir = "{}"
+"#,
+            dir.path().display(),
+            dir.path().display(),
+        );
+        let cfg: MultiAccountConfig = toml::from_str(&toml_str).unwrap();
+        let v = validate_multi(cfg).unwrap();
+        assert_eq!(v.accounts.len(), 2);
+    }
+
+    #[test]
+    fn legacy_wraps_as_default_account() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_config(dir.path());
+        let v = validate_legacy_as_multi(cfg).unwrap();
+        assert_eq!(v.accounts.len(), 1);
+        let id = AccountId::default_account();
+        assert!(v.accounts.contains_key(&id));
+        assert_eq!(v.accounts[&id].id, id);
+    }
+
+    #[test]
+    fn duplicate_account_name_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![raw_account("work"), raw_account("work")]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DuplicateAccountName { ref name } if name == "work"),
+            "expected DuplicateAccountName, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn no_accounts_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(matches!(err, ConfigError::NoAccounts));
+    }
+
+    #[test]
+    fn invalid_account_name_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![raw_account("bad name")]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidAccountName(_)));
+    }
+
+    #[test]
+    fn defaults_inherited_when_account_omits() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = base_multi_config(dir.path(), vec![raw_account("work")]);
+        cfg.defaults.limits.commands_per_second = 42;
+        cfg.defaults.security.posture = Posture::Readonly;
+        let v = validate_multi(cfg).unwrap();
+        let acct = &v.accounts[&AccountId::new("work").unwrap()];
+        assert_eq!(acct.limits.commands_per_second, 42);
+        assert_eq!(acct.security.posture, Posture::Readonly);
+    }
+
+    #[test]
+    fn account_overrides_defaults() {
+        let dir = TempDir::new().unwrap();
+        let mut acct = raw_account("work");
+        acct.limits = Some(LimitsConfig {
+            commands_per_second: 99,
+            ..LimitsConfig::default()
+        });
+        let mut cfg = base_multi_config(dir.path(), vec![acct]);
+        cfg.defaults.limits.commands_per_second = 42;
+        let v = validate_multi(cfg).unwrap();
+        let validated_acct = &v.accounts[&AccountId::new("work").unwrap()];
+        assert_eq!(validated_acct.limits.commands_per_second, 99);
+    }
+
+    #[test]
+    fn per_account_smtp_required_still_works() {
+        let dir = TempDir::new().unwrap();
+        let mut acct = raw_account("work");
+        acct.security = Some(SecurityConfig {
+            posture: Posture::Full,
+            ..SecurityConfig::default()
+        });
+        let cfg = base_multi_config(dir.path(), vec![acct]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(matches!(err, ConfigError::SmtpRequired { .. }));
+    }
+
+    #[test]
+    fn per_account_conflicting_folders_still_works() {
+        let dir = TempDir::new().unwrap();
+        let mut acct = raw_account("work");
+        acct.security = Some(SecurityConfig {
+            protected_folders: vec!["Trash".into()],
+            expunge_folders: vec!["Trash".into()],
+            ..SecurityConfig::default()
+        });
+        let cfg = base_multi_config(dir.path(), vec![acct]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(matches!(err, ConfigError::ConflictingFolders { .. }));
     }
 }

--- a/crates/rimap-core/src/account.rs
+++ b/crates/rimap-core/src/account.rs
@@ -1,0 +1,144 @@
+//! Account identity type.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum length of an account name.
+const MAX_ACCOUNT_NAME_LEN: usize = 64;
+
+/// The name used when no account is explicitly configured.
+pub const DEFAULT_ACCOUNT_NAME: &str = "default";
+
+/// Validated account identifier.
+/// ASCII alphanumeric + hyphens, 1–64 characters.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AccountId(String);
+
+impl AccountId {
+    /// Parse and validate an account name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidAccountName`] if the name is empty, longer than
+    /// 64 characters, or contains characters other than ASCII
+    /// alphanumerics and hyphens.
+    pub fn new(name: &str) -> Result<Self, InvalidAccountName> {
+        if name.is_empty() {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: "must not be empty".to_string(),
+            });
+        }
+        if name.len() > MAX_ACCOUNT_NAME_LEN {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: format!("must be at most {MAX_ACCOUNT_NAME_LEN} characters"),
+            });
+        }
+        if let Some(bad) = name
+            .chars()
+            .find(|c| !c.is_ascii_alphanumeric() && *c != '-')
+        {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: format!(
+                    "contains invalid character '{bad}'; \
+                     only ASCII alphanumerics and hyphens allowed"
+                ),
+            });
+        }
+        Ok(Self(name.to_string()))
+    }
+
+    /// The built-in default account name.
+    #[must_use]
+    pub fn default_account() -> Self {
+        Self(DEFAULT_ACCOUNT_NAME.to_string())
+    }
+
+    /// Borrow the inner string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Error returned when an account name fails validation.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid account name `{name}`: {reason}")]
+pub struct InvalidAccountName {
+    /// The name that was rejected.
+    pub name: String,
+    /// Why it was rejected.
+    pub reason: String,
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names() {
+        for name in ["work", "personal-2", "default", "a", "A-1-b"] {
+            let id = AccountId::new(name).expect("should be valid");
+            assert_eq!(id.as_str(), name);
+        }
+    }
+
+    #[test]
+    fn max_length_accepted() {
+        let name = "a".repeat(MAX_ACCOUNT_NAME_LEN);
+        assert!(AccountId::new(&name).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(AccountId::new("").is_err());
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let name = "a".repeat(MAX_ACCOUNT_NAME_LEN + 1);
+        assert!(AccountId::new(&name).is_err());
+    }
+
+    #[test]
+    fn rejects_spaces() {
+        assert!(AccountId::new("my account").is_err());
+    }
+
+    #[test]
+    fn rejects_underscores() {
+        assert!(AccountId::new("my_account").is_err());
+    }
+
+    #[test]
+    fn rejects_special_chars() {
+        for name in ["user@host", "path/part", "a!b", "c.d"] {
+            assert!(
+                AccountId::new(name).is_err(),
+                "expected rejection for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let id = AccountId::new("work").expect("should be valid");
+        assert_eq!(format!("{id}"), "work");
+    }
+
+    #[test]
+    fn default_account_valid() {
+        let id = AccountId::default_account();
+        assert_eq!(id.as_str(), DEFAULT_ACCOUNT_NAME);
+    }
+}

--- a/crates/rimap-core/src/account.rs
+++ b/crates/rimap-core/src/account.rs
@@ -73,6 +73,7 @@ impl fmt::Display for AccountId {
 /// Error returned when an account name fails validation.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("invalid account name `{name}`: {reason}")]
+#[non_exhaustive]
 pub struct InvalidAccountName {
     /// The name that was rejected.
     pub name: String,

--- a/crates/rimap-core/src/error.rs
+++ b/crates/rimap-core/src/error.rs
@@ -41,6 +41,10 @@ pub enum ErrorCode {
     Config,
     /// Bug, invariant violation, or audit failure.
     Internal,
+    /// Multiple accounts configured but none selected.
+    NoAccount,
+    /// Named account not found in registry.
+    UnknownAccount,
 }
 
 impl ErrorCode {
@@ -64,6 +68,8 @@ impl ErrorCode {
             Self::ExpungeDenied => "ERR_EXPUNGE_DENIED",
             Self::Config => "ERR_CONFIG",
             Self::Internal => "ERR_INTERNAL",
+            Self::NoAccount => "ERR_NO_ACCOUNT",
+            Self::UnknownAccount => "ERR_UNKNOWN_ACCOUNT",
         }
     }
 }
@@ -132,6 +138,24 @@ pub enum RimapError {
     /// Bug / invariant violation.
     #[error("ERR_INTERNAL: {0}")]
     Internal(String),
+    /// Multiple accounts configured but none selected.
+    #[error(
+        "multiple accounts configured; call `use_account` or pass \
+         `account` parameter. Available: {}",
+        available.join(", ")
+    )]
+    NoAccount {
+        /// Names of the available accounts.
+        available: Vec<String>,
+    },
+    /// Named account not found in registry.
+    #[error("account '{name}' not found. Available: {}", available.join(", "))]
+    UnknownAccount {
+        /// The name that was looked up.
+        name: String,
+        /// Names of the available accounts.
+        available: Vec<String>,
+    },
 }
 
 impl RimapError {
@@ -145,6 +169,8 @@ impl RimapError {
             | Self::Audit { code, .. } => *code,
             Self::Config(_) => ErrorCode::Config,
             Self::Internal(_) => ErrorCode::Internal,
+            Self::NoAccount { .. } => ErrorCode::NoAccount,
+            Self::UnknownAccount { .. } => ErrorCode::UnknownAccount,
         }
     }
 }
@@ -172,6 +198,8 @@ mod tests {
             (ErrorCode::ExpungeDenied, "ERR_EXPUNGE_DENIED"),
             (ErrorCode::Config, "ERR_CONFIG"),
             (ErrorCode::Internal, "ERR_INTERNAL"),
+            (ErrorCode::NoAccount, "ERR_NO_ACCOUNT"),
+            (ErrorCode::UnknownAccount, "ERR_UNKNOWN_ACCOUNT"),
         ];
         for (code, expected) in cases {
             assert_eq!(code.as_str(), expected);

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+pub mod account;
 pub mod error;
 pub mod posture;
 pub mod posture_matrix;

--- a/crates/rimap-core/src/posture_matrix.rs
+++ b/crates/rimap-core/src/posture_matrix.rs
@@ -9,9 +9,9 @@ use crate::tool::ToolName;
 
 /// Compile-time truth table. `true` = allowed by base posture.
 ///
-/// Layout: outer by [`ToolName`] (19 tools),
+/// Layout: outer by [`ToolName`] (22 tools),
 /// inner `[readonly, draft_safe, full, destructive]`.
-pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 19] = [
+pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 22] = [
     (ToolName::ListFolders, [true, true, true, true]),
     (ToolName::Search, [true, true, true, true]),
     (ToolName::SearchAdvanced, [false, false, true, true]),
@@ -23,6 +23,9 @@ pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 19] = [
     (ToolName::MarkUnread, [false, true, true, true]),
     (ToolName::Flag, [false, true, true, true]),
     (ToolName::Unflag, [false, true, true, true]),
+    (ToolName::AddLabel, [false, true, true, true]),
+    (ToolName::RemoveLabel, [false, true, true, true]),
+    (ToolName::ListLabels, [true, true, true, true]),
     (ToolName::MoveMessage, [false, true, true, true]),
     (ToolName::CreateDraft, [false, true, true, true]),
     // v2 tools:

--- a/crates/rimap-core/src/tool.rs
+++ b/crates/rimap-core/src/tool.rs
@@ -57,6 +57,12 @@ pub enum ToolName {
     RenameFolder,
     /// `delete_folder`
     DeleteFolder,
+    /// `use_account` — switch the active account context.
+    /// Bypasses posture/rate-limit checks.
+    UseAccount,
+    /// `list_accounts` — enumerate configured accounts.
+    /// Bypasses posture/rate-limit checks.
+    ListAccounts,
 }
 
 impl ToolName {
@@ -88,6 +94,8 @@ impl ToolName {
             Self::CreateFolder => "create_folder",
             Self::RenameFolder => "rename_folder",
             Self::DeleteFolder => "delete_folder",
+            Self::UseAccount => "use_account",
+            Self::ListAccounts => "list_accounts",
         }
     }
 
@@ -136,9 +144,9 @@ mod tests {
     use strum::IntoEnumIterator;
 
     #[test]
-    fn all_has_exactly_twenty_two_variants() {
-        assert_eq!(ToolName::all().len(), 22);
-        assert_eq!(ToolName::iter().count(), 22);
+    fn all_has_exactly_twenty_four_variants() {
+        assert_eq!(ToolName::all().len(), 24);
+        assert_eq!(ToolName::iter().count(), 24);
     }
 
     #[test]

--- a/crates/rimap-core/src/tool.rs
+++ b/crates/rimap-core/src/tool.rs
@@ -136,9 +136,9 @@ mod tests {
     use strum::IntoEnumIterator;
 
     #[test]
-    fn all_has_exactly_nineteen_variants() {
-        assert_eq!(ToolName::all().len(), 19);
-        assert_eq!(ToolName::iter().count(), 19);
+    fn all_has_exactly_twenty_two_variants() {
+        assert_eq!(ToolName::all().len(), 22);
+        assert_eq!(ToolName::iter().count(), 22);
     }
 
     #[test]

--- a/crates/rimap-core/src/tool.rs
+++ b/crates/rimap-core/src/tool.rs
@@ -107,6 +107,15 @@ impl ToolName {
     pub fn all() -> Vec<Self> {
         Self::iter().collect()
     }
+
+    /// Whether this tool is an infrastructure tool that bypasses the
+    /// posture matrix (not gated by posture, rate limits, or circuit
+    /// breakers). Infrastructure tools are always available regardless
+    /// of security posture.
+    #[must_use]
+    pub fn is_infrastructure(self) -> bool {
+        matches!(self, Self::UseAccount | Self::ListAccounts)
+    }
 }
 
 impl fmt::Display for ToolName {

--- a/crates/rimap-core/src/tool.rs
+++ b/crates/rimap-core/src/tool.rs
@@ -35,6 +35,12 @@ pub enum ToolName {
     Flag,
     /// `unflag`
     Unflag,
+    /// `add_label`
+    AddLabel,
+    /// `remove_label`
+    RemoveLabel,
+    /// `list_labels`
+    ListLabels,
     /// `move_message`
     MoveMessage,
     /// `create_draft` (appends to Drafts with `$PendingReview`).
@@ -71,6 +77,9 @@ impl ToolName {
             Self::MarkUnread => "mark_unread",
             Self::Flag => "flag",
             Self::Unflag => "unflag",
+            Self::AddLabel => "add_label",
+            Self::RemoveLabel => "remove_label",
+            Self::ListLabels => "list_labels",
             Self::MoveMessage => "move_message",
             Self::CreateDraft => "create_draft",
             Self::SendEmail => "send_email",

--- a/crates/rimap-imap/Cargo.toml
+++ b/crates/rimap-imap/Cargo.toml
@@ -14,9 +14,9 @@ workspace = true
 
 [dependencies]
 # Internal — direct path + explicit version to satisfy cargo-deny's wildcard ban.
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
-rimap-config = { path = "../rimap-config", version = "0.0.0" }
-rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-config = { path = "../rimap-config", version = "1.0.0" }
+rimap-audit = { path = "../rimap-audit", version = "1.0.0" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/rimap-imap/Cargo.toml
+++ b/crates/rimap-imap/Cargo.toml
@@ -29,6 +29,9 @@ tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 webpki-roots = { workspace = true }
 
+# Credentials (SecretString exposure at call site)
+secrecy = { workspace = true }
+
 # Error handling
 thiserror = { workspace = true }
 

--- a/crates/rimap-imap/src/auth.rs
+++ b/crates/rimap-imap/src/auth.rs
@@ -7,6 +7,9 @@ use rimap_core::TlsFingerprint;
 
 /// Inputs every `Auth` record needs.
 pub(crate) struct AuthContext<'a> {
+    /// Account name this auth attempt belongs to. `None` for legacy
+    /// single-account deployments; `Some(name)` in multi-account configs.
+    pub account: Option<&'a str>,
     /// IMAP server host.
     pub host: &'a str,
     /// IMAP server port.
@@ -35,7 +38,7 @@ impl AuthContext<'_> {
 /// Build a successful `Auth` record.
 pub(crate) fn auth_success(ctx: &AuthContext<'_>) -> Auth {
     Auth {
-        account: None,
+        account: ctx.account.map(str::to_string),
         result: AuthResult::Success,
         host: ctx.host.to_string(),
         port: ctx.port,
@@ -49,7 +52,7 @@ pub(crate) fn auth_success(ctx: &AuthContext<'_>) -> Auth {
 /// Build a failure `Auth` record carrying the stable error code.
 pub(crate) fn auth_failure(ctx: &AuthContext<'_>, error_code: &str) -> Auth {
     Auth {
-        account: None,
+        account: ctx.account.map(str::to_string),
         result: AuthResult::Failure,
         host: ctx.host.to_string(),
         port: ctx.port,
@@ -74,6 +77,7 @@ mod tests {
     fn success_with_matching_fingerprint() {
         let pin = fp(b"good");
         let ctx = AuthContext {
+            account: None,
             host: "h",
             port: 993,
             username: "u",
@@ -92,6 +96,7 @@ mod tests {
         let pin = fp(b"good");
         let observed = fp(b"bad");
         let ctx = AuthContext {
+            account: None,
             host: "h",
             port: 993,
             username: "u",
@@ -108,6 +113,7 @@ mod tests {
     fn unpinned_observed_yields_none_match() {
         let observed = fp(b"x");
         let ctx = AuthContext {
+            account: None,
             host: "h",
             port: 993,
             username: "u",
@@ -127,6 +133,7 @@ mod tests {
         // verdict — recording stale data here would mislead operators.
         let pin = fp(b"good");
         let ctx = AuthContext {
+            account: None,
             host: "h",
             port: 993,
             username: "u",

--- a/crates/rimap-imap/src/auth.rs
+++ b/crates/rimap-imap/src/auth.rs
@@ -35,6 +35,7 @@ impl AuthContext<'_> {
 /// Build a successful `Auth` record.
 pub(crate) fn auth_success(ctx: &AuthContext<'_>) -> Auth {
     Auth {
+        account: None,
         result: AuthResult::Success,
         host: ctx.host.to_string(),
         port: ctx.port,
@@ -48,6 +49,7 @@ pub(crate) fn auth_success(ctx: &AuthContext<'_>) -> Auth {
 /// Build a failure `Auth` record carrying the stable error code.
 pub(crate) fn auth_failure(ctx: &AuthContext<'_>, error_code: &str) -> Auth {
     Auth {
+        account: None,
         result: AuthResult::Failure,
         host: ctx.host.to_string(),
         port: ctx.port,

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -39,6 +39,10 @@ use crate::tls::{TlsConfigBundle, build_tls_config};
 /// value once at construction time.
 #[derive(Debug, Clone)]
 pub struct ConnectionConfig {
+    /// Account name this connection belongs to. `None` for the legacy
+    /// single-account `"default"` deployment; `Some(name)` in multi-account
+    /// configs. Populated into `Auth` audit records.
+    pub account: Option<String>,
     /// IMAP server host.
     pub host: String,
     /// IMAP server port (typically 993 for IMAPS).
@@ -177,6 +181,7 @@ impl Connection {
 
         let observed = bundle.last_observed.get().copied();
         let ctx = AuthContext {
+            account: cfg.account.as_deref(),
             host: &cfg.host,
             port: cfg.port,
             username: &cfg.username,

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -23,6 +23,7 @@ use rimap_audit::AuditWriter;
 use rimap_audit::record::Auth;
 use rimap_config::credential::{CredentialStore, resolve_credential};
 use rimap_core::TlsFingerprint;
+use secrecy::ExposeSecret;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -318,7 +319,9 @@ impl Connection {
             })?;
 
         // Attempt LOGIN. On NO response the server rejected the credentials.
-        let mut session = match client.login(&cfg.username, &password).await {
+        // Expose the secret only at the moment of use; the borrow ends
+        // when `client.login` returns.
+        let mut session = match client.login(&cfg.username, password.expose_secret()).await {
             Ok(session) => session,
             Err((err, _client)) => {
                 return match err {

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -123,6 +123,13 @@ impl Connection {
         &self.inner.cfg.host
     }
 
+    /// Read the configured IMAP username. Typically the account's
+    /// email address, and suitable for use as the `From:` header.
+    #[must_use]
+    pub fn username(&self) -> &str {
+        &self.inner.cfg.username
+    }
+
     /// Acquire the session lock; lazy-connect if needed. The returned guard
     /// holds the tokio mutex; drop it before any other method on `Connection`.
     pub(crate) async fn session(

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -114,8 +114,11 @@ async fn case_04_login_rejected_emits_audit() {
 
     struct WrongPass;
     impl CredentialStore for WrongPass {
-        fn get_password(&self, _: &str) -> Result<Option<String>, rimap_config::ConfigError> {
-            Ok(Some("wrong-password".to_string()))
+        fn get_password(
+            &self,
+            _: &str,
+        ) -> Result<Option<secrecy::SecretString>, rimap_config::ConfigError> {
+            Ok(Some(secrecy::SecretString::from("wrong-password")))
         }
         #[expect(clippy::panic, clippy::panic_in_result_fn, reason = "test stub")]
         fn set_password(&self, _: &str, _: &str) -> Result<(), rimap_config::ConfigError> {

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -127,6 +127,7 @@ async fn case_04_login_rejected_emits_audit() {
         return;
     };
     let cfg = ConnectionConfig {
+        account: None,
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),
@@ -181,7 +182,7 @@ async fn case_06_search_structured_subject_match() {
         subject: Some("Sprint 3 plain text fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = h.connection.search("INBOX", q).await.unwrap();
+    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(
         !uids.is_empty(),
         "expected at least one UID for the seeded subject"
@@ -196,7 +197,7 @@ async fn case_07_search_raw_passthrough() {
         return;
     };
     let q = SearchQuery::Raw("HEADER \"X-Test\" \"marker\"".to_string());
-    let uids = h.connection.search("INBOX", q).await.unwrap();
+    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(
         !uids.is_empty(),
         "expected at least one UID for X-Test: marker"
@@ -214,7 +215,7 @@ async fn case_08_fetch_envelope_and_bodystructure() {
         subject: Some("Sprint 3 multipart fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = h.connection.search("INBOX", q).await.unwrap();
+    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(!uids.is_empty());
     let spec = FetchSpec {
         envelope: true,
@@ -242,7 +243,7 @@ async fn case_09_fetch_body_under_limit() {
         subject: Some("Sprint 3 plain text fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = h.connection.search("INBOX", q).await.unwrap();
+    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(!uids.is_empty());
     let body = h.connection.fetch_body("INBOX", uids[0]).await.unwrap();
     assert!(!body.is_empty());
@@ -259,6 +260,7 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
         return;
     };
     let cfg = ConnectionConfig {
+        account: None,
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),
@@ -280,7 +282,7 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
         subject: Some("Sprint 3 multipart fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = conn.search("INBOX", q).await.unwrap();
+    let uids = Box::pin(conn.search("INBOX", q)).await.unwrap();
     let result = conn.fetch_body("INBOX", uids[0]).await;
     match result {
         Err(Error::SizeLimit { limit }) => assert_eq!(limit, 10),
@@ -332,17 +334,15 @@ async fn case_12_store_add_seen_flag() {
         .unwrap();
 
     // Search for it.
-    let uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("store-seen".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("store-seen".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty(), "seeded message not found");
     let uid = uids[0];
 
@@ -389,17 +389,15 @@ async fn case_13_store_remove_seen_flag() {
         .await
         .unwrap();
 
-    let uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("store-unseen".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("store-unseen".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty());
     let uid = uids[0];
 
@@ -485,17 +483,15 @@ async fn case_15_append_message_to_inbox() {
     assert_eq!(result.uid, None);
 
     // Verify the message is in INBOX by searching for it.
-    let uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("append-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("append-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty(), "appended message not found");
 
     // Verify it has the \Draft flag.
@@ -528,17 +524,15 @@ async fn case_16_move_message_between_folders() {
         .await
         .unwrap();
 
-    let uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("move-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("move-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty(), "seeded message not found");
     let uid = uids[0];
 
@@ -552,34 +546,30 @@ async fn case_16_move_message_between_folders() {
     assert_eq!(outcome.results[0].old_uid, uid);
 
     // Verify the message is gone from INBOX.
-    let after_uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("move-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let after_uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("move-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(
         after_uids.is_empty(),
         "message should be gone from INBOX after move"
     );
 
     // Verify the message is in Archive.
-    let archive_uids = h
-        .connection
-        .search(
-            "Archive",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("move-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let archive_uids = Box::pin(h.connection.search(
+        "Archive",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("move-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(
         !archive_uids.is_empty(),
         "message should be in Archive after move"
@@ -600,17 +590,15 @@ async fn case_17_delete_message() {
         .unwrap();
 
     // Find the appended message
-    let uids = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("delete-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("delete-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty(), "seeded message not found");
     let uid = uids[0];
 
@@ -626,17 +614,15 @@ async fn case_17_delete_message() {
     assert!(result.moved_to_trash);
 
     // Verify it's gone from INBOX
-    let after = h
-        .connection
-        .search(
-            "INBOX",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("delete-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let after = Box::pin(h.connection.search(
+        "INBOX",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("delete-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(
         !after.contains(&uid),
         "message should be gone from INBOX after delete"
@@ -659,17 +645,15 @@ async fn case_18_expunge() {
         .unwrap();
 
     // Find it
-    let uids = h
-        .connection
-        .search(
-            "Trash",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("expunge-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let uids = Box::pin(h.connection.search(
+        "Trash",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("expunge-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(!uids.is_empty());
     let uid = uids[0];
 
@@ -693,17 +677,15 @@ async fn case_18_expunge() {
     assert!(count > 0, "should expunge at least one message");
 
     // Verify it's gone
-    let after = h
-        .connection
-        .search(
-            "Trash",
-            rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
-                subject: Some("expunge-test".to_string()),
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
+    let after = Box::pin(h.connection.search(
+        "Trash",
+        rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
+            subject: Some("expunge-test".to_string()),
+            ..Default::default()
+        }),
+    ))
+    .await
+    .unwrap();
     assert!(
         !after.contains(&uid),
         "message should be gone after expunge"

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -68,6 +68,7 @@ fn build_connection(cfg: &ProtonConfig) -> Connection {
     })
     .unwrap();
     let conn_cfg = ConnectionConfig {
+        account: None,
         host: cfg.host.clone(),
         port: cfg.port,
         username: cfg.user.clone(),
@@ -98,8 +99,7 @@ async fn proton_bridge_connect_and_fetch_one_envelope() {
     };
     let conn = build_connection(&cfg);
     let _ = conn.select("INBOX", true).await.unwrap();
-    let uids = conn
-        .search("INBOX", rimap_imap::types::SearchQuery::Raw("ALL".into()))
+    let uids = Box::pin(conn.search("INBOX", rimap_imap::types::SearchQuery::Raw("ALL".into())))
         .await
         .unwrap();
     assert!(!uids.is_empty(), "expected at least one message in INBOX");

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -16,8 +16,11 @@ use rimap_imap::{Connection, ConnectionConfig};
 
 struct EnvCreds(String);
 impl CredentialStore for EnvCreds {
-    fn get_password(&self, _: &str) -> Result<Option<String>, rimap_config::ConfigError> {
-        Ok(Some(self.0.clone()))
+    fn get_password(
+        &self,
+        _: &str,
+    ) -> Result<Option<secrecy::SecretString>, rimap_config::ConfigError> {
+        Ok(Some(secrecy::SecretString::from(self.0.clone())))
     }
     #[expect(clippy::panic, clippy::panic_in_result_fn, reason = "test stub")]
     fn set_password(&self, _: &str, _: &str) -> Result<(), rimap_config::ConfigError> {

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -479,8 +479,11 @@ use tempfile::TempDir;
 pub struct StaticCreds(pub String);
 
 impl CredentialStore for StaticCreds {
-    fn get_password(&self, _account: &str) -> Result<Option<String>, rimap_config::ConfigError> {
-        Ok(Some(self.0.clone()))
+    fn get_password(
+        &self,
+        _account: &str,
+    ) -> Result<Option<secrecy::SecretString>, rimap_config::ConfigError> {
+        Ok(Some(secrecy::SecretString::from(self.0.clone())))
     }
 
     #[expect(clippy::panic, clippy::panic_in_result_fn, reason = "test stub")]

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -524,6 +524,7 @@ impl ConnectedHarness {
         };
 
         let cfg = ConnectionConfig {
+            account: None,
             host: DovecotHarness::host().to_string(),
             port: harness.port(),
             username: DovecotHarness::username().to_string(),

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -33,6 +33,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
 anyhow = { workspace = true }
+secrecy = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 clap = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -16,13 +16,13 @@ name = "rusty-imap-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
-rimap-config = { path = "../rimap-config", version = "0.0.0" }
-rimap-authz = { path = "../rimap-authz", version = "0.0.0" }
-rimap-audit = { path = "../rimap-audit", version = "0.0.0" }
-rimap-content = { path = "../rimap-content", version = "0.0.0" }
-rimap-imap = { path = "../rimap-imap", version = "0.0.0" }
-rimap-smtp = { path = "../rimap-smtp", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-config = { path = "../rimap-config", version = "1.0.0" }
+rimap-authz = { path = "../rimap-authz", version = "1.0.0" }
+rimap-audit = { path = "../rimap-audit", version = "1.0.0" }
+rimap-content = { path = "../rimap-content", version = "1.0.0" }
+rimap-imap = { path = "../rimap-imap", version = "1.0.0" }
+rimap-smtp = { path = "../rimap-smtp", version = "1.0.0" }
 lettre = { workspace = true }
 mail-builder = { workspace = true }
 mail-parser = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -39,6 +39,7 @@ clap = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+governor = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -42,9 +42,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 governor = { workspace = true }
 arc-swap = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 governor = { workspace = true }
+arc-swap = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/rimap-server/src/audit_cmd.rs
+++ b/crates/rimap-server/src/audit_cmd.rs
@@ -29,6 +29,7 @@ pub fn run(
     tool: Option<&str>,
     kind: Option<&str>,
     process: Option<&str>,
+    account: Option<&str>,
 ) -> anyhow::Result<()> {
     let filter = Filter {
         since: since
@@ -42,6 +43,7 @@ pub fn run(
         tool: tool.map(str::to_string),
         kind: kind.map(str::to_string),
         process: process.map(str::to_string),
+        account: account.map(str::to_string),
     };
 
     let mut stdout = std::io::stdout().lock();

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -132,8 +132,16 @@ fn compute_config_hash(path: &Path) -> String {
     // Intentional: if the config file disappears between load and hash,
     // record an empty hash rather than panic. The config was already
     // successfully loaded earlier in the boot sequence; this is a startup
-    // hot path, not user-facing input validation.
-    let bytes = std::fs::read(path).unwrap_or_default();
+    // hot path, not user-facing input validation. Log the failure so an
+    // operator investigating an empty hash can see why.
+    let bytes = std::fs::read(path).unwrap_or_else(|e| {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "failed to read config for hash; audit record will have empty hash",
+        );
+        Vec::new()
+    });
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
     hex::encode(hasher.finalize())

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -3,16 +3,23 @@
 
 use std::path::Path;
 
+use rimap_audit::record::AccountSummary;
 use rimap_audit::{AuditError, AuditOptions, AuditWriter, ProcessStartInputs, Seq};
+#[cfg(test)]
 use rimap_config::ValidatedConfig;
+use rimap_config::validate::ValidatedMultiConfig;
 use sha2::{Digest, Sha256};
 
-/// Open the audit writer, run the pre-flight self-check, and emit the
-/// `process_start` record. Returns the writer ready for production use.
+/// Open the audit writer from a legacy `ValidatedConfig`, run the pre-flight
+/// self-check, and emit the `process_start` record.
+///
+/// Retained for test compatibility. Production code uses
+/// [`init_audit_writer_multi`].
 ///
 /// # Errors
 /// Propagates any `AuditError` from the trailing-state read, open, inode
 /// fetch, or `process_start` write.
+#[cfg(test)]
 pub fn init_audit_writer(
     cfg: &ValidatedConfig,
     config_file_path: &Path,
@@ -42,6 +49,76 @@ pub fn init_audit_writer(
         git_commit: String::new(),
         posture: Some(cfg.config.security.posture.to_string()),
         accounts: None,
+        config_path: config_file_path.to_path_buf(),
+        config_hash_sha256: config_hash,
+        trailing,
+        current_inode: current,
+    })?;
+
+    Ok(writer)
+}
+
+/// Open the audit writer for a multi-account config and emit the
+/// `process_start` record with per-account summaries.
+///
+/// # Errors
+/// Propagates any `AuditError` from the trailing-state read, open, inode
+/// fetch, or `process_start` write.
+pub fn init_audit_writer_multi(
+    multi: &ValidatedMultiConfig,
+    config_file_path: &Path,
+) -> Result<AuditWriter, AuditError> {
+    let audit_path = &multi.audit.path;
+    let trailing = rimap_audit::read_trailing_state(audit_path)?;
+    let initial_seq = trailing.last_seq.map_or(Seq::FIRST, Seq::next);
+
+    let writer = AuditWriter::open(&AuditOptions {
+        path: audit_path.clone(),
+        rotate_bytes: multi.audit.rotate_bytes,
+        rotate_keep: multi.audit.rotate_keep,
+        retention_seconds: multi.audit.retention_seconds,
+        fail_open: multi.audit.fail_open,
+        initial_seq,
+    })?;
+
+    if let Some(parent) = writer.path().parent() {
+        rimap_audit::backup_exclude::exclude_from_backup(parent);
+    }
+
+    let current = rimap_audit::current_inode(audit_path)?;
+    let config_hash = compute_config_hash(config_file_path);
+
+    let single_account = multi.accounts.len() == 1;
+    let posture = if single_account {
+        multi
+            .accounts
+            .values()
+            .next()
+            .map(|a| a.security.posture.to_string())
+    } else {
+        None
+    };
+    let accounts = if single_account {
+        None
+    } else {
+        Some(
+            multi
+                .accounts
+                .values()
+                .map(|a| AccountSummary {
+                    name: a.id.as_str().to_string(),
+                    posture: a.security.posture.to_string(),
+                    imap_host: a.imap.host.clone(),
+                })
+                .collect(),
+        )
+    };
+
+    writer.log_process_start(ProcessStartInputs {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git_commit: String::new(),
+        posture,
+        accounts,
         config_path: config_file_path.to_path_buf(),
         config_hash_sha256: config_hash,
         trailing,

--- a/crates/rimap-server/src/audit_init.rs
+++ b/crates/rimap-server/src/audit_init.rs
@@ -40,7 +40,8 @@ pub fn init_audit_writer(
     writer.log_process_start(ProcessStartInputs {
         version: env!("CARGO_PKG_VERSION").to_string(),
         git_commit: String::new(),
-        posture: cfg.config.security.posture.to_string(),
+        posture: Some(cfg.config.security.posture.to_string()),
+        accounts: None,
         config_path: config_file_path.to_path_buf(),
         config_hash_sha256: config_hash,
         trailing,

--- a/crates/rimap-server/src/cli.rs
+++ b/crates/rimap-server/src/cli.rs
@@ -78,6 +78,9 @@ pub enum AuditAction {
         /// Only include records whose `process_id` matches this ULID.
         #[arg(long)]
         process: Option<String>,
+        /// Only include records whose `account` field matches this name.
+        #[arg(long)]
+        account: Option<String>,
     },
 }
 
@@ -145,6 +148,8 @@ mod tests {
             "tool_end",
             "--process",
             "01JXAAAAAAAAAAAAAAAAAAAAAA",
+            "--account",
+            "work",
         ])
         .unwrap();
         match cli.command {
@@ -157,6 +162,7 @@ mod tests {
                         tool,
                         kind,
                         process,
+                        account,
                     },
             }) => {
                 assert_eq!(path, std::path::PathBuf::from("/tmp/audit.jsonl"));
@@ -165,6 +171,7 @@ mod tests {
                 assert_eq!(tool.as_deref(), Some("search"));
                 assert_eq!(kind.as_deref(), Some("tool_end"));
                 assert_eq!(process.as_deref(), Some("01JXAAAAAAAAAAAAAAAAAAAAAA"));
+                assert_eq!(account.as_deref(), Some("work"));
             }
             other => panic!("expected Audit::Merge, got {other:?}"),
         }

--- a/crates/rimap-server/src/dry_run.rs
+++ b/crates/rimap-server/src/dry_run.rs
@@ -23,8 +23,7 @@ use std::path::Path;
 use anyhow::Context;
 use rimap_audit::{AuditOptions, AuditWriter};
 use rimap_authz::matrix::EffectiveMatrix;
-use rimap_config::loader::load_from_path;
-use rimap_config::validate::validate;
+use rimap_config::loader::load_and_validate;
 
 /// Load `path`, validate, acquire an exclusive audit lock, build the effective
 /// matrix, print to `out`, and return. The audit lock is held for the duration
@@ -34,31 +33,33 @@ use rimap_config::validate::validate;
 /// Propagates config load/validate errors, audit lock acquisition errors, and
 /// I/O errors from the writer.
 pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
-    let raw = load_from_path(path).with_context(|| format!("loading config {}", path.display()))?;
-    let validated = validate(raw).context("validating config")?;
+    let multi =
+        load_and_validate(path).with_context(|| format!("loading config {}", path.display()))?;
 
-    let audit_path = validated.config.audit.path.clone();
-    let rotate_bytes = validated.config.audit.rotate_bytes;
-    let rotate_keep = validated.config.audit.rotate_keep;
-    let retention_seconds = validated.config.audit.retention_seconds;
+    let audit_path = multi.audit.path.clone();
     // dry-run is a one-shot diagnostic path that exits immediately after
     // printing the matrix. Chain-of-history continuation (trailing state) is
     // not useful here; Seq::FIRST is correct.
     let _audit_writer = AuditWriter::open(&AuditOptions {
         path: audit_path.clone(),
-        rotate_bytes,
-        rotate_keep,
-        retention_seconds,
-        fail_open: validated.config.audit.fail_open,
+        rotate_bytes: multi.audit.rotate_bytes,
+        rotate_keep: multi.audit.rotate_keep,
+        retention_seconds: multi.audit.retention_seconds,
+        fail_open: multi.audit.fail_open,
         initial_seq: rimap_audit::Seq::FIRST,
     })
     .with_context(|| format!("opening audit log at {}", audit_path.display()))?;
 
-    let matrix = EffectiveMatrix::from_validated(&validated);
-    writeln!(out, "Effective matrix (posture = {})", matrix.posture())?;
-    for (tool, allowed) in matrix.rows() {
-        let tag = if allowed { "[ok ]" } else { "[deny]" };
-        writeln!(out, "  {tag} {tool}")?;
+    for (id, acfg) in &multi.accounts {
+        let matrix = EffectiveMatrix::build(acfg.security.posture, &acfg.tool_overrides);
+        if multi.accounts.len() > 1 {
+            writeln!(out, "Account: {}", id.as_str())?;
+        }
+        writeln!(out, "Effective matrix (posture = {})", matrix.posture())?;
+        for (tool, allowed) in matrix.rows() {
+            let tag = if allowed { "[ok ]" } else { "[deny]" };
+            writeln!(out, "  {tag} {tool}")?;
+        }
     }
     Ok(())
 }

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -251,12 +251,9 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
         &config.config.security.protected_folders,
         &config.config.security.expunge_folders,
     );
-    let from_address = config.config.imap.username.clone();
-
     let id = rimap_core::account::AccountId::default_account();
     let state = crate::registry::AccountState {
         id: id.clone(),
-        from_address,
         imap,
         smtp: None,
         guard,

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -263,11 +263,7 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
     accounts.insert(id, state);
     let registry = crate::registry::AccountRegistry::new(accounts);
 
-    let server = ImapMcpServer {
-        registry,
-        audit,
-        download_dir: download_dir.path().to_path_buf(),
-    };
+    let server = ImapMcpServer::new(registry, audit, download_dir.path().to_path_buf());
 
     TestEnv {
         _harness: harness,

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -312,6 +312,7 @@ fn test_config(harness: &DovecotHarness, audit_dir: &TempDir) -> ValidatedConfig
 
 fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection {
     let conn_cfg = ConnectionConfig {
+        account: None,
         host: "127.0.0.1".into(),
         port: harness.port,
         username: "rimap-test".into(),

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -244,15 +244,27 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
     let config = test_config(&harness, &audit_dir);
     let imap = test_connection(&harness, &audit);
     let guard = test_guard(&config);
+    let folder_guard = rimap_authz::FolderGuard::new(
+        &config.config.security.protected_folders,
+        &config.config.security.expunge_folders,
+    );
+    let from_address = config.config.imap.username.clone();
+
+    let id = rimap_core::account::AccountId::default_account();
+    let state = crate::registry::AccountState {
+        id: id.clone(),
+        from_address,
+        imap,
+        smtp: None,
+        guard,
+        folder_guard,
+    };
+    let mut accounts = BTreeMap::new();
+    accounts.insert(id, state);
+    let registry = crate::registry::AccountRegistry::new(accounts);
 
     let server = ImapMcpServer {
-        folder_guard: rimap_authz::FolderGuard::new(
-            &config.config.security.protected_folders,
-            &config.config.security.expunge_folders,
-        ),
-        config,
-        imap,
-        guard,
+        registry,
         audit,
         download_dir: download_dir.path().to_path_buf(),
     };
@@ -336,14 +348,16 @@ async fn call_tool(
         |e: rimap_core::tool::ParseToolNameError| rimap_core::RimapError::Internal(e.to_string()),
     )?;
 
-    crate::dispatch::pre_call_guards(&server.guard, tool)?;
+    let account = server.registry.resolve(None)?;
+
+    crate::dispatch::pre_call_guards(&account.guard, tool)?;
 
     let args_map = match args {
         serde_json::Value::Object(m) => m,
         _ => serde_json::Map::new(),
     };
 
-    server.dispatch_tool(tool, &args_map).await
+    server.dispatch_tool(account, tool, &args_map).await
 }
 
 /// Extract a u32 from a JSON value (safe truncation check).
@@ -403,7 +417,8 @@ async fn assert_list_folders(server: &ImapMcpServer) {
 }
 
 async fn seed_message(server: &ImapMcpServer) {
-    server
+    let account = server.registry.resolve(None).expect("resolve account");
+    account
         .imap
         .append_message("INBOX", &test_message(), &[], &[])
         .await

--- a/crates/rimap-server/src/e2e_test.rs
+++ b/crates/rimap-server/src/e2e_test.rs
@@ -204,8 +204,11 @@ fn pick_free_port() -> Option<u16> {
 struct StaticCreds(String);
 
 impl CredentialStore for StaticCreds {
-    fn get_password(&self, _account: &str) -> Result<Option<String>, rimap_config::ConfigError> {
-        Ok(Some(self.0.clone()))
+    fn get_password(
+        &self,
+        _account: &str,
+    ) -> Result<Option<secrecy::SecretString>, rimap_config::ConfigError> {
+        Ok(Some(secrecy::SecretString::from(self.0.clone())))
     }
 
     #[expect(clippy::panic, clippy::panic_in_result_fn, reason = "test stub")]

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -11,6 +11,9 @@ mod download;
 mod dry_run;
 mod logging;
 mod mcp_error;
+// TODO(sprint-3b-T5): remove once ImapMcpServer uses AccountRegistry
+#[expect(dead_code, reason = "wired in sprint-3b-T5")]
+mod registry;
 mod response;
 mod server;
 mod tools;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -11,8 +11,6 @@ mod download;
 mod dry_run;
 mod logging;
 mod mcp_error;
-// TODO(sprint-3b-T5): remove once ImapMcpServer uses AccountRegistry
-#[expect(dead_code, reason = "wired in sprint-3b-T5")]
 mod registry;
 mod response;
 mod server;
@@ -109,15 +107,28 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     let imap = Connection::new(conn_cfg, audit.clone(), credentials);
     let download_dir = resolve_download_dir(&validated)?;
 
+    let folder_guard = rimap_authz::FolderGuard::new(
+        &validated.config.security.protected_folders,
+        &validated.config.security.expunge_folders,
+    );
+    let from_address = validated.config.imap.username.clone();
+
+    let id = rimap_core::account::AccountId::default_account();
+    let state = registry::AccountState {
+        id: id.clone(),
+        from_address,
+        imap,
+        smtp: None,
+        guard,
+        folder_guard,
+    };
+    let mut accounts = std::collections::BTreeMap::new();
+    accounts.insert(id, state);
+    let registry = registry::AccountRegistry::new(accounts);
+
     let audit_for_shutdown = audit.clone();
     let mcp_server = server::ImapMcpServer {
-        folder_guard: rimap_authz::FolderGuard::new(
-            &validated.config.security.protected_folders,
-            &validated.config.security.expunge_folders,
-        ),
-        config: validated,
-        imap,
-        guard,
+        registry,
         audit,
         download_dir,
     };

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -166,7 +166,6 @@ fn build_registry(
 
         let state = registry::AccountState {
             id: id.clone(),
-            from_address: acfg.imap.username.clone(),
             imap,
             smtp,
             guard,

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -70,6 +70,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 tool,
                 kind,
                 process,
+                account,
             },
     }) = cli.command
     {
@@ -80,6 +81,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             tool.as_deref(),
             kind.as_deref(),
             process.as_deref(),
+            account.as_deref(),
         );
     }
 

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -187,9 +187,11 @@ fn build_smtp_client(
     };
     let smtp_password =
         rimap_config::resolve_credential(&**credentials, &smtp_cfg.username, &smtp_cfg.host)
-            .with_context(|| format!("resolving SMTP credential for {}", smtp_cfg.username))?;
+            .with_context(|| {
+                format!("resolving SMTP credential for account {}", acfg.id.as_str())
+            })?;
     let client = rimap_smtp::SmtpClient::new(smtp_cfg, smtp_password.expose_secret())
-        .with_context(|| format!("building SMTP client for {}", smtp_cfg.host))?;
+        .with_context(|| format!("building SMTP client for account {}", acfg.id.as_str()))?;
     drop(smtp_password);
     Ok(Some(client))
 }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -36,6 +36,7 @@ use rimap_config::loader::{load_and_validate, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
 use rimap_config::validate::ValidatedAccountConfig;
 use rimap_imap::{Connection, ConnectionConfig};
+use secrecy::ExposeSecret;
 
 use crate::cli::{AuditAction, Cli, Command};
 
@@ -187,8 +188,9 @@ fn build_smtp_client(
     let smtp_password =
         rimap_config::resolve_credential(&**credentials, &smtp_cfg.username, &smtp_cfg.host)
             .with_context(|| format!("resolving SMTP credential for {}", smtp_cfg.username))?;
-    let client = rimap_smtp::SmtpClient::new(smtp_cfg, &smtp_password)
+    let client = rimap_smtp::SmtpClient::new(smtp_cfg, smtp_password.expose_secret())
         .with_context(|| format!("building SMTP client for {}", smtp_cfg.host))?;
+    drop(smtp_password);
     Ok(Some(client))
 }
 

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -32,9 +32,9 @@ use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, SystemClock};
 use rimap_authz::matrix::EffectiveMatrix;
 use rimap_authz::rate_limit::Governor;
 use rimap_config::credential::{CredentialStore, KeyringStore};
-use rimap_config::loader::{load_from_path, resolve_config_path};
+use rimap_config::loader::{load_and_validate, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
-use rimap_config::validate::{ValidatedConfig, validate};
+use rimap_config::validate::ValidatedAccountConfig;
 use rimap_imap::{Connection, ConnectionConfig};
 
 use crate::cli::{AuditAction, Cli, Command};
@@ -93,40 +93,14 @@ fn run(cli: Cli) -> anyhow::Result<()> {
 
     // Server mode: load config, build subsystems, run MCP transport.
     let config_path = resolve_cli_config_path(&cli)?;
-    let raw = load_from_path(&config_path)
+    let multi = load_and_validate(&config_path)
         .with_context(|| format!("loading config {}", config_path.display()))?;
-    let validated = validate(raw).context("validating config")?;
-    let audit = audit_init::init_audit_writer(&validated, &config_path).with_context(|| {
-        format!(
-            "opening audit log at {}",
-            validated.config.audit.path.display()
-        )
-    })?;
+    let audit = audit_init::init_audit_writer_multi(&multi, &config_path)
+        .with_context(|| format!("opening audit log at {}", multi.audit.path.display()))?;
 
-    let guard = build_dispatch_guard(&validated).context("building dispatch guard")?;
-    let conn_cfg = build_connection_config(&validated);
     let credentials: Arc<dyn CredentialStore> = Arc::new(KeyringStore);
-    let imap = Connection::new(conn_cfg, audit.clone(), credentials);
-    let download_dir = resolve_download_dir(&validated)?;
-
-    let folder_guard = rimap_authz::FolderGuard::new(
-        &validated.config.security.protected_folders,
-        &validated.config.security.expunge_folders,
-    );
-    let from_address = validated.config.imap.username.clone();
-
-    let id = rimap_core::account::AccountId::default_account();
-    let state = registry::AccountState {
-        id: id.clone(),
-        from_address,
-        imap,
-        smtp: None,
-        guard,
-        folder_guard,
-    };
-    let mut accounts = std::collections::BTreeMap::new();
-    accounts.insert(id, state);
-    let registry = registry::AccountRegistry::new(accounts);
+    let download_dir = resolve_download_dir_multi(&multi)?;
+    let registry = build_registry(&multi, &audit, &credentials)?;
 
     let audit_for_shutdown = audit.clone();
     let mcp_server = server::ImapMcpServer {
@@ -174,44 +148,93 @@ fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
         })
 }
 
-/// Build the composed authz guard from validated config.
-fn build_dispatch_guard(cfg: &ValidatedConfig) -> anyhow::Result<DispatchGuard<SystemClock>> {
-    let matrix = EffectiveMatrix::from_validated(cfg);
-    let limits = &cfg.config.limits;
+/// Build the account registry from a validated multi-account config.
+fn build_registry(
+    multi: &rimap_config::validate::ValidatedMultiConfig,
+    audit: &rimap_audit::AuditWriter,
+    credentials: &Arc<dyn CredentialStore>,
+) -> anyhow::Result<registry::AccountRegistry> {
+    let mut account_states = std::collections::BTreeMap::new();
+    for (id, acfg) in &multi.accounts {
+        let guard = build_account_guard(acfg).context("building dispatch guard")?;
+        let conn_cfg = build_account_connection(acfg);
+        let imap = Connection::new(conn_cfg, audit.clone(), credentials.clone());
+
+        let smtp = build_smtp_client(acfg, credentials)?;
+
+        let folder_guard = rimap_authz::FolderGuard::new(
+            &acfg.security.protected_folders,
+            &acfg.security.expunge_folders,
+        );
+
+        let state = registry::AccountState {
+            id: id.clone(),
+            from_address: acfg.imap.username.clone(),
+            imap,
+            smtp,
+            guard,
+            folder_guard,
+        };
+        account_states.insert(id.clone(), state);
+    }
+    Ok(registry::AccountRegistry::new(account_states))
+}
+
+/// Build an SMTP client from account config, if SMTP is configured.
+fn build_smtp_client(
+    acfg: &ValidatedAccountConfig,
+    credentials: &Arc<dyn CredentialStore>,
+) -> anyhow::Result<Option<rimap_smtp::SmtpClient>> {
+    let Some(ref smtp_cfg) = acfg.smtp else {
+        return Ok(None);
+    };
+    let smtp_password =
+        rimap_config::resolve_credential(&**credentials, &smtp_cfg.username, &smtp_cfg.host)
+            .with_context(|| format!("resolving SMTP credential for {}", smtp_cfg.username))?;
+    let client = rimap_smtp::SmtpClient::new(smtp_cfg, &smtp_password)
+        .with_context(|| format!("building SMTP client for {}", smtp_cfg.host))?;
+    Ok(Some(client))
+}
+
+/// Build the composed authz guard from a per-account config.
+fn build_account_guard(
+    acfg: &ValidatedAccountConfig,
+) -> anyhow::Result<DispatchGuard<SystemClock>> {
+    let matrix = EffectiveMatrix::build(acfg.security.posture, &acfg.tool_overrides);
     let breaker_cfg = BreakerConfig {
-        error_threshold: limits.circuit_breaker_error_threshold,
-        window: Duration::from_secs(u64::from(limits.circuit_breaker_window_seconds)),
+        error_threshold: acfg.limits.circuit_breaker_error_threshold,
+        window: Duration::from_secs(u64::from(acfg.limits.circuit_breaker_window_seconds)),
         ..BreakerConfig::default_spec()
     };
     let breaker = CircuitBreaker::new(SystemClock::new(), breaker_cfg);
     let governor = Governor::new(
-        limits.commands_per_second,
-        limits.drafts_per_minute,
-        limits.sends_per_minute,
+        acfg.limits.commands_per_second,
+        acfg.limits.drafts_per_minute,
+        acfg.limits.sends_per_minute,
     )
     .map_err(|e| anyhow::anyhow!("governor: {e}"))?;
     Ok(DispatchGuard::new(matrix, breaker, governor))
 }
 
-/// Map validated config fields to a `ConnectionConfig`.
-fn build_connection_config(cfg: &ValidatedConfig) -> ConnectionConfig {
-    let imap = &cfg.config.imap;
+/// Map a per-account config to a `ConnectionConfig`.
+fn build_account_connection(acfg: &ValidatedAccountConfig) -> ConnectionConfig {
     ConnectionConfig {
-        host: imap.host.clone(),
-        port: imap.port,
-        username: imap.username.clone(),
-        pinned_fingerprint: cfg.tls_fingerprint,
-        connect_timeout: Duration::from_secs(u64::from(imap.connect_timeout_seconds)),
-        command_timeout: Duration::from_secs(u64::from(imap.command_timeout_seconds)),
-        max_fetch_body_bytes: cfg.config.limits.max_fetch_body_bytes,
-        max_append_bytes: cfg.config.limits.max_append_bytes,
+        host: acfg.imap.host.clone(),
+        port: acfg.imap.port,
+        username: acfg.imap.username.clone(),
+        pinned_fingerprint: acfg.tls_fingerprint,
+        connect_timeout: Duration::from_secs(u64::from(acfg.imap.connect_timeout_seconds)),
+        command_timeout: Duration::from_secs(u64::from(acfg.imap.command_timeout_seconds)),
+        max_fetch_body_bytes: acfg.limits.max_fetch_body_bytes,
+        max_append_bytes: acfg.limits.max_append_bytes,
     }
 }
 
-/// Resolve the attachment download directory. Uses the configured
-/// path if non-empty, otherwise creates a temporary directory.
-fn resolve_download_dir(cfg: &ValidatedConfig) -> anyhow::Result<PathBuf> {
-    let dir_str = &cfg.config.attachments.download_dir;
+/// Resolve the attachment download directory from a multi-account config.
+fn resolve_download_dir_multi(
+    multi: &rimap_config::validate::ValidatedMultiConfig,
+) -> anyhow::Result<PathBuf> {
+    let dir_str = &multi.attachments.download_dir;
     if dir_str.is_empty() {
         let tmp = std::env::temp_dir().join("rusty-imap-mcp-downloads");
         std::fs::create_dir_all(&tmp)

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -157,7 +157,7 @@ fn build_registry(
     let mut account_states = std::collections::BTreeMap::new();
     for (id, acfg) in &multi.accounts {
         let guard = build_account_guard(acfg).context("building dispatch guard")?;
-        let conn_cfg = build_account_connection(acfg);
+        let conn_cfg = build_account_connection(id, acfg);
         let imap = Connection::new(conn_cfg, audit.clone(), credentials.clone());
 
         let smtp = build_smtp_client(acfg, credentials)?;
@@ -217,8 +217,17 @@ fn build_account_guard(
 }
 
 /// Map a per-account config to a `ConnectionConfig`.
-fn build_account_connection(acfg: &ValidatedAccountConfig) -> ConnectionConfig {
+fn build_account_connection(
+    id: &rimap_core::account::AccountId,
+    acfg: &ValidatedAccountConfig,
+) -> ConnectionConfig {
+    let account = if id.as_str() == rimap_core::account::DEFAULT_ACCOUNT_NAME {
+        None
+    } else {
+        Some(id.as_str().to_string())
+    };
     ConnectionConfig {
+        account,
         host: acfg.imap.host.clone(),
         port: acfg.imap.port,
         username: acfg.imap.username.clone(),

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -103,11 +103,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     let registry = build_registry(&multi, &audit, &credentials)?;
 
     let audit_for_shutdown = audit.clone();
-    let mcp_server = server::ImapMcpServer {
-        registry,
-        audit,
-        download_dir,
-    };
+    let mcp_server = server::ImapMcpServer::new(registry, audit, download_dir);
 
     let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
     let mcp_result: anyhow::Result<()> = rt.block_on(async {

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -240,23 +240,92 @@ fn build_account_connection(
 }
 
 /// Resolve the attachment download directory from a multi-account config.
+///
+/// If `attachments.download_dir` is set, the path is created (if needed) and
+/// locked down to 0700 on Unix. Otherwise a per-process tempdir is created
+/// via `tempfile` (TOCTOU-safe) and then locked down to 0700 on Unix. The
+/// per-process dir is intentionally leaked (no automatic cleanup) so that
+/// downloaded attachments remain readable for the server's lifetime.
 fn resolve_download_dir_multi(
     multi: &rimap_config::validate::ValidatedMultiConfig,
 ) -> anyhow::Result<PathBuf> {
     let dir_str = &multi.attachments.download_dir;
-    if dir_str.is_empty() {
-        let tmp = std::env::temp_dir().join("rusty-imap-mcp-downloads");
-        std::fs::create_dir_all(&tmp)
-            .with_context(|| format!("creating download dir {}", tmp.display()))?;
-        Ok(tmp)
-    } else {
-        let path = PathBuf::from(dir_str);
-        if !path.is_dir() {
-            anyhow::bail!(
-                "download_dir {} does not exist or is not a directory",
-                path.display()
-            );
+    if !dir_str.is_empty() {
+        let dir = PathBuf::from(dir_str);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating attachment download_dir at {}", dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("setting 0700 perms on {}", dir.display()))?;
         }
-        Ok(path)
+        return Ok(dir);
+    }
+
+    let dir = tempfile::Builder::new()
+        .prefix("rusty-imap-mcp-")
+        .tempdir()
+        .context("creating per-process tempdir for attachments")?
+        .keep();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("setting 0700 perms on {}", dir.display()))?;
+    }
+    Ok(dir)
+}
+
+#[cfg(all(test, unix))]
+#[expect(clippy::expect_used, reason = "tests")]
+mod resolve_download_dir_tests {
+    use super::resolve_download_dir_multi;
+    use rimap_config::model::{AttachmentsConfig, AuditConfig};
+    use rimap_config::validate::ValidatedMultiConfig;
+    use std::collections::BTreeMap;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    fn minimal_multi(download_dir: String) -> ValidatedMultiConfig {
+        ValidatedMultiConfig {
+            accounts: BTreeMap::new(),
+            audit: AuditConfig {
+                path: PathBuf::from("/tmp/unused-audit.log"),
+                rotate_bytes: 10_485_760,
+                rotate_keep: 5,
+                retention_seconds: None,
+                provenance_window_seconds: 60,
+                fail_open: false,
+                allowed_base_dir: None,
+            },
+            attachments: AttachmentsConfig { download_dir },
+        }
+    }
+
+    #[test]
+    fn default_tempdir_has_0700_perms() {
+        let multi = minimal_multi(String::new());
+        let dir = resolve_download_dir_multi(&multi).expect("resolve ok");
+        let meta = std::fs::metadata(&dir).expect("metadata");
+        assert!(meta.is_dir(), "expected a directory at {}", dir.display());
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "expected 0700, got {mode:o}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn configured_dir_is_locked_down_to_0700() {
+        let base = tempfile::tempdir().expect("tempdir");
+        let target = base.path().join("attachments");
+        let multi = minimal_multi(target.to_string_lossy().into_owned());
+        let dir = resolve_download_dir_multi(&multi).expect("resolve ok");
+        assert_eq!(dir, target);
+        let mode = std::fs::metadata(&dir)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "expected 0700, got {mode:o}");
     }
 }

--- a/crates/rimap-server/src/mcp_error.rs
+++ b/crates/rimap-server/src/mcp_error.rs
@@ -30,7 +30,10 @@ pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
 pub fn to_mcp_error(err: &RimapError) -> ErrorData {
     let message = err.to_string();
     match err.code() {
-        ErrorCode::InvalidInput => ErrorData::invalid_params(message, None),
+        ErrorCode::InvalidInput | ErrorCode::NoAccount | ErrorCode::UnknownAccount => {
+            ErrorData::invalid_params(message, None)
+        }
+
         ErrorCode::NotFound => ErrorData::new(McpCode::RESOURCE_NOT_FOUND, message, None),
         ErrorCode::PostureDenied => ErrorData::new(POSTURE_DENIED, message, None),
         ErrorCode::ProtectedFolder | ErrorCode::ExpungeDenied => ErrorData::new(

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -1,0 +1,197 @@
+//! Account registry: holds per-account runtime state and resolves
+//! which account a request targets.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use rimap_authz::breaker::SystemClock;
+use rimap_authz::{DispatchGuard, FolderGuard};
+use rimap_core::RimapError;
+use rimap_core::account::AccountId;
+use rimap_imap::Connection;
+use rimap_smtp::SmtpClient;
+
+/// Per-account runtime bundle.
+///
+/// Manual `Debug` impl prints only the account id, since several
+/// inner types do not implement `Debug`.
+pub struct AccountState {
+    /// Validated account identifier.
+    pub id: AccountId,
+    /// IMAP connection for this account.
+    pub imap: Connection,
+    /// Optional SMTP client (present when sending is configured).
+    pub smtp: Option<SmtpClient>,
+    /// Rate-limit and circuit-breaker guard.
+    pub guard: DispatchGuard<SystemClock>,
+    /// Folder-level access guard.
+    pub folder_guard: FolderGuard,
+}
+
+impl std::fmt::Debug for AccountState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccountState")
+            .field("id", &self.id)
+            .field("smtp", &self.smtp.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Holds all configured accounts and the session-scoped active
+/// account selection.
+pub struct AccountRegistry {
+    accounts: BTreeMap<AccountId, AccountState>,
+    active: Mutex<Option<AccountId>>,
+}
+
+impl AccountRegistry {
+    /// Build a registry from the given accounts.
+    #[must_use]
+    pub fn new(accounts: BTreeMap<AccountId, AccountState>) -> Self {
+        Self {
+            accounts,
+            active: Mutex::new(None),
+        }
+    }
+
+    /// Resolve which account a request targets.
+    ///
+    /// Resolution order:
+    /// 1. Explicit name passed by the caller.
+    /// 2. Session-scoped active account (set via `use_account`).
+    /// 3. Auto-select when exactly one account is configured.
+    /// 4. Error listing available accounts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RimapError::UnknownAccount`] if the explicit name
+    /// does not match any configured account, or
+    /// [`RimapError::NoAccount`] if no account can be determined.
+    pub fn resolve(&self, explicit: Option<&str>) -> Result<&AccountState, RimapError> {
+        let names = || {
+            self.accounts
+                .keys()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        };
+
+        if let Some(name) = explicit {
+            return self
+                .find_by_name(name)
+                .ok_or_else(|| RimapError::UnknownAccount {
+                    name: name.to_string(),
+                    available: names(),
+                });
+        }
+
+        // Check session-scoped active account.
+        let lock = self
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(state) = lock.as_ref().and_then(|id| self.accounts.get(id)) {
+            return Ok(state);
+        }
+        drop(lock);
+
+        // Auto-select when there is exactly one account.
+        if let Some((_, state)) = (self.accounts.len() == 1)
+            .then(|| self.accounts.iter().next())
+            .flatten()
+        {
+            return Ok(state);
+        }
+
+        Err(RimapError::NoAccount { available: names() })
+    }
+
+    /// Set the session-scoped active account, returning the previous
+    /// account name (if any).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RimapError::UnknownAccount`] if `name` does not
+    /// match any configured account.
+    pub fn set_active(&self, name: &str) -> Result<Option<String>, RimapError> {
+        let id = self
+            .accounts
+            .keys()
+            .find(|k| k.as_str() == name)
+            .ok_or_else(|| RimapError::UnknownAccount {
+                name: name.to_string(),
+                available: self.accounts.keys().map(ToString::to_string).collect(),
+            })?
+            .clone();
+
+        let mut lock = self
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = lock.as_ref().map(ToString::to_string);
+        *lock = Some(id);
+        Ok(prev)
+    }
+
+    /// List all configured account names in sorted order.
+    #[must_use]
+    pub fn account_names(&self) -> Vec<&AccountId> {
+        self.accounts.keys().collect()
+    }
+
+    /// Borrow the full accounts map.
+    #[must_use]
+    pub fn accounts(&self) -> &BTreeMap<AccountId, AccountState> {
+        &self.accounts
+    }
+
+    /// Look up an account by its string name.
+    fn find_by_name(&self, name: &str) -> Option<&AccountState> {
+        self.accounts
+            .iter()
+            .find(|(k, _)| k.as_str() == name)
+            .map(|(_, v)| v)
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap_err for assertions")]
+mod tests {
+    use super::*;
+
+    // We test resolution logic through the public API using an empty
+    // registry. Constructing `AccountState` requires real IMAP
+    // connections, so full-path tests live in integration/e2e suites.
+
+    #[test]
+    fn empty_registry_returns_no_account() {
+        let reg = AccountRegistry::new(BTreeMap::new());
+        let err = reg.resolve(None).unwrap_err();
+        assert!(matches!(err, RimapError::NoAccount { available } if available.is_empty()));
+    }
+
+    #[test]
+    fn explicit_unknown_returns_unknown_account() {
+        let reg = AccountRegistry::new(BTreeMap::new());
+        let err = reg.resolve(Some("work")).unwrap_err();
+        assert!(matches!(err, RimapError::UnknownAccount { name, .. } if name == "work"));
+    }
+
+    #[test]
+    fn set_active_unknown_returns_error() {
+        let reg = AccountRegistry::new(BTreeMap::new());
+        let err = reg.set_active("nope").unwrap_err();
+        assert!(matches!(err, RimapError::UnknownAccount { name, .. } if name == "nope"));
+    }
+
+    #[test]
+    fn account_names_empty() {
+        let reg = AccountRegistry::new(BTreeMap::new());
+        assert!(reg.account_names().is_empty());
+    }
+
+    #[test]
+    fn accounts_returns_map() {
+        let reg = AccountRegistry::new(BTreeMap::new());
+        assert!(reg.accounts().is_empty());
+    }
+}

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -28,8 +28,6 @@ type InfrastructureLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, 
 pub struct AccountState {
     /// Validated account identifier.
     pub id: AccountId,
-    /// Email address used as the From header (typically the IMAP username).
-    pub from_address: String,
     /// IMAP connection for this account.
     pub imap: Connection,
     /// Optional SMTP client (present when sending is configured).

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -18,6 +18,8 @@ use rimap_smtp::SmtpClient;
 pub struct AccountState {
     /// Validated account identifier.
     pub id: AccountId,
+    /// Email address used as the From header (typically the IMAP username).
+    pub from_address: String,
     /// IMAP connection for this account.
     pub imap: Connection,
     /// Optional SMTP client (present when sending is configured).
@@ -112,6 +114,10 @@ impl AccountRegistry {
     ///
     /// Returns [`RimapError::UnknownAccount`] if `name` does not
     /// match any configured account.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by use_account handler in T6")
+    )]
     pub fn set_active(&self, name: &str) -> Result<Option<String>, RimapError> {
         let id = self
             .accounts
@@ -134,6 +140,10 @@ impl AccountRegistry {
 
     /// List all configured account names in sorted order.
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by list_accounts handler in T6")
+    )]
     pub fn account_names(&self) -> Vec<&AccountId> {
         self.accounts.keys().collect()
     }

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -112,19 +112,12 @@ impl AccountRegistry {
     /// does not match any configured account, or
     /// [`RimapError::NoAccount`] if no account can be determined.
     pub fn resolve(&self, explicit: Option<&str>) -> Result<&AccountState, RimapError> {
-        let names = || {
-            self.accounts
-                .keys()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-        };
-
         if let Some(name) = explicit {
             return self
                 .find_by_name(name)
                 .ok_or_else(|| RimapError::UnknownAccount {
                     name: name.to_string(),
-                    available: names(),
+                    available: self.account_name_strings(),
                 });
         }
 
@@ -142,7 +135,9 @@ impl AccountRegistry {
             return Ok(state);
         }
 
-        Err(RimapError::NoAccount { available: names() })
+        Err(RimapError::NoAccount {
+            available: self.account_name_strings(),
+        })
     }
 
     /// Set the session-scoped active account, returning the previous
@@ -159,7 +154,7 @@ impl AccountRegistry {
             .find(|k| k.as_str() == name)
             .ok_or_else(|| RimapError::UnknownAccount {
                 name: name.to_string(),
-                available: self.accounts.keys().map(ToString::to_string).collect(),
+                available: self.account_name_strings(),
             })?
             .clone();
 
@@ -167,14 +162,12 @@ impl AccountRegistry {
         Ok(prev.as_deref().map(ToString::to_string))
     }
 
-    /// List all configured account names in sorted order.
+    /// List all configured account names as owned strings, in sorted
+    /// order. Used to populate the `available` field on
+    /// [`RimapError::NoAccount`] and [`RimapError::UnknownAccount`].
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "convenience accessor for future use")
-    )]
-    pub fn account_names(&self) -> Vec<&AccountId> {
-        self.accounts.keys().collect()
+    fn account_name_strings(&self) -> Vec<String> {
+        self.accounts.keys().map(ToString::to_string).collect()
     }
 
     /// Borrow the full accounts map.
@@ -223,9 +216,9 @@ mod tests {
     }
 
     #[test]
-    fn account_names_empty() {
+    fn account_name_strings_empty() {
         let reg = AccountRegistry::new(BTreeMap::new());
-        assert!(reg.account_names().is_empty());
+        assert!(reg.account_name_strings().is_empty());
     }
 
     #[test]

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -3,8 +3,9 @@
 
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
-use std::sync::Mutex;
+use std::sync::Arc;
 
+use arc_swap::ArcSwapOption;
 use governor::clock::{Clock, DefaultClock};
 use governor::middleware::NoOpMiddleware;
 use governor::state::{InMemoryState, NotKeyed};
@@ -52,7 +53,7 @@ impl std::fmt::Debug for AccountState {
 /// account selection.
 pub struct AccountRegistry {
     accounts: BTreeMap<AccountId, AccountState>,
-    active: Mutex<Option<AccountId>>,
+    active: ArcSwapOption<AccountId>,
     /// Process-wide rate limiter for infrastructure tools
     /// (`use_account`, `list_accounts`). Prevents an injected prompt
     /// from flip-flopping the active account faster than a human
@@ -73,7 +74,7 @@ impl AccountRegistry {
         let quota = Quota::per_second(per_sec).allow_burst(burst);
         Self {
             accounts,
-            active: Mutex::new(None),
+            active: ArcSwapOption::empty(),
             infrastructure_limiter: RateLimiter::direct(quota),
             clock: DefaultClock::default(),
         }
@@ -130,14 +131,10 @@ impl AccountRegistry {
         }
 
         // Check session-scoped active account.
-        let lock = self
-            .active
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(state) = lock.as_ref().and_then(|id| self.accounts.get(id)) {
+        let active = self.active.load_full();
+        if let Some(state) = active.as_deref().and_then(|id| self.accounts.get(id)) {
             return Ok(state);
         }
-        drop(lock);
 
         // Auto-select when there is exactly one account.
         if let Some((_, state)) = (self.accounts.len() == 1)
@@ -168,13 +165,8 @@ impl AccountRegistry {
             })?
             .clone();
 
-        let mut lock = self
-            .active
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = lock.as_ref().map(ToString::to_string);
-        *lock = Some(id);
-        Ok(prev)
+        let prev = self.active.swap(Some(Arc::new(id)));
+        Ok(prev.as_deref().map(ToString::to_string))
     }
 
     /// List all configured account names in sorted order.
@@ -242,5 +234,47 @@ mod tests {
     fn accounts_returns_map() {
         let reg = AccountRegistry::new(BTreeMap::new());
         assert!(reg.accounts().is_empty());
+    }
+
+    #[test]
+    fn concurrent_active_swap_and_resolve() {
+        // Exercises the ArcSwapOption-backed active slot under
+        // concurrent writers and readers. The registry is empty
+        // (AccountState requires live IMAP connections), so resolve()
+        // must always return NoAccount regardless of interleaving;
+        // the property under test is that readers never observe a
+        // torn or invalid state and the process does not panic.
+        use std::sync::Arc;
+        use std::thread;
+
+        let reg = Arc::new(AccountRegistry::new(BTreeMap::new()));
+        let mut handles = Vec::new();
+
+        for _ in 0..2 {
+            let reg = Arc::clone(&reg);
+            handles.push(thread::spawn(move || {
+                for _ in 0..100 {
+                    // set_active on an unknown name must return
+                    // UnknownAccount, not panic, even when other
+                    // threads are swapping or loading concurrently.
+                    let err = reg.set_active("nope").unwrap_err();
+                    assert!(matches!(err, RimapError::UnknownAccount { .. }));
+                }
+            }));
+        }
+
+        for _ in 0..2 {
+            let reg = Arc::clone(&reg);
+            handles.push(thread::spawn(move || {
+                for _ in 0..100 {
+                    let err = reg.resolve(None).unwrap_err();
+                    assert!(matches!(err, RimapError::NoAccount { .. }));
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
     }
 }

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -114,10 +114,6 @@ impl AccountRegistry {
     ///
     /// Returns [`RimapError::UnknownAccount`] if `name` does not
     /// match any configured account.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by use_account handler in T6")
-    )]
     pub fn set_active(&self, name: &str) -> Result<Option<String>, RimapError> {
         let id = self
             .accounts
@@ -142,7 +138,7 @@ impl AccountRegistry {
     #[must_use]
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "used by list_accounts handler in T6")
+        expect(dead_code, reason = "convenience accessor for future use")
     )]
     pub fn account_names(&self) -> Vec<&AccountId> {
         self.accounts.keys().collect()

--- a/crates/rimap-server/src/registry.rs
+++ b/crates/rimap-server/src/registry.rs
@@ -2,14 +2,23 @@
 //! which account a request targets.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroU32;
 use std::sync::Mutex;
 
+use governor::clock::{Clock, DefaultClock};
+use governor::middleware::NoOpMiddleware;
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter};
 use rimap_authz::breaker::SystemClock;
 use rimap_authz::{DispatchGuard, FolderGuard};
 use rimap_core::RimapError;
 use rimap_core::account::AccountId;
+use rimap_core::error::ErrorCode;
 use rimap_imap::Connection;
 use rimap_smtp::SmtpClient;
+
+/// In-memory, unkeyed governor limiter used for infrastructure tools.
+type InfrastructureLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;
 
 /// Per-account runtime bundle.
 ///
@@ -44,16 +53,50 @@ impl std::fmt::Debug for AccountState {
 pub struct AccountRegistry {
     accounts: BTreeMap<AccountId, AccountState>,
     active: Mutex<Option<AccountId>>,
+    /// Process-wide rate limiter for infrastructure tools
+    /// (`use_account`, `list_accounts`). Prevents an injected prompt
+    /// from flip-flopping the active account faster than a human
+    /// would. 5 req/sec sustained, burst of 10.
+    infrastructure_limiter: InfrastructureLimiter,
+    /// Clock used by the infrastructure limiter; stored so that
+    /// `wait_time_from` can format retry hints.
+    clock: DefaultClock,
 }
 
 impl AccountRegistry {
     /// Build a registry from the given accounts.
     #[must_use]
     pub fn new(accounts: BTreeMap<AccountId, AccountState>) -> Self {
+        // Safety: literals are non-zero.
+        let per_sec = NonZeroU32::new(5).unwrap_or(NonZeroU32::MIN);
+        let burst = NonZeroU32::new(10).unwrap_or(NonZeroU32::MIN);
+        let quota = Quota::per_second(per_sec).allow_burst(burst);
         Self {
             accounts,
             active: Mutex::new(None),
+            infrastructure_limiter: RateLimiter::direct(quota),
+            clock: DefaultClock::default(),
         }
+    }
+
+    /// Check the infrastructure-tool rate limit. Called by
+    /// `dispatch_infrastructure` before executing `use_account` or
+    /// `list_accounts`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RimapError::Authz`] with
+    /// [`ErrorCode::RateLimited`] when the limit is exceeded. The
+    /// error message includes a retry hint in milliseconds.
+    pub fn check_infrastructure_rate(&self) -> Result<(), RimapError> {
+        self.infrastructure_limiter.check().map_err(|not_until| {
+            let wait_ms = u64::try_from(not_until.wait_time_from(self.clock.now()).as_millis())
+                .unwrap_or(u64::MAX);
+            RimapError::Authz {
+                code: ErrorCode::RateLimited,
+                message: format!("infrastructure tool rate limit exceeded; retry in {wait_ms}ms",),
+            }
+        })
     }
 
     /// Resolve which account a request targets.

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -134,6 +134,16 @@ impl ServerHandler for ImapMcpServer {
             )
         })?;
 
+        // Validate the account name before using it in a lookup or
+        // echoing it back in any error. Do not reflect the raw input.
+        AccountId::new(account_name).map_err(|_| {
+            ErrorData::new(
+                McpCode::RESOURCE_NOT_FOUND,
+                "invalid account name in resource URI".to_string(),
+                None,
+            )
+        })?;
+
         let state = self
             .registry
             .resolve(Some(account_name))
@@ -308,6 +318,11 @@ impl ImapMcpServer {
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<CallToolResult, ErrorData> {
+        // Infrastructure tools bypass posture + breaker, but still
+        // enforce a process-wide rate limit.
+        if let Err(e) = self.registry.check_infrastructure_rate() {
+            return Err(crate::mcp_error::to_mcp_error(&e));
+        }
         let result = match tool {
             ToolName::UseAccount => {
                 let input: crate::tools::accounts::UseAccountInput =

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -49,6 +49,15 @@ impl ServerHandler for ImapMcpServer {
         let mut tools: Vec<Tool> = Vec::new();
         let mut seen = std::collections::HashSet::new();
 
+        // Infrastructure tools — always advertised.
+        for name in [ToolName::UseAccount, ToolName::ListAccounts] {
+            if let Some(def) = tool_definition(name) {
+                seen.insert(name);
+                tools.push(def);
+            }
+        }
+
+        // Union of posture-filtered tools from all accounts.
         for state in self.registry.accounts().values() {
             for &tn in &state.guard.matrix().advertised() {
                 if seen.insert(tn)
@@ -191,16 +200,33 @@ impl ImapMcpServer {
     }
 
     /// Handle infrastructure tools that bypass account resolution.
-    #[expect(clippy::unused_self, reason = "T6 will use self.registry")]
     fn dispatch_infrastructure(
         &self,
         tool: ToolName,
-        _args: &serde_json::Map<String, serde_json::Value>,
+        args: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<CallToolResult, ErrorData> {
-        Err(ErrorData::internal_error(
-            format!("{} not yet implemented", tool.as_str()),
-            None,
-        ))
+        let result = match tool {
+            ToolName::UseAccount => {
+                let input: crate::tools::accounts::UseAccountInput =
+                    parse_args(args).map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
+                crate::tools::accounts::handle_use_account(&self.registry, &input)
+            }
+            ToolName::ListAccounts => crate::tools::accounts::handle_list_accounts(&self.registry),
+            _ => {
+                return Err(ErrorData::internal_error(
+                    format!("not an infrastructure tool: {}", tool.as_str(),),
+                    None,
+                ));
+            }
+        };
+        match result {
+            Ok(resp) => {
+                let value = serde_json::to_value(&resp)
+                    .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+                Ok(CallToolResult::structured(value))
+            }
+            Err(e) => Err(crate::mcp_error::to_mcp_error(&e)),
+        }
     }
 }
 
@@ -234,7 +260,8 @@ fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::
 fn tool_definition(name: ToolName) -> Option<Tool> {
     let (tool_name, description, schema) = tool_spec_v1(name)
         .or_else(|| tool_spec_v2(name))
-        .or_else(|| tool_spec_v3(name))?;
+        .or_else(|| tool_spec_v3(name))
+        .or_else(|| tool_spec_infra(name))?;
     Some(Tool::new(tool_name, description, Arc::new(schema)))
 }
 
@@ -384,6 +411,26 @@ fn tool_spec_v3(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
+/// Return (name, description, schema) for infrastructure tools.
+fn tool_spec_infra(name: ToolName) -> Option<ToolSpec> {
+    use crate::tools::accounts::UseAccountInput;
+
+    let tuple = match name {
+        ToolName::UseAccount => (
+            "use_account",
+            "Set the active account for subsequent tool calls",
+            schema_map::<UseAccountInput>(),
+        ),
+        ToolName::ListAccounts => (
+            "list_accounts",
+            "List all configured email accounts",
+            serde_json::Map::new(),
+        ),
+        _ => return None,
+    };
+    Some(tuple)
+}
+
 #[cfg(test)]
 mod tests {
     use rimap_core::tool::ToolName;
@@ -396,8 +443,8 @@ mod tests {
             .into_iter()
             .filter_map(tool_definition)
             .collect();
-        // 22 tool variants minus 2 sub-capabilities = 20
-        assert_eq!(defs.len(), 20);
+        // 24 tool variants minus 2 sub-capabilities = 22
+        assert_eq!(defs.len(), 22);
     }
 
     #[test]
@@ -420,8 +467,9 @@ mod tests {
     #[test]
     fn tool_definitions_have_non_empty_schemas() {
         for def in ToolName::all().into_iter().filter_map(tool_definition) {
-            // list_folders has no input — empty schema is expected.
-            if def.name == "list_folders" {
+            // list_folders and list_accounts have no input — empty
+            // schema is expected.
+            if def.name == "list_folders" || def.name == "list_accounts" {
                 continue;
             }
             let schema = &def.input_schema;

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -172,6 +172,9 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::folder_mgmt::handle_delete(self, input)).await
             }
+            ToolName::AddLabel | ToolName::RemoveLabel | ToolName::ListLabels => Err(
+                rimap_core::RimapError::Internal("label tools not yet implemented".into()),
+            ),
         }
     }
 }

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -876,12 +876,16 @@ mod tests {
 
     #[test]
     fn tool_definition_covers_all_mcp_tools() {
+        // Sub-capabilities are surfaced via their parent tool's schema, not
+        // as standalone MCP tools, so they do not appear in `TOOL_DEFS`.
+        const SUB_CAPABILITIES: &[ToolName] =
+            &[ToolName::SearchAdvanced, ToolName::FetchMessageHtml];
+        let expected = ToolName::all().len() - SUB_CAPABILITIES.len();
         let defs: Vec<_> = ToolName::all()
             .into_iter()
             .filter_map(|tn| TOOL_DEFS.get(&tn))
             .collect();
-        // 24 tool variants minus 2 sub-capabilities = 22
-        assert_eq!(defs.len(), 22);
+        assert_eq!(defs.len(), expected);
     }
 
     #[test]

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -150,7 +150,6 @@ impl ServerHandler for ImapMcpServer {
         let metadata = serde_json::json!({
             "name": account_name,
             "imap_host": state.imap.host(),
-            "posture": state.guard.matrix().posture().as_str(),
             "smtp_configured": state.smtp.is_some(),
             "available_tools": available_tools,
         });

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -451,7 +451,9 @@ impl ImapMcpServer {
                     Err(e) => Err(e),
                 }
             }
-            ToolName::ListAccounts => crate::tools::accounts::handle_list_accounts(&self.registry),
+            ToolName::ListAccounts => {
+                Ok(crate::tools::accounts::handle_list_accounts(&self.registry))
+            }
             _ => Err(rimap_core::RimapError::Internal(format!(
                 "not an infrastructure tool: {}",
                 tool.as_str(),

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -16,7 +16,8 @@ use rmcp::RoleServer;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ErrorCode as McpCode, ErrorData, Implementation,
-    ListToolsResult, PaginatedRequestParams, ServerInfo, Tool,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, RawResource,
+    ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 
@@ -69,6 +70,77 @@ impl ServerHandler for ImapMcpServer {
         }
 
         Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        let resources: Vec<Resource> = self
+            .registry
+            .accounts()
+            .values()
+            .map(|state| {
+                let name = state.id.as_str();
+                let desc = format!(
+                    "IMAP account: {} on {}",
+                    state.from_address,
+                    state.imap.host(),
+                );
+                Resource {
+                    raw: RawResource::new(format!("rimap://accounts/{name}"), name)
+                        .with_description(desc)
+                        .with_mime_type("application/json"),
+                    annotations: None,
+                }
+            })
+            .collect();
+        Ok(ListResourcesResult::with_all_items(resources))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        let uri = &request.uri;
+        let account_name = uri.strip_prefix("rimap://accounts/").ok_or_else(|| {
+            ErrorData::new(
+                McpCode::INVALID_PARAMS,
+                format!("unsupported resource URI: {uri}"),
+                None,
+            )
+        })?;
+
+        let state = self
+            .registry
+            .resolve(Some(account_name))
+            .map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
+
+        let available_tools: Vec<String> = state
+            .guard
+            .matrix()
+            .advertised()
+            .iter()
+            .filter_map(|tn| tool_definition(*tn).map(|d| d.name.to_string()))
+            .collect();
+
+        let metadata = serde_json::json!({
+            "name": account_name,
+            "imap_host": state.imap.host(),
+            "posture": state.guard.matrix().posture().as_str(),
+            "smtp_configured": state.smtp.is_some(),
+            "available_tools": available_tools,
+        });
+
+        let text = serde_json::to_string_pretty(&metadata)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let contents =
+            ResourceContents::text(text, uri.as_str()).with_mime_type("application/json");
+
+        Ok(ReadResourceResult::new(vec![contents]))
     }
 
     async fn call_tool(

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use rimap_audit::AuditWriter;
+use rimap_core::account::{AccountId, DEFAULT_ACCOUNT_NAME};
 use rimap_core::tool::ToolName;
 use rmcp::RoleServer;
 use rmcp::handler::server::ServerHandler;
@@ -48,24 +49,44 @@ impl ServerHandler for ImapMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         let mut tools: Vec<Tool> = Vec::new();
-        let mut seen = std::collections::HashSet::new();
 
-        // Infrastructure tools — always advertised.
+        // Infrastructure tools — always advertised, never namespaced.
         for name in [ToolName::UseAccount, ToolName::ListAccounts] {
             if let Some(def) = tool_definition(name) {
-                seen.insert(name);
                 tools.push(def);
             }
         }
 
-        // Union of posture-filtered tools from all accounts.
-        for state in self.registry.accounts().values() {
+        let accounts = self.registry.accounts();
+        let use_bare_names = is_legacy_single_account(accounts);
+
+        for (id, state) in accounts {
             for &tn in &state.guard.matrix().advertised() {
-                if seen.insert(tn)
-                    && let Some(def) = tool_definition(tn)
-                {
-                    tools.push(def);
-                }
+                let Some(base_def) = tool_definition(tn) else {
+                    continue;
+                };
+                let tool_name = if use_bare_names {
+                    base_def.name.clone()
+                } else {
+                    format!("{}.{}", id.as_str(), base_def.name).into()
+                };
+                let description = if use_bare_names {
+                    base_def.description.clone()
+                } else {
+                    Some(
+                        format!(
+                            "[account: {}, posture: {}] {}",
+                            id.as_str(),
+                            state.guard.matrix().posture().as_str(),
+                            base_def.description.as_deref().unwrap_or(""),
+                        )
+                        .into(),
+                    )
+                };
+                let mut def = base_def.clone();
+                def.name = tool_name;
+                def.description = description;
+                tools.push(def);
             }
         }
 
@@ -148,7 +169,9 @@ impl ServerHandler for ImapMcpServer {
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let tool_name = ToolName::from_str(&request.name)
+        let (namespaced_account, bare_name) = split_tool_name(&request.name);
+
+        let tool_name = ToolName::from_str(bare_name)
             .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
 
         // Reject tools that have no definition (not yet implemented).
@@ -164,19 +187,28 @@ impl ServerHandler for ImapMcpServer {
 
         let mut args = request.arguments.unwrap_or_default();
 
-        // Infrastructure tools bypass account resolution and guards.
+        // Infrastructure tools bypass account resolution and guards and
+        // must never be namespaced.
         if matches!(tool_name, ToolName::UseAccount | ToolName::ListAccounts) {
+            if namespaced_account.is_some() {
+                return Err(ErrorData::invalid_params(
+                    "infrastructure tools cannot be namespaced".to_string(),
+                    None,
+                ));
+            }
             return self.dispatch_infrastructure(tool_name, &args);
         }
 
-        // Extract and strip the optional "account" key.
-        let account_name = args
-            .remove("account")
-            .and_then(|v| v.as_str().map(String::from));
+        // Account resolution order: URI namespace > args["account"] >
+        // session default > auto-select.
+        let explicit_account = namespaced_account.map(String::from).or_else(|| {
+            args.remove("account")
+                .and_then(|v| v.as_str().map(String::from))
+        });
 
         let account = self
             .registry
-            .resolve(account_name.as_deref())
+            .resolve(explicit_account.as_deref())
             .map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
 
         if let Err(e) = crate::dispatch::pre_call_guards(&account.guard, tool_name) {
@@ -323,6 +355,45 @@ fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::
         }
         _ => serde_json::Map::new(),
     }
+}
+
+/// Whether the registry holds exactly one account and its id is the
+/// legacy `"default"` value. Used to preserve bare (non-namespaced)
+/// tool names for single-account deployments.
+fn is_legacy_single_account(
+    accounts: &std::collections::BTreeMap<AccountId, AccountState>,
+) -> bool {
+    accounts.len() == 1
+        && accounts
+            .keys()
+            .next()
+            .is_some_and(|id| id.as_str() == DEFAULT_ACCOUNT_NAME)
+}
+
+/// Split a possibly-namespaced MCP tool name into `(account, tool)`.
+///
+/// Preserves sub-capability tool names that contain dots (e.g.
+/// `search.advanced_query`): if the raw name parses as a `ToolName`
+/// directly, return it as bare.
+fn split_tool_name(raw: &str) -> (Option<&str>, &str) {
+    if ToolName::from_str(raw).is_ok() {
+        return (None, raw);
+    }
+    match raw.split_once('.') {
+        Some((prefix, rest))
+            if is_valid_account_prefix(prefix) && ToolName::from_str(rest).is_ok() =>
+        {
+            (Some(prefix), rest)
+        }
+        _ => (None, raw),
+    }
+}
+
+/// Structural check on an account-namespace prefix. Mirrors the
+/// `AccountId` character rules (ASCII alphanumerics + hyphens, 1–64
+/// chars) without allocating.
+fn is_valid_account_prefix(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 64 && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
 /// Build an rmcp `Tool` definition for a `ToolName`. Returns `None`
@@ -507,7 +578,50 @@ fn tool_spec_infra(name: ToolName) -> Option<ToolSpec> {
 mod tests {
     use rimap_core::tool::ToolName;
 
-    use super::tool_definition;
+    use super::{split_tool_name, tool_definition};
+
+    #[test]
+    fn split_tool_name_bare() {
+        assert_eq!(split_tool_name("send_email"), (None, "send_email"));
+    }
+
+    #[test]
+    fn split_tool_name_namespaced() {
+        assert_eq!(
+            split_tool_name("work.send_email"),
+            (Some("work"), "send_email"),
+        );
+    }
+
+    #[test]
+    fn split_tool_name_preserves_dotted_sub_capability() {
+        // `search.advanced_query` is a valid ToolName and must not be
+        // interpreted as account="search", tool="advanced_query".
+        assert_eq!(
+            split_tool_name("search.advanced_query"),
+            (None, "search.advanced_query"),
+        );
+        assert_eq!(
+            split_tool_name("fetch_message.include_html"),
+            (None, "fetch_message.include_html"),
+        );
+    }
+
+    #[test]
+    fn split_tool_name_unknown_returns_bare() {
+        // Unknown names pass through; `from_str` at the caller rejects.
+        assert_eq!(split_tool_name("garbage"), (None, "garbage"));
+        assert_eq!(split_tool_name("work.garbage"), (None, "work.garbage"),);
+    }
+
+    #[test]
+    fn split_tool_name_rejects_invalid_prefix() {
+        // Underscore is not valid in an account prefix.
+        assert_eq!(
+            split_tool_name("bad_name.send_email"),
+            (None, "bad_name.send_email"),
+        );
+    }
 
     #[test]
     fn tool_definition_covers_all_mcp_tools() {

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -184,6 +184,9 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::labels::handle_list_labels(self, input)).await
             }
+            ToolName::UseAccount | ToolName::ListAccounts => Err(rimap_core::RimapError::Internal(
+                "not yet implemented".into(),
+            )),
         }
     }
 }

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -52,8 +52,8 @@ impl ServerHandler for ImapMcpServer {
 
         // Infrastructure tools — always advertised, never namespaced.
         for name in [ToolName::UseAccount, ToolName::ListAccounts] {
-            if let Some(def) = tool_definition(name) {
-                tools.push(def);
+            if let Some(def) = TOOL_DEFS.get(&name) {
+                tools.push(def.clone());
             }
         }
 
@@ -62,7 +62,7 @@ impl ServerHandler for ImapMcpServer {
 
         for (id, state) in accounts {
             for &tn in &state.guard.matrix().advertised() {
-                let Some(base_def) = tool_definition(tn) else {
+                let Some(base_def) = TOOL_DEFS.get(&tn) else {
                     continue;
                 };
                 let tool_name = if use_bare_names {
@@ -144,7 +144,7 @@ impl ServerHandler for ImapMcpServer {
             .matrix()
             .advertised()
             .iter()
-            .filter_map(|tn| tool_definition(*tn).map(|d| d.name.to_string()))
+            .filter_map(|tn| TOOL_DEFS.get(tn).map(|d| d.name.to_string()))
             .collect();
 
         let metadata = serde_json::json!({
@@ -177,7 +177,7 @@ impl ServerHandler for ImapMcpServer {
         // Reject tools that have no definition (not yet implemented).
         // This prevents unimplemented v2 tools from consuming rate
         // limiter tokens and producing misleading INTERNAL_ERROR.
-        if tool_definition(tool_name).is_none() {
+        if TOOL_DEFS.get(&tool_name).is_none() {
             return Err(ErrorData::new(
                 McpCode::RESOURCE_NOT_FOUND,
                 format!("tool `{}` is not available", request.name),
@@ -396,18 +396,6 @@ fn is_valid_account_prefix(s: &str) -> bool {
     !s.is_empty() && s.len() <= 64 && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
-/// Build an rmcp `Tool` definition for a `ToolName`. Returns `None`
-/// for sub-capabilities that share an MCP tool name with a parent
-/// (e.g. `SearchAdvanced` and `FetchMessageHtml` are gated
-/// sub-capabilities, not separate MCP tools).
-fn tool_definition(name: ToolName) -> Option<Tool> {
-    let (tool_name, description, schema) = tool_spec_v1(name)
-        .or_else(|| tool_spec_v2(name))
-        .or_else(|| tool_spec_v3(name))
-        .or_else(|| tool_spec_infra(name))?;
-    Some(Tool::new(tool_name, description, Arc::new(schema)))
-}
-
 /// Type alias for tool spec tuples.
 type ToolSpec = (
     &'static str,
@@ -415,14 +403,22 @@ type ToolSpec = (
     serde_json::Map<String, serde_json::Value>,
 );
 
-/// Return (name, description, schema) for v1 read/organize tools.
-fn tool_spec_v1(name: ToolName) -> Option<ToolSpec> {
+/// Return (name, description, schema) for the given `ToolName`, or
+/// `None` for sub-capabilities that share an MCP tool name with a
+/// parent (e.g. `SearchAdvanced`, `FetchMessageHtml`).
+fn tool_spec(name: ToolName) -> Option<ToolSpec> {
+    tool_spec_read(name)
+        .or_else(|| tool_spec_write(name))
+        .or_else(|| tool_spec_labels(name))
+        .or_else(|| tool_spec_infra(name))
+}
+
+fn tool_spec_read(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::{
         create_draft::CreateDraftInput, download_attachment::DownloadAttachmentInput,
         fetch_message::FetchMessageInput, flags::FlagInput, list_attachments::ListAttachmentsInput,
         move_message::MoveInput, search::SearchInput,
     };
-
     let tuple = match name {
         ToolName::ListFolders => (
             "list_folders",
@@ -484,15 +480,13 @@ fn tool_spec_v1(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
-/// Return (name, description, schema) for v2 write/management tools.
-fn tool_spec_v2(name: ToolName) -> Option<ToolSpec> {
+fn tool_spec_write(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::{
         delete_message::DeleteMessageInput,
         expunge::ExpungeInput,
         folder_mgmt::{CreateFolderInput, DeleteFolderInput, RenameFolderInput},
         send_email::SendEmailInput,
     };
-
     let tuple = match name {
         ToolName::SendEmail => (
             "send_email",
@@ -529,10 +523,8 @@ fn tool_spec_v2(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
-/// Return (name, description, schema) for v3 label tools.
-fn tool_spec_v3(name: ToolName) -> Option<ToolSpec> {
+fn tool_spec_labels(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::labels::{LabelInput, ListLabelsInput};
-
     let tuple = match name {
         ToolName::AddLabel => (
             "add_label",
@@ -554,10 +546,8 @@ fn tool_spec_v3(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
-/// Return (name, description, schema) for infrastructure tools.
 fn tool_spec_infra(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::accounts::UseAccountInput;
-
     let tuple = match name {
         ToolName::UseAccount => (
             "use_account",
@@ -574,11 +564,25 @@ fn tool_spec_infra(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
+/// Memoized MCP tool definitions. Built once at first access; each
+/// `list_tools` call reuses the same `Arc<JsonObject>` for schemas.
+static TOOL_DEFS: std::sync::LazyLock<std::collections::HashMap<ToolName, Tool>> =
+    std::sync::LazyLock::new(|| {
+        let mut map = std::collections::HashMap::new();
+        for tn in ToolName::all() {
+            let Some((name, description, schema)) = tool_spec(tn) else {
+                continue;
+            };
+            map.insert(tn, Tool::new(name, description, Arc::new(schema)));
+        }
+        map
+    });
+
 #[cfg(test)]
 mod tests {
     use rimap_core::tool::ToolName;
 
-    use super::{split_tool_name, tool_definition};
+    use super::{TOOL_DEFS, split_tool_name};
 
     #[test]
     fn split_tool_name_bare() {
@@ -627,7 +631,7 @@ mod tests {
     fn tool_definition_covers_all_mcp_tools() {
         let defs: Vec<_> = ToolName::all()
             .into_iter()
-            .filter_map(tool_definition)
+            .filter_map(|tn| TOOL_DEFS.get(&tn))
             .collect();
         // 24 tool variants minus 2 sub-capabilities = 22
         assert_eq!(defs.len(), 22);
@@ -635,13 +639,16 @@ mod tests {
 
     #[test]
     fn sub_capabilities_return_none() {
-        assert!(tool_definition(ToolName::SearchAdvanced).is_none());
-        assert!(tool_definition(ToolName::FetchMessageHtml).is_none());
+        assert!(TOOL_DEFS.get(&ToolName::SearchAdvanced).is_none());
+        assert!(TOOL_DEFS.get(&ToolName::FetchMessageHtml).is_none());
     }
 
     #[test]
     fn tool_names_are_snake_case() {
-        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+        for def in ToolName::all()
+            .into_iter()
+            .filter_map(|tn| TOOL_DEFS.get(&tn))
+        {
             assert!(
                 def.name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
                 "tool name {} is not snake_case",
@@ -652,7 +659,10 @@ mod tests {
 
     #[test]
     fn tool_definitions_have_non_empty_schemas() {
-        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+        for def in ToolName::all()
+            .into_iter()
+            .filter_map(|tn| TOOL_DEFS.get(&tn))
+        {
             // list_folders and list_accounts have no input — empty
             // schema is expected.
             if def.name == "list_folders" || def.name == "list_accounts" {
@@ -669,7 +679,10 @@ mod tests {
 
     #[test]
     fn every_tool_has_a_description() {
-        for def in ToolName::all().into_iter().filter_map(tool_definition) {
+        for def in ToolName::all()
+            .into_iter()
+            .filter_map(|tn| TOOL_DEFS.get(&tn))
+        {
             assert!(
                 def.description.is_some(),
                 "tool {} missing description",

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -131,7 +131,7 @@ impl ServerHandler for ImapMcpServer {
                 let name = state.id.as_str();
                 let desc = format!(
                     "IMAP account: {} on {}",
-                    state.from_address,
+                    state.imap.username(),
                     state.imap.host(),
                 );
                 Resource {

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -1,21 +1,17 @@
 //! MCP server struct and `ServerHandler` implementation.
 //!
-//! `ImapMcpServer` holds the validated config, IMAP connection, authz
-//! guard, audit writer, and download directory. The `ServerHandler`
-//! trait wires `list_tools` (posture-filtered) and `call_tool`
-//! (dispatch pipeline).
+//! `ImapMcpServer` owns an `AccountRegistry` (per-account IMAP/SMTP
+//! connections, guards), an audit writer, and the download directory.
+//! The `ServerHandler` trait wires `list_tools` (posture-filtered
+//! union across accounts) and `call_tool` (account resolution +
+//! dispatch pipeline).
 
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use rimap_audit::AuditWriter;
-use rimap_authz::DispatchGuard;
-use rimap_authz::FolderGuard;
-use rimap_authz::breaker::SystemClock;
-use rimap_config::validate::ValidatedConfig;
 use rimap_core::tool::ToolName;
-use rimap_imap::Connection;
 use rmcp::RoleServer;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
@@ -24,21 +20,17 @@ use rmcp::model::{
 };
 use rmcp::service::RequestContext;
 
+use crate::registry::{AccountRegistry, AccountState};
+
 /// Core MCP server. Owns every resource the handler methods need.
 pub struct ImapMcpServer {
-    /// Validated configuration snapshot.
-    pub(crate) config: ValidatedConfig,
-    /// Lazy-connect IMAP connection handle.
-    pub(crate) imap: Connection,
-    /// Posture + circuit breaker + rate limiter guard.
-    pub(crate) guard: DispatchGuard<SystemClock>,
+    /// Account registry holding per-account state.
+    pub(crate) registry: AccountRegistry,
     /// Append-only audit writer.
     #[expect(dead_code, reason = "used by audit logging in later sprint")]
     pub(crate) audit: AuditWriter,
     /// Directory for attachment downloads.
     pub(crate) download_dir: PathBuf,
-    /// Folder safety guard (protected folders + expunge allowlist).
-    pub(crate) folder_guard: FolderGuard,
 }
 
 impl ServerHandler for ImapMcpServer {
@@ -54,11 +46,19 @@ impl ServerHandler for ImapMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        let allowed = self.guard.matrix().advertised();
-        let tools: Vec<Tool> = allowed
-            .iter()
-            .filter_map(|&tn| tool_definition(tn))
-            .collect();
+        let mut tools: Vec<Tool> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for state in self.registry.accounts().values() {
+            for &tn in &state.guard.matrix().advertised() {
+                if seen.insert(tn)
+                    && let Some(def) = tool_definition(tn)
+                {
+                    tools.push(def);
+                }
+            }
+        }
+
         Ok(ListToolsResult::with_all_items(tools))
     }
 
@@ -81,12 +81,28 @@ impl ServerHandler for ImapMcpServer {
             ));
         }
 
-        if let Err(e) = crate::dispatch::pre_call_guards(&self.guard, tool_name) {
+        let mut args = request.arguments.unwrap_or_default();
+
+        // Infrastructure tools bypass account resolution and guards.
+        if matches!(tool_name, ToolName::UseAccount | ToolName::ListAccounts) {
+            return self.dispatch_infrastructure(tool_name, &args);
+        }
+
+        // Extract and strip the optional "account" key.
+        let account_name = args
+            .remove("account")
+            .and_then(|v| v.as_str().map(String::from));
+
+        let account = self
+            .registry
+            .resolve(account_name.as_deref())
+            .map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
+
+        if let Err(e) = crate::dispatch::pre_call_guards(&account.guard, tool_name) {
             return Err(crate::mcp_error::to_mcp_error(&e));
         }
 
-        let args = request.arguments.unwrap_or_default();
-        let result = Box::pin(self.dispatch_tool(tool_name, &args)).await;
+        let result = Box::pin(self.dispatch_tool(account, tool_name, &args)).await;
 
         match result {
             Ok(resp) => {
@@ -103,91 +119,88 @@ impl ImapMcpServer {
     /// Dispatch to the tool handler for `tool`.
     pub(crate) async fn dispatch_tool(
         &self,
+        account: &AccountState,
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
+        use crate::tools::{
+            create_draft, delete_message, download_attachment, expunge, fetch_message, flags,
+            folder_mgmt, labels, list_attachments, list_folders, move_message, search, send_email,
+        };
         match tool {
-            ToolName::ListFolders => Box::pin(crate::tools::list_folders::handle(self)).await,
+            ToolName::ListFolders => Box::pin(list_folders::handle(account)).await,
             ToolName::MarkRead => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::flags::handle_mark_read(self, input)).await
+                Box::pin(flags::handle_mark_read(account, parse_args(args)?)).await
             }
             ToolName::MarkUnread => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::flags::handle_mark_unread(self, input)).await
+                Box::pin(flags::handle_mark_unread(account, parse_args(args)?)).await
             }
-            ToolName::Flag => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::flags::handle_flag(self, input)).await
-            }
-            ToolName::Unflag => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::flags::handle_unflag(self, input)).await
-            }
+            ToolName::Flag => Box::pin(flags::handle_flag(account, parse_args(args)?)).await,
+            ToolName::Unflag => Box::pin(flags::handle_unflag(account, parse_args(args)?)).await,
             ToolName::MoveMessage => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::move_message::handle(self, input)).await
+                Box::pin(move_message::handle(account, parse_args(args)?)).await
             }
             ToolName::Search | ToolName::SearchAdvanced => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::search::handle(self, input)).await
+                Box::pin(search::handle(account, parse_args(args)?)).await
             }
             ToolName::FetchMessage | ToolName::FetchMessageHtml => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::fetch_message::handle(self, input)).await
+                Box::pin(fetch_message::handle(account, parse_args(args)?)).await
             }
             ToolName::ListAttachments => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::list_attachments::handle(self, input)).await
+                Box::pin(list_attachments::handle(account, parse_args(args)?)).await
             }
             ToolName::DownloadAttachment => {
                 let input = parse_args(args)?;
-                Box::pin(crate::tools::download_attachment::handle(self, input)).await
+                Box::pin(download_attachment::handle(
+                    account,
+                    input,
+                    &self.download_dir,
+                ))
+                .await
             }
             ToolName::CreateDraft => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::create_draft::handle(self, input)).await
+                Box::pin(create_draft::handle(account, parse_args(args)?)).await
             }
-            ToolName::SendEmail => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::send_email::handle(self, input)).await
-            }
+            ToolName::SendEmail => Box::pin(send_email::handle(account, parse_args(args)?)).await,
             ToolName::DeleteMessage => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::delete_message::handle(self, input)).await
+                Box::pin(delete_message::handle(account, parse_args(args)?)).await
             }
-            ToolName::Expunge => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::expunge::handle(self, input)).await
-            }
+            ToolName::Expunge => Box::pin(expunge::handle(account, parse_args(args)?)).await,
             ToolName::CreateFolder => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::folder_mgmt::handle_create(self, input)).await
+                Box::pin(folder_mgmt::handle_create(account, parse_args(args)?)).await
             }
             ToolName::RenameFolder => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::folder_mgmt::handle_rename(self, input)).await
+                Box::pin(folder_mgmt::handle_rename(account, parse_args(args)?)).await
             }
             ToolName::DeleteFolder => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::folder_mgmt::handle_delete(self, input)).await
+                Box::pin(folder_mgmt::handle_delete(account, parse_args(args)?)).await
             }
             ToolName::AddLabel => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::labels::handle_add_label(self, input)).await
+                Box::pin(labels::handle_add_label(account, parse_args(args)?)).await
             }
             ToolName::RemoveLabel => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::labels::handle_remove_label(self, input)).await
+                Box::pin(labels::handle_remove_label(account, parse_args(args)?)).await
             }
             ToolName::ListLabels => {
-                let input = parse_args(args)?;
-                Box::pin(crate::tools::labels::handle_list_labels(self, input)).await
+                Box::pin(labels::handle_list_labels(account, parse_args(args)?)).await
             }
             ToolName::UseAccount | ToolName::ListAccounts => Err(rimap_core::RimapError::Internal(
-                "not yet implemented".into(),
+                "infrastructure tools must not reach dispatch_tool".into(),
             )),
         }
+    }
+
+    /// Handle infrastructure tools that bypass account resolution.
+    #[expect(clippy::unused_self, reason = "T6 will use self.registry")]
+    fn dispatch_infrastructure(
+        &self,
+        tool: ToolName,
+        _args: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Err(ErrorData::internal_error(
+            format!("{} not yet implemented", tool.as_str()),
+            None,
+        ))
     }
 }
 

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -172,9 +172,18 @@ impl ImapMcpServer {
                 let input = parse_args(args)?;
                 Box::pin(crate::tools::folder_mgmt::handle_delete(self, input)).await
             }
-            ToolName::AddLabel | ToolName::RemoveLabel | ToolName::ListLabels => Err(
-                rimap_core::RimapError::Internal("label tools not yet implemented".into()),
-            ),
+            ToolName::AddLabel => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::labels::handle_add_label(self, input)).await
+            }
+            ToolName::RemoveLabel => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::labels::handle_remove_label(self, input)).await
+            }
+            ToolName::ListLabels => {
+                let input = parse_args(args)?;
+                Box::pin(crate::tools::labels::handle_list_labels(self, input)).await
+            }
         }
     }
 }
@@ -207,7 +216,9 @@ fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::
 /// (e.g. `SearchAdvanced` and `FetchMessageHtml` are gated
 /// sub-capabilities, not separate MCP tools).
 fn tool_definition(name: ToolName) -> Option<Tool> {
-    let (tool_name, description, schema) = tool_spec_v1(name).or_else(|| tool_spec_v2(name))?;
+    let (tool_name, description, schema) = tool_spec_v1(name)
+        .or_else(|| tool_spec_v2(name))
+        .or_else(|| tool_spec_v3(name))?;
     Some(Tool::new(tool_name, description, Arc::new(schema)))
 }
 
@@ -332,6 +343,31 @@ fn tool_spec_v2(name: ToolName) -> Option<ToolSpec> {
     Some(tuple)
 }
 
+/// Return (name, description, schema) for v3 label tools.
+fn tool_spec_v3(name: ToolName) -> Option<ToolSpec> {
+    use crate::tools::labels::{LabelInput, ListLabelsInput};
+
+    let tuple = match name {
+        ToolName::AddLabel => (
+            "add_label",
+            "Add a keyword label to messages",
+            schema_map::<LabelInput>(),
+        ),
+        ToolName::RemoveLabel => (
+            "remove_label",
+            "Remove a keyword label from messages",
+            schema_map::<LabelInput>(),
+        ),
+        ToolName::ListLabels => (
+            "list_labels",
+            "List keyword labels on a message",
+            schema_map::<ListLabelsInput>(),
+        ),
+        _ => return None,
+    };
+    Some(tuple)
+}
+
 #[cfg(test)]
 mod tests {
     use rimap_core::tool::ToolName;
@@ -344,8 +380,8 @@ mod tests {
             .into_iter()
             .filter_map(tool_definition)
             .collect();
-        // 19 tool variants minus 2 sub-capabilities = 17
-        assert_eq!(defs.len(), 17);
+        // 22 tool variants minus 2 sub-capabilities = 20
+        assert_eq!(defs.len(), 20);
     }
 
     #[test]

--- a/crates/rimap-server/src/server.rs
+++ b/crates/rimap-server/src/server.rs
@@ -6,11 +6,14 @@
 //! union across accounts) and `call_tool` (account resolution +
 //! dispatch pipeline).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use rimap_audit::AuditWriter;
+use rimap_audit::record::{Provenance, ResultSummary, ToolStatus};
+use rimap_audit::redact::{RedactionSalt, RedactionSchema, Redactor, hash_arguments, schemas};
 use rimap_core::account::{AccountId, DEFAULT_ACCOUNT_NAME};
 use rimap_core::tool::ToolName;
 use rmcp::RoleServer;
@@ -29,10 +32,32 @@ pub struct ImapMcpServer {
     /// Account registry holding per-account state.
     pub(crate) registry: AccountRegistry,
     /// Append-only audit writer.
-    #[expect(dead_code, reason = "used by audit logging in later sprint")]
     pub(crate) audit: AuditWriter,
     /// Directory for attachment downloads.
     pub(crate) download_dir: PathBuf,
+    /// Per-process salt used when applying `Redactor` to tool arguments.
+    /// Wrapped in `Arc` so `spawn_blocking` closures can cheaply capture it.
+    pub(crate) redaction_salt: Arc<RedactionSalt>,
+    /// Redaction schemas keyed by tool name (matches `ToolName::as_str`).
+    /// Built once at construction from `rimap_audit::redact::schemas()`.
+    pub(crate) redaction_schemas: Arc<HashMap<&'static str, RedactionSchema>>,
+}
+
+impl ImapMcpServer {
+    /// Construct a new server. Builds the redaction salt and schema map
+    /// from [`rimap_audit::redact::schemas`].
+    #[must_use]
+    pub fn new(registry: AccountRegistry, audit: AuditWriter, download_dir: PathBuf) -> Self {
+        let schema_map: HashMap<&'static str, RedactionSchema> =
+            schemas().into_iter().map(|s| (s.tool, s)).collect();
+        Self {
+            registry,
+            audit,
+            download_dir,
+            redaction_salt: Arc::new(RedactionSalt::new_random()),
+            redaction_schemas: Arc::new(schema_map),
+        }
+    }
 }
 
 impl ServerHandler for ImapMcpServer {
@@ -205,7 +230,7 @@ impl ServerHandler for ImapMcpServer {
                     None,
                 ));
             }
-            return self.dispatch_infrastructure(tool_name, &args);
+            return Box::pin(self.dispatch_infrastructure(tool_name, &args)).await;
         }
 
         // Account resolution order: URI namespace > args["account"] >
@@ -220,11 +245,74 @@ impl ServerHandler for ImapMcpServer {
             .resolve(explicit_account.as_deref())
             .map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
 
+        // Compute the account field for audit records. Legacy single-account
+        // `"default"` records `None`; multi-account records the account name.
+        let audit_account: Option<String> =
+            if account.id.as_str() == rimap_core::account::DEFAULT_ACCOUNT_NAME {
+                None
+            } else {
+                Some(account.id.as_str().to_string())
+            };
+        let posture_str = account.guard.matrix().posture().as_str().to_string();
+
+        // Emit `tool_start` BEFORE the guard chain so guard failures also
+        // produce a matching `tool_end` record.
+        let args_value = serde_json::Value::Object(args.clone());
+        let redacted = self.redact_tool_args(tool_name.as_str(), &args_value);
+        let hash = hash_arguments(&args_value);
+        let tool_str = tool_name.as_str().to_string();
+
+        let start_seq = self
+            .emit_tool_start(
+                &tool_str,
+                audit_account.clone(),
+                posture_str.clone(),
+                redacted,
+                hash,
+            )
+            .await?;
+
+        let start_time = std::time::Instant::now();
+
         if let Err(e) = crate::dispatch::pre_call_guards(&account.guard, tool_name) {
+            let err_code = e.code().as_str().to_string();
+            let duration_ms = start_time
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
+            self.emit_tool_end(
+                start_seq,
+                tool_str.clone(),
+                audit_account.clone(),
+                ToolStatus::Error,
+                Some(err_code),
+                duration_ms,
+            )
+            .await;
             return Err(crate::mcp_error::to_mcp_error(&e));
         }
 
         let result = Box::pin(self.dispatch_tool(account, tool_name, &args)).await;
+
+        let duration_ms = start_time
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let (status, error_code) = match &result {
+            Ok(_) => (ToolStatus::Ok, None),
+            Err(e) => (ToolStatus::Error, Some(e.code().as_str().to_string())),
+        };
+        self.emit_tool_end(
+            start_seq,
+            tool_str,
+            audit_account,
+            status,
+            error_code,
+            duration_ms,
+        )
+        .await;
 
         match result {
             Ok(resp) => {
@@ -313,30 +401,75 @@ impl ImapMcpServer {
     }
 
     /// Handle infrastructure tools that bypass account resolution.
-    fn dispatch_infrastructure(
+    ///
+    /// Infrastructure tools are not scoped to an account, so their audit
+    /// records record `account: None` regardless of deployment mode.
+    async fn dispatch_infrastructure(
         &self,
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<CallToolResult, ErrorData> {
+        let args_value = serde_json::Value::Object(args.clone());
+        let redacted = self.redact_tool_args(tool.as_str(), &args_value);
+        let hash = hash_arguments(&args_value);
+        let tool_str = tool.as_str().to_string();
+        // Infrastructure tools have no per-account posture; record an
+        // explicit sentinel so log readers can distinguish these from
+        // per-account dispatches.
+        let posture_str = "infrastructure".to_string();
+
+        let start_seq = self
+            .emit_tool_start(&tool_str, None, posture_str, redacted, hash)
+            .await?;
+        let start_time = std::time::Instant::now();
+
         // Infrastructure tools bypass posture + breaker, but still
         // enforce a process-wide rate limit.
         if let Err(e) = self.registry.check_infrastructure_rate() {
+            let duration_ms = start_time
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
+            let err_code = e.code().as_str().to_string();
+            self.emit_tool_end(
+                start_seq,
+                tool_str.clone(),
+                None,
+                ToolStatus::Error,
+                Some(err_code),
+                duration_ms,
+            )
+            .await;
             return Err(crate::mcp_error::to_mcp_error(&e));
         }
+
         let result = match tool {
             ToolName::UseAccount => {
-                let input: crate::tools::accounts::UseAccountInput =
-                    parse_args(args).map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
-                crate::tools::accounts::handle_use_account(&self.registry, &input)
+                match parse_args::<crate::tools::accounts::UseAccountInput>(args) {
+                    Ok(input) => crate::tools::accounts::handle_use_account(&self.registry, &input),
+                    Err(e) => Err(e),
+                }
             }
             ToolName::ListAccounts => crate::tools::accounts::handle_list_accounts(&self.registry),
-            _ => {
-                return Err(ErrorData::internal_error(
-                    format!("not an infrastructure tool: {}", tool.as_str(),),
-                    None,
-                ));
-            }
+            _ => Err(rimap_core::RimapError::Internal(format!(
+                "not an infrastructure tool: {}",
+                tool.as_str(),
+            ))),
         };
+
+        let duration_ms = start_time
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let (status, error_code) = match &result {
+            Ok(_) => (ToolStatus::Ok, None),
+            Err(e) => (ToolStatus::Error, Some(e.code().as_str().to_string())),
+        };
+        self.emit_tool_end(start_seq, tool_str, None, status, error_code, duration_ms)
+            .await;
+
         match result {
             Ok(resp) => {
                 let value = serde_json::to_value(&resp)
@@ -344,6 +477,105 @@ impl ImapMcpServer {
                 Ok(CallToolResult::structured(value))
             }
             Err(e) => Err(crate::mcp_error::to_mcp_error(&e)),
+        }
+    }
+
+    /// Apply the registered [`rimap_audit::redact::Redactor`] schema for
+    /// `tool`. If no schema matches, returns an empty object and emits
+    /// a `warn!` — the schema registry is expected to cover every
+    /// advertised tool.
+    fn redact_tool_args(&self, tool: &str, args: &serde_json::Value) -> serde_json::Value {
+        if let Some(schema) = self.redaction_schemas.get(tool) {
+            Redactor::new(schema, self.redaction_salt.as_ref()).apply(args)
+        } else {
+            tracing::warn!(
+                tool,
+                "no redaction schema for tool; recording empty arguments_redacted",
+            );
+            serde_json::Value::Object(serde_json::Map::new())
+        }
+    }
+
+    /// Emit a `tool_start` audit record via `spawn_blocking`. Returns the
+    /// allocated `seq` on success; on audit failure emits a `warn!` and
+    /// returns a synthetic `Seq::FIRST` so the call can proceed.
+    ///
+    /// Errors bubble up only when `fail_open = false` AND the write fails:
+    /// in that case the tool call MUST fail because the audit trail is
+    /// broken. `fail_open = true` deployments swallow the error inside
+    /// the writer and return `Ok`.
+    async fn emit_tool_start(
+        &self,
+        tool: &str,
+        account: Option<String>,
+        posture: String,
+        redacted: serde_json::Value,
+        hash: String,
+    ) -> Result<rimap_audit::Seq, ErrorData> {
+        let audit = self.audit.clone();
+        let tool_owned = tool.to_string();
+        let join = tokio::task::spawn_blocking(move || {
+            audit.log_tool_start(&tool_owned, account.as_deref(), &posture, redacted, hash)
+        })
+        .await;
+        match join {
+            Ok(Ok(seq)) => Ok(seq),
+            Ok(Err(audit_err)) => {
+                tracing::error!(error = %audit_err, "tool_start audit write failed");
+                Err(ErrorData::internal_error(
+                    format!("audit write failed: {}", audit_err.code()),
+                    None,
+                ))
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "tool_start join error");
+                Err(ErrorData::internal_error(join_err.to_string(), None))
+            }
+        }
+    }
+
+    /// Emit a `tool_end` audit record via `spawn_blocking`. Failures are
+    /// logged but not propagated — at end-of-call the tool has already
+    /// finished and the caller sees its original result.
+    async fn emit_tool_end(
+        &self,
+        start_seq: rimap_audit::Seq,
+        tool: String,
+        account: Option<String>,
+        status: ToolStatus,
+        error_code: Option<String>,
+        duration_ms: u64,
+    ) {
+        let audit = self.audit.clone();
+        // The provenance ring buffer is not yet wired for multi-account.
+        // Record an empty snapshot with the window placeholder until a
+        // per-account buffer lands.
+        let provenance = Provenance {
+            window_seconds: 60,
+            message_ids_recently_read: Vec::new(),
+        };
+        let summary = ResultSummary::default();
+        let join = tokio::task::spawn_blocking(move || {
+            audit.log_tool_end(
+                start_seq,
+                &tool,
+                account.as_deref(),
+                status,
+                error_code,
+                duration_ms,
+                summary,
+                provenance,
+            )
+        })
+        .await;
+        match join {
+            Ok(Ok(_)) => {}
+            Ok(Err(audit_err)) => {
+                tracing::error!(error = %audit_err, "tool_end audit write failed");
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "tool_end join error");
+            }
         }
     }
 }
@@ -593,6 +825,7 @@ static TOOL_DEFS: std::sync::LazyLock<std::collections::HashMap<ToolName, Tool>>
     });
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
 mod tests {
     use rimap_core::tool::ToolName;
 
@@ -703,5 +936,60 @@ mod tests {
                 def.name,
             );
         }
+    }
+
+    #[tokio::test]
+    async fn infrastructure_tool_emits_tool_start_and_tool_end() {
+        use std::collections::BTreeMap;
+
+        use rimap_audit::{AuditOptions, AuditWriter, Seq};
+        use tempfile::TempDir;
+
+        use crate::registry::AccountRegistry;
+        use crate::server::ImapMcpServer;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let audit_path = tmp.path().join("audit.jsonl");
+        let audit = AuditWriter::open(&AuditOptions {
+            path: audit_path.clone(),
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .expect("audit open");
+
+        let registry = AccountRegistry::new(BTreeMap::new());
+        let server = ImapMcpServer::new(registry, audit, tmp.path().to_path_buf());
+
+        // list_accounts needs no args and no IMAP connection.
+        let args = serde_json::Map::new();
+        let _ = server
+            .dispatch_infrastructure(ToolName::ListAccounts, &args)
+            .await
+            .expect("list_accounts dispatch");
+
+        drop(server);
+
+        let contents = std::fs::read_to_string(&audit_path).expect("read audit log");
+        let records: Vec<serde_json::Value> = contents
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("parse record"))
+            .collect();
+
+        let start = records
+            .iter()
+            .find(|r| r["kind"] == "tool_start" && r["tool"] == "list_accounts")
+            .expect("tool_start record");
+        let end = records
+            .iter()
+            .find(|r| r["kind"] == "tool_end" && r["tool"] == "list_accounts")
+            .expect("tool_end record");
+
+        assert_eq!(start["seq"], end["start_seq"]);
+        assert_eq!(end["status"], "ok");
+        assert!(start["account"].is_null());
+        assert!(end["account"].is_null());
     }
 }

--- a/crates/rimap-server/src/tools/accounts.rs
+++ b/crates/rimap-server/src/tools/accounts.rs
@@ -16,6 +16,10 @@ pub fn handle_use_account(
     registry: &AccountRegistry,
     input: &UseAccountInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
+    // Validate the account-name shape first so invalid input cannot be
+    // echoed into error messages or reach `set_active`'s lookup code.
+    rimap_core::account::AccountId::new(&input.account)
+        .map_err(|_| rimap_core::RimapError::Internal("invalid account name".to_string()))?;
     let previous = registry.set_active(&input.account)?;
     Ok(ToolResponse {
         meta: serde_json::json!({

--- a/crates/rimap-server/src/tools/accounts.rs
+++ b/crates/rimap-server/src/tools/accounts.rs
@@ -31,15 +31,8 @@ pub fn handle_use_account(
     })
 }
 
-/// List all configured accounts. Returns `Result` for consistency
-/// with the dispatch pipeline, though it cannot currently fail.
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "consistent Result return with dispatch pipeline"
-)]
-pub fn handle_list_accounts(
-    registry: &AccountRegistry,
-) -> Result<ToolResponse, rimap_core::RimapError> {
+/// List all configured accounts.
+pub fn handle_list_accounts(registry: &AccountRegistry) -> ToolResponse {
     let mut accounts: Vec<serde_json::Value> = Vec::new();
     for state in registry.accounts().values() {
         accounts.push(serde_json::json!({
@@ -48,12 +41,12 @@ pub fn handle_list_accounts(
         }));
     }
     let count = accounts.len();
-    Ok(ToolResponse {
+    ToolResponse {
         meta: serde_json::json!({
             "accounts": accounts,
             "count": count,
         }),
         untrusted: None,
         security_warnings: Vec::new(),
-    })
+    }
 }

--- a/crates/rimap-server/src/tools/accounts.rs
+++ b/crates/rimap-server/src/tools/accounts.rs
@@ -1,0 +1,56 @@
+//! Infrastructure tool handlers for account management.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::registry::AccountRegistry;
+use crate::response::ToolResponse;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UseAccountInput {
+    /// Account name to select as the session default.
+    pub account: String,
+}
+
+pub fn handle_use_account(
+    registry: &AccountRegistry,
+    input: &UseAccountInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let previous = registry.set_active(&input.account)?;
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "account": input.account,
+            "previous": previous,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// List all configured accounts. Returns `Result` for consistency
+/// with the dispatch pipeline, though it cannot currently fail.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "consistent Result return with dispatch pipeline"
+)]
+pub fn handle_list_accounts(
+    registry: &AccountRegistry,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let mut accounts: Vec<serde_json::Value> = Vec::new();
+    for state in registry.accounts().values() {
+        accounts.push(serde_json::json!({
+            "name": state.id.as_str(),
+            "imap_host": state.imap.host(),
+            "smtp_configured": state.smtp.is_some(),
+        }));
+    }
+    let count = accounts.len();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "accounts": accounts,
+            "count": count,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}

--- a/crates/rimap-server/src/tools/accounts.rs
+++ b/crates/rimap-server/src/tools/accounts.rs
@@ -40,7 +40,6 @@ pub fn handle_list_accounts(
     for state in registry.accounts().values() {
         accounts.push(serde_json::json!({
             "name": state.id.as_str(),
-            "imap_host": state.imap.host(),
             "smtp_configured": state.smtp.is_some(),
         }));
     }

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     input: CreateDraftInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     message_builder::validate_compose_input(&input)?;
-    let from_addr = &account.from_address;
+    let from_addr = account.imap.username();
     let raw_msg = message_builder::build_message(account, from_addr, &input).await?;
 
     let drafts_folder = "Drafts";

--- a/crates/rimap-server/src/tools/create_draft.rs
+++ b/crates/rimap-server/src/tools/create_draft.rs
@@ -1,8 +1,8 @@
 //! `create_draft` tool handler: compose a draft email and APPEND it
 //! to the Drafts folder with a `$PendingReview` keyword.
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 use crate::tools::message_builder::{self, ComposeInput};
 
 /// Input for `create_draft` — identical to shared `ComposeInput`.
@@ -10,15 +10,15 @@ pub type CreateDraftInput = ComposeInput;
 
 /// `create_draft` handler.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: CreateDraftInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     message_builder::validate_compose_input(&input)?;
-    let from_addr = &server.config.config.imap.username;
-    let raw_msg = message_builder::build_message(server, from_addr, &input).await?;
+    let from_addr = &account.from_address;
+    let raw_msg = message_builder::build_message(account, from_addr, &input).await?;
 
     let drafts_folder = "Drafts";
-    let result = server
+    let result = account
         .imap
         .append_message(
             drafts_folder,

--- a/crates/rimap-server/src/tools/delete_message.rs
+++ b/crates/rimap-server/src/tools/delete_message.rs
@@ -3,8 +3,8 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for `delete_message`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -17,7 +17,7 @@ pub struct DeleteMessageInput {
 
 /// `delete_message` handler.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: DeleteMessageInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uid =
@@ -27,7 +27,7 @@ pub async fn handle(
         })?;
 
     let trash_folder = "Trash";
-    let result = server
+    let result = account
         .imap
         .delete_message(&input.folder, uid, trash_folder)
         .await?;

--- a/crates/rimap-server/src/tools/download_attachment.rs
+++ b/crates/rimap-server/src/tools/download_attachment.rs
@@ -6,8 +6,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::download;
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for the `download_attachment` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -34,8 +34,9 @@ pub struct DownloadAttachmentInput {
 /// Returns `RimapError` on invalid input, IMAP failure, part not
 /// found, or filesystem errors.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: DownloadAttachmentInput,
+    download_dir: &std::path::Path,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uid = Uid::new(input.uid).ok_or_else(|| rimap_core::RimapError::Authz {
         code: rimap_core::error::ErrorCode::InvalidInput,
@@ -51,12 +52,12 @@ pub async fn handle(
 
     let dest = download::resolve_dest_dir_async(
         input.dest_dir,
-        server.download_dir.clone(),
-        server.download_dir.clone(),
+        download_dir.to_path_buf(),
+        download_dir.to_path_buf(),
     )
     .await?;
 
-    let raw = server.imap.fetch_body(&input.folder, uid).await?;
+    let raw = account.imap.fetch_body(&input.folder, uid).await?;
 
     let parsed = tokio::task::spawn_blocking(move || {
         mail_parser::MessageParser::new()
@@ -95,7 +96,7 @@ pub async fn handle(
         bodystructure: true,
         ..FetchSpec::default()
     };
-    if let Ok(msgs) = server.imap.fetch(&input.folder, &[uid], spec).await
+    if let Ok(msgs) = account.imap.fetch(&input.folder, &[uid], spec).await
         && let Some(bs) = msgs.into_iter().next().and_then(|m| m.bodystructure)
         && let Some(bs_type) = lookup_bodystructure_type(&bs, &input.part_id)
     {

--- a/crates/rimap-server/src/tools/expunge.rs
+++ b/crates/rimap-server/src/tools/expunge.rs
@@ -3,8 +3,8 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for `expunge`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -15,10 +15,10 @@ pub struct ExpungeInput {
 
 /// `expunge` handler.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: ExpungeInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
-    server
+    account
         .folder_guard
         .check_expunge(&input.folder)
         .map_err(|e| rimap_core::RimapError::Authz {
@@ -26,7 +26,7 @@ pub async fn handle(
             message: e.to_string(),
         })?;
 
-    let (deleted_uids, expunged_count) = server.imap.expunge(&input.folder).await?;
+    let (deleted_uids, expunged_count) = account.imap.expunge(&input.folder).await?;
 
     Ok(ToolResponse {
         meta: serde_json::json!({

--- a/crates/rimap-server/src/tools/fetch_message.rs
+++ b/crates/rimap-server/src/tools/fetch_message.rs
@@ -4,8 +4,8 @@ use rimap_imap::types::Uid;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for the `fetch_message` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -22,13 +22,13 @@ pub struct FetchMessageInput {
 
 /// Execute the `fetch_message` tool.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FetchMessageInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let include_html = input.include_html.unwrap_or(false);
     if include_html {
         use rimap_core::tool::ToolName;
-        server
+        account
             .guard
             .matrix()
             .check(ToolName::FetchMessageHtml)
@@ -43,7 +43,7 @@ pub async fn handle(
         message: "UID must be non-zero".to_string(),
     })?;
 
-    let raw = server.imap.fetch_body(&input.folder, uid).await?;
+    let raw = account.imap.fetch_body(&input.folder, uid).await?;
     let raw_size = raw.len();
 
     let content = crate::content::parse_message_async(raw)

--- a/crates/rimap-server/src/tools/flags.rs
+++ b/crates/rimap-server/src/tools/flags.rs
@@ -5,8 +5,8 @@ use rimap_imap::types::{Flag, FlagAction, Uid};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for flag mutation tools.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -21,11 +21,11 @@ pub struct FlagInput {
 
 /// `mark_read` handler.
 pub async fn handle_mark_read(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FlagInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     Box::pin(handle_flag_op(
-        server,
+        account,
         input,
         &[Flag::Seen],
         FlagAction::Add,
@@ -35,11 +35,11 @@ pub async fn handle_mark_read(
 
 /// `mark_unread` handler.
 pub async fn handle_mark_unread(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FlagInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     Box::pin(handle_flag_op(
-        server,
+        account,
         input,
         &[Flag::Seen],
         FlagAction::Remove,
@@ -49,11 +49,11 @@ pub async fn handle_mark_unread(
 
 /// `flag` handler.
 pub async fn handle_flag(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FlagInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     Box::pin(handle_flag_op(
-        server,
+        account,
         input,
         &[Flag::Flagged],
         FlagAction::Add,
@@ -63,11 +63,11 @@ pub async fn handle_flag(
 
 /// `unflag` handler.
 pub async fn handle_unflag(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FlagInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     Box::pin(handle_flag_op(
-        server,
+        account,
         input,
         &[Flag::Flagged],
         FlagAction::Remove,
@@ -76,13 +76,13 @@ pub async fn handle_unflag(
 }
 
 async fn handle_flag_op(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: FlagInput,
     flags: &[Flag],
     action: FlagAction,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uids = resolve_uids(input.uid, input.uids)?;
-    let updated = server
+    let updated = account
         .imap
         .store_flags(&input.folder, &uids, flags, action)
         .await?;

--- a/crates/rimap-server/src/tools/folder_mgmt.rs
+++ b/crates/rimap-server/src/tools/folder_mgmt.rs
@@ -3,8 +3,8 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for `create_folder`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -31,10 +31,10 @@ pub struct DeleteFolderInput {
 
 /// `create_folder` handler.
 pub async fn handle_create(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: CreateFolderInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
-    server
+    account
         .folder_guard
         .check_protected(&input.name, "create")
         .map_err(|e| rimap_core::RimapError::Authz {
@@ -42,7 +42,7 @@ pub async fn handle_create(
             message: e.to_string(),
         })?;
 
-    server.imap.create_folder(&input.name).await?;
+    account.imap.create_folder(&input.name).await?;
 
     Ok(ToolResponse {
         meta: serde_json::json!({
@@ -56,10 +56,10 @@ pub async fn handle_create(
 
 /// `rename_folder` handler.
 pub async fn handle_rename(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: RenameFolderInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
-    server
+    account
         .folder_guard
         .check_rename(&input.old_name, &input.new_name)
         .map_err(|e| rimap_core::RimapError::Authz {
@@ -67,7 +67,7 @@ pub async fn handle_rename(
             message: e.to_string(),
         })?;
 
-    server
+    account
         .imap
         .rename_folder(&input.old_name, &input.new_name)
         .await?;
@@ -85,10 +85,10 @@ pub async fn handle_rename(
 
 /// `delete_folder` handler.
 pub async fn handle_delete(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: DeleteFolderInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
-    server
+    account
         .folder_guard
         .check_protected(&input.name, "delete")
         .map_err(|e| rimap_core::RimapError::Authz {
@@ -96,7 +96,7 @@ pub async fn handle_delete(
             message: e.to_string(),
         })?;
 
-    server
+    account
         .folder_guard
         .check_expunge(&input.name)
         .map_err(|e| rimap_core::RimapError::Authz {
@@ -104,7 +104,7 @@ pub async fn handle_delete(
             message: e.to_string(),
         })?;
 
-    let status = server
+    let status = account
         .imap
         .status(
             &input.name,
@@ -119,7 +119,7 @@ pub async fn handle_delete(
         .await?;
     let message_count = status.messages.unwrap_or(0);
 
-    server.imap.delete_folder(&input.name).await?;
+    account.imap.delete_folder(&input.name).await?;
 
     Ok(ToolResponse {
         meta: serde_json::json!({

--- a/crates/rimap-server/src/tools/labels.rs
+++ b/crates/rimap-server/src/tools/labels.rs
@@ -5,8 +5,8 @@ use rimap_imap::types::{FetchSpec, Flag, FlagAction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 use crate::tools::flags::resolve_uids;
 
 /// IMAP atom specials (RFC 3501 §9) plus backslash. Any of these
@@ -85,12 +85,12 @@ pub struct ListLabelsInput {
 
 /// `add_label` handler.
 pub async fn handle_add_label(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: LabelInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     validate_label(&input.label)?;
     let uids = resolve_uids(input.uid, input.uids)?;
-    let updated = server
+    let updated = account
         .imap
         .store_flags(
             &input.folder,
@@ -114,12 +114,12 @@ pub async fn handle_add_label(
 
 /// `remove_label` handler.
 pub async fn handle_remove_label(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: LabelInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     validate_label(&input.label)?;
     let uids = resolve_uids(input.uid, input.uids)?;
-    let updated = server
+    let updated = account
         .imap
         .store_flags(
             &input.folder,
@@ -143,7 +143,7 @@ pub async fn handle_remove_label(
 
 /// `list_labels` handler.
 pub async fn handle_list_labels(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: ListLabelsInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uid = rimap_imap::types::Uid::new(input.uid)
@@ -153,7 +153,7 @@ pub async fn handle_list_labels(
         flags: true,
         ..FetchSpec::default()
     };
-    let messages = server.imap.fetch(&input.folder, &[uid], spec).await?;
+    let messages = account.imap.fetch(&input.folder, &[uid], spec).await?;
 
     let msg = messages
         .into_iter()

--- a/crates/rimap-server/src/tools/labels.rs
+++ b/crates/rimap-server/src/tools/labels.rs
@@ -1,0 +1,280 @@
+//! Label (custom keyword) tool handlers: `add_label`, `remove_label`,
+//! `list_labels`.
+
+use rimap_imap::types::{FetchSpec, Flag, FlagAction};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+use crate::tools::flags::resolve_uids;
+
+/// IMAP atom specials (RFC 3501 §9) plus backslash. Any of these
+/// inside a keyword would break the STORE command or collide with
+/// the system-flag namespace.
+const ATOM_SPECIALS: &[char] = &['(', ')', '{', ' ', '%', '*', '"', ']', '\\'];
+
+/// System flag names that must not be used as custom keywords.
+const SYSTEM_FLAGS: &[&str] = &["seen", "answered", "flagged", "deleted", "draft", "recent"];
+
+/// Maximum label length in bytes.
+const MAX_LABEL_BYTES: usize = 256;
+
+/// Validate a custom keyword label for IMAP STORE safety.
+pub fn validate_label(label: &str) -> Result<(), rimap_core::RimapError> {
+    if label.is_empty() {
+        return Err(invalid_input("label must not be empty"));
+    }
+    if label.len() > MAX_LABEL_BYTES {
+        return Err(invalid_input(&format!(
+            "label exceeds maximum of {MAX_LABEL_BYTES} bytes"
+        )));
+    }
+    if label.as_bytes().contains(&0) {
+        return Err(invalid_input("label must not contain null bytes"));
+    }
+    if label.starts_with('\\') {
+        return Err(invalid_input(
+            "label must not start with '\\' (system flag namespace)",
+        ));
+    }
+    if label.chars().any(|c| ATOM_SPECIALS.contains(&c)) {
+        return Err(invalid_input("label contains IMAP atom special characters"));
+    }
+    if label.chars().any(|c| c.is_ascii_control()) {
+        return Err(invalid_input(
+            "label must not contain ASCII control characters",
+        ));
+    }
+    if SYSTEM_FLAGS.contains(&label.to_ascii_lowercase().as_str()) {
+        return Err(invalid_input(&format!(
+            "'{label}' is a reserved system flag name"
+        )));
+    }
+    Ok(())
+}
+
+fn invalid_input(message: &str) -> rimap_core::RimapError {
+    rimap_core::RimapError::Authz {
+        code: rimap_core::error::ErrorCode::InvalidInput,
+        message: message.to_string(),
+    }
+}
+
+/// Input for `add_label` and `remove_label` tools.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LabelInput {
+    /// Target folder.
+    pub folder: String,
+    /// Single UID.
+    pub uid: Option<u32>,
+    /// Batch of UIDs (max 100).
+    pub uids: Option<Vec<u32>>,
+    /// Custom keyword label to add or remove.
+    pub label: String,
+}
+
+/// Input for `list_labels` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListLabelsInput {
+    /// Target folder.
+    pub folder: String,
+    /// Message UID.
+    pub uid: u32,
+}
+
+/// `add_label` handler.
+pub async fn handle_add_label(
+    server: &ImapMcpServer,
+    input: LabelInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    validate_label(&input.label)?;
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let updated = server
+        .imap
+        .store_flags(
+            &input.folder,
+            &uids,
+            &[Flag::Keyword(input.label.clone())],
+            FlagAction::Add,
+        )
+        .await?;
+
+    let updated_ids: Vec<u32> = updated.iter().map(|u| u.get()).collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "label": input.label,
+            "uids_updated": updated_ids,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// `remove_label` handler.
+pub async fn handle_remove_label(
+    server: &ImapMcpServer,
+    input: LabelInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    validate_label(&input.label)?;
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let updated = server
+        .imap
+        .store_flags(
+            &input.folder,
+            &uids,
+            &[Flag::Keyword(input.label.clone())],
+            FlagAction::Remove,
+        )
+        .await?;
+
+    let updated_ids: Vec<u32> = updated.iter().map(|u| u.get()).collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "label": input.label,
+            "uids_updated": updated_ids,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// `list_labels` handler.
+pub async fn handle_list_labels(
+    server: &ImapMcpServer,
+    input: ListLabelsInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let uid = rimap_imap::types::Uid::new(input.uid)
+        .ok_or_else(|| invalid_input("UID must be non-zero"))?;
+
+    let spec = FetchSpec {
+        flags: true,
+        ..FetchSpec::default()
+    };
+    let messages = server.imap.fetch(&input.folder, &[uid], spec).await?;
+
+    let msg = messages
+        .into_iter()
+        .next()
+        .ok_or_else(|| rimap_core::RimapError::Authz {
+            code: rimap_core::error::ErrorCode::NotFound,
+            message: format!(
+                "message UID {} not found in folder '{}'",
+                input.uid, input.folder
+            ),
+        })?;
+
+    let labels: Vec<&str> = msg
+        .flags
+        .as_ref()
+        .map(|flags| {
+            flags
+                .iter()
+                .filter_map(|f| match f {
+                    Flag::Keyword(kw) => Some(kw.as_str()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uid": input.uid,
+            "labels": labels,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_label() {
+        let err = validate_label("").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn rejects_overlength_label() {
+        let long = "a".repeat(257);
+        let err = validate_label(&long).unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn accepts_max_length_label() {
+        let exact = "a".repeat(256);
+        validate_label(&exact).unwrap();
+    }
+
+    #[test]
+    fn rejects_null_bytes() {
+        let err = validate_label("foo\0bar").unwrap_err();
+        assert!(err.to_string().contains("null"));
+    }
+
+    #[test]
+    fn rejects_backslash_prefix() {
+        let err = validate_label("\\Seen").unwrap_err();
+        assert!(err.to_string().contains("system flag namespace"));
+    }
+
+    #[test]
+    fn rejects_system_flags_case_insensitive() {
+        for name in &[
+            "Seen", "SEEN", "seen", "Answered", "Flagged", "Deleted", "Draft", "Recent", "DRAFT",
+            "rEcEnT",
+        ] {
+            let err = validate_label(name).unwrap_err();
+            assert!(
+                err.to_string().contains("reserved system flag"),
+                "expected rejection for '{name}', got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_atom_specials() {
+        for ch in ATOM_SPECIALS {
+            let label = format!("foo{ch}bar");
+            let result = validate_label(&label);
+            assert!(result.is_err(), "expected rejection for char '{ch}'");
+        }
+    }
+
+    #[test]
+    fn rejects_control_characters() {
+        let err = validate_label("foo\x01bar").unwrap_err();
+        assert!(err.to_string().contains("control"));
+
+        let err = validate_label("foo\x7Fbar").unwrap_err();
+        assert!(err.to_string().contains("control"));
+
+        let err = validate_label("\t").unwrap_err();
+        assert!(err.to_string().contains("control"));
+    }
+
+    #[test]
+    fn accepts_valid_labels() {
+        validate_label("Urgent").unwrap();
+        validate_label("$PendingReview").unwrap();
+        validate_label("project/alpha").unwrap();
+        validate_label("my-label").unwrap();
+        validate_label("Label_123").unwrap();
+    }
+
+    #[test]
+    fn accepts_dollar_prefix_keywords() {
+        validate_label("$Junk").unwrap();
+        validate_label("$NotJunk").unwrap();
+        validate_label("$MDNSent").unwrap();
+    }
+}

--- a/crates/rimap-server/src/tools/labels.rs
+++ b/crates/rimap-server/src/tools/labels.rs
@@ -86,7 +86,15 @@ pub struct ListLabelsInput {
     pub uid: u32,
 }
 
-/// `add_label` handler.
+/// `add_label` handler — STORE +FLAGS with a custom keyword.
+///
+/// # Limitations
+///
+/// The response does not include UIDVALIDITY. If the folder's UID namespace
+/// rotates between the caller's UID acquisition and this call, labels may
+/// be applied to unintended messages. This is consistent with other flag
+/// tools (`mark_read`, `flag`, etc.) and will be addressed in a future
+/// release.
 pub async fn handle_add_label(
     account: &AccountState,
     input: LabelInput,
@@ -115,7 +123,15 @@ pub async fn handle_add_label(
     })
 }
 
-/// `remove_label` handler.
+/// `remove_label` handler — STORE -FLAGS with a custom keyword.
+///
+/// # Limitations
+///
+/// The response does not include UIDVALIDITY. If the folder's UID namespace
+/// rotates between the caller's UID acquisition and this call, labels may
+/// be removed from unintended messages. This is consistent with other flag
+/// tools (`mark_read`, `flag`, etc.) and will be addressed in a future
+/// release.
 pub async fn handle_remove_label(
     account: &AccountState,
     input: LabelInput,
@@ -144,7 +160,15 @@ pub async fn handle_remove_label(
     })
 }
 
-/// `list_labels` handler.
+/// `list_labels` handler — FETCH FLAGS and return keyword entries.
+///
+/// # Limitations
+///
+/// The response does not include UIDVALIDITY. If the folder's UID namespace
+/// rotates between the caller's UID acquisition and this call, the returned
+/// labels may belong to an unintended message. This is consistent with other
+/// flag tools (`mark_read`, `flag`, etc.) and will be addressed in a future
+/// release.
 pub async fn handle_list_labels(
     account: &AccountState,
     input: ListLabelsInput,

--- a/crates/rimap-server/src/tools/labels.rs
+++ b/crates/rimap-server/src/tools/labels.rs
@@ -12,7 +12,7 @@ use crate::tools::flags::resolve_uids;
 /// IMAP atom specials (RFC 3501 §9) plus backslash. Any of these
 /// inside a keyword would break the STORE command or collide with
 /// the system-flag namespace.
-const ATOM_SPECIALS: &[char] = &['(', ')', '{', ' ', '%', '*', '"', ']', '\\'];
+const ATOM_SPECIALS: &[char] = &['(', ')', '{', ' ', '%', '*', '"', '[', ']', '\\'];
 
 /// System flag names that must not be used as custom keywords.
 const SYSTEM_FLAGS: &[&str] = &["seen", "answered", "flagged", "deleted", "draft", "recent"];
@@ -24,6 +24,9 @@ const MAX_LABEL_BYTES: usize = 256;
 pub fn validate_label(label: &str) -> Result<(), rimap_core::RimapError> {
     if label.is_empty() {
         return Err(invalid_input("label must not be empty"));
+    }
+    if !label.is_ascii() {
+        return Err(invalid_input("label must be ASCII (RFC 3501 atom syntax)"));
     }
     if label.len() > MAX_LABEL_BYTES {
         return Err(invalid_input(&format!(
@@ -269,6 +272,19 @@ mod tests {
         validate_label("project/alpha").unwrap();
         validate_label("my-label").unwrap();
         validate_label("Label_123").unwrap();
+    }
+
+    #[test]
+    fn non_ascii_label_rejected() {
+        assert!(validate_label("résumé").is_err());
+        assert!(validate_label("Urgеnt").is_err()); // Cyrillic 'е'
+        assert!(validate_label("\u{202E}evil").is_err()); // RTL override
+        assert!(validate_label("foo\u{200B}bar").is_err()); // zero-width space
+    }
+
+    #[test]
+    fn left_bracket_rejected() {
+        assert!(validate_label("foo[bar").is_err());
     }
 
     #[test]

--- a/crates/rimap-server/src/tools/list_attachments.rs
+++ b/crates/rimap-server/src/tools/list_attachments.rs
@@ -4,8 +4,8 @@ use rimap_imap::types::{BodyStructure, FetchSpec, Uid};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Input for the `list_attachments` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -34,7 +34,7 @@ struct AttachmentInfo {
 ///
 /// Returns `RimapError` on invalid input or IMAP failure.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: ListAttachmentsInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uid = Uid::new(input.uid).ok_or_else(|| rimap_core::RimapError::Authz {
@@ -46,7 +46,7 @@ pub async fn handle(
         bodystructure: true,
         ..FetchSpec::default()
     };
-    let messages = server.imap.fetch(&input.folder, &[uid], spec).await?;
+    let messages = account.imap.fetch(&input.folder, &[uid], spec).await?;
 
     let msg = messages
         .into_iter()

--- a/crates/rimap-server/src/tools/list_folders.rs
+++ b/crates/rimap-server/src/tools/list_folders.rs
@@ -1,15 +1,15 @@
 //! `list_folders` tool handler.
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Execute the `list_folders` tool.
-pub async fn handle(server: &ImapMcpServer) -> Result<ToolResponse, rimap_core::RimapError> {
-    let folders = server.imap.list_folders("*").await?;
+pub async fn handle(account: &AccountState) -> Result<ToolResponse, rimap_core::RimapError> {
+    let folders = account.imap.list_folders("*").await?;
 
     let mut folder_entries = Vec::with_capacity(folders.len());
     for folder in &folders {
-        let status = server
+        let status = account
             .imap
             .status(&folder.name, rimap_imap::types::StatusItems::all())
             .await?;

--- a/crates/rimap-server/src/tools/message_builder.rs
+++ b/crates/rimap-server/src/tools/message_builder.rs
@@ -10,7 +10,7 @@ use mail_builder::headers::message_id::MessageId;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::server::ImapMcpServer;
+use crate::registry::AccountState;
 
 /// An email address with optional display name.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -212,7 +212,7 @@ pub(crate) fn cap_references(mut refs: Vec<String>) -> Vec<String> {
 
 /// Fetch referenced message and set In-Reply-To / References headers.
 pub(crate) async fn apply_threading_headers<'a>(
-    server: &ImapMcpServer,
+    account: &AccountState,
     builder: MessageBuilder<'a>,
     reply_uid: u32,
     in_reply_to_folder: Option<&str>,
@@ -224,7 +224,7 @@ pub(crate) async fn apply_threading_headers<'a>(
             message: "in_reply_to_uid must be non-zero".into(),
         })?;
 
-    let raw = server.imap.fetch_body(folder, uid).await?;
+    let raw = account.imap.fetch_body(folder, uid).await?;
     let parsed = mail_parser::MessageParser::new()
         .parse(&raw)
         .ok_or_else(|| {
@@ -261,7 +261,7 @@ pub(crate) async fn apply_threading_headers<'a>(
 /// Build raw RFC 5322 bytes from compose input, applying threading
 /// if `in_reply_to_uid` is set.
 pub(crate) async fn build_message(
-    server: &ImapMcpServer,
+    account: &AccountState,
     from_addr: &str,
     input: &ComposeInput,
 ) -> Result<Vec<u8>, rimap_core::RimapError> {
@@ -269,7 +269,7 @@ pub(crate) async fn build_message(
 
     let builder = if let Some(reply_uid) = input.in_reply_to_uid {
         Box::pin(apply_threading_headers(
-            server,
+            account,
             builder,
             reply_uid,
             input.in_reply_to_folder.as_deref(),

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -1,5 +1,6 @@
 //! MCP tool handlers.
 
+pub mod accounts;
 pub mod create_draft;
 pub mod delete_message;
 pub mod download_attachment;

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -7,7 +7,6 @@ pub mod expunge;
 pub mod fetch_message;
 pub mod flags;
 pub mod folder_mgmt;
-#[expect(dead_code, reason = "handlers wired in 3a-T5 dispatch")]
 pub mod labels;
 pub mod list_attachments;
 pub mod list_folders;

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -7,6 +7,8 @@ pub mod expunge;
 pub mod fetch_message;
 pub mod flags;
 pub mod folder_mgmt;
+#[expect(dead_code, reason = "handlers wired in 3a-T5 dispatch")]
+pub mod labels;
 pub mod list_attachments;
 pub mod list_folders;
 pub(crate) mod message_builder;

--- a/crates/rimap-server/src/tools/move_message.rs
+++ b/crates/rimap-server/src/tools/move_message.rs
@@ -4,8 +4,8 @@ use rimap_imap::types::Uid;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 use crate::tools::flags::resolve_uids;
 
 /// Input for `move_message`.
@@ -23,11 +23,11 @@ pub struct MoveInput {
 
 /// Execute the `move_message` tool.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: MoveInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let uids = resolve_uids(input.uid, input.uids)?;
-    let outcome = server
+    let outcome = account
         .imap
         .move_messages(&input.source_folder, &input.dest_folder, &uids)
         .await?;

--- a/crates/rimap-server/src/tools/search.rs
+++ b/crates/rimap-server/src/tools/search.rs
@@ -48,7 +48,7 @@ pub async fn handle(
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     let query = build_query(account, &input)?;
 
-    let uids = account.imap.search(&input.folder, query).await?;
+    let uids = Box::pin(account.imap.search(&input.folder, query)).await?;
     let total_matched = uids.len();
 
     let offset = input.offset.unwrap_or(0);

--- a/crates/rimap-server/src/tools/search.rs
+++ b/crates/rimap-server/src/tools/search.rs
@@ -8,8 +8,8 @@ use rimap_imap::types::{
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 
 /// Maximum number of results per page.
 const MAX_LIMIT: usize = 100;
@@ -43,12 +43,12 @@ pub struct SearchInput {
 
 /// Execute the `search` tool.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: SearchInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
-    let query = build_query(server, &input)?;
+    let query = build_query(account, &input)?;
 
-    let uids = server.imap.search(&input.folder, query).await?;
+    let uids = account.imap.search(&input.folder, query).await?;
     let total_matched = uids.len();
 
     let offset = input.offset.unwrap_or(0);
@@ -61,7 +61,7 @@ pub async fn handle(
     let messages = if page_uids.is_empty() {
         Vec::new()
     } else {
-        let fetched = server
+        let fetched = account
             .imap
             .fetch(
                 &input.folder,
@@ -94,11 +94,11 @@ pub async fn handle(
 /// Build a `SearchQuery` from the input, checking posture for
 /// advanced queries.
 fn build_query(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: &SearchInput,
 ) -> Result<SearchQuery, rimap_core::RimapError> {
     if let Some(raw) = &input.advanced_query {
-        server
+        account
             .guard
             .matrix()
             .check(ToolName::SearchAdvanced)

--- a/crates/rimap-server/src/tools/send_email.rs
+++ b/crates/rimap-server/src/tools/send_email.rs
@@ -19,7 +19,7 @@ pub async fn handle(
         rimap_core::RimapError::Config("send_email requires SMTP configuration".into())
     })?;
 
-    let from_addr = &account.from_address;
+    let from_addr = account.imap.username();
     let raw_msg = message_builder::build_message(account, from_addr, &input).await?;
 
     // Build SMTP envelope from the compose addresses

--- a/crates/rimap-server/src/tools/send_email.rs
+++ b/crates/rimap-server/src/tools/send_email.rs
@@ -1,8 +1,8 @@
 //! `send_email` tool handler: compose and send via SMTP, then APPEND
 //! a copy to the Sent folder.
 
+use crate::registry::AccountState;
 use crate::response::ToolResponse;
-use crate::server::ImapMcpServer;
 use crate::tools::message_builder::{self, ComposeInput};
 
 /// Input for `send_email` — identical fields to `create_draft`.
@@ -10,33 +10,23 @@ pub type SendEmailInput = ComposeInput;
 
 /// `send_email` handler.
 pub async fn handle(
-    server: &ImapMcpServer,
+    account: &AccountState,
     input: SendEmailInput,
 ) -> Result<ToolResponse, rimap_core::RimapError> {
     message_builder::validate_compose_input(&input)?;
 
-    let smtp_config = server.config.config.smtp.as_ref().ok_or_else(|| {
-        rimap_core::RimapError::Config("send_email requires [smtp] configuration".into())
+    let smtp = account.smtp.as_ref().ok_or_else(|| {
+        rimap_core::RimapError::Config("send_email requires SMTP configuration".into())
     })?;
 
-    let from_addr = &server.config.config.imap.username;
-    let raw_msg = message_builder::build_message(server, from_addr, &input).await?;
+    let from_addr = &account.from_address;
+    let raw_msg = message_builder::build_message(account, from_addr, &input).await?;
 
     // Build SMTP envelope from the compose addresses
     let envelope = build_envelope(from_addr, &input)?;
 
-    // Resolve SMTP credential and build client
-    let password = rimap_config::resolve_credential(
-        &rimap_config::KeyringStore,
-        &smtp_config.username,
-        &smtp_config.host,
-    )
-    .map_err(|e| rimap_core::RimapError::Config(format!("SMTP credential: {e}")))?;
-
-    let client = rimap_smtp::SmtpClient::new(smtp_config, &password)?;
-
     // Send via SMTP using raw bytes
-    let smtp_response = client.send_raw(&envelope, &raw_msg).await?;
+    let smtp_response = smtp.send_raw(&envelope, &raw_msg).await?;
     tracing::info!(smtp_response, "send_email: SMTP send succeeded");
 
     // Extract Message-ID for the response
@@ -46,7 +36,7 @@ pub async fn handle(
 
     // Best-effort: APPEND copy to Sent folder
     let sent_folder = "Sent";
-    let (sent_uid, sent_copy_failed) = match server
+    let (sent_uid, sent_copy_failed) = match account
         .imap
         .append_message(sent_folder, &raw_msg, &[rimap_imap::types::Flag::Seen], &[])
         .await

--- a/crates/rimap-server/tests/audit_merge.rs
+++ b/crates/rimap-server/tests/audit_merge.rs
@@ -49,7 +49,8 @@ fn audit_merge_round_trips_synthetic_log() {
             .log_process_start(ProcessStartInputs {
                 version: "0.0.0-test".to_string(),
                 git_commit: String::new(),
-                posture: "readonly".to_string(),
+                posture: Some("readonly".to_string()),
+                accounts: None,
                 config_path: config_path.clone(),
                 config_hash_sha256: String::new(),
                 trailing,

--- a/crates/rimap-smtp/Cargo.toml
+++ b/crates/rimap-smtp/Cargo.toml
@@ -13,8 +13,8 @@ description = "SMTP client for rusty-imap-mcp — lettre wrapper with TLS and er
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "0.0.0" }
-rimap-config = { path = "../rimap-config", version = "0.0.0" }
+rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-config = { path = "../rimap-config", version = "1.0.0" }
 
 lettre = { workspace = true }
 tokio = { workspace = true }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,13 @@
 # Configuration
 
-rusty-imap-mcp uses a single TOML config file. All sections except `[imap]`
-and `[audit]` have defaults and can be omitted.
+rusty-imap-mcp uses a single TOML config file. Two formats are supported:
+
+- **Single-account (legacy):** flat `[imap]` / `[security]` / `[limits]`
+  sections. Works unchanged from pre-1.0.
+- **Multi-account:** `[[accounts]]` array with optional `[defaults]`.
+  Each account has its own IMAP, SMTP, security, and limits settings.
+
+Mixing both formats in one file is a startup error.
 
 ## Config file location
 
@@ -14,54 +20,126 @@ Resolution order:
      (falls back to `~/.config/rusty-imap-mcp/config.toml`)
    - macOS: `~/Library/Application Support/rusty-imap-mcp/config.toml`
 
-## Minimal example
+## Single-account example (legacy)
 
 ```toml
 [imap]
 host = "127.0.0.1"
 port = 1143
-username = "alice@example.test"
+username = "alice@proton.me"
+tls_fingerprint_sha256 = "ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89"
+
+[smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "alice@proton.me"
+
+[security]
+posture = "draft-safe"
+
+[limits]
+commands_per_second = 10
 
 [audit]
 path = "/home/alice/.local/state/rusty-imap-mcp/audit.jsonl"
+
+[attachments]
+download_dir = ""
 ```
 
-All other sections use defaults when omitted.
+## Multi-account example
+
+```toml
+[defaults.security]
+posture = "draft-safe"
+protected_folders = ["INBOX", "Sent", "Drafts", "Trash"]
+
+[defaults.limits]
+commands_per_second = 10
+
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "user@proton.me"
+tls_fingerprint_sha256 = "ab:cd:..."
+
+[accounts.smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "user@proton.me"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.fastmail.com"
+port = 993
+username = "me@fastmail.com"
+
+[accounts.security]
+posture = "readonly"
+
+[audit]
+path = "/home/user/.local/state/rusty-imap-mcp/audit.jsonl"
+```
+
+See [multi-account.md](multi-account.md) for account discovery and
+selection details.
 
 ## `[imap]` section
 
-IMAP connection settings. `host`, `port`, and `username` are required.
+IMAP connection settings. Required per account (or at the top level in
+single-account format).
 
 | Field | Type | Default | Description |
-|---|---|---|---|
+|-------|------|---------|-------------|
 | `host` | string | (required) | IMAP server hostname or IP |
 | `port` | u16 | (required) | IMAP server port (IMAPS) |
 | `username` | string | (required) | IMAP login identity |
-| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional (`"ab:cd:..."` or `"abcd..."`). Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. |
+| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional. Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. |
 | `command_timeout_seconds` | u32 | 30 | Per-command timeout for IMAP operations |
 | `connect_timeout_seconds` | u32 | 10 | TCP + TLS handshake + greeting + CAPABILITY probe deadline |
+
+## `[smtp]` section
+
+SMTP connection settings. Optional -- required only when `send_email` is
+enabled by the active posture.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | string | (required) | SMTP server hostname or IP |
+| `port` | u16 | (required) | SMTP server port (587 for STARTTLS, 465 for implicit TLS) |
+| `encryption` | string | (required) | `"starttls"`, `"tls"`, or `"none"` |
+| `username` | string | (required) | SMTP login identity |
+| `command_timeout_seconds` | u32 | 30 | Per-command timeout for SMTP operations |
 
 ## `[security]` section
 
 Controls which tools are available.
 
 | Field | Type | Default | Description |
-|---|---|---|---|
-| `posture` | string | `"draft-safe"` | Base posture: `"readonly"`, `"draft-safe"`, or `"full"`. See [postures.md](postures.md). |
+|-------|------|---------|-------------|
+| `posture` | string | `"draft-safe"` | Base posture: `"readonly"`, `"draft-safe"`, `"full"`, or `"destructive"`. See [security-model.md](security-model.md). |
 | `tools` | table | (empty) | Per-tool overrides. Keys are tool names, values are `"allow"` or `"deny"`. |
+| `protected_folders` | list | `["INBOX", "Sent", "Drafts", "Trash"]` | Folders that cannot be renamed or deleted |
+| `expunge_folders` | list | `[]` | Folders where `expunge` and `delete_folder` are permitted (default empty = deny all) |
 
 ### `[security.lookalike]` subsection
 
 | Field | Type | Default | Description |
-|---|---|---|---|
+|-------|------|---------|-------------|
 | `enabled` | bool | true | Enable look-alike detection on addresses, domains, links, and filenames |
-| `known_domains` | list of strings | `[]` | User-curated watchlist of protected domains (e.g. `["paypal.com"]`) |
+| `known_domains` | list | `[]` | User-curated watchlist of protected domains (e.g. `["paypal.com"]`) |
 | `warn_on_any_non_ascii_domain` | bool | false | Warn on any non-ASCII domain, even if not in the watchlist |
 
 ### Per-tool overrides
 
-Override the posture's default for individual tools. Use the tool's
-canonical name as the key:
+Override the posture's default for individual tools:
 
 ```toml
 [security]
@@ -75,89 +153,70 @@ mark_read = "deny"                # deny even though draft-safe allows it
 Valid tool names: `list_folders`, `search`, `search.advanced_query`,
 `fetch_message`, `fetch_message.include_html`, `list_attachments`,
 `download_attachment`, `mark_read`, `mark_unread`, `flag`, `unflag`,
-`move_message`, `create_draft`.
-
-Overrides referencing unknown or v2 tools (`delete_message`, `expunge`,
-`send_email`) are a startup error.
+`add_label`, `remove_label`, `list_labels`, `move_message`,
+`create_draft`, `send_email`, `delete_message`, `create_folder`,
+`rename_folder`, `expunge`, `delete_folder`.
 
 ## `[limits]` section
 
 Numeric limits for rate limiting, search, and size caps.
 
 | Field | Type | Default | Description |
-|---|---|---|---|
+|-------|------|---------|-------------|
 | `max_search_results` | u32 | 200 | Default search result limit |
-| `max_search_results_cap` | u32 | 1000 | Hard ceiling on `max_search_results` |
-| `max_fetch_body_bytes` | u64 | 5,242,880 (5 MiB) | Max fetched body bytes per message. Bodies exceeding this are truncated. |
-| `max_attachment_bytes` | u64 | 26,214,400 (25 MiB) | Max attachment bytes. Attachments exceeding this are refused at download. |
+| `max_search_results_cap` | u32 | 1000 | Hard ceiling on search results |
+| `max_fetch_body_bytes` | u64 | 5,242,880 (5 MiB) | Max fetched body bytes per message |
+| `max_attachment_bytes` | u64 | 26,214,400 (25 MiB) | Max attachment download size |
+| `max_append_bytes` | u64 | 10,485,760 (10 MiB) | Max APPEND message size (drafts, sent copy) |
 | `commands_per_second` | u32 | 10 | Rate limiter: tool calls per second |
 | `drafts_per_minute` | u32 | 5 | Separate rate limit for `create_draft` |
+| `sends_per_minute` | u32 | 3 | Separate rate limit for `send_email` |
 | `circuit_breaker_error_threshold` | u32 | 5 | Error count within the window to trip the circuit breaker |
 | `circuit_breaker_window_seconds` | u32 | 30 | Sliding window for the circuit breaker error counter |
 
 ## `[audit]` section
 
-Audit log file settings. `path` is required.
+Audit log settings. `path` is required. Global (shared across all
+accounts in multi-account configs).
 
 | Field | Type | Default | Description |
-|---|---|---|---|
+|-------|------|---------|-------------|
 | `path` | string | (required) | Path to the audit log file (JSONL) |
 | `rotate_bytes` | u64 | 10,485,760 (10 MiB) | Rotate when the file reaches this size. `0` disables rotation. |
 | `rotate_keep` | u32 | 5 | Number of rotated files to keep after rotation |
-| `provenance_window_seconds` | u32 | 60 | Provenance ring buffer window for tracking recently-read message IDs |
-| `fail_open` | bool | false | If true, continue on audit write failure (insecure). Default is false: audit write failure fails the tool call. |
-| `allowed_base_dir` | string | (platform default) | Containment base for `audit.path`. The path must resolve under this directory. Defaults to `$XDG_STATE_HOME/rusty-imap-mcp/` or platform equivalent. Set to `"/"` to disable containment (not recommended). |
+| `retention_seconds` | u64 | (none) | Time-based retention for rotated files. Omit to disable. |
+| `provenance_window_seconds` | u32 | 60 | Provenance ring buffer window |
+| `fail_open` | bool | false | If true, continue on audit write failure (insecure). Default: audit write failure fails the tool call. |
+| `allowed_base_dir` | string | (platform default) | Containment base for `audit.path`. Defaults to `$XDG_STATE_HOME/rusty-imap-mcp/`. Set to `"/"` to disable (not recommended). |
 
 See [audit-log.md](audit-log.md) for the log format and record types.
 
 ## `[attachments]` section
 
+Global (shared across all accounts).
+
 | Field | Type | Default | Description |
-|---|---|---|---|
+|-------|------|---------|-------------|
 | `download_dir` | string | `""` | Directory for downloaded attachments. Empty string means a per-session temporary directory. |
 
-## Full example
+## `[defaults]` section (multi-account only)
+
+Default security and limits settings inherited by all accounts unless
+overridden per-account. Only valid in multi-account configs.
 
 ```toml
-[imap]
-host = "127.0.0.1"
-port = 1143
-username = "dave@proton.me"
-tls_fingerprint_sha256 = "ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89"
-command_timeout_seconds = 30
-connect_timeout_seconds = 10
-
-[security]
+[defaults.security]
 posture = "draft-safe"
+protected_folders = ["INBOX", "Sent", "Drafts", "Trash"]
 
-[security.tools]
-# mark_read = "deny"
-
-[security.lookalike]
-enabled = true
-known_domains = ["paypal.com", "example.com"]
-warn_on_any_non_ascii_domain = false
-
-[limits]
-max_search_results = 200
-max_search_results_cap = 1000
-max_fetch_body_bytes = 5_242_880
-max_attachment_bytes = 26_214_400
+[defaults.limits]
 commands_per_second = 10
 drafts_per_minute = 5
-circuit_breaker_error_threshold = 5
-circuit_breaker_window_seconds = 30
-
-[audit]
-path = "/home/dave/.local/state/rusty-imap-mcp/audit.jsonl"
-rotate_bytes = 10_485_760
-rotate_keep = 5
-provenance_window_seconds = 60
-fail_open = false
-
-[attachments]
-download_dir = ""
 ```
+
+Per-account `[accounts.security]` and `[accounts.limits]` sections
+override the corresponding `[defaults.*]` sections. Fields not specified
+in the per-account section inherit from defaults.
 
 ## Credential resolution
 
@@ -179,11 +238,16 @@ transport). The `login` subcommand is the only interactive mode.
 
 ## Validation
 
-The config is validated at startup. Validation errors are fatal. Checks
-include:
+The config is validated at startup. Validation errors are fatal:
 
-- Posture name is one of `readonly`, `draft-safe`, `full`
-- Every tool override name exists in the v1 tool set
+- Posture name is one of `readonly`, `draft-safe`, `full`, `destructive`
+- Every tool override name exists in the tool set
 - TLS fingerprint (if set) parses as 32 hex bytes
 - Numeric limits are positive
 - Unknown fields in any section are rejected (`deny_unknown_fields`)
+- Account names: non-empty, ASCII alphanumeric + hyphens, max 64 chars,
+  unique across all accounts
+- At least one account (flat `[imap]` or `[[accounts]]`) must exist
+- Flat `[imap]` and `[[accounts]]` cannot coexist (`MixedConfigFormat`)
+- SMTP required when `send_email` is enabled for an account
+- `protected_folders` and `expunge_folders` must not overlap

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -1,0 +1,172 @@
+# Multi-Account Support
+
+rusty-imap-mcp supports multiple IMAP/SMTP accounts in a single server
+process. Each account has its own IMAP connection, SMTP client, rate
+limiter, circuit breaker, and folder guard. There is no shared mutable
+state between accounts.
+
+## Configuration
+
+Define accounts with the `[[accounts]]` array in the config file:
+
+```toml
+[defaults.security]
+posture = "draft-safe"
+
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "user@proton.me"
+tls_fingerprint_sha256 = "ab:cd:..."
+
+[accounts.smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "user@proton.me"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.fastmail.com"
+port = 993
+username = "me@fastmail.com"
+
+[accounts.security]
+posture = "readonly"
+```
+
+See [configuration.md](configuration.md) for the full config reference.
+
+## Account discovery via MCP resources
+
+Agents discover accounts through the MCP resource protocol.
+`list_resources` returns one resource per configured account:
+
+```json
+[
+  {
+    "uri": "rimap://accounts/work",
+    "name": "work",
+    "description": "IMAP account: user@proton.me on 127.0.0.1",
+    "mimeType": "application/json"
+  },
+  {
+    "uri": "rimap://accounts/personal",
+    "name": "personal",
+    "description": "IMAP account: me@fastmail.com on imap.fastmail.com",
+    "mimeType": "application/json"
+  }
+]
+```
+
+Reading a resource returns account metadata:
+
+```json
+{
+  "name": "work",
+  "imap_host": "127.0.0.1",
+  "imap_port": 1143,
+  "imap_username": "user@proton.me",
+  "posture": "draft-safe",
+  "smtp_configured": true,
+  "protected_folders": ["INBOX", "Sent", "Drafts", "Trash"],
+  "available_tools": ["list_folders", "search", "fetch_message", "..."]
+}
+```
+
+No credentials, TLS fingerprints, or passwords are exposed in resources.
+
+## Account selection
+
+### `use_account` tool
+
+Sets the session-scoped default account:
+
+```json
+{ "account": "work" }
+```
+
+All subsequent tool calls use this account unless overridden per-call.
+`use_account` bypasses posture checks, rate limiting, and circuit
+breaker -- it is an infrastructure tool, not an IMAP operation.
+
+### Per-call `account` parameter
+
+Any tool call can include an `"account"` parameter to target a specific
+account for that call only:
+
+```json
+{ "account": "personal", "folder": "INBOX", "limit": 10 }
+```
+
+The per-call parameter does not change the session default.
+
+### Resolution order
+
+On every tool call (except `use_account` and `list_accounts`):
+
+1. If the tool arguments contain `"account": "<name>"` -- use that account.
+2. Else if `use_account` has been called -- use the session default.
+3. Else if exactly one account is configured -- auto-select it.
+4. Else -- return `ERR_NO_ACCOUNT` with a list of available accounts.
+
+### `list_accounts` tool
+
+Returns an array of account summaries:
+
+```json
+[
+  { "name": "work", "imap_host": "127.0.0.1", "posture": "full", "smtp_configured": true },
+  { "name": "personal", "imap_host": "imap.fastmail.com", "posture": "readonly", "smtp_configured": false }
+]
+```
+
+`list_accounts` bypasses posture checks and is always available.
+
+## Per-account isolation
+
+Each account has independent:
+
+- IMAP connection
+- SMTP client (if configured)
+- Rate limiter (`commands_per_second`, `drafts_per_minute`,
+  `sends_per_minute`)
+- Circuit breaker
+- Folder guard (`protected_folders`, `expunge_folders`)
+- Security posture
+
+One account's rate limit or circuit breaker state does not affect
+another.
+
+## Backward compatibility
+
+A config with no `[[accounts]]` section and the existing flat `[imap]` /
+`[smtp]` / `[security]` / `[limits]` structure is treated as a single
+anonymous account named `"default"`. No config changes are required when
+upgrading from pre-1.0.
+
+Mixing flat top-level `[imap]` and `[[accounts]]` is a startup error
+(`MixedConfigFormat`).
+
+## Audit log
+
+All accounts share a single audit log file. Every record includes an
+`account` field identifying which account the operation targeted. The
+`audit merge --account <name>` flag filters records by account name.
+
+## Threat model
+
+Multi-account introduces a cross-account data exfiltration vector: a
+prompt-injected agent with access to multiple accounts could read from
+one account and send via another. Mitigations:
+
+- Per-account posture gates -- a `readonly` account cannot send even if
+  another account is `full`.
+- Per-account rate limiting and circuit breakers.
+- Audit log records include the account name on every operation for
+  forensic reconstruction.

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -160,6 +160,39 @@ All accounts share a single audit log file. Every record includes an
 `account` field identifying which account the operation targeted. The
 `audit merge --account <name>` flag filters records by account name.
 
+## Credential Resolution
+
+Each account resolves its IMAP (and SMTP) password via:
+
+1. **OS keyring** keyed by `<username>@<host>`, service `rusty-imap-mcp`.
+2. **Environment variable** `RUSTY_IMAP_MCP_PASSWORD` (single global value).
+3. Failure (`ERR_CONFIG`) if neither is set.
+
+### Keyring Collision (Multi-Account)
+
+The keyring key is `<username>@<host>`, NOT `<account>/<username>@<host>`. If two
+accounts share a `username@host` tuple (e.g., the same email configured for two
+logical accounts), they share a keyring entry — the last `rusty-imap-mcp login`
+wins.
+
+**Workaround:** Give each account a distinct IMAP username (include `+alias`
+suffixes if your provider supports them), or use the environment variable
+fallback for one of the two.
+
+### Env-var Fallback (Multi-Account)
+
+`RUSTY_IMAP_MCP_PASSWORD` is a single global fallback. In multi-account configs,
+if the keyring lookup fails for account A, every subsequent account falls back
+to the same env-var value. This can send account B's password to account A's
+server.
+
+**Recommendation:** In multi-account deployments, use the keyring for every
+account. Do not set `RUSTY_IMAP_MCP_PASSWORD` in production. The fallback exists
+for CI/test automation only.
+
+Tracking issues for per-account keyring namespacing and per-account env vars
+are linked in the v1.x roadmap.
+
 ## Threat model
 
 Multi-account introduces a cross-account data exfiltration vector: a

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -70,16 +70,14 @@ Reading a resource returns account metadata:
 {
   "name": "work",
   "imap_host": "127.0.0.1",
-  "imap_port": 1143,
-  "imap_username": "user@proton.me",
-  "posture": "draft-safe",
   "smtp_configured": true,
-  "protected_folders": ["INBOX", "Sent", "Drafts", "Trash"],
   "available_tools": ["list_folders", "search", "fetch_message", "..."]
 }
 ```
 
-No credentials, TLS fingerprints, or passwords are exposed in resources.
+No credentials, TLS fingerprints, passwords, or posture are exposed in
+resources. Posture is intentionally withheld so an injected prompt
+cannot discover which account has the most-permissive posture.
 
 ## Account selection
 

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -119,10 +119,13 @@ Returns an array of account summaries:
 
 ```json
 [
-  { "name": "work", "imap_host": "127.0.0.1", "posture": "full", "smtp_configured": true },
-  { "name": "personal", "imap_host": "imap.fastmail.com", "posture": "readonly", "smtp_configured": false }
+  { "name": "work", "smtp_configured": true },
+  { "name": "personal", "smtp_configured": false }
 ]
 ```
+
+`imap_host` and `posture` are intentionally omitted to avoid leaking
+provider fingerprints or security-posture signals to injected prompts.
 
 `list_accounts` bypasses posture checks and is always available.
 

--- a/docs/postures.md
+++ b/docs/postures.md
@@ -1,16 +1,17 @@
 # Security Postures
 
-rusty-imap-mcp uses three security postures to control which tools are
-available. The posture is set in the config file under `[security].posture`
-and defaults to `draft-safe`.
+rusty-imap-mcp uses four security postures to control which tools are
+available. The posture is set in the config file under
+`[security].posture` and defaults to `draft-safe`.
 
 ## Posture values
 
 | Posture | Description |
-|---|---|
+|---------|-------------|
 | `readonly` | Read-only operations. No flag changes, no drafts, no moves. |
-| `draft-safe` | Read + safe mutations: flag changes, moves, and draft creation with `$PendingReview`. Default. |
-| `full` | Everything in `draft-safe` plus escape hatches: `search.advanced_query` and `fetch_message.include_html`. |
+| `draft-safe` | Read + safe mutations: flag/label changes, moves, and draft creation with `$PendingReview`. Default. |
+| `full` | Everything in `draft-safe` plus send, delete, folder management, HTML bodies, advanced search. |
+| `destructive` | Everything in `full` plus permanent deletion: expunge and delete_folder. |
 
 ## Tool matrix
 
@@ -18,21 +19,33 @@ Each row is a dispatchable capability. Some MCP tools expose multiple
 gated capabilities (e.g. `search` has a separate `search.advanced_query`
 capability).
 
-| Capability | `readonly` | `draft-safe` | `full` |
-|---|---|---|---|
-| `list_folders` | allowed | allowed | allowed |
-| `search` | allowed | allowed | allowed |
-| `search.advanced_query` | **denied** | **denied** | allowed |
-| `fetch_message` | allowed | allowed | allowed |
-| `fetch_message.include_html` | **denied** | **denied** | allowed |
-| `list_attachments` | allowed | allowed | allowed |
-| `download_attachment` | allowed | allowed | allowed |
-| `mark_read` | **denied** | allowed | allowed |
-| `mark_unread` | **denied** | allowed | allowed |
-| `flag` | **denied** | allowed | allowed |
-| `unflag` | **denied** | allowed | allowed |
-| `move_message` | **denied** | allowed | allowed |
-| `create_draft` | **denied** | allowed | allowed |
+| Capability | `readonly` | `draft-safe` | `full` | `destructive` |
+|------------|:----------:|:------------:|:------:|:-------------:|
+| `list_folders` | allowed | allowed | allowed | allowed |
+| `search` | allowed | allowed | allowed | allowed |
+| `search.advanced_query` | denied | denied | allowed | allowed |
+| `fetch_message` | allowed | allowed | allowed | allowed |
+| `fetch_message.include_html` | denied | denied | allowed | allowed |
+| `list_attachments` | allowed | allowed | allowed | allowed |
+| `download_attachment` | allowed | allowed | allowed | allowed |
+| `mark_read` | denied | allowed | allowed | allowed |
+| `mark_unread` | denied | allowed | allowed | allowed |
+| `flag` | denied | allowed | allowed | allowed |
+| `unflag` | denied | allowed | allowed | allowed |
+| `add_label` | denied | allowed | allowed | allowed |
+| `remove_label` | denied | allowed | allowed | allowed |
+| `list_labels` | allowed | allowed | allowed | allowed |
+| `move_message` | denied | allowed | allowed | allowed |
+| `create_draft` | denied | allowed | allowed | allowed |
+| `send_email` | denied | denied | allowed | allowed |
+| `delete_message` | denied | denied | allowed | allowed |
+| `create_folder` | denied | denied | allowed | allowed |
+| `rename_folder` | denied | denied | allowed | allowed |
+| `expunge` | denied | denied | denied | allowed |
+| `delete_folder` | denied | denied | denied | allowed |
+
+`use_account` and `list_accounts` are infrastructure tools that bypass
+posture checks entirely and are always available.
 
 ## Per-tool overrides
 
@@ -50,8 +63,6 @@ mark_read = "deny"                # deny even though draft-safe allows it
 - `"allow"` grants the tool regardless of what the posture would deny.
 - `"deny"` blocks the tool regardless of what the posture would allow.
 - An override that matches the posture's default is a no-op (not an error).
-- Overrides referencing unknown tool names or v2 tools (`delete_message`,
-  `expunge`, `send_email`) cause a startup error.
 
 ## Tool advertisement
 
@@ -59,54 +70,16 @@ Tools denied by the effective matrix (posture + overrides) are **not
 advertised** via the MCP `list_tools` response. Denial is enforced at
 both discovery and dispatch (defense in depth).
 
-The `advertised` set is the list of tool names where the effective
-matrix resolves to `allowed`. For example, with `readonly` posture and
-no overrides, `list_tools` returns only: `list_folders`, `search`,
-`fetch_message`, `list_attachments`, `download_attachment`.
+## Folder safety (full and destructive postures)
 
-## Escape hatches (full posture only)
-
-Two capabilities are restricted to the `full` posture by default:
-
-- **`search.advanced_query`** -- allows raw IMAP search queries
-  (e.g. `"OR FROM alice FROM bob"`). Bypasses the structured query
-  builder. Useful for queries the structured form cannot express, but
-  exposes the full IMAP SEARCH grammar.
-
-- **`fetch_message.include_html`** -- returns sanitized HTML alongside
-  the text body. The HTML is sanitized by `ammonia` with a conservative
-  allowlist, but still carries more attack surface than plain text.
-
-Both can be individually enabled in lower postures via per-tool
-overrides if the operator accepts the tradeoff.
+- `protected_folders` (default: INBOX, Sent, Drafts, Trash) blocks
+  `rename_folder` and `delete_folder` on critical folders.
+- `expunge_folders` (default empty = deny all) is an allowlist for
+  `expunge` and `delete_folder`.
 
 ## `$PendingReview` flag
 
-In both `draft-safe` and `full` postures, `create_draft` appends
-messages to the Drafts folder with the `\Draft` flag and a
-`$PendingReview` keyword. This acts as a human-in-the-loop gate: the
-agent can compose a draft, but a human must review and send it from
-their mail client. The server never opens an SMTP connection in v1.
-
-## Config example
-
-```toml
-# Read-only posture for monitoring/analysis use cases
-[security]
-posture = "readonly"
-```
-
-```toml
-# Default posture (can be omitted entirely)
-[security]
-posture = "draft-safe"
-```
-
-```toml
-# Full posture with one tool locked down
-[security]
-posture = "full"
-
-[security.tools]
-create_draft = "deny"
-```
+In `draft-safe` and above, `create_draft` appends messages to the
+Drafts folder with the `\Draft` flag and a `$PendingReview` keyword.
+This acts as a human-in-the-loop gate: the agent can compose a draft,
+but a human must review and send it from their mail client.

--- a/docs/proton-bridge-setup.md
+++ b/docs/proton-bridge-setup.md
@@ -2,7 +2,7 @@
 
 rusty-imap-mcp's primary target is Proton Mail via
 [Proton Bridge](https://proton.me/mail/bridge), which exposes a local
-IMAP server on `127.0.0.1:1143` with a self-signed TLS certificate.
+IMAP/SMTP server on `127.0.0.1` with a self-signed TLS certificate.
 
 ## Prerequisites
 
@@ -13,8 +13,8 @@ IMAP server on `127.0.0.1:1143` with a self-signed TLS certificate.
 
 ## Capture the TLS fingerprint
 
-Proton Bridge uses a self-signed certificate. You must pin the
-certificate fingerprint in the config file so the server can verify it.
+Proton Bridge uses a self-signed certificate. Pin the certificate
+fingerprint in the config file so the server can verify it.
 
 ```bash
 openssl s_client -connect 127.0.0.1:1143 < /dev/null 2>/dev/null \
@@ -29,7 +29,9 @@ The fingerprint changes when Proton Bridge regenerates its certificate
 (e.g. after a Bridge update or reinstall). If the server fails to
 connect with `ERR_TLS`, recapture the fingerprint.
 
-## Store the credential
+## Store credentials
+
+Store the IMAP password:
 
 ```bash
 rusty-imap-mcp login
@@ -40,9 +42,19 @@ OS keychain under service `rusty-imap-mcp`, account
 `<username>@127.0.0.1`. Use the bridge password from step 3, not your
 Proton account password.
 
-Alternatively, set `RUSTY_IMAP_MCP_PASSWORD` for headless environments.
+For SMTP (if using `send_email` in `full` posture), the same bridge
+password is used. Store it for the SMTP host:
+
+```bash
+RUSTY_IMAP_MCP_PASSWORD=<bridge-password> rusty-imap-mcp login
+```
+
+Alternatively, set `RUSTY_IMAP_MCP_PASSWORD` for headless environments
+(applies to both IMAP and SMTP).
 
 ## Config file
+
+### Single-account
 
 ```toml
 [imap]
@@ -51,6 +63,12 @@ port = 1143
 username = "dave@proton.me"
 tls_fingerprint_sha256 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
+[smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "dave@proton.me"
+
 [security]
 posture = "draft-safe"
 
@@ -58,8 +76,42 @@ posture = "draft-safe"
 path = "/home/dave/.local/state/rusty-imap-mcp/audit.jsonl"
 ```
 
+### Multi-account
+
+```toml
+[[accounts]]
+name = "proton"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "dave@proton.me"
+tls_fingerprint_sha256 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[accounts.smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "dave@proton.me"
+
+[audit]
+path = "/home/dave/.local/state/rusty-imap-mcp/audit.jsonl"
+```
+
 Replace `username` with your Proton email address and
 `tls_fingerprint_sha256` with the output from the openssl command above.
+
+## Verify with --dry-run
+
+Test the configuration without starting the MCP server:
+
+```bash
+rusty-imap-mcp --dry-run
+```
+
+This validates the config, resolves credentials, and attempts an IMAP
+connection (including TLS fingerprint verification), then exits. A
+successful run prints the account summary and server capabilities.
 
 ## Known quirks
 
@@ -93,9 +145,14 @@ MOVE directly rather than the COPY+STORE+EXPUNGE fallback.
 
 ### Bridge password vs. account password
 
-The IMAP password is the bridge-specific password displayed in Proton
-Bridge settings, not your Proton account password. Using the wrong
-password results in `ERR_AUTH`.
+The IMAP/SMTP password is the bridge-specific password displayed in
+Proton Bridge settings, not your Proton account password. Using the
+wrong password results in `ERR_AUTH`.
+
+### SMTP port
+
+Proton Bridge typically uses port 1025 for SMTP with STARTTLS. The
+exact port is shown in Bridge settings.
 
 ### Timeouts
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -10,6 +10,10 @@ mailbox state, or pivot to other tools.
 Secondary adversaries include a hostile IMAP server (MITM, malformed
 responses) and local malware with the user's file-system privileges.
 
+Multi-account introduces a cross-account exfiltration vector: a
+compromised agent could read from one account and send via another.
+Per-account posture gates, rate limits, and audit logging mitigate this.
+
 **The server does not trust:** email bodies, headers, sender addresses,
 display names, attachment filenames, link targets, or any
 server-provided content. All of these are treated as untrusted input
@@ -102,46 +106,53 @@ Body text prose is not scanned (false-positive rate on multilingual
 content is too high). All detection is local, deterministic, and
 rules-based -- no network lookups, no ML.
 
-Warning codes include `LOOKALIKE_SENDER_MIXED_SCRIPT`,
-`LOOKALIKE_SENDER_CONFUSABLE`, `LOOKALIKE_DISPLAY_NAME_SPOOFS_ADDRESS`,
-`LOOKALIKE_REPLY_TO_DOMAIN_MISMATCH`, `LOOKALIKE_LINK_DOMAIN_MISMATCH`,
-`LOOKALIKE_FILENAME_BIDI_EXTENSION`, and others.
-
 ### 5. `$PendingReview` human-in-the-loop gate
 
 `create_draft` appends messages to the Drafts folder with `\Draft` and
-`$PendingReview` keywords. The server never opens an SMTP connection in
-v1. A human must review and send from their mail client. This prevents
-an agent from autonomously sending mail, even in the `full` posture.
+`$PendingReview` keywords. A human must review and send from their mail
+client. This provides a safe drafting workflow in `draft-safe` posture
+without granting autonomous send capability.
 
 ### 6. Posture-based authorization
 
-Three postures (`readonly`, `draft-safe`, `full`) control which tools
-are available. Tools denied by the active posture are not advertised via
-`list_tools` and are rejected at dispatch. See [postures.md](postures.md).
+Four postures control which tools are available. Tools denied by the
+active posture are not advertised via `list_tools` and are rejected at
+dispatch.
 
-### 7. Audit log
+### 7. Folder safety
+
+- `protected_folders` (default: INBOX, Sent, Drafts, Trash) prevents
+  `rename_folder` and `delete_folder` on critical folders.
+- `expunge_folders` (default empty = deny all) is an allowlist for
+  `expunge` and `delete_folder`. Folders not in this list cannot be
+  expunged or deleted.
+- `create_folder` rejects names that collide with protected folders
+  (case-insensitive).
+
+### 8. Audit log
 
 Every tool invocation produces exactly two audit records (`tool_start`
 + `tool_end`), linked by a monotonic sequence number. The audit log
 tracks content provenance: a ring buffer of recently-read message IDs
 is snapshotted into every `tool_end` record, enabling post-hoc
-detection of suspicious read-then-draft sequences.
+detection of suspicious read-then-send sequences.
 
 The audit file is exclusively locked for the process lifetime. Write
 failures fail the tool call by default (`fail_open = false`). See
 [audit-log.md](audit-log.md).
 
-### 8. Rate limiting
+### 9. Rate limiting
 
 - Global rate limiter: `commands_per_second` (default 10/sec) with a
   burst of 20.
 - Separate stricter limit for `create_draft`: `drafts_per_minute`
   (default 5/min).
+- Separate stricter limit for `send_email`: `sends_per_minute`
+  (default 3/min).
 - On exceed: waits up to 250ms, then fails with `ERR_RATE_LIMITED` and
   a `retry_after_ms` hint.
 
-### 9. Circuit breaker
+### 10. Circuit breaker
 
 Sliding-window count-based breaker protects against cascading failures:
 
@@ -158,12 +169,45 @@ Errors that trip the breaker: `ConnectionLost`, `AuthFailure`,
 (`NotFound`, `InvalidInput`, `PostureDenied`, `RateLimited`) do not
 trip it.
 
-### 10. TLS fingerprint pinning
+### 11. TLS fingerprint pinning
 
 When `imap.tls_fingerprint_sha256` is set, the server verifies the
 IMAP server's TLS certificate fingerprint before any application data
 flows. A mismatch is a hard failure -- the server does not fall back
 to the system trust store when pinning is configured.
+
+## Posture matrix
+
+22 posture-gated tools across 4 postures. `use_account` and
+`list_accounts` are infrastructure tools that bypass the posture matrix.
+
+| Tool | `readonly` | `draft-safe` | `full` | `destructive` |
+|------|:----------:|:------------:|:------:|:-------------:|
+| `list_folders` | yes | yes | yes | yes |
+| `search` | yes | yes | yes | yes |
+| `search_advanced` | - | - | yes | yes |
+| `fetch_message` | yes | yes | yes | yes |
+| `fetch_message_html` | - | - | yes | yes |
+| `list_attachments` | yes | yes | yes | yes |
+| `download_attachment` | yes | yes | yes | yes |
+| `mark_read` | - | yes | yes | yes |
+| `mark_unread` | - | yes | yes | yes |
+| `flag` | - | yes | yes | yes |
+| `unflag` | - | yes | yes | yes |
+| `add_label` | - | yes | yes | yes |
+| `remove_label` | - | yes | yes | yes |
+| `list_labels` | yes | yes | yes | yes |
+| `move_message` | - | yes | yes | yes |
+| `create_draft` | - | yes | yes | yes |
+| `send_email` | - | - | yes | yes |
+| `delete_message` | - | - | yes | yes |
+| `create_folder` | - | - | yes | yes |
+| `rename_folder` | - | - | yes | yes |
+| `expunge` | - | - | - | yes |
+| `delete_folder` | - | - | - | yes |
+
+Per-tool overrides (`"allow"` / `"deny"`) merge on top of the base
+posture. An override that matches the posture's default is a no-op.
 
 ## Dispatch chain
 

--- a/docs/superpowers/plans/2026-04-13-sprint-3a-labels.md
+++ b/docs/superpowers/plans/2026-04-13-sprint-3a-labels.md
@@ -1,0 +1,591 @@
+# Sprint 3a: Label Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three IMAP keyword label tools (`add_label`, `remove_label`, `list_labels`) to the MCP server, expanding the tool surface from 19 to 22 variants.
+
+**Architecture:** Labels map to standard IMAP keywords via the existing `STORE +FLAGS`/`-FLAGS` and `FETCH FLAGS` commands. The `rimap-imap` crate already has `store_flags` with `Flag::Keyword(String)` support. New tool handlers in `rimap-server` validate label input, delegate to `Connection::store_flags` or `Connection::fetch`, and filter system flags from results.
+
+**Tech Stack:** Rust, async-imap (via rimap-imap), rmcp, schemars, serde
+
+**Depends on:** Nothing — lands independently on a feature branch off `main`.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/rimap-core/src/tool.rs` | Add `AddLabel`, `RemoveLabel`, `ListLabels` variants |
+| Modify | `crates/rimap-core/src/posture_matrix.rs` | Expand `POSTURE_MATRIX` to 22 rows |
+| Modify | `crates/rimap-authz/src/matrix.rs` | Update test expectations for 22 tools |
+| Create | `crates/rimap-server/src/tools/labels.rs` | Label tool handlers + input validation |
+| Modify | `crates/rimap-server/src/tools/mod.rs` | Register `labels` module |
+| Modify | `crates/rimap-server/src/server.rs` | Add dispatch arms + tool definitions |
+| Modify | `crates/rimap-audit/src/redact.rs` | Add redaction schemas for 3 label tools |
+
+---
+
+## Task 1: Add label `ToolName` variants
+
+**Files:**
+- Modify: `crates/rimap-core/src/tool.rs`
+- Modify: `crates/rimap-core/src/posture_matrix.rs`
+
+- [ ] **Step 1: Add three variants to `ToolName`**
+
+In `crates/rimap-core/src/tool.rs`, add three variants to the `ToolName` enum after `Unflag`:
+
+```rust
+    Unflag,
+    AddLabel,
+    RemoveLabel,
+    ListLabels,
+    MoveMessage,
+```
+
+Add the corresponding `as_str()` arms:
+
+```rust
+    Self::AddLabel => "add_label",
+    Self::RemoveLabel => "remove_label",
+    Self::ListLabels => "list_labels",
+```
+
+- [ ] **Step 2: Update `POSTURE_MATRIX` to 22 rows**
+
+In `crates/rimap-core/src/posture_matrix.rs`, change the const array size from 19 to 22 and add three rows after `Unflag`. `add_label` and `remove_label` are metadata mutations (same tier as `flag`), `list_labels` is read-only:
+
+```rust
+pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 22] = [
+    // ... existing rows up through Unflag ...
+    (ToolName::AddLabel,           [false, true,  true,  true ]),
+    (ToolName::RemoveLabel,        [false, true,  true,  true ]),
+    (ToolName::ListLabels,         [true,  true,  true,  true ]),
+    (ToolName::MoveMessage,        [false, true,  true,  true ]),
+    // ... remaining rows unchanged ...
+];
+```
+
+- [ ] **Step 3: Run `cargo check --workspace` to verify compilation**
+
+Run: `cargo check --workspace`
+Expected: compiles successfully. Some tests may fail due to count assertions — that's expected, fixed in next task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-core/src/tool.rs crates/rimap-core/src/posture_matrix.rs
+git commit -m "feat(core): add AddLabel, RemoveLabel, ListLabels tool variants"
+```
+
+---
+
+## Task 2: Update authz tests for 22-tool matrix
+
+**Files:**
+- Modify: `crates/rimap-authz/src/matrix.rs` (tests)
+- Modify: `crates/rimap-server/src/server.rs` (tests)
+
+- [ ] **Step 1: Update matrix test expectations**
+
+In `crates/rimap-authz/src/matrix.rs`, find tests that assert on the number of tools (e.g. `advertised()` count tests). Update expectations:
+- `Readonly` advertised count: was 7, now 8 (adds `ListLabels`)
+- `DraftSafe` advertised count: was 13, now 16 (adds `AddLabel`, `RemoveLabel`, `ListLabels`)
+- `Full` advertised count: was 17, now 20
+- `Destructive` advertised count: was 19, now 22
+
+Verify these counts by examining the existing tests. The exact numbers depend on how sub-capabilities (`SearchAdvanced`, `FetchMessageHtml`) are counted in the matrix — they ARE counted since `EffectiveMatrix` stores all 22 `ToolName` variants.
+
+- [ ] **Step 2: Update server test expectations**
+
+In `crates/rimap-server/src/server.rs`, update the `tool_definition_covers_all_mcp_tools` test. `tool_definition` returns `None` for sub-capabilities (`SearchAdvanced`, `FetchMessageHtml`). With 22 total variants minus 2 sub-capabilities = 20 MCP tools:
+
+```rust
+#[test]
+fn tool_definition_covers_all_mcp_tools() {
+    let defs: Vec<_> = ToolName::all()
+        .into_iter()
+        .filter_map(tool_definition)
+        .collect();
+    // 22 tool variants minus 2 sub-capabilities = 20
+    assert_eq!(defs.len(), 20);
+}
+```
+
+- [ ] **Step 3: Run `cargo test --workspace`**
+
+Run: `cargo test --workspace`
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-authz/src/matrix.rs crates/rimap-server/src/server.rs
+git commit -m "test(authz,server): update expectations for 22-tool posture matrix"
+```
+
+---
+
+## Task 3: Write label validation and tool handlers
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/labels.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Write the failing tests for label validation**
+
+Create `crates/rimap-server/src/tools/labels.rs` with validation logic and tests:
+
+```rust
+//! Label tool handlers: `add_label`, `remove_label`, `list_labels`.
+//!
+//! Labels are standard IMAP keywords (non-system flags). Validation
+//! rejects system flags, backslash-prefixed strings, and IMAP atom
+//! syntax violations.
+
+use rimap_core::RimapError;
+use rimap_imap::types::{Flag, FlagAction, Uid};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::response::ToolResponse;
+use crate::server::ImapMcpServer;
+use crate::tools::flags::resolve_uids;
+
+/// Maximum label length in bytes.
+const MAX_LABEL_BYTES: usize = 256;
+
+/// System flags that must not be set via label tools.
+const SYSTEM_FLAGS: &[&str] = &[
+    "\\Seen",
+    "\\Answered",
+    "\\Flagged",
+    "\\Deleted",
+    "\\Draft",
+    "\\Recent",
+];
+
+/// Characters forbidden in IMAP atoms (RFC 9051 §4.1).
+const ATOM_SPECIALS: &[char] = &[
+    '(', ')', '{', ' ', '%', '*', '"', ']', '\\',
+];
+
+/// Input for `add_label` and `remove_label`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LabelInput {
+    /// IMAP folder name.
+    pub folder: String,
+    /// Single message UID.
+    pub uid: Option<u32>,
+    /// Multiple message UIDs (max 100).
+    pub uids: Option<Vec<u32>>,
+    /// Keyword label to add or remove.
+    pub label: String,
+}
+
+/// Input for `list_labels`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListLabelsInput {
+    /// IMAP folder name.
+    pub folder: String,
+    /// Message UID.
+    pub uid: u32,
+}
+
+/// Validate a label string.
+fn validate_label(label: &str) -> Result<(), RimapError> {
+    if label.is_empty() {
+        return Err(RimapError::Internal(
+            "label must not be empty".to_string(),
+        ));
+    }
+    if label.len() > MAX_LABEL_BYTES {
+        return Err(RimapError::Internal(format!(
+            "label exceeds {MAX_LABEL_BYTES} byte limit: {} bytes",
+            label.len(),
+        )));
+    }
+    if label.contains('\0') {
+        return Err(RimapError::Internal(
+            "label must not contain null bytes".to_string(),
+        ));
+    }
+    if label.starts_with('\\') {
+        return Err(RimapError::Internal(
+            "label must not start with '\\' (reserved for system flags)"
+                .to_string(),
+        ));
+    }
+    if label.chars().any(|c| ATOM_SPECIALS.contains(&c)) {
+        return Err(RimapError::Internal(
+            "label contains characters invalid in IMAP atoms".to_string(),
+        ));
+    }
+    if label.chars().any(|c| c.is_ascii_control()) {
+        return Err(RimapError::Internal(
+            "label must not contain control characters".to_string(),
+        ));
+    }
+    for sys in SYSTEM_FLAGS {
+        if label.eq_ignore_ascii_case(&sys[1..]) {
+            return Err(RimapError::Internal(format!(
+                "label '{}' conflicts with system flag {}",
+                label, sys,
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_labels_pass() {
+        assert!(validate_label("urgent").is_ok());
+        assert!(validate_label("project-x").is_ok());
+        assert!(validate_label("$PendingReview").is_ok());
+        assert!(validate_label("$label1").is_ok());
+    }
+
+    #[test]
+    fn empty_label_rejected() {
+        assert!(validate_label("").is_err());
+    }
+
+    #[test]
+    fn overlength_label_rejected() {
+        let long = "a".repeat(257);
+        assert!(validate_label(&long).is_err());
+    }
+
+    #[test]
+    fn null_byte_rejected() {
+        assert!(validate_label("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn backslash_prefix_rejected() {
+        assert!(validate_label("\\Custom").is_err());
+    }
+
+    #[test]
+    fn system_flag_names_rejected() {
+        assert!(validate_label("Seen").is_err());
+        assert!(validate_label("seen").is_err());
+        assert!(validate_label("Flagged").is_err());
+        assert!(validate_label("Deleted").is_err());
+        assert!(validate_label("Draft").is_err());
+        assert!(validate_label("Answered").is_err());
+        assert!(validate_label("Recent").is_err());
+    }
+
+    #[test]
+    fn atom_special_chars_rejected() {
+        assert!(validate_label("foo bar").is_err());
+        assert!(validate_label("foo(bar)").is_err());
+        assert!(validate_label("foo{bar}").is_err());
+        assert!(validate_label("foo%bar").is_err());
+        assert!(validate_label("foo*bar").is_err());
+        assert!(validate_label("foo\"bar").is_err());
+        assert!(validate_label("foo]bar").is_err());
+    }
+
+    #[test]
+    fn control_chars_rejected() {
+        assert!(validate_label("foo\x01bar").is_err());
+        assert!(validate_label("foo\tbar").is_err());
+    }
+
+    #[test]
+    fn max_length_label_accepted() {
+        let exact = "a".repeat(256);
+        assert!(validate_label(&exact).is_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `crates/rimap-server/src/tools/mod.rs`, add:
+
+```rust
+pub mod labels;
+```
+
+- [ ] **Step 3: Run the validation tests**
+
+Run: `cargo test -p rimap-server labels`
+Expected: all validation tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/labels.rs crates/rimap-server/src/tools/mod.rs
+git commit -m "feat(server): add label validation with unit tests"
+```
+
+---
+
+## Task 4: Implement label tool handler functions
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/labels.rs`
+
+The existing `Connection::store_flags` and `Connection::fetch` methods handle the IMAP layer. The handlers validate input, convert to `Flag::Keyword`, and delegate.
+
+- [ ] **Step 1: Add `handle_add_label` and `handle_remove_label`**
+
+Append to `crates/rimap-server/src/tools/labels.rs`, above the `#[cfg(test)]` block:
+
+```rust
+/// Handle `add_label` — STORE +FLAGS with a keyword.
+pub async fn handle_add_label(
+    server: &ImapMcpServer,
+    input: LabelInput,
+) -> Result<ToolResponse, RimapError> {
+    validate_label(&input.label)?;
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let flags = vec![Flag::Keyword(input.label.clone())];
+    let updated = server
+        .imap
+        .store_flags(&input.folder, &uids, &flags, FlagAction::Add)
+        .await?;
+    let updated_ids: Vec<u32> = updated.iter().map(|u| u.0).collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "label": input.label,
+            "uids_updated": updated_ids,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Handle `remove_label` — STORE -FLAGS with a keyword.
+pub async fn handle_remove_label(
+    server: &ImapMcpServer,
+    input: LabelInput,
+) -> Result<ToolResponse, RimapError> {
+    validate_label(&input.label)?;
+    let uids = resolve_uids(input.uid, input.uids)?;
+    let flags = vec![Flag::Keyword(input.label.clone())];
+    let updated = server
+        .imap
+        .store_flags(&input.folder, &uids, &flags, FlagAction::Remove)
+        .await?;
+    let updated_ids: Vec<u32> = updated.iter().map(|u| u.0).collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "label": input.label,
+            "uids_updated": updated_ids,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+```
+
+- [ ] **Step 2: Add `handle_list_labels`**
+
+`list_labels` fetches FLAGS for a single UID and filters out system flags. The `Connection::fetch` method with `FetchSpec::flags_only()` returns flags. Check how `FetchSpec` works and how flags are returned in `FetchedMessage`. The handler needs to filter to non-system flags:
+
+```rust
+/// Handle `list_labels` — fetch FLAGS and return non-system keywords.
+pub async fn handle_list_labels(
+    server: &ImapMcpServer,
+    input: ListLabelsInput,
+) -> Result<ToolResponse, RimapError> {
+    let uid = Uid(input.uid);
+    let messages = server
+        .imap
+        .fetch(
+            &input.folder,
+            &[uid],
+            rimap_imap::types::FetchSpec::Envelope,
+        )
+        .await?;
+    let msg = messages.into_iter().next().ok_or_else(|| {
+        RimapError::Imap {
+            code: rimap_core::error::ErrorCode::NotFound,
+            message: format!(
+                "message UID {} not found in {}",
+                input.uid, input.folder,
+            ),
+            source: None,
+        }
+    })?;
+    let labels: Vec<&str> = msg
+        .flags
+        .iter()
+        .filter_map(|f| match f {
+            Flag::Keyword(kw) => Some(kw.as_str()),
+            _ => None,
+        })
+        .collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "folder": input.folder,
+            "uid": input.uid,
+            "labels": labels,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+```
+
+Note: the exact `FetchSpec` variant and `FetchedMessage` field names may differ — check `crates/rimap-imap/src/types.rs` during implementation and adjust. The key point is: fetch the message's flags, filter to `Flag::Keyword` variants.
+
+- [ ] **Step 3: Run `cargo check -p rimap-server`**
+
+Run: `cargo check -p rimap-server`
+Expected: compiles. May need import adjustments based on exact types in `rimap-imap`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/labels.rs
+git commit -m "feat(server): implement add_label, remove_label, list_labels handlers"
+```
+
+---
+
+## Task 5: Wire label tools into dispatch and tool definitions
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs`
+
+- [ ] **Step 1: Add tool definitions**
+
+In `crates/rimap-server/src/server.rs`, add a new `tool_spec_v3` function (following the `tool_spec_v1`/`tool_spec_v2` pattern):
+
+```rust
+/// Return (name, description, schema) for v3 label tools.
+fn tool_spec_v3(name: ToolName) -> Option<ToolSpec> {
+    use crate::tools::labels::{LabelInput, ListLabelsInput};
+
+    let tuple = match name {
+        ToolName::AddLabel => (
+            "add_label",
+            "Add a keyword label to messages",
+            schema_map::<LabelInput>(),
+        ),
+        ToolName::RemoveLabel => (
+            "remove_label",
+            "Remove a keyword label from messages",
+            schema_map::<LabelInput>(),
+        ),
+        ToolName::ListLabels => (
+            "list_labels",
+            "List keyword labels on a message",
+            schema_map::<ListLabelsInput>(),
+        ),
+        _ => return None,
+    };
+    Some(tuple)
+}
+```
+
+Update `tool_definition` to chain `tool_spec_v3`:
+
+```rust
+fn tool_definition(name: ToolName) -> Option<Tool> {
+    let (tool_name, description, schema) = tool_spec_v1(name)
+        .or_else(|| tool_spec_v2(name))
+        .or_else(|| tool_spec_v3(name))?;
+    Some(Tool::new(tool_name, description, Arc::new(schema)))
+}
+```
+
+- [ ] **Step 2: Add dispatch arms**
+
+In `ImapMcpServer::dispatch_tool`, add three new arms:
+
+```rust
+    ToolName::AddLabel => {
+        let input = parse_args(args)?;
+        Box::pin(crate::tools::labels::handle_add_label(self, input)).await
+    }
+    ToolName::RemoveLabel => {
+        let input = parse_args(args)?;
+        Box::pin(crate::tools::labels::handle_remove_label(self, input)).await
+    }
+    ToolName::ListLabels => {
+        let input = parse_args(args)?;
+        Box::pin(crate::tools::labels::handle_list_labels(self, input)).await
+    }
+```
+
+- [ ] **Step 3: Run `cargo test -p rimap-server`**
+
+Run: `cargo test -p rimap-server`
+Expected: all tests pass, including the updated `tool_definition_covers_all_mcp_tools` (20 tools).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/server.rs
+git commit -m "feat(server): wire label tools into dispatch and tool_definition"
+```
+
+---
+
+## Task 6: Add label redaction schemas
+
+**Files:**
+- Modify: `crates/rimap-audit/src/redact.rs`
+
+- [ ] **Step 1: Add redaction schemas for label tools**
+
+In the `schemas()` function in `crates/rimap-audit/src/redact.rs`, add three new schemas following the existing pattern. Label arguments are not PII — log them verbatim:
+
+```rust
+    RedactionSchema {
+        tool: "add_label",
+        policies: BTreeMap::from([
+            ("folder", FieldPolicy::Verbatim),
+            ("uid", FieldPolicy::Verbatim),
+            ("uids", FieldPolicy::Verbatim),
+            ("label", FieldPolicy::Verbatim),
+        ]),
+    },
+    RedactionSchema {
+        tool: "remove_label",
+        policies: BTreeMap::from([
+            ("folder", FieldPolicy::Verbatim),
+            ("uid", FieldPolicy::Verbatim),
+            ("uids", FieldPolicy::Verbatim),
+            ("label", FieldPolicy::Verbatim),
+        ]),
+    },
+    RedactionSchema {
+        tool: "list_labels",
+        policies: BTreeMap::from([
+            ("folder", FieldPolicy::Verbatim),
+            ("uid", FieldPolicy::Verbatim),
+        ]),
+    },
+```
+
+- [ ] **Step 2: Run `cargo test -p rimap-audit`**
+
+Run: `cargo test -p rimap-audit`
+Expected: all tests pass. If there's a test asserting schema count, update it.
+
+- [ ] **Step 3: Run `just ci` to verify everything is clean**
+
+Run: `just ci`
+Expected: all checks pass (fmt, clippy, test, deny).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-audit/src/redact.rs
+git commit -m "feat(audit): add redaction schemas for label tools"
+```

--- a/docs/superpowers/plans/2026-04-13-sprint-3b-multi-account.md
+++ b/docs/superpowers/plans/2026-04-13-sprint-3b-multi-account.md
@@ -1,0 +1,1573 @@
+# Sprint 3b: Multi-Account Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add multi-account support: multiple IMAP/SMTP accounts in a single process, discoverable via MCP resources, selectable per-session or per-call. Existing single-account configs continue to work unchanged.
+
+**Architecture:** An `AccountRegistry` holds a `BTreeMap<AccountId, AccountState>` where each `AccountState` bundles a per-account `Connection`, `DispatchGuard`, `FolderGuard`, and optional `SmtpClient`. The server resolves an account on every tool call (explicit param > session default > auto-select > error), then delegates to the existing handler with the resolved account's state. MCP resources expose accounts for agent discovery. A shared `AuditWriter` tags every record with the account name.
+
+**Tech Stack:** Rust, rmcp (ServerHandler + resources), serde/toml, schemars
+
+**Depends on:** Sprint 3a (label tools — so the ToolName enum has 22 variants).
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/rimap-core/src/error.rs` | Add `NoAccount`, `UnknownAccount` error codes |
+| Modify | `crates/rimap-core/src/tool.rs` | Add `UseAccount`, `ListAccounts` variants |
+| Modify | `crates/rimap-core/src/posture_matrix.rs` | No change — infrastructure tools bypass matrix |
+| Create | `crates/rimap-core/src/account.rs` | `AccountId` newtype |
+| Modify | `crates/rimap-core/src/lib.rs` | Re-export `account` module |
+| Modify | `crates/rimap-config/src/model.rs` | `MultiAccountConfig`, `AccountConfig`, `DefaultsConfig` structs |
+| Modify | `crates/rimap-config/src/validate.rs` | `ValidatedAccountConfig`, per-account validation, legacy detection |
+| Modify | `crates/rimap-config/src/loader.rs` | Two-pass loading: try multi-account, fall back to legacy |
+| Modify | `crates/rimap-config/src/error.rs` | New config error variants |
+| Create | `crates/rimap-server/src/registry.rs` | `AccountState`, `AccountRegistry`, resolution logic |
+| Modify | `crates/rimap-server/src/server.rs` | Restructure to use registry, add resource handlers |
+| Modify | `crates/rimap-server/src/dispatch.rs` | Account-aware guard dispatch |
+| Create | `crates/rimap-server/src/tools/accounts.rs` | `use_account`, `list_accounts` handlers |
+| Modify | `crates/rimap-server/src/tools/mod.rs` | Register `accounts` module |
+| Modify | `crates/rimap-server/src/main.rs` | Multi-account bootstrap |
+| Modify | `crates/rimap-audit/src/record.rs` | Add `account` field to records |
+
+---
+
+## Task 1: Add `AccountId` newtype and new error codes
+
+**Files:**
+- Create: `crates/rimap-core/src/account.rs`
+- Modify: `crates/rimap-core/src/lib.rs`
+- Modify: `crates/rimap-core/src/error.rs`
+
+- [ ] **Step 1: Create `AccountId` newtype**
+
+Create `crates/rimap-core/src/account.rs`:
+
+```rust
+//! Account identity type.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Validated account identifier.
+///
+/// ASCII alphanumeric + hyphens, 1–64 characters. The special name
+/// `"default"` is used for legacy single-account configs.
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct AccountId(String);
+
+/// Maximum length of an account name.
+const MAX_ACCOUNT_NAME_LEN: usize = 64;
+
+/// The synthetic name for legacy single-account configs.
+pub const DEFAULT_ACCOUNT_NAME: &str = "default";
+
+impl AccountId {
+    /// Create an `AccountId` from a validated string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the name is empty, too long, or contains
+    /// characters outside `[a-zA-Z0-9-]`.
+    pub fn new(name: &str) -> Result<Self, InvalidAccountName> {
+        if name.is_empty() {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: "account name must not be empty".to_string(),
+            });
+        }
+        if name.len() > MAX_ACCOUNT_NAME_LEN {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: format!(
+                    "account name exceeds {} character limit",
+                    MAX_ACCOUNT_NAME_LEN,
+                ),
+            });
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+        {
+            return Err(InvalidAccountName {
+                name: name.to_string(),
+                reason: "account name must be ASCII alphanumeric or hyphens"
+                    .to_string(),
+            });
+        }
+        Ok(Self(name.to_string()))
+    }
+
+    /// Create the default account ID for legacy configs.
+    pub fn default_account() -> Self {
+        Self(DEFAULT_ACCOUNT_NAME.to_string())
+    }
+
+    /// Return the inner string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Error returned when an account name fails validation.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid account name `{name}`: {reason}")]
+pub struct InvalidAccountName {
+    /// The rejected name.
+    pub name: String,
+    /// Why it was rejected.
+    pub reason: String,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names() {
+        assert!(AccountId::new("work").is_ok());
+        assert!(AccountId::new("personal-2").is_ok());
+        assert!(AccountId::new("default").is_ok());
+        assert!(AccountId::new("a").is_ok());
+    }
+
+    #[test]
+    fn empty_rejected() {
+        assert!(AccountId::new("").is_err());
+    }
+
+    #[test]
+    fn too_long_rejected() {
+        let long = "a".repeat(65);
+        assert!(AccountId::new(&long).is_err());
+    }
+
+    #[test]
+    fn max_length_accepted() {
+        let exact = "a".repeat(64);
+        assert!(AccountId::new(&exact).is_ok());
+    }
+
+    #[test]
+    fn spaces_rejected() {
+        assert!(AccountId::new("my account").is_err());
+    }
+
+    #[test]
+    fn underscores_rejected() {
+        assert!(AccountId::new("my_account").is_err());
+    }
+
+    #[test]
+    fn special_chars_rejected() {
+        assert!(AccountId::new("work@home").is_err());
+        assert!(AccountId::new("work/home").is_err());
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let id = AccountId::new("work").unwrap();
+        assert_eq!(id.to_string(), "work");
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from `rimap-core/src/lib.rs`**
+
+Add to `crates/rimap-core/src/lib.rs`:
+
+```rust
+pub mod account;
+```
+
+- [ ] **Step 3: Add error codes for account resolution**
+
+In `crates/rimap-core/src/error.rs`, add two variants to `ErrorCode`:
+
+```rust
+    NoAccount,
+    UnknownAccount,
+```
+
+And their on-wire strings in the `as_str()` / `Display` impl:
+
+```rust
+    Self::NoAccount => "ERR_NO_ACCOUNT",
+    Self::UnknownAccount => "ERR_UNKNOWN_ACCOUNT",
+```
+
+Add two variants to `RimapError`:
+
+```rust
+    /// No account selected in a multi-account configuration.
+    NoAccount {
+        available: Vec<String>,
+    },
+    /// The requested account does not exist.
+    UnknownAccount {
+        name: String,
+        available: Vec<String>,
+    },
+```
+
+Implement `code()` for the new variants:
+
+```rust
+    Self::NoAccount { .. } => ErrorCode::NoAccount,
+    Self::UnknownAccount { .. } => ErrorCode::UnknownAccount,
+```
+
+Implement `Display` for the new variants:
+
+```rust
+    Self::NoAccount { available } => write!(
+        f,
+        "multiple accounts configured; call `use_account` or pass \
+         `account` parameter. Available: {}",
+        available.join(", "),
+    ),
+    Self::UnknownAccount { name, available } => write!(
+        f,
+        "account '{}' not found. Available: {}",
+        name,
+        available.join(", "),
+    ),
+```
+
+- [ ] **Step 4: Run `cargo test -p rimap-core`**
+
+Run: `cargo test -p rimap-core`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-core/src/account.rs crates/rimap-core/src/lib.rs crates/rimap-core/src/error.rs
+git commit -m "feat(core): add AccountId newtype and NoAccount/UnknownAccount errors"
+```
+
+---
+
+## Task 2: Add `UseAccount` and `ListAccounts` tool variants
+
+**Files:**
+- Modify: `crates/rimap-core/src/tool.rs`
+
+- [ ] **Step 1: Add tool variants**
+
+Add two variants to `ToolName` after `DeleteFolder`:
+
+```rust
+    DeleteFolder,
+    UseAccount,
+    ListAccounts,
+```
+
+Add `as_str()` arms:
+
+```rust
+    Self::UseAccount => "use_account",
+    Self::ListAccounts => "list_accounts",
+```
+
+These tools are NOT added to `POSTURE_MATRIX` — they bypass posture checks entirely. They ARE in the `ToolName` enum so they can be parsed from MCP tool names and dispatched.
+
+- [ ] **Step 2: Update `FromStr` — verify it works**
+
+`FromStr` uses `EnumIter` + `as_str()` matching, so the new variants are automatically parseable. No code change needed — just verify:
+
+Run: `cargo test -p rimap-core`
+Expected: passes. The `all()` method now returns 24 variants.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-core/src/tool.rs
+git commit -m "feat(core): add UseAccount and ListAccounts tool variants"
+```
+
+---
+
+## Task 3: Restructure config for multi-account
+
+**Files:**
+- Modify: `crates/rimap-config/src/model.rs`
+- Modify: `crates/rimap-config/src/error.rs`
+- Modify: `crates/rimap-config/src/loader.rs`
+- Modify: `crates/rimap-config/src/validate.rs`
+
+This is the largest task. The config system needs to support both legacy flat configs and the new `[[accounts]]` format.
+
+- [ ] **Step 1: Add new config error variants**
+
+In `crates/rimap-config/src/error.rs`, add:
+
+```rust
+    DuplicateAccountName { name: String },
+    MixedConfigFormat,
+    InvalidAccountName(#[from] rimap_core::account::InvalidAccountName),
+    NoAccounts,
+```
+
+- [ ] **Step 2: Define multi-account config structs**
+
+In `crates/rimap-config/src/model.rs`, add the new types. Keep all existing types unchanged — they become the "legacy" format:
+
+```rust
+/// Multi-account configuration format.
+///
+/// Deserialized from TOML files with `[[accounts]]` sections.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MultiAccountConfig {
+    #[serde(default)]
+    pub defaults: DefaultsConfig,
+    pub accounts: Vec<RawAccountConfig>,
+    pub audit: AuditConfig,
+    #[serde(default)]
+    pub attachments: AttachmentsConfig,
+}
+
+/// Defaults section — inherited by accounts that don't override.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DefaultsConfig {
+    #[serde(default)]
+    pub security: SecurityConfig,
+    #[serde(default)]
+    pub limits: LimitsConfig,
+}
+
+/// A single account entry from `[[accounts]]`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawAccountConfig {
+    pub name: String,
+    pub imap: ImapConfig,
+    #[serde(default)]
+    pub smtp: Option<SmtpConfig>,
+    #[serde(default)]
+    pub security: Option<SecurityConfig>,
+    #[serde(default)]
+    pub limits: Option<LimitsConfig>,
+}
+```
+
+- [ ] **Step 3: Create `ValidatedAccountConfig`**
+
+In `crates/rimap-config/src/validate.rs`, add:
+
+```rust
+use std::collections::BTreeMap;
+
+use rimap_core::account::AccountId;
+use rimap_core::posture::Posture;
+use rimap_core::tool::ToolName;
+
+use crate::model::{
+    AuditConfig, AttachmentsConfig, ImapConfig, LimitsConfig,
+    SecurityConfig, SmtpConfig, Verdict,
+};
+use rimap_core::tls::TlsFingerprint;
+
+/// Validated per-account configuration.
+#[derive(Debug)]
+pub struct ValidatedAccountConfig {
+    pub id: AccountId,
+    pub imap: ImapConfig,
+    pub smtp: Option<SmtpConfig>,
+    pub security: SecurityConfig,
+    pub limits: LimitsConfig,
+    pub tool_overrides: BTreeMap<ToolName, Verdict>,
+    pub tls_fingerprint: Option<TlsFingerprint>,
+}
+
+/// Validated multi-account configuration.
+#[derive(Debug)]
+pub struct ValidatedMultiConfig {
+    pub accounts: BTreeMap<AccountId, ValidatedAccountConfig>,
+    pub audit: AuditConfig,
+    pub attachments: AttachmentsConfig,
+}
+```
+
+- [ ] **Step 4: Implement multi-account validation**
+
+Add a `validate_multi` function that:
+
+1. Validates account names (no duplicates, valid `AccountId`)
+2. For each account, merges defaults with per-account overrides
+3. Runs the same per-account validations as the existing `validate()`: fingerprint parsing, limit validation, folder safety, SMTP required, SMTP encryption, tool override resolution
+4. Validates global settings: audit path, download dir
+
+```rust
+pub fn validate_multi(
+    config: MultiAccountConfig,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    if config.accounts.is_empty() {
+        return Err(ConfigError::NoAccounts);
+    }
+
+    let mut validated_accounts = BTreeMap::new();
+
+    for raw in &config.accounts {
+        let id = AccountId::new(&raw.name)?;
+        if validated_accounts.contains_key(&id) {
+            return Err(ConfigError::DuplicateAccountName {
+                name: raw.name.clone(),
+            });
+        }
+
+        // Merge defaults with per-account overrides
+        let security = raw.security.clone()
+            .unwrap_or_else(|| config.defaults.security.clone());
+        let limits = raw.limits.clone()
+            .unwrap_or_else(|| config.defaults.limits.clone());
+
+        // Run per-account validations (same as existing validate())
+        let tls_fingerprint = parse_fingerprint(
+            &raw.imap.tls_fingerprint_sha256,
+        )?;
+        validate_limits(&limits)?;
+        validate_folder_safety(&security)?;
+        let tool_overrides = resolve_tool_overrides(&security)?;
+        validate_smtp_required(
+            &security, &tool_overrides, &raw.smtp,
+        )?;
+        if let Some(ref smtp) = raw.smtp {
+            validate_smtp_encryption(smtp)?;
+        }
+
+        validated_accounts.insert(id.clone(), ValidatedAccountConfig {
+            id,
+            imap: raw.imap.clone(),
+            smtp: raw.smtp.clone(),
+            security,
+            limits,
+            tool_overrides,
+            tls_fingerprint,
+        });
+    }
+
+    // Validate global settings
+    validate_audit(&config.audit)?;
+    validate_paths_global(&config.audit, &config.attachments)?;
+
+    Ok(ValidatedMultiConfig {
+        accounts: validated_accounts,
+        audit: config.audit,
+        attachments: config.attachments,
+    })
+}
+```
+
+The exact function signatures for helpers like `parse_fingerprint`, `validate_limits`, etc. should match the existing private functions already in `validate.rs`. Some may need their signatures adjusted to accept borrowed sub-configs rather than the monolithic `Config`.
+
+- [ ] **Step 5: Implement legacy config conversion**
+
+Add a function to convert a legacy `Config` into `ValidatedMultiConfig`:
+
+```rust
+/// Convert a legacy flat config into a multi-account config with one
+/// `"default"` account.
+pub fn validate_legacy_as_multi(
+    config: Config,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    let validated = validate(config)?;
+    let id = AccountId::default_account();
+    let account = ValidatedAccountConfig {
+        id: id.clone(),
+        imap: validated.config.imap.clone(),
+        smtp: validated.config.smtp.clone(),
+        security: validated.config.security.clone(),
+        limits: validated.config.limits.clone(),
+        tool_overrides: validated.tool_overrides,
+        tls_fingerprint: validated.tls_fingerprint,
+    };
+    let mut accounts = BTreeMap::new();
+    accounts.insert(id, account);
+    Ok(ValidatedMultiConfig {
+        accounts,
+        audit: validated.config.audit,
+        attachments: validated.config.attachments,
+    })
+}
+```
+
+- [ ] **Step 6: Implement two-pass loading in `loader.rs`**
+
+In `crates/rimap-config/src/loader.rs`, add a function that tries multi-account parsing first, then falls back to legacy:
+
+```rust
+pub fn load_and_validate(
+    path: &Path,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        ConfigError::Read { path: path.to_path_buf(), source: e }
+    })?;
+
+    // Detect format: if the text contains `[[accounts]]`, try multi-account.
+    // If it contains `[imap]` at the top level, try legacy.
+    // If both are present, error.
+    let has_accounts = text.contains("[[accounts]]");
+    let has_flat_imap = text.contains("[imap]")
+        && !text.contains("[accounts.imap]");
+
+    if has_accounts && has_flat_imap {
+        return Err(ConfigError::MixedConfigFormat);
+    }
+
+    if has_accounts {
+        let config: MultiAccountConfig =
+            toml::from_str(&text).map_err(|e| {
+                ConfigError::Parse { path: path.to_path_buf(), source: e }
+            })?;
+        validate::validate_multi(config)
+    } else {
+        let config: Config =
+            toml::from_str(&text).map_err(|e| {
+                ConfigError::Parse { path: path.to_path_buf(), source: e }
+            })?;
+        validate::validate_legacy_as_multi(config)
+    }
+}
+```
+
+Note: the heuristic detection (`contains("[[accounts]]")`) is intentionally simple. `serde(deny_unknown_fields)` on both `Config` and `MultiAccountConfig` provides the real enforcement — if a field doesn't belong, TOML parsing fails with a clear error.
+
+- [ ] **Step 7: Write tests for multi-account config parsing**
+
+Add tests in `crates/rimap-config/src/validate.rs` (or a new test file):
+
+```rust
+#[cfg(test)]
+mod multi_account_tests {
+    use super::*;
+
+    #[test]
+    fn multi_account_parses() {
+        let toml = r#"
+[audit]
+path = "/tmp/audit.jsonl"
+
+[[accounts]]
+name = "work"
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "user@example.com"
+
+[[accounts]]
+name = "personal"
+[accounts.imap]
+host = "imap.example.com"
+port = 993
+username = "me@example.com"
+"#;
+        let config: MultiAccountConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.accounts.len(), 2);
+        assert_eq!(config.accounts[0].name, "work");
+        assert_eq!(config.accounts[1].name, "personal");
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        // Two accounts named "work" → DuplicateAccountName
+    }
+
+    #[test]
+    fn legacy_config_wraps_as_default() {
+        // Flat [imap] config → single "default" account
+    }
+
+    #[test]
+    fn mixed_format_rejected() {
+        // Both [imap] and [[accounts]] → MixedConfigFormat
+    }
+
+    #[test]
+    fn defaults_inherited() {
+        // [defaults.security] posture = "full"
+        // Account with no [accounts.security] → inherits "full"
+    }
+
+    #[test]
+    fn account_overrides_defaults() {
+        // [defaults.security] posture = "full"
+        // [accounts.security] posture = "readonly" → account is "readonly"
+    }
+
+    #[test]
+    fn no_accounts_rejected() {
+        // [audit] only, no [imap] or [[accounts]] → NoAccounts
+    }
+
+    #[test]
+    fn invalid_account_name_rejected() {
+        // name = "my account" → InvalidAccountName
+    }
+}
+```
+
+- [ ] **Step 8: Run `cargo test -p rimap-config`**
+
+Run: `cargo test -p rimap-config`
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-config/
+git commit -m "feat(config): add multi-account config schema with legacy backward compat"
+```
+
+---
+
+## Task 4: Build `AccountRegistry` and `AccountState`
+
+**Files:**
+- Create: `crates/rimap-server/src/registry.rs`
+
+- [ ] **Step 1: Define `AccountState` and `AccountRegistry`**
+
+Create `crates/rimap-server/src/registry.rs`:
+
+```rust
+//! Account registry: per-account runtime state and session-scoped
+//! account selection.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use rimap_authz::DispatchGuard;
+use rimap_authz::FolderGuard;
+use rimap_authz::breaker::SystemClock;
+use rimap_core::RimapError;
+use rimap_core::account::AccountId;
+use rimap_imap::Connection;
+use rimap_smtp::SmtpClient;
+
+/// Per-account runtime state.
+pub struct AccountState {
+    /// Account identifier.
+    pub id: AccountId,
+    /// Lazy-connect IMAP connection handle.
+    pub imap: Connection,
+    /// SMTP client, if configured for this account.
+    pub smtp: Option<SmtpClient>,
+    /// Posture + circuit breaker + rate limiter.
+    pub guard: DispatchGuard<SystemClock>,
+    /// Folder safety guard.
+    pub folder_guard: FolderGuard,
+}
+
+/// Holds all accounts and the session-scoped default selection.
+pub struct AccountRegistry {
+    accounts: BTreeMap<AccountId, AccountState>,
+    active: Mutex<Option<AccountId>>,
+}
+
+impl AccountRegistry {
+    /// Create a registry from validated account states.
+    pub fn new(
+        accounts: BTreeMap<AccountId, AccountState>,
+    ) -> Self {
+        Self {
+            accounts,
+            active: Mutex::new(None),
+        }
+    }
+
+    /// Resolve the account for a tool call.
+    ///
+    /// Priority: explicit name > session default > auto-select (single
+    /// account) > error.
+    pub fn resolve(
+        &self,
+        explicit: Option<&str>,
+    ) -> Result<&AccountState, RimapError> {
+        let available: Vec<String> = self
+            .accounts
+            .keys()
+            .map(|id| id.as_str().to_string())
+            .collect();
+
+        if let Some(name) = explicit {
+            return self.get_by_name(name, &available);
+        }
+
+        let guard = self.active.lock().map_err(|e| {
+            RimapError::Internal(format!("account mutex poisoned: {e}"))
+        })?;
+        if let Some(ref id) = *guard {
+            return self
+                .accounts
+                .get(id)
+                .ok_or_else(|| RimapError::Internal(
+                    "active account no longer in registry".to_string(),
+                ));
+        }
+        drop(guard);
+
+        if self.accounts.len() == 1 {
+            return Ok(self.accounts.values().next().ok_or_else(|| {
+                RimapError::Internal("empty registry".to_string())
+            })?);
+        }
+
+        Err(RimapError::NoAccount { available })
+    }
+
+    /// Set the session-scoped default account.
+    pub fn set_active(
+        &self,
+        name: &str,
+    ) -> Result<Option<String>, RimapError> {
+        let available: Vec<String> = self
+            .accounts
+            .keys()
+            .map(|id| id.as_str().to_string())
+            .collect();
+
+        // Validate the name exists
+        let _ = self.get_by_name(name, &available)?;
+
+        let id = AccountId::new(name).map_err(|e| {
+            RimapError::Internal(e.to_string())
+        })?;
+        let mut guard = self.active.lock().map_err(|e| {
+            RimapError::Internal(format!("account mutex poisoned: {e}"))
+        })?;
+        let previous = guard.as_ref().map(|id| id.as_str().to_string());
+        *guard = Some(id);
+        Ok(previous)
+    }
+
+    /// List all account names.
+    pub fn account_names(&self) -> Vec<&AccountId> {
+        self.accounts.keys().collect()
+    }
+
+    /// Get all account states for iteration.
+    pub fn accounts(&self) -> &BTreeMap<AccountId, AccountState> {
+        &self.accounts
+    }
+
+    fn get_by_name<'a>(
+        &'a self,
+        name: &str,
+        available: &[String],
+    ) -> Result<&'a AccountState, RimapError> {
+        // Linear scan is fine — account count is small.
+        for (id, state) in &self.accounts {
+            if id.as_str() == name {
+                return Ok(state);
+            }
+        }
+        Err(RimapError::UnknownAccount {
+            name: name.to_string(),
+            available: available.to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // Tests require constructing AccountState which needs Connection etc.
+    // Use integration-style tests or mock the registry for unit tests.
+    // Detailed test cases:
+    // - Single account auto-selects without explicit name
+    // - Multi-account with no selection returns NoAccount
+    // - Explicit name resolves correct account
+    // - set_active + resolve returns the active account
+    // - set_active returns previous account name
+    // - Unknown name returns UnknownAccount with available list
+}
+```
+
+- [ ] **Step 2: Run `cargo check -p rimap-server`**
+
+Run: `cargo check -p rimap-server`
+Expected: compiles. Tests are placeholder — will be filled in when wiring is complete.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/src/registry.rs
+git commit -m "feat(server): add AccountRegistry with session-scoped account resolution"
+```
+
+---
+
+## Task 5: Restructure `ImapMcpServer` to use registry
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs`
+- Modify: `crates/rimap-server/src/dispatch.rs`
+
+This is the core refactor. `ImapMcpServer` drops its singular `config`, `imap`, `guard`, `folder_guard` fields and gains a `registry`.
+
+- [ ] **Step 1: Update `ImapMcpServer` struct**
+
+```rust
+pub struct ImapMcpServer {
+    /// Account registry with all configured accounts.
+    pub(crate) registry: crate::registry::AccountRegistry,
+    /// Shared append-only audit writer.
+    pub(crate) audit: AuditWriter,
+    /// Directory for attachment downloads.
+    pub(crate) download_dir: PathBuf,
+}
+```
+
+- [ ] **Step 2: Update `call_tool` to resolve account and strip `account` key**
+
+In `call_tool`, after parsing the tool name, extract the optional `"account"` key from the arguments:
+
+```rust
+async fn call_tool(
+    &self,
+    request: CallToolRequestParams,
+    _context: RequestContext<RoleServer>,
+) -> Result<CallToolResult, ErrorData> {
+    let tool_name = ToolName::from_str(&request.name)
+        .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+
+    if tool_definition(tool_name).is_none() {
+        return Err(ErrorData::new(
+            McpCode::RESOURCE_NOT_FOUND,
+            format!("tool `{}` is not available", request.name),
+            None,
+        ));
+    }
+
+    let mut args = request.arguments.unwrap_or_default();
+
+    // Infrastructure tools bypass account resolution and guards
+    match tool_name {
+        ToolName::UseAccount | ToolName::ListAccounts => {
+            return self
+                .dispatch_infrastructure(tool_name, &args)
+                .await;
+        }
+        _ => {}
+    }
+
+    // Extract and strip the optional "account" key
+    let account_name = args
+        .remove("account")
+        .and_then(|v| v.as_str().map(String::from));
+
+    // Resolve account
+    let account = self
+        .registry
+        .resolve(account_name.as_deref())
+        .map_err(|e| crate::mcp_error::to_mcp_error(&e))?;
+
+    // Run pre-call guards on the resolved account's guard
+    if let Err(e) = crate::dispatch::pre_call_guards(
+        &account.guard, tool_name,
+    ) {
+        return Err(crate::mcp_error::to_mcp_error(&e));
+    }
+
+    let result = Box::pin(
+        self.dispatch_tool(account, tool_name, &args),
+    ).await;
+
+    match result {
+        Ok(resp) => {
+            let value = serde_json::to_value(&resp)
+                .map_err(|e| {
+                    ErrorData::internal_error(e.to_string(), None)
+                })?;
+            Ok(CallToolResult::structured(value))
+        }
+        Err(e) => Err(crate::mcp_error::to_mcp_error(&e)),
+    }
+}
+```
+
+- [ ] **Step 3: Update `dispatch_tool` to take `&AccountState`**
+
+Change the method signature:
+
+```rust
+impl ImapMcpServer {
+    pub(crate) async fn dispatch_tool(
+        &self,
+        account: &crate::registry::AccountState,
+        tool: ToolName,
+        args: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<crate::response::ToolResponse, rimap_core::RimapError> {
+        // ... match arms unchanged but pass account instead of self ...
+    }
+}
+```
+
+- [ ] **Step 4: Update every tool handler to take `&AccountState` instead of `&ImapMcpServer`**
+
+This is a mechanical change across all tool handler files. Every handler's signature changes from:
+
+```rust
+pub async fn handle(server: &ImapMcpServer, input: T) -> Result<ToolResponse, RimapError>
+```
+
+to:
+
+```rust
+pub async fn handle(account: &AccountState, input: T) -> Result<ToolResponse, RimapError>
+```
+
+And references change: `server.imap` → `account.imap`, `server.folder_guard` → `account.folder_guard`, `server.config` → accessed via `account` fields as needed.
+
+Files to update:
+- `tools/list_folders.rs` — `server.imap` → `account.imap`
+- `tools/search.rs` — `server.imap`, `server.config.limits.*` → `account.imap`
+- `tools/fetch_message.rs` — `server.imap`, `server.config.*` → `account.imap`
+- `tools/list_attachments.rs` — `server.imap` → `account.imap`
+- `tools/download_attachment.rs` — `server.imap`, `server.download_dir` → `account.imap` (download_dir stays on server, pass separately or via context)
+- `tools/flags.rs` — `server.imap` → `account.imap`
+- `tools/labels.rs` — `server.imap` → `account.imap`
+- `tools/move_message.rs` — `server.imap` → `account.imap`
+- `tools/create_draft.rs` — `server.imap`, `server.config.*` → `account.imap`
+- `tools/send_email.rs` — `server.imap`, `server.config.smtp.*` → `account.imap`, `account.smtp`
+- `tools/delete_message.rs` — `server.imap` → `account.imap`
+- `tools/expunge.rs` — `server.imap`, `server.folder_guard` → `account.imap`, `account.folder_guard`
+- `tools/folder_mgmt.rs` — `server.imap`, `server.folder_guard` → `account.imap`, `account.folder_guard`
+
+For handlers that need `download_dir` or `audit`, use a context struct or pass them as separate parameters from the dispatch layer.
+
+- [ ] **Step 5: Update dispatch arms in `dispatch_tool`**
+
+Each match arm changes from `self` to `account`:
+
+```rust
+    ToolName::ListFolders => {
+        Box::pin(crate::tools::list_folders::handle(account)).await
+    }
+    ToolName::Search | ToolName::SearchAdvanced => {
+        let input = parse_args(args)?;
+        Box::pin(crate::tools::search::handle(account, input)).await
+    }
+    // ... etc for all tools ...
+```
+
+For `download_attachment`, pass download_dir from self:
+
+```rust
+    ToolName::DownloadAttachment => {
+        let input = parse_args(args)?;
+        Box::pin(crate::tools::download_attachment::handle(
+            account, input, &self.download_dir,
+        )).await
+    }
+```
+
+- [ ] **Step 6: Run `cargo check -p rimap-server`**
+
+Run: `cargo check -p rimap-server`
+Expected: compiles. Tests may fail — they construct `ImapMcpServer` with the old fields.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/
+git commit -m "refactor(server): restructure dispatch to use AccountState"
+```
+
+---
+
+## Task 6: Add `use_account` and `list_accounts` tool handlers
+
+**Files:**
+- Create: `crates/rimap-server/src/tools/accounts.rs`
+- Modify: `crates/rimap-server/src/tools/mod.rs`
+- Modify: `crates/rimap-server/src/server.rs`
+
+- [ ] **Step 1: Create account tool handlers**
+
+Create `crates/rimap-server/src/tools/accounts.rs`:
+
+```rust
+//! Infrastructure tool handlers for account management.
+//!
+//! `use_account` and `list_accounts` bypass posture checks and rate
+//! limiting — they are infrastructure tools, not IMAP operations.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::registry::AccountRegistry;
+use crate::response::ToolResponse;
+
+/// Input for `use_account`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UseAccountInput {
+    /// Account name to select as the session default.
+    pub account: String,
+}
+
+/// Handle `use_account` — set the session-scoped default account.
+pub fn handle_use_account(
+    registry: &AccountRegistry,
+    input: UseAccountInput,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let previous = registry.set_active(&input.account)?;
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "account": input.account,
+            "previous": previous,
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+
+/// Handle `list_accounts` — return all configured account summaries.
+pub fn handle_list_accounts(
+    registry: &AccountRegistry,
+) -> Result<ToolResponse, rimap_core::RimapError> {
+    let accounts: Vec<serde_json::Value> = registry
+        .accounts()
+        .values()
+        .map(|state| {
+            serde_json::json!({
+                "name": state.id.as_str(),
+                "imap_host": state.imap.host(),
+                "smtp_configured": state.smtp.is_some(),
+            })
+        })
+        .collect();
+    Ok(ToolResponse {
+        meta: serde_json::json!({
+            "accounts": accounts,
+            "count": accounts.len(),
+        }),
+        untrusted: None,
+        security_warnings: Vec::new(),
+    })
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `crates/rimap-server/src/tools/mod.rs`:
+
+```rust
+pub mod accounts;
+```
+
+- [ ] **Step 3: Wire into server dispatch**
+
+In `server.rs`, add the `dispatch_infrastructure` method and tool definitions:
+
+```rust
+impl ImapMcpServer {
+    async fn dispatch_infrastructure(
+        &self,
+        tool: ToolName,
+        args: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let result = match tool {
+            ToolName::UseAccount => {
+                let input: crate::tools::accounts::UseAccountInput =
+                    parse_args(args).map_err(|e| {
+                        crate::mcp_error::to_mcp_error(&e)
+                    })?;
+                crate::tools::accounts::handle_use_account(
+                    &self.registry, input,
+                )
+            }
+            ToolName::ListAccounts => {
+                crate::tools::accounts::handle_list_accounts(
+                    &self.registry,
+                )
+            }
+            _ => {
+                return Err(ErrorData::internal_error(
+                    format!("not an infrastructure tool: {}", tool.as_str()),
+                    None,
+                ));
+            }
+        };
+        match result {
+            Ok(resp) => {
+                let value = serde_json::to_value(&resp).map_err(|e| {
+                    ErrorData::internal_error(e.to_string(), None)
+                })?;
+                Ok(CallToolResult::structured(value))
+            }
+            Err(e) => Err(crate::mcp_error::to_mcp_error(&e)),
+        }
+    }
+}
+```
+
+Add tool definitions. These are always advertised (not posture-gated):
+
+```rust
+fn tool_spec_infra(name: ToolName) -> Option<ToolSpec> {
+    use crate::tools::accounts::UseAccountInput;
+
+    let tuple = match name {
+        ToolName::UseAccount => (
+            "use_account",
+            "Set the active account for subsequent tool calls",
+            schema_map::<UseAccountInput>(),
+        ),
+        ToolName::ListAccounts => (
+            "list_accounts",
+            "List all configured email accounts",
+            serde_json::Map::new(),
+        ),
+        _ => return None,
+    };
+    Some(tuple)
+}
+```
+
+Update `tool_definition` to include `tool_spec_infra`:
+
+```rust
+fn tool_definition(name: ToolName) -> Option<Tool> {
+    let (tool_name, description, schema) = tool_spec_v1(name)
+        .or_else(|| tool_spec_v2(name))
+        .or_else(|| tool_spec_v3(name))
+        .or_else(|| tool_spec_infra(name))?;
+    Some(Tool::new(tool_name, description, Arc::new(schema)))
+}
+```
+
+Update `list_tools` to include infrastructure tools alongside posture-filtered tools:
+
+```rust
+async fn list_tools(&self, ...) -> Result<ListToolsResult, ErrorData> {
+    // Get the advertised tools from the first account's matrix
+    // (for single-account compat) or union across all accounts.
+    // Infrastructure tools are always included.
+    let mut tools: Vec<Tool> = Vec::new();
+
+    // Infrastructure tools — always advertised
+    for name in [ToolName::UseAccount, ToolName::ListAccounts] {
+        if let Some(def) = tool_definition(name) {
+            tools.push(def);
+        }
+    }
+
+    // Union of tools advertised by any account's posture
+    let mut seen = std::collections::HashSet::new();
+    for state in self.registry.accounts().values() {
+        for &tn in &state.guard.matrix().advertised() {
+            if seen.insert(tn) {
+                if let Some(def) = tool_definition(tn) {
+                    tools.push(def);
+                }
+            }
+        }
+    }
+
+    Ok(ListToolsResult::with_all_items(tools))
+}
+```
+
+- [ ] **Step 4: Run `cargo check -p rimap-server`**
+
+Run: `cargo check -p rimap-server`
+Expected: compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/accounts.rs crates/rimap-server/src/tools/mod.rs crates/rimap-server/src/server.rs
+git commit -m "feat(server): add use_account and list_accounts tools"
+```
+
+---
+
+## Task 7: Add MCP resource handlers for account discovery
+
+**Files:**
+- Modify: `crates/rimap-server/src/server.rs`
+
+- [ ] **Step 1: Implement `list_resources`**
+
+Override `list_resources` in the `ServerHandler` impl:
+
+```rust
+async fn list_resources(
+    &self,
+    _request: Option<PaginatedRequestParams>,
+    _context: RequestContext<RoleServer>,
+) -> Result<ListResourcesResult, ErrorData> {
+    let resources: Vec<Resource> = self
+        .registry
+        .accounts()
+        .values()
+        .map(|state| {
+            Resource::new(
+                format!("rimap://accounts/{}", state.id.as_str()),
+                state.id.as_str(),
+            )
+            .with_description(format!(
+                "IMAP account: {} on {}",
+                // username from imap config — need accessor
+                state.imap.host(),
+                state.imap.host(),
+            ))
+            .with_mime_type("application/json")
+        })
+        .collect();
+    Ok(ListResourcesResult::with_all_items(resources))
+}
+```
+
+Note: the exact rmcp `Resource` constructor and builder methods need to be checked against the rmcp API. The types `Resource`, `ListResourcesResult`, `ReadResourceResult` should be imported from `rmcp::model`.
+
+- [ ] **Step 2: Implement `read_resource`**
+
+```rust
+async fn read_resource(
+    &self,
+    request: ReadResourceRequestParams,
+    _context: RequestContext<RoleServer>,
+) -> Result<ReadResourceResult, ErrorData> {
+    let uri = &request.uri;
+    let prefix = "rimap://accounts/";
+    let name = uri.strip_prefix(prefix).ok_or_else(|| {
+        ErrorData::new(
+            McpCode::RESOURCE_NOT_FOUND,
+            format!("unknown resource URI: {uri}"),
+            None,
+        )
+    })?;
+
+    let account = self.registry.resolve(Some(name)).map_err(|e| {
+        crate::mcp_error::to_mcp_error(&e)
+    })?;
+
+    let available_tools: Vec<&str> = account
+        .guard
+        .matrix()
+        .advertised()
+        .iter()
+        .filter_map(|tn| tool_definition(*tn).map(|_| tn.as_str()))
+        .collect();
+
+    let metadata = serde_json::json!({
+        "name": account.id.as_str(),
+        "imap_host": account.imap.host(),
+        "posture": account.guard.matrix().posture().as_str(),
+        "smtp_configured": account.smtp.is_some(),
+        "available_tools": available_tools,
+    });
+
+    let content = ResourceContents::text(
+        uri,
+        serde_json::to_string_pretty(&metadata)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?,
+        Some("application/json".to_string()),
+    );
+    Ok(ReadResourceResult::with_contents(vec![content]))
+}
+```
+
+The exact rmcp types (`ReadResourceRequestParams`, `ResourceContents`, etc.) need to be verified against the rmcp API during implementation.
+
+- [ ] **Step 3: Run `cargo check -p rimap-server`**
+
+Run: `cargo check -p rimap-server`
+Expected: compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/server.rs
+git commit -m "feat(server): add MCP resource handlers for account discovery"
+```
+
+---
+
+## Task 8: Add `account` field to audit records
+
+**Files:**
+- Modify: `crates/rimap-audit/src/record.rs`
+
+- [ ] **Step 1: Add `account` field to relevant record types**
+
+Add `#[serde(skip_serializing_if = "Option::is_none")]` so the field is absent for legacy configs:
+
+In `Auth`:
+```rust
+pub struct Auth {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    // ... existing fields ...
+}
+```
+
+In `ToolStart`:
+```rust
+pub struct ToolStart {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    // ... existing fields ...
+}
+```
+
+In `ToolEnd`:
+```rust
+pub struct ToolEnd {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    // ... existing fields ...
+}
+```
+
+In `ProcessStart`, replace the singular `posture` field with a conditional structure:
+```rust
+pub struct ProcessStart {
+    // Legacy single-account: flat posture string
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub posture: Option<String>,
+    // Multi-account: array of account summaries
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accounts: Option<Vec<AccountSummary>>,
+    // ... remaining existing fields ...
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountSummary {
+    pub name: String,
+    pub posture: String,
+    pub imap_host: String,
+}
+```
+
+- [ ] **Step 2: Add `--account` filter to `Filter`**
+
+In `crates/rimap-audit/src/reader.rs`, add to `Filter`:
+
+```rust
+pub struct Filter {
+    // ... existing fields ...
+    pub account: Option<String>,
+}
+```
+
+Update the filter application logic to check the `account` field on records that have one.
+
+- [ ] **Step 3: Update `ProcessStartInputs` for multi-account**
+
+In `crates/rimap-audit/src/writer.rs`:
+
+```rust
+pub struct ProcessStartInputs {
+    pub version: String,
+    pub git_commit: String,
+    /// Single posture for legacy, None for multi-account.
+    pub posture: Option<String>,
+    /// Account summaries for multi-account, None for legacy.
+    pub accounts: Option<Vec<crate::record::AccountSummary>>,
+    pub config_path: std::path::PathBuf,
+    pub config_hash_sha256: String,
+    pub trailing: crate::self_check::TrailingState,
+    pub current_inode: u64,
+}
+```
+
+- [ ] **Step 4: Run `cargo test -p rimap-audit`**
+
+Run: `cargo test -p rimap-audit`
+Expected: tests pass. Some tests constructing `ProcessStart` or other records will need the new `account` field set to `None`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-audit/
+git commit -m "feat(audit): add account field to records and --account merge filter"
+```
+
+---
+
+## Task 9: Update `main.rs` bootstrap for multi-account
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+- [ ] **Step 1: Replace single-account bootstrap with multi-account**
+
+The bootstrap sequence changes from constructing one `Connection` + one `DispatchGuard` to iterating over `ValidatedMultiConfig.accounts` and building an `AccountState` for each:
+
+```rust
+// Replace load_from_path + validate with load_and_validate
+let multi_config = rimap_config::loader::load_and_validate(&config_path)?;
+
+// Build audit writer (same as before, using multi_config.audit)
+let audit = audit_init::init_audit_writer_multi(&multi_config, &config_path)?;
+
+// Build per-account states
+let mut account_states = BTreeMap::new();
+for (id, acfg) in &multi_config.accounts {
+    let guard = build_dispatch_guard_from_account(acfg)?;
+    let conn_cfg = build_connection_config_from_account(acfg);
+    let imap = Connection::new(conn_cfg, audit.clone(), credentials.clone());
+    let smtp = build_smtp_client(acfg)?;
+    let folder_guard = FolderGuard::new(
+        &acfg.security.protected_folders,
+        &acfg.security.expunge_folders,
+    );
+    account_states.insert(id.clone(), AccountState {
+        id: id.clone(),
+        imap,
+        smtp,
+        guard,
+        folder_guard,
+    });
+}
+
+let registry = AccountRegistry::new(account_states);
+let download_dir = resolve_download_dir_multi(&multi_config)?;
+let server = ImapMcpServer { registry, audit, download_dir };
+```
+
+The helper functions (`build_dispatch_guard_from_account`, `build_connection_config_from_account`, `build_smtp_client`) extract the same logic that currently exists in `build_dispatch_guard` and `build_connection_config`, but take `&ValidatedAccountConfig` instead of `&ValidatedConfig`.
+
+- [ ] **Step 2: Update dry-run mode for multi-account**
+
+The `--dry-run` output should show the effective matrix per account:
+
+```
+Account: work
+  Posture: full
+  Tools: list_folders, search, ...
+
+Account: personal
+  Posture: readonly
+  Tools: list_folders, search, fetch_message, ...
+```
+
+- [ ] **Step 3: Update `ProcessStart` audit record**
+
+Emit the multi-account `ProcessStart` with `accounts` array instead of flat `posture`:
+
+```rust
+let accounts = multi_config.accounts.values().map(|acfg| {
+    AccountSummary {
+        name: acfg.id.as_str().to_string(),
+        posture: acfg.security.posture.as_str().to_string(),
+        imap_host: acfg.imap.host.clone(),
+    }
+}).collect();
+
+audit.log_process_start(ProcessStartInputs {
+    posture: None,
+    accounts: Some(accounts),
+    // ... other fields ...
+})?;
+```
+
+- [ ] **Step 4: Run `cargo check --workspace`**
+
+Run: `cargo check --workspace`
+Expected: compiles.
+
+- [ ] **Step 5: Run `just ci`**
+
+Run: `just ci`
+Expected: all checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "feat(server): multi-account bootstrap with per-account Connection and DispatchGuard"
+```
+
+---
+
+## Task 10: Update tests for multi-account
+
+**Files:**
+- Modify: `crates/rimap-server/src/e2e_test.rs`
+- Modify: `crates/rimap-server/src/server.rs` (tests)
+
+- [ ] **Step 1: Update server unit tests**
+
+The `tool_definition_covers_all_mcp_tools` test needs updating. With 24 total variants (22 posture-matrix + 2 infrastructure), minus 2 sub-capabilities = 22 MCP tools:
+
+```rust
+#[test]
+fn tool_definition_covers_all_mcp_tools() {
+    let defs: Vec<_> = ToolName::all()
+        .into_iter()
+        .filter_map(tool_definition)
+        .collect();
+    // 24 tool variants minus 2 sub-capabilities = 22
+    assert_eq!(defs.len(), 22);
+}
+```
+
+Update `sub_capabilities_return_none` — unchanged, `SearchAdvanced` and `FetchMessageHtml` still return `None`.
+
+- [ ] **Step 2: Update e2e tests**
+
+The e2e test helper `call_tool` constructs an `ImapMcpServer` directly. Update it to use the new struct shape with `AccountRegistry`:
+
+```rust
+fn test_server(/* ... */) -> ImapMcpServer {
+    let id = AccountId::default_account();
+    let state = AccountState {
+        id: id.clone(),
+        imap: /* ... */,
+        smtp: None,
+        guard: /* ... */,
+        folder_guard: /* ... */,
+    };
+    let mut accounts = BTreeMap::new();
+    accounts.insert(id, state);
+    let registry = AccountRegistry::new(accounts);
+    ImapMcpServer {
+        registry,
+        audit: /* ... */,
+        download_dir: /* ... */,
+    }
+}
+```
+
+- [ ] **Step 3: Add registry-specific unit tests**
+
+Test account resolution logic:
+- Single account auto-selects
+- Multi-account with no selection → `NoAccount`
+- `set_active` + resolve → correct account
+- Unknown account name → `UnknownAccount`
+- Explicit param overrides session default
+
+- [ ] **Step 4: Run `just ci`**
+
+Run: `just ci`
+Expected: all checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/
+git commit -m "test(server): update tests for multi-account registry"
+```

--- a/docs/superpowers/plans/2026-04-13-sprint-3c-release.md
+++ b/docs/superpowers/plans/2026-04-13-sprint-3c-release.md
@@ -1,0 +1,457 @@
+# Sprint 3c: v1.0.0 Release Preparation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare and ship v1.0.0: version bump, CHANGELOG, documentation, cross-platform release workflow with pre-built binaries for five targets.
+
+**Architecture:** A GitHub Actions release workflow triggered on `v*` tags builds binaries in parallel across five platform targets. Linux x86_64 and macOS aarch64 use native builds, Linux aarch64 uses `cross`, and Linux ppc64le and s390x use QEMU user-mode emulation for native builds inside platform containers.
+
+**Tech Stack:** GitHub Actions, `cross`, QEMU/binfmt_misc, Docker, `cargo build --release`
+
+**Depends on:** Sprint 3a (labels) and Sprint 3b (multi-account) merged to the feature branch.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `Cargo.toml` | Version bump to 1.0.0 |
+| Modify | `CHANGELOG.md` | Full v1.0.0 release entry |
+| Modify | `README.md` | Rewrite for v1.0 |
+| Create | `docs/configuration.md` | Full config reference |
+| Create | `docs/multi-account.md` | Multi-account guide |
+| Create | `docs/security-model.md` | Posture matrix, threat model |
+| Create | `docs/proton-bridge-setup.md` | Setup walkthrough |
+| Create | `.github/workflows/release.yml` | Release build + publish workflow |
+| Modify | `AGENTS.md` | Update repo status, tool counts, sprint references |
+
+---
+
+## Task 1: Version bump
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root)
+
+- [ ] **Step 1: Update workspace version**
+
+In the root `Cargo.toml`, update `[workspace.package]`:
+
+```toml
+[workspace.package]
+version = "1.0.0"
+```
+
+- [ ] **Step 2: Run `cargo check --workspace`**
+
+Run: `cargo check --workspace`
+Expected: compiles with new version.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml
+git commit -m "chore: bump workspace version to 1.0.0"
+```
+
+---
+
+## Task 2: Write CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Write the v1.0.0 entry**
+
+Replace the `## [Unreleased]` section with a full release entry. Organize by capability, not sprint. Cover the entire feature surface from sprints 0 through 3:
+
+```markdown
+## [1.0.0] — 2026-04-XX
+
+### Features
+
+- **Multi-account support:** Configure multiple IMAP/SMTP accounts in a
+  single process. Accounts are discoverable via MCP resources
+  (`rimap://accounts/<name>`) and selectable per-session (`use_account`)
+  or per-call (`account` parameter). Existing single-account configs
+  work unchanged.
+
+- **22 MCP tools** across four security postures:
+  - **Read:** `list_folders`, `search`, `fetch_message`, `list_attachments`,
+    `download_attachment`, `list_labels`
+  - **Organize:** `mark_read`, `mark_unread`, `flag`, `unflag`,
+    `add_label`, `remove_label`, `move_message`, `create_draft`
+  - **Write:** `send_email`, `delete_message`, `create_folder`,
+    `rename_folder`
+  - **Destructive:** `expunge`, `delete_folder`
+  - **Infrastructure:** `use_account`, `list_accounts`
+
+- **Security postures:** `readonly`, `draft-safe` (default), `full`,
+  `destructive`. Per-account posture configuration with per-tool
+  allow/deny overrides. Tools denied by posture are not advertised.
+
+- **SMTP sending** via `lettre` with TLS (STARTTLS or implicit),
+  rate-limited (`sends_per_minute`), with Sent folder copy.
+
+- **Content pipeline:** MIME parsing, Unicode normalization (NFKC),
+  HTML-to-text conversion, look-alike detection (mixed-script, TR39
+  confusables, IDN, bidi tricks), structured security warnings.
+
+- **Audit log:** Append-only JSONL with exclusive file locking,
+  per-record timestamps, process IDs, sequence numbers, provenance
+  tracking, and argument redaction. `audit merge` subcommand with
+  time/tool/account/process filters.
+
+- **Folder safety:** Protected folders list (default: INBOX, Sent,
+  Drafts, Trash) prevents deletion and rename. Expunge folder
+  allowlist (default: deny all) gates permanent message removal.
+  INBOX is always protected regardless of configuration.
+
+- **Rate limiting and circuit breaker:** Per-account token bucket
+  rate limiter and sliding-window circuit breaker. Separate rate
+  limits for general commands, drafts, and sends.
+
+- **TLS fingerprint pinning:** SHA-256 certificate fingerprint
+  verification for Proton Bridge and other self-signed setups.
+  Constant-time comparison, redacted in debug output.
+
+- **IMAP keyword labels:** `add_label`, `remove_label`, `list_labels`
+  tools for managing custom IMAP keyword flags.
+
+### Platform Support
+
+Pre-built binaries for:
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `powerpc64le-unknown-linux-gnu`
+- `s390x-unknown-linux-gnu`
+- `aarch64-apple-darwin`
+
+### Development
+
+- Rust 1.88.0 MSRV, Edition 2024
+- `just ci` runs full local CI equivalent
+- `prek` pre-commit hooks
+- `cargo deny` for supply chain auditing
+- `zizmor` for GitHub Actions security scanning
+```
+
+Adjust the date when the release is cut.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: write CHANGELOG for v1.0.0 release"
+```
+
+---
+
+## Task 3: Write documentation
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/configuration.md`
+- Create: `docs/multi-account.md`
+- Create: `docs/security-model.md`
+- Create: `docs/proton-bridge-setup.md`
+
+- [ ] **Step 1: Rewrite README.md**
+
+Rewrite for v1.0: what the project is, quick-start with a minimal config, multi-account example, posture overview, link to docs, build instructions, license.
+
+Key sections:
+- What is this (one paragraph)
+- Quick start (install binary, create config, run)
+- Configuration overview (link to docs/configuration.md)
+- Security postures (table with the four postures)
+- Multi-account (brief example, link to docs/multi-account.md)
+- Building from source
+- License (MIT/Apache-2.0)
+
+- [ ] **Step 2: Write docs/configuration.md**
+
+Full config reference covering:
+- Legacy single-account format (all fields, defaults, types)
+- Multi-account format (`[defaults]`, `[[accounts]]`, `[audit]`, `[attachments]`)
+- Credential resolution (keyring, environment variable)
+- SMTP configuration
+- Security settings (postures, tool overrides, protected folders, expunge folders)
+- Limits (rate limiting, circuit breaker, size caps)
+- Audit settings
+- Validation rules and error messages
+
+Include complete example configs for both formats.
+
+- [ ] **Step 3: Write docs/multi-account.md**
+
+Guide covering:
+- Account discovery via MCP resources (`rimap://accounts/<name>`)
+- `use_account` tool for session-scoped default
+- Per-call `account` parameter override
+- Single-account backward compatibility
+- Example agent workflow (discover → select → operate)
+
+- [ ] **Step 4: Write docs/security-model.md**
+
+Document covering:
+- Threat model (email as adversarial input, prompt injection, autonomous send risk, data destruction)
+- Posture matrix (full 22-tool × 4-posture table)
+- Per-account isolation (separate rate limiters, circuit breakers, postures)
+- Content pipeline defenses (sanitization, look-alike detection, structured warnings)
+- Audit log (what's logged, redaction, provenance)
+- Folder safety (protected folders, expunge allowlist)
+- TLS fingerprint pinning
+
+- [ ] **Step 5: Write docs/proton-bridge-setup.md**
+
+Walkthrough covering:
+- Installing Proton Bridge
+- Capturing the TLS fingerprint (`openssl s_client` command)
+- Creating the config file for Bridge (localhost IMAP + SMTP)
+- Running `rusty-imap-mcp login` to store credentials
+- Verifying with `--dry-run`
+- Setting up SMTP for `send_email`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md docs/
+git commit -m "docs: write v1.0.0 documentation (config, multi-account, security, proton bridge)"
+```
+
+---
+
+## Task 4: Create release workflow
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Write the release workflow**
+
+Create `.github/workflows/release.yml`. Look up current SHA pins for all actions before writing. The workflow:
+
+1. Triggers on `v*` tags
+2. Five parallel build jobs
+3. Artifact collection and checksum generation
+4. GitHub release creation
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  BINARY_NAME: rusty-imap-mcp
+
+jobs:
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@<SHA>  # stable
+        with:
+          toolchain: stable
+      - run: cargo build --release --locked
+      - run: |
+          mv target/release/${{ env.BINARY_NAME }} \
+             ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
+      - uses: actions/upload-artifact@<SHA>  # v4.x.x
+        with:
+          name: binary-linux-x86_64
+          path: ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu
+
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@<SHA>  # stable
+        with:
+          toolchain: stable
+          targets: aarch64-unknown-linux-gnu
+      - run: cargo install cross --locked
+      - run: cross build --release --locked --target aarch64-unknown-linux-gnu
+      - run: |
+          mv target/aarch64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} \
+             ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
+      - uses: actions/upload-artifact@<SHA>  # v4.x.x
+        with:
+          name: binary-linux-aarch64
+          path: ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
+
+  build-linux-ppc64le:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@<SHA>  # v3.x.x
+        with:
+          platforms: ppc64le
+      - run: |
+          docker run --rm --platform linux/ppc64le \
+            -v "${{ github.workspace }}:/src" \
+            -w /src \
+            rust:latest \
+            cargo build --release --locked
+      - run: |
+          mv target/release/${{ env.BINARY_NAME }} \
+             ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
+      - uses: actions/upload-artifact@<SHA>  # v4.x.x
+        with:
+          name: binary-linux-ppc64le
+          path: ${{ env.BINARY_NAME }}-powerpc64le-unknown-linux-gnu
+
+  build-linux-s390x:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@<SHA>  # v3.x.x
+        with:
+          platforms: s390x
+      - run: |
+          docker run --rm --platform linux/s390x \
+            -v "${{ github.workspace }}:/src" \
+            -w /src \
+            rust:latest \
+            cargo build --release --locked
+      - run: |
+          mv target/release/${{ env.BINARY_NAME }} \
+             ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
+      - uses: actions/upload-artifact@<SHA>  # v4.x.x
+        with:
+          name: binary-linux-s390x
+          path: ${{ env.BINARY_NAME }}-s390x-unknown-linux-gnu
+
+  build-macos-aarch64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@<SHA>  # stable
+        with:
+          toolchain: stable
+      - run: cargo build --release --locked
+      - run: |
+          mv target/release/${{ env.BINARY_NAME }} \
+             ${{ env.BINARY_NAME }}-aarch64-apple-darwin
+      - uses: actions/upload-artifact@<SHA>  # v4.x.x
+        with:
+          name: binary-macos-aarch64
+          path: ${{ env.BINARY_NAME }}-aarch64-apple-darwin
+
+  release:
+    needs:
+      - build-linux-x86_64
+      - build-linux-aarch64
+      - build-linux-ppc64le
+      - build-linux-s390x
+      - build-macos-aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v4.x.x
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@<SHA>  # v4.x.x
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum ${{ env.BINARY_NAME }}-* > SHA256SUMS
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@<SHA>  # v2.x.x
+        with:
+          files: |
+            artifacts/${{ env.BINARY_NAME }}-*
+            artifacts/SHA256SUMS
+          generate_release_notes: false
+          body_path: RELEASE_NOTES.md
+          draft: true
+```
+
+All `<SHA>` placeholders MUST be replaced with full 40-character SHA hashes with version comments during implementation. Look up the current stable versions of each action.
+
+Note: the QEMU builds output to `target/release/` (not a target-specific directory) because they run inside a platform container where the native architecture matches.
+
+- [ ] **Step 2: Run `actionlint` and `zizmor`**
+
+Run: `actionlint .github/workflows/release.yml && zizmor .github/workflows/release.yml`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add release workflow for 5-target binary builds"
+```
+
+---
+
+## Task 5: Update AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update repository status**
+
+Change the "Repository status" section from:
+
+> The repo is under active pre-v1 development.
+
+To reflect the current state: multi-account, 22 tools + 2 infrastructure tools, v1.0.0.
+
+Update tool counts, sprint references, and any stale information.
+
+- [ ] **Step 2: Run `just ci`**
+
+Run: `just ci`
+Expected: all checks pass on the complete sprint 3 branch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: update AGENTS.md for v1.0.0 release"
+```
+
+---
+
+## Task 6: Final release validation
+
+- [ ] **Step 1: Run full CI locally**
+
+Run: `just ci`
+Expected: clean pass.
+
+- [ ] **Step 2: Verify `--dry-run` with multi-account config**
+
+Create a test config with two accounts and verify `--dry-run` output shows both accounts with their effective matrices.
+
+- [ ] **Step 3: Verify `--dry-run` with legacy config**
+
+Verify an existing single-account config still works with `--dry-run`.
+
+- [ ] **Step 4: Review the diff against main**
+
+Run: `git diff main...HEAD --stat`
+Review the full changeset for anything that shouldn't be in the release.
+
+- [ ] **Step 5: Open PR against main**
+
+Push the branch and create a PR. CI must pass all status checks before merge.

--- a/docs/superpowers/specs/2026-04-13-sprint-3-design.md
+++ b/docs/superpowers/specs/2026-04-13-sprint-3-design.md
@@ -1,0 +1,604 @@
+# Rusty IMAP MCP — Sprint 3 Design Specification
+
+**Status:** Approved 2026-04-13
+**Target:** v1.0.0
+**Scope:** Multi-account support via account registry and MCP resource discovery,
+IMAP keyword-based label tools, and v1.0.0 release preparation with pre-built
+binaries for five platform targets.
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Configuration Changes](#2-configuration-changes)
+3. [Account Registry & Session State](#3-account-registry--session-state)
+4. [MCP Resources for Account Discovery](#4-mcp-resources-for-account-discovery)
+5. [Label Tools](#5-label-tools)
+6. [Posture Matrix Update](#6-posture-matrix-update)
+7. [Audit Log Changes](#7-audit-log-changes)
+8. [Error Handling](#8-error-handling)
+9. [Testing Strategy](#9-testing-strategy)
+10. [Release Preparation](#10-release-preparation)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Add multi-account support: multiple IMAP/SMTP accounts in a single process,
+  discoverable via MCP resources, selectable per-session or per-call.
+- Add three label tools (`add_label`, `remove_label`, `list_labels`) using
+  standard IMAP keywords.
+- Ship v1.0.0 with pre-built binaries for five platform targets.
+- Maintain full backward compatibility — existing single-account configs work
+  unchanged.
+
+### Non-Goals (v1.0.0)
+
+- Provider-specific label backends (Gmail `X-GM-LABELS`, Exchange categories).
+  Standard IMAP keywords only.
+- Per-account audit log files. Single shared writer with account-tagged records.
+- Per-account download directories. Shared `download_dir`.
+- crates.io publishing. GitHub release only.
+- Container images. Binary releases only.
+- IDLE / push notifications.
+- OAuth2 / XOAUTH2.
+- HTTP / streamable MCP transport.
+
+### Threat Model Additions
+
+Multi-account introduces one new threat vector: a prompt-injected agent with
+access to multiple accounts could exfiltrate data from one account via another
+(read from account A, send via account B). Mitigations:
+
+- Per-account posture gates — a `readonly` account cannot be used for sending
+  even if another account is `full`.
+- Per-account rate limiting and circuit breakers — one account's limits do not
+  affect another.
+- Audit log records include the account name on every operation, enabling
+  forensic reconstruction of cross-account sequences.
+- The existing provenance ring buffer (future v1.x analyzer) can detect
+  read-then-send-across-accounts patterns.
+
+---
+
+## 2. Configuration Changes
+
+### New Config Schema
+
+```toml
+# Global settings — shared across all accounts
+[audit]
+path = "~/.local/share/rusty-imap-mcp/audit.jsonl"
+rotate_bytes = 10485760
+rotate_keep = 3
+
+[attachments]
+download_dir = "~/.local/share/rusty-imap-mcp/downloads"
+
+# Defaults inherited by all accounts unless overridden
+[defaults.security]
+posture = "draft-safe"
+protected_folders = ["INBOX", "Sent", "Drafts", "Trash"]
+expunge_folders = []
+
+[defaults.limits]
+commands_per_second = 10
+drafts_per_minute = 5
+sends_per_minute = 3
+
+# Accounts
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "user@proton.me"
+credential = "keyring:proton-bridge"
+tls_fingerprint_sha256 = "AA:BB:CC:..."
+
+[accounts.smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "user@proton.me"
+credential = "keyring:proton-bridge"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "imap.fastmail.com"
+port = 993
+username = "me@fastmail.com"
+credential = "keyring:fastmail"
+# No [accounts.smtp] — send_email not available for this account
+
+[accounts.security]
+posture = "readonly"  # overrides the default
+```
+
+### Backward Compatibility
+
+A config with no `[[accounts]]` section and the existing flat `[imap]` /
+`[smtp]` / `[security]` / `[limits]` structure is treated as a single
+anonymous account named `"default"`. Existing v1/v2 configs work unchanged.
+
+Mixing flat top-level `[imap]` and `[[accounts]]` is a startup error
+(`MixedConfigFormat`).
+
+### Defaults Inheritance
+
+Per-account `[accounts.security]` and `[accounts.limits]` sections override
+the corresponding `[defaults.*]` sections. Fields not specified in the
+per-account section inherit from defaults. Fields not specified in defaults
+use the same hardcoded defaults as the current flat config.
+
+### Validation Rules
+
+- **Account names:** non-empty, ASCII alphanumeric + hyphens, max 64
+  characters. Must be unique across all `[[accounts]]` entries.
+- **At least one account:** either flat `[imap]` or at least one
+  `[[accounts]]` entry must exist.
+- **Per-account `SmtpRequired`:** if `send_email` is effectively enabled
+  for an account (posture + per-tool overrides) but that account has no
+  `[accounts.smtp]` section, startup error.
+- **Per-account `ConflictingFolders`:** if an account's `protected_folders`
+  and `expunge_folders` overlap, startup error.
+- **`MixedConfigFormat`:** both flat `[imap]` and `[[accounts]]` present.
+- **`DuplicateAccountName`:** two accounts share a name.
+
+---
+
+## 3. Account Registry & Session State
+
+### `AccountState`
+
+Per-account runtime bundle in `rimap-server`:
+
+```rust
+struct AccountState {
+    name:         AccountId,
+    config:       AccountConfig,
+    imap:         Connection,
+    smtp:         Option<SmtpClient>,
+    guard:        DispatchGuard<SystemClock>,
+    folder_guard: FolderGuard,
+}
+```
+
+Each account owns its own IMAP connection, SMTP client, rate limiter,
+circuit breaker, and folder guard. No shared mutable state between
+accounts.
+
+### `AccountRegistry`
+
+```rust
+struct AccountRegistry {
+    accounts: BTreeMap<AccountId, AccountState>,
+    active:   Mutex<Option<AccountId>>,
+}
+```
+
+The `active` field holds the session-scoped default account set by
+`use_account`. It is protected by a `std::sync::Mutex` (not `tokio::Mutex`)
+since the critical section is a trivial read/write of an `Option`.
+
+### `ImapMcpServer` Restructure
+
+```rust
+pub struct ImapMcpServer {
+    registry:     AccountRegistry,
+    audit:        AuditWriter,
+    download_dir: PathBuf,
+}
+```
+
+Replaces the current singular `config`, `imap`, `guard`, `folder_guard`
+fields.
+
+### Account Resolution
+
+On every tool call (except `use_account` and `list_accounts`):
+
+1. If the tool arguments contain `"account": "<name>"` — use that account.
+2. Else if `registry.active` is set — use the session default.
+3. Else if exactly one account exists — auto-select it.
+4. Else — return `ERR_NO_ACCOUNT`.
+
+### New Tools
+
+**`use_account`:**
+- Input: `{ "account": "work" }`
+- Sets `registry.active` to the named account.
+- Returns confirmation with the account name.
+- Bypasses posture checks, rate limiting, and circuit breaker — it is an
+  infrastructure tool, not an IMAP operation.
+- Audit: `use_account` event with `account` and `previous` fields.
+
+**`list_accounts`:**
+- No input.
+- Returns array of account summaries:
+  `{ "name", "imap_host", "posture", "smtp_configured" }`.
+- Bypasses posture checks, rate limiting, and circuit breaker.
+- Audit: `list_accounts` event with `count`.
+
+### Tool Handler Changes
+
+Each handler currently takes `&ImapMcpServer`. The dispatch layer resolves
+the account first, then passes `(&AccountState, &AuditWriter)` (or an
+equivalent context struct) to the handler. The handler signature change is
+mechanical: `self.imap` becomes `account.imap`, `self.guard` becomes
+`account.guard`, etc.
+
+The `dispatch_tool` method on `ImapMcpServer` resolves the account from the
+arguments map before delegating to the tool handler. The `account` key is
+stripped from the arguments before passing to `parse_args`.
+
+---
+
+## 4. MCP Resources for Account Discovery
+
+### Resource List
+
+`list_resources` returns one resource per configured account:
+
+```json
+[
+  {
+    "uri": "rimap://accounts/work",
+    "name": "work",
+    "description": "IMAP account: user@proton.me on 127.0.0.1",
+    "mimeType": "application/json"
+  },
+  {
+    "uri": "rimap://accounts/personal",
+    "name": "personal",
+    "description": "IMAP account: me@fastmail.com on imap.fastmail.com",
+    "mimeType": "application/json"
+  }
+]
+```
+
+### Resource Read
+
+`read_resource("rimap://accounts/work")` returns account metadata:
+
+```json
+{
+  "name": "work",
+  "imap_host": "127.0.0.1",
+  "imap_port": 1143,
+  "imap_username": "user@proton.me",
+  "posture": "draft-safe",
+  "smtp_configured": true,
+  "protected_folders": ["INBOX", "Sent", "Drafts", "Trash"],
+  "available_tools": ["list_folders", "search", "fetch_message", "..."]
+}
+```
+
+### Security
+
+No credentials in resources. Username is metadata (the agent needs it for
+context like "which email am I replying from"), but passwords, keyring
+references, and TLS fingerprints are never exposed in resource responses.
+
+### URI Scheme
+
+`rimap://accounts/<account-name>` is the only resource URI pattern. Unknown
+URIs return `RESOURCE_NOT_FOUND`. The URI scheme is not extensible in v1.0.0
+— per-account folder or message resources are a future consideration.
+
+---
+
+## 5. Label Tools
+
+Three new tools using standard IMAP keywords via `STORE +FLAGS` / `-FLAGS`.
+No provider-specific extensions.
+
+### Tool Definitions
+
+| Tool | Input | Behavior |
+|------|-------|----------|
+| `add_label` | `folder`, `uids`, `label` | `STORE +FLAGS (<label>)` on each UID. Returns count of affected messages. |
+| `remove_label` | `folder`, `uids`, `label` | `STORE -FLAGS (<label>)` on each UID. Returns count of affected messages. |
+| `list_labels` | `folder`, `uid` | `FETCH <uid> (FLAGS)`, returns all non-system flags. |
+
+### What Counts as a Label
+
+Any IMAP flag that is not a system flag (`\Seen`, `\Answered`, `\Flagged`,
+`\Deleted`, `\Draft`, `\Recent`). The `$PendingReview` flag used by
+`create_draft` is a label by this definition.
+
+### Label Validation
+
+- Max 256 bytes
+- No null bytes
+- No spaces (IMAP atom syntax)
+- No characters outside the IMAP atom character set (no `(`, `)`, `{`, `%`,
+  `*`, `"`, `]`)
+- Reject flags starting with `\` (reserved for system flag namespace)
+
+Validation failures return `ERR_INVALID_PARAMS`.
+
+### Server Keyword Support
+
+Not all IMAP servers support arbitrary keywords. If the server rejects a
+`STORE` for an unknown keyword, the IMAP error propagates as `ERR_IMAP`. No
+server capability probing — fail fast, let the agent interpret the error.
+
+### IMAP Operations
+
+`add_label` and `remove_label` require new `Connection` methods in
+`rimap-imap`:
+
+- `store_add_flags(folder, uids, flags)` — `SELECT` + `UID STORE +FLAGS`
+- `store_remove_flags(folder, uids, flags)` — `SELECT` + `UID STORE -FLAGS`
+
+These are thin wrappers distinct from the existing flag manipulation used by
+`mark_read`/`flag` etc., which operate on system flags. The underlying IMAP
+command is the same (`STORE`), but the label tools pass arbitrary keyword
+strings rather than well-known flag constants.
+
+`list_labels` uses the existing `FETCH FLAGS` capability, filtering the
+result to exclude system flags.
+
+---
+
+## 6. Posture Matrix Update
+
+The matrix expands from 19 tools x 4 postures to 22 tools x 4 postures.
+
+| Tool | readonly | draft-safe | full | destructive |
+|------|----------|------------|------|-------------|
+| `list_folders` | yes | yes | yes | yes |
+| `search` | yes | yes | yes | yes |
+| `search_advanced` | - | - | yes | yes |
+| `fetch_message` | yes | yes | yes | yes |
+| `fetch_message_html` | - | - | yes | yes |
+| `list_attachments` | yes | yes | yes | yes |
+| `download_attachment` | yes | yes | yes | yes |
+| `mark_read` | - | yes | yes | yes |
+| `mark_unread` | - | yes | yes | yes |
+| `flag` | - | yes | yes | yes |
+| `unflag` | - | yes | yes | yes |
+| `add_label` | - | yes | yes | yes |
+| `remove_label` | - | yes | yes | yes |
+| `list_labels` | yes | yes | yes | yes |
+| `move_message` | - | yes | yes | yes |
+| `create_draft` | - | yes | yes | yes |
+| `send_email` | - | - | yes | yes |
+| `delete_message` | - | - | yes | yes |
+| `create_folder` | - | - | yes | yes |
+| `rename_folder` | - | - | yes | yes |
+| `expunge` | - | - | - | yes |
+| `delete_folder` | - | - | - | yes |
+
+### Rationale
+
+- `add_label` / `remove_label` at `draft-safe` — same tier as `flag` /
+  `mark_read`; they are metadata mutations, not content mutations.
+- `list_labels` at `readonly` — read-only flag inspection, same tier as
+  `list_attachments`.
+
+### Infrastructure Tools
+
+`use_account` and `list_accounts` are **not in the posture matrix**. They
+bypass posture checks, rate limiting, and circuit breaker gating entirely.
+They are always available regardless of account posture. They still produce
+audit records.
+
+---
+
+## 7. Audit Log Changes
+
+### Shared Writer, Account-Tagged Records
+
+The `AuditWriter` remains singular. All accounts write to one JSONL file.
+
+### New Record Field
+
+`account: Option<String>` added to all record types (`ProcessStart`, `Auth`,
+`ToolStart`, `ToolEnd`). `None` for legacy single-account configs (the
+`"default"` synthetic account), `Some("work")` for named multi-account
+configs.
+
+### `ProcessStart` Changes
+
+Currently records a single `posture` field. With multi-account, it records
+an array of account summaries:
+
+```json
+{
+  "type": "process_start",
+  "accounts": [
+    { "name": "work", "posture": "full", "imap_host": "127.0.0.1" },
+    { "name": "personal", "posture": "readonly", "imap_host": "imap.fastmail.com" }
+  ]
+}
+```
+
+For legacy single-account configs, the existing flat `posture` field is
+emitted instead. No breaking change to the JSONL schema for existing users.
+
+### New Audit Events
+
+| Event | Key Fields |
+|-------|-----------|
+| `use_account` | `account` (selected), `previous` (if changing) |
+| `list_accounts` | `count` |
+| `add_label` | `folder`, `uids`, `label` |
+| `remove_label` | `folder`, `uids`, `label` |
+| `list_labels` | `folder`, `uid` |
+
+### Redaction
+
+- Label values logged verbatim (not PII — user-defined categories).
+- Account names logged verbatim (needed for forensic reconstruction).
+- No new PII fields introduced.
+
+### `audit merge` Filter
+
+Add `--account <name>` filter to the merge subcommand for extracting
+single-account timelines from shared logs.
+
+---
+
+## 8. Error Handling
+
+### New Error Types
+
+| Error | Crate | Trigger |
+|-------|-------|---------|
+| `RimapError::NoAccount` | `rimap-core` | Tool call with no account selected and multiple accounts configured |
+| `RimapError::UnknownAccount` | `rimap-core` | `account` param or `use_account` names a nonexistent account |
+| `ConfigError::DuplicateAccountName` | `rimap-config` | Two `[[accounts]]` entries share a name |
+| `ConfigError::MixedConfigFormat` | `rimap-config` | Both flat `[imap]` and `[[accounts]]` present |
+| `ConfigError::InvalidAccountName` | `rimap-config` | Name fails validation (empty, non-ASCII, too long, spaces) |
+| `ConfigError::NoAccounts` | `rimap-config` | Config has neither flat `[imap]` nor `[[accounts]]` |
+
+### New Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `ERR_NO_ACCOUNT` | No account selected; agent must call `use_account` or pass `account` param |
+| `ERR_UNKNOWN_ACCOUNT` | Named account not found in config |
+
+### Actionable Messages
+
+- `ERR_NO_ACCOUNT`: "Multiple accounts configured; call `use_account` or
+  pass `account` parameter. Available: work, personal"
+- `ERR_UNKNOWN_ACCOUNT`: "Account 'typo' not found. Available: work,
+  personal"
+
+### Label Errors
+
+No new error types for labels. `STORE +FLAGS` failures propagate as
+`ERR_IMAP`. Label validation failures use `ERR_INVALID_PARAMS`.
+
+---
+
+## 9. Testing Strategy
+
+### Config Tests (`rimap-config`)
+
+- Multi-account TOML parsing with defaults inheritance
+- Legacy flat config auto-wrapped as `"default"` account
+- `MixedConfigFormat` error on flat + `[[accounts]]`
+- `DuplicateAccountName` detection
+- `InvalidAccountName` validation (empty, spaces, too long, non-ASCII)
+- Per-account `SmtpRequired` and `ConflictingFolders` checks
+- Defaults override: account `[security]` overrides `[defaults.security]`
+
+### Account Registry Tests (`rimap-server`)
+
+- Account resolution: explicit param > session default > auto-select > error
+- `use_account` sets and overwrites session default
+- `list_accounts` returns all configured accounts
+- `ERR_NO_ACCOUNT` when multi-account, no selection
+- `ERR_UNKNOWN_ACCOUNT` for nonexistent name
+- Single-account auto-select without `use_account`
+
+### Label Tests
+
+**Unit (`rimap-server`):**
+- Label validation: reject system flags, backslash prefix, null bytes, overlength
+- `list_labels` filters system flags from response
+
+**Integration (`rimap-imap`):**
+- `add_label` / `remove_label` round-trip via Dovecot harness
+- `list_labels` returns custom flags, excludes system flags
+- Multiple UIDs in one `add_label` call
+
+### Authz Tests (`rimap-authz`)
+
+- Expanded posture matrix: 22 tools x 4 postures
+- `use_account` and `list_accounts` bypass posture checks
+- Label tools at correct posture levels
+
+### Audit Tests (`rimap-audit`)
+
+- `account` field present on records when multi-account
+- `account` field `None` for legacy single-account
+- `ProcessStart` records multi-account summary
+- `audit merge --account work` filters correctly
+
+### MCP Resource Tests (`rimap-server`)
+
+- `list_resources` returns one resource per account
+- `read_resource` returns metadata without credentials
+- Unknown URI returns not-found error
+
+### Release Validation
+
+- All five binary targets build and print `--version`
+- `just ci` green on the release commit
+
+---
+
+## 10. Release Preparation
+
+### Version
+
+`workspace.package.version` set to `1.0.0`. The semver stability
+commitment covers:
+
+- Config file format (TOML schema)
+- MCP tool names and input/output schemas
+- MCP resource URI scheme (`rimap://accounts/<name>`)
+- Audit log JSONL schema
+- CLI flags and exit codes
+
+### CHANGELOG
+
+Full v1.0.0 entry covering the entire feature surface. Organized by
+capability, not by sprint or development history.
+
+### Documentation
+
+| Document | Content |
+|----------|---------|
+| `README.md` | Rewrite for v1.0: what it does, quick-start, multi-account config example, posture overview, links to detailed docs |
+| `docs/configuration.md` | Full config reference with multi-account and legacy examples |
+| `docs/multi-account.md` | Account discovery, `use_account`, MCP resources, single-account backward compat |
+| `docs/security-model.md` | Posture matrix (22 tools x 4 postures), threat model, audit log |
+| `docs/proton-bridge-setup.md` | TLS fingerprint capture walkthrough |
+
+### Build Targets
+
+| Target | Build Method |
+|--------|-------------|
+| `x86_64-unknown-linux-gnu` | Native `cargo build` (CI runner) |
+| `aarch64-unknown-linux-gnu` | `cross` |
+| `aarch64-apple-darwin` | Native `cargo build` (macOS runner) |
+| `powerpc64le-unknown-linux-gnu` | QEMU user-mode emulation — native `cargo build` inside ppc64le container |
+| `s390x-unknown-linux-gnu` | QEMU user-mode emulation — native `cargo build` inside s390x container |
+
+### QEMU Build Strategy
+
+GitHub Actions jobs use `docker/setup-qemu-action` to register binfmt_misc
+handlers, then run `docker run --platform linux/ppc64le` (and `linux/s390x`)
+with a Rust container image, mounting the source tree and running
+`cargo build --release` natively under emulation. Slower than
+cross-compilation but avoids linker/toolchain issues with `cross` on these
+architectures.
+
+### Release Workflow
+
+A new `.github/workflows/release.yml` triggered on version tags (`v*`):
+
+1. Run five build jobs in parallel (one per target).
+2. Collect binary artifacts.
+3. Generate SHA256 checksums file.
+4. Create GitHub release with all binaries and checksums attached.
+5. Release notes generated from CHANGELOG.
+
+### Not in Scope for v1.0.0
+
+- crates.io publishing
+- Container / OCI images
+- `cargo vet` adoption
+- `cargo-mutants` CI gate
+- Provenance analyzer
+- IDLE / push notifications

--- a/scripts/setup-tag-protection.md
+++ b/scripts/setup-tag-protection.md
@@ -1,0 +1,54 @@
+# Release tag protection setup
+
+Releases in this repository are triggered by pushing a `v*` tag. Protect
+those tags so only authorized maintainers can create them, and so the
+release workflow can be gated on a review step.
+
+## 1. Create a tag ruleset via `gh`
+
+Run this once per repository (requires admin access):
+
+```bash
+gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/:owner/:repo/rulesets \
+  -f name='Protect release tags' \
+  -f target='tag' \
+  -f enforcement='active' \
+  -F 'conditions[ref_name][include][]=refs/tags/v*' \
+  -F 'rules[][type]=creation' \
+  -F 'rules[][type]=deletion' \
+  -F 'rules[][type]=update' \
+  -F 'bypass_actors[][actor_id]=<REPO_ADMIN_TEAM_ID>' \
+  -F 'bypass_actors[][actor_type]=Team' \
+  -F 'bypass_actors[][bypass_mode]=always'
+```
+
+Replace `:owner/:repo` and `<REPO_ADMIN_TEAM_ID>` with real values. Without a
+bypass actor, even repo admins cannot push tags; with one, only members of
+the designated team can.
+
+## 2. Verify the ruleset
+
+```bash
+gh api /repos/:owner/:repo/rulesets | jq '.[] | {id, name, target, enforcement}'
+```
+
+You should see `Protect release tags` with `target: "tag"` and
+`enforcement: "active"`.
+
+## 3. Configure the `release` environment
+
+The release workflow declares `environment: release` on the release job.
+Create that environment and attach required reviewers so every tag push
+waits for human approval before artifacts are published and attestations
+are signed:
+
+1. Repo -> Settings -> Environments -> New environment -> `release`.
+2. Add one or more **Required reviewers** (individuals or teams).
+3. Optionally scope deployment branches to `v*` tags only.
+
+With the ruleset and the environment combined, a rogue push of a `v*` tag
+is rejected at tag creation time, and if it slips past, the workflow still
+blocks on reviewer approval before anything is published.


### PR DESCRIPTION
## Summary

This PR lands sprint-3 feature work, sprint-3 review remediations, and v1.0.0 release prep on `main`. It is large (56 commits) but commits are atomic; the three-layer breakdown below is meant to guide review order.

- **Layer 1 — v1.0.0 release prep** (5 commits): workspace version bump to 1.0.0, CHANGELOG, 5-target release workflow, AGENTS.md + v1.0 docs.
- **Layer 2 — Sprint-3 feature work** (22 commits): multi-account bootstrap, `AccountId` newtype, labels (add/remove/list), `use_account`/`list_accounts` infrastructure tools, MCP resource handlers, audit `account` attribution.
- **Layer 3 — Sprint-3 review remediations** (29 commits, 27 findings across 8 task groups): plan at `docs/superpowers/plans/2026-04-13-sprint-3-review-remediations.md`.

## Breaking Changes

- **Multi-account tool namespacing.** In multi-account configs, tools are advertised as `<account>.<tool>` (e.g., `work.send_email`). Single-account configs keep bare tool names. This is an intentional breaking change for multi-account deployments, consistent with v1.0.0 being the first stable release.

## Review Remediation Coverage

All 27 findings from the 7-reviewer sprint-3 review have matching commits:

| Group | Tasks | Commits |
|-------|-------|---------|
| A — MCP Surface Hardening | A1–A5 | 7e9ad0d, e3f8aa3, b256413, a026ed4, 5237bb4 |
| B — Audit Plumbing | B1–B2 | e473fa2, f22e45c |
| C — Credential & Log Hygiene | C1–C4 | a5215c2, 5e70261, 2579cf8, 2206b92 |
| D — Label Hardening | D1 | ac07a45 |
| E — Supply Chain & CI/CD | E1–E6 | 0aa8317, 6ea54a2, 9d31e2e, dd6f62e, 24088e8, 96a1345 |
| F — Rust Safety Follow-ups | F1–F2 | 3907a9e, a9d98f4 |
| G — Filesystem Hardening | G1 | 9e77506 |
| H — Code Quality & Docs | H1–H7 | 2342e59, f212397, e7bf780, 87314e0, 24b4715, da842e6, 7d683b9 |

## Deferred to v1.1

Five findings were carved out to separate issues as either too breaking, too design-heavy, or too cross-cutting for the v1.0.0 gate. Plan: `docs/superpowers/plans/2026-04-14-v1.1-followups.md`.

- #70 UIDVALIDITY echo + `expected_uidvalidity` across mutation tools
- #71 `ToolCallGuard` with Drop → synthetic `Cancelled` tool_end
- #77 Keyring namespace by account id (BREAKING + `migrate-keyring` subcommand)
- #78 Strict credential mode (`keyring-only`) + audit `credential_source`
- #79 Embed cargo-auditable SBOM in aarch64-linux via `cross`

Seven smaller issues (#72, #73, #74, #75, #76, #80, #81) are planned for the v1.0.0 gate as a follow-up PR: `docs/superpowers/plans/2026-04-14-v1.0.0-issue-closeout.md`.

## Local Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — pass

## Test plan

- [ ] CI green on feat/sprint-3 (all 5 release targets build; nextest + deny + zizmor + typos)
- [ ] Single-account config: tool names unchanged (regression guard)
- [ ] Multi-account config: tools appear as `<account>.<tool>` in `list_tools`
- [ ] Multi-account `use_account` switches the default account for bare-name calls (until #80 adds `tools/list_changed`)
- [ ] Audit records carry `account` field on Auth and `tool_start`/`tool_end` records
- [ ] Release workflow smoke test on a tag: verify SBOM embedded in x86_64-linux/aarch64-darwin/ppc64le/s390x artifacts (aarch64-linux pending #79); verify SLSA attestation present

🤖 Generated with [Claude Code](https://claude.com/claude-code)