### PR TITLE
fix: skip STATUS on \Noselect folders in list_folders

### DIFF
--- a/crates/rimap-imap/src/ops/folders.rs
+++ b/crates/rimap-imap/src/ops/folders.rs
@@ -1,5 +1,6 @@
 //! `LIST`, `STATUS`, `SELECT` / `EXAMINE` against an active `async-imap` session.
 
+use async_imap::types::NameAttribute;
 use futures_util::StreamExt;
 
 use crate::connection::ImapSession;
@@ -17,6 +18,7 @@ pub(crate) async fn list(
     let mut out = Vec::new();
     while let Some(name) = stream.next().await {
         let name = name.map_err(map_err)?;
+        let selectable = is_selectable(name.attributes());
         out.push(Folder {
             name: name.name().to_string(),
             attributes: name
@@ -25,9 +27,32 @@ pub(crate) async fn list(
                 .map(|attr| format!("{attr:?}"))
                 .collect(),
             delimiter: name.delimiter().and_then(|s| s.chars().next()),
+            selectable,
         });
     }
     Ok(out)
+}
+
+/// Returns `false` if any attribute marks the mailbox non-selectable —
+/// RFC 3501 `\Noselect` or RFC 5258 `\NonExistent`. Running `STATUS`,
+/// `SELECT`, or `EXAMINE` against such an entry is a protocol error on
+/// strict servers (Gmail returns `[NONEXISTENT] Invalid folder` and drops
+/// the response).
+///
+/// `\NonExistent` is not a dedicated variant in the `imap-proto` enum (it
+/// arrives as `Extension("\\NonExistent")`), so the check walks both the
+/// named variant and the extension string with a case-insensitive compare.
+fn is_selectable(attrs: &[NameAttribute<'_>]) -> bool {
+    for attr in attrs {
+        match attr {
+            NameAttribute::NoSelect => return false,
+            NameAttribute::Extension(ext) if ext.eq_ignore_ascii_case("\\NonExistent") => {
+                return false;
+            }
+            _ => {}
+        }
+    }
+    true
 }
 
 pub(crate) async fn status(
@@ -174,6 +199,50 @@ fn is_dead_tcp_kind(kind: std::io::ErrorKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_selectable_accepts_normal_folder() {
+        let attrs = [
+            NameAttribute::Unmarked,
+            NameAttribute::Extension("\\HasNoChildren".into()),
+        ];
+        assert!(is_selectable(&attrs));
+    }
+
+    #[test]
+    fn is_selectable_rejects_noselect() {
+        let attrs = [
+            NameAttribute::Extension("\\HasChildren".into()),
+            NameAttribute::NoSelect,
+        ];
+        assert!(!is_selectable(&attrs));
+    }
+
+    #[test]
+    fn is_selectable_rejects_rfc5258_nonexistent_extension() {
+        let attrs = [NameAttribute::Extension("\\NonExistent".into())];
+        assert!(!is_selectable(&attrs));
+    }
+
+    #[test]
+    fn is_selectable_nonexistent_match_is_case_insensitive() {
+        let attrs = [NameAttribute::Extension("\\nonexistent".into())];
+        assert!(!is_selectable(&attrs));
+    }
+
+    #[test]
+    fn is_selectable_ignores_unrelated_extensions() {
+        let attrs = [
+            NameAttribute::Extension("\\All".into()),
+            NameAttribute::Extension("\\Sent".into()),
+        ];
+        assert!(is_selectable(&attrs));
+    }
+
+    #[test]
+    fn is_selectable_empty_attribute_list_is_selectable() {
+        assert!(is_selectable(&[]));
+    }
 
     #[test]
     fn status_items_empty_selection_renders_empty_parens() {

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -55,6 +55,12 @@ pub struct Folder {
     pub attributes: Vec<String>,
     /// Hierarchy delimiter, if the server reported one.
     pub delimiter: Option<char>,
+    /// Whether the folder can be the target of `SELECT`/`EXAMINE`/`STATUS`.
+    /// False for RFC 3501 `\Noselect` parents (Gmail's `[Gmail]`, some
+    /// Exchange public-folder namespaces) and RFC 5258 `\NonExistent`
+    /// entries. `STATUS` against a non-selectable folder aborts the
+    /// connection with `ERR_IMAP_PROTOCOL` on many servers.
+    pub selectable: bool,
 }
 
 /// Bitflags-style selection for `STATUS` items.

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -31,11 +31,18 @@ pub struct ListFoldersMeta {
 
 /// Execute the `list_folders` tool.
 ///
+/// Non-selectable folders (RFC 3501 `\Noselect` namespace parents such as
+/// Gmail's `[Gmail]`, RFC 5258 `\NonExistent` entries) are returned with
+/// `exists`/`unseen`/`uid_validity` left as `None`. Running `STATUS`
+/// against them is a protocol error on strict servers and would abort the
+/// whole tool call.
+///
 /// # Errors
 ///
 /// Returns `RimapError::Imap { ... }` if the server rejects LIST or any
-/// of the per-folder STATUS calls. The upstream
-/// `DispatchGuard::pre_dispatch` gate may also return `PostureDenied`.
+/// of the per-folder STATUS calls against a selectable folder. The
+/// upstream `DispatchGuard::pre_dispatch` gate may also return
+/// `PostureDenied`.
 pub async fn handle(
     account: &AccountState,
 ) -> Result<ToolResponse<ListFoldersMeta>, rimap_core::RimapError> {
@@ -43,18 +50,23 @@ pub async fn handle(
 
     let mut folder_entries = Vec::with_capacity(folders.len());
     for folder in &folders {
-        let status = account
-            .imap
-            .status(&folder.name, rimap_imap::types::StatusItems::all())
-            .await?;
+        let (exists, unseen, uid_validity) = if folder.selectable {
+            let status = account
+                .imap
+                .status(&folder.name, rimap_imap::types::StatusItems::all())
+                .await?;
+            (status.messages, status.unseen, status.uid_validity)
+        } else {
+            (None, None, None)
+        };
 
         folder_entries.push(FolderEntry {
             name: folder.name.clone(),
             delimiter: folder.delimiter,
             flags: folder.attributes.clone(),
-            exists: status.messages,
-            unseen: status.unseen,
-            uid_validity: status.uid_validity,
+            exists,
+            unseen,
+            uid_validity,
         });
     }
 


### PR DESCRIPTION
## Summary

- `list_folders` aborted with `ERR_IMAP_PROTOCOL` on Gmail because it iterated every `LIST` entry with `STATUS`, including `[Gmail]` which is `\HasChildren \Noselect`. Gmail rejects `STATUS` on a `\Noselect` parent with `[NONEXISTENT] Invalid folder: [Gmail]`.
- Added `selectable: bool` on `rimap_imap::types::Folder`, computed from the raw `NameAttribute` enum (handles RFC 3501 `\Noselect` and RFC 5258 `\NonExistent`, the latter arriving as an `Extension` string).
- Handler now skips `STATUS` for non-selectable folders and returns them with `exists`/`unseen`/`uid_validity` as `null`.

Same hazard affects any IMAP server exposing `\Noselect` namespace parents (Exchange public folders, Dovecot multi-namespace configs).

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean
- [x] 6 new unit tests for `is_selectable` (covers `\Noselect`, `\NonExistent` case-insensitive, normal folders, empty attrs)
- [x] `just test` — 784/784 pass, including Dovecot integration and rimap-server e2e
- [x] Manually verified end-to-end against Gmail: 42 folders returned, `[Gmail]` has null status, all others show counts