### PR TITLE
feat: credential hardening — redact ConfigError, namespace keyring, strict fallback mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking (keyring):** Credential keyring entries are now namespaced by
+  account id (`<account-id>/<username>@<host>`) to prevent collisions in
+  multi-account deployments (#77). Existing entries under the legacy
+  `<username>@<host>` key continue to resolve via a transparent fallback
+  that emits a `tracing::warn!` — run
+  `rusty-imap-mcp migrate-keyring --account <id> --host <h> --username <u>`
+  once per account to migrate.
+- `rusty-imap-mcp login` gains a `--account <id>` argument (default
+  `default`), so multi-account deployments can store credentials under
+  the correct namespaced key. Single-account invocations remain
+  unchanged.
+- `ConfigError::NoCredential` and `ConfigError::Keychain` Display strings no
+  longer include the username; they now show the host and a short
+  `account_tag` hash for log correlation (#76).
+
+### Added
+
+- `[defaults.credentials]` / `[[accounts.credentials]]` TOML section with a
+  `fallback` knob (`keyring-only` vs `keyring-then-env`, default
+  `keyring-then-env`). Setting `keyring-only` disables the
+  `RUSTY_IMAP_MCP_PASSWORD` env-var fallback for multi-account deployments
+  where a shared fallback would cross account boundaries (#78).
+- Audit records of kind `auth` now include a `credential_source` field
+  (`keyring` / `legacy_keyring` / `env_var`) for post-incident analysis.
+- `rusty-imap-mcp migrate-keyring` CLI subcommand to migrate credentials
+  from the legacy keyring key format to the new namespaced format.
+
 ## [1.0.0] - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ dependencies = [
  "rpassword",
  "secrecy",
  "serde",
+ "sha2",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,6 +2133,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
  "utf7-imap",
 ]
 

--- a/crates/rimap-audit/src/record/mod.rs
+++ b/crates/rimap-audit/src/record/mod.rs
@@ -208,6 +208,10 @@ pub struct Auth {
     /// On failure, the stable error code (`ERR_TLS`, `ERR_AUTH`, …); `None`
     /// on success.
     pub error_code: Option<ErrorCode>,
+    /// Credential source on success; `None` on failure (credential was never
+    /// resolved) or on `auth` records from code paths that predate #78.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_source: Option<rimap_core::CredentialSource>,
 }
 
 /// Payload of the `tool_start` kind. Recorded before dispatch begins so a
@@ -414,6 +418,7 @@ mod tests {
                 tls_fingerprint_sha256: Some("ab".repeat(32)),
                 fingerprint_match: Some(true),
                 error_code: None,
+                credential_source: None,
             }),
         };
         let json = serde_json::to_string(&rec).unwrap();

--- a/crates/rimap-audit/src/writer/mod.rs
+++ b/crates/rimap-audit/src/writer/mod.rs
@@ -958,6 +958,7 @@ mod tests {
                 tls_fingerprint_sha256: Some("ab".repeat(32)),
                 fingerprint_match: Some(true),
                 error_code: None,
+                credential_source: None,
             })
             .unwrap();
 
@@ -1000,6 +1001,7 @@ mod tests {
             tls_fingerprint_sha256: None,
             fingerprint_match: None,
             error_code: Some(rimap_core::ErrorCode::Tls),
+            credential_source: None,
         };
         writer.log_auth(make()).unwrap();
         writer.log_auth(make()).unwrap();

--- a/crates/rimap-config/Cargo.toml
+++ b/crates/rimap-config/Cargo.toml
@@ -21,6 +21,7 @@ directories = { workspace = true }
 keyring = { workspace = true }
 rpassword = { workspace = true }
 secrecy = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rimap-config/Cargo.toml
+++ b/crates/rimap-config/Cargo.toml
@@ -22,6 +22,7 @@ keyring = { workspace = true }
 rpassword = { workspace = true }
 secrecy = { workspace = true }
 sha2 = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -85,27 +85,34 @@ fn split_account_for_error(account: &str) -> (String, String) {
     (host.to_string(), hash_account_tag(username, host))
 }
 
-/// Resolve a credential: try the store first, then env var, then fail.
+/// Resolve a credential: try the store first (new key, then legacy key), then
+/// optionally the env var (depending on `fallback_mode`), then fail.
 ///
 /// Accepts `&dyn CredentialStore` so callers that hold an
 /// `Arc<dyn CredentialStore>` can pass `&*arc` without a generic bound.
 /// Concrete references (e.g. `&KeyringStore`) coerce to `&dyn CredentialStore`
 /// automatically, so existing callers are unaffected.
 ///
+/// Returns `(SecretString, CredentialSource)` — the source lets callers record
+/// where the credential came from for audit/observability purposes.
+///
 /// # Errors
 /// - `ConfigError::Keychain` if the store itself errored.
-/// - `ConfigError::NoCredential` if neither source had a value.
+/// - `ConfigError::NoCredential` if no source produced a value.
 pub fn resolve_credential(
     store: &dyn CredentialStore,
     account_id: &AccountId,
     username: &str,
     host: &str,
-) -> Result<SecretString, ConfigError> {
+    fallback_mode: crate::model::FallbackMode,
+) -> Result<(SecretString, rimap_core::CredentialSource), ConfigError> {
+    use rimap_core::CredentialSource;
+
     let new_key = account_key(account_id, username, host);
     if let Some(p) = store.get_password(&new_key)?
         && !p.expose_secret().is_empty()
     {
-        return Ok(p);
+        return Ok((p, CredentialSource::Keyring));
     }
 
     // Back-compat: before #77 the keyring key was <username>@<host>, with no
@@ -122,26 +129,45 @@ pub fn resolve_credential(
              run `rusty-imap-mcp migrate-keyring --account {}` to migrate",
             account_id.as_str(),
         );
-        return Ok(p);
+        return Ok((p, CredentialSource::LegacyKeyring));
     }
 
-    if let Ok(env) = std::env::var(PASSWORD_ENV_VAR)
+    if fallback_mode == crate::model::FallbackMode::KeyringThenEnv
+        && let Ok(env) = std::env::var(PASSWORD_ENV_VAR)
         && !env.is_empty()
     {
-        return Ok(SecretString::from(env));
+        return Ok((SecretString::from(env), CredentialSource::EnvVar));
     }
 
     Err(ConfigError::NoCredential {
         host: host.to_string(),
         account_tag: hash_account_tag(username, host),
-        reason: format!(
-            "no entry in keychain service `{KEYCHAIN_SERVICE}` (under key \
-             `{new_key}` or legacy `{legacy_key}`) and `{PASSWORD_ENV_VAR}` \
-             is unset or empty; run `rusty-imap-mcp login --account \
-             {}` or set the environment variable",
+        reason: build_no_credential_reason(account_id, fallback_mode, &new_key, &legacy_key),
+    })
+}
+
+fn build_no_credential_reason(
+    account_id: &AccountId,
+    fallback_mode: crate::model::FallbackMode,
+    new_key: &str,
+    legacy_key: &str,
+) -> String {
+    match fallback_mode {
+        crate::model::FallbackMode::KeyringOnly => format!(
+            "no entry in keychain service `{KEYCHAIN_SERVICE}` under key \
+             `{new_key}` or legacy `{legacy_key}`; fallback mode is \
+             keyring-only (env var not consulted). Run `rusty-imap-mcp \
+             login --account {}`",
             account_id.as_str(),
         ),
-    })
+        crate::model::FallbackMode::KeyringThenEnv => format!(
+            "no entry in keychain service `{KEYCHAIN_SERVICE}` under key \
+             `{new_key}` or legacy `{legacy_key}`, and `{PASSWORD_ENV_VAR}` \
+             is unset or empty. Run `rusty-imap-mcp login --account {}` \
+             or set the environment variable",
+            account_id.as_str(),
+        ),
+    }
 }
 
 /// Keychain-backed [`CredentialStore`] using the `keyring` crate. Not
@@ -206,6 +232,7 @@ mod tests {
 
     use crate::credential::{CredentialStore, PASSWORD_ENV_VAR, account_key, resolve_credential};
     use crate::error::ConfigError;
+    use crate::model::FallbackMode;
 
     #[test]
     fn hash_account_tag_is_16_hex_and_deterministic() {
@@ -303,7 +330,9 @@ mod tests {
             ("alice@host", "from_legacy_key"),
         ]);
         temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
-            let got = resolve_credential(&store, &id, "alice", "host").unwrap();
+            let (got, _src) =
+                resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringThenEnv)
+                    .unwrap();
             assert_eq!(got.expose_secret(), "from_new_key");
         });
     }
@@ -314,7 +343,9 @@ mod tests {
         let id = AccountId::new("work").unwrap();
         let store = MockStore::with(&[("alice@host", "from_legacy_key")]);
         temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
-            let got = resolve_credential(&store, &id, "alice", "host").unwrap();
+            let (got, _src) =
+                resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringThenEnv)
+                    .unwrap();
             assert_eq!(got.expose_secret(), "from_legacy_key");
         });
     }
@@ -324,7 +355,14 @@ mod tests {
         let default_id = AccountId::default_account();
         let store = MockStore::with(&[("default/alice@host", "from_keychain")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
-            let got = resolve_credential(&store, &default_id, "alice", "host").unwrap();
+            let (got, _src) = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringThenEnv,
+            )
+            .unwrap();
             assert_eq!(got.expose_secret(), "from_keychain");
         });
     }
@@ -334,7 +372,14 @@ mod tests {
         let store = MockStore::default();
         let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
-            let got = resolve_credential(&store, &default_id, "alice", "host").unwrap();
+            let (got, _src) = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringThenEnv,
+            )
+            .unwrap();
             assert_eq!(got.expose_secret(), "from_env");
         });
     }
@@ -344,7 +389,14 @@ mod tests {
         let store = MockStore::default();
         let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
-            let err = resolve_credential(&store, &default_id, "alice", "host").unwrap_err();
+            let err = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringThenEnv,
+            )
+            .unwrap_err();
             match err {
                 ConfigError::NoCredential {
                     host,
@@ -366,7 +418,14 @@ mod tests {
         let store = MockStore::failing();
         let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("unused"), || {
-            let err = resolve_credential(&store, &default_id, "alice", "host").unwrap_err();
+            let err = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringThenEnv,
+            )
+            .unwrap_err();
             assert!(matches!(err, ConfigError::Keychain { .. }));
         });
     }
@@ -377,9 +436,16 @@ mod tests {
         let store = MockStore::with(&[("default/alice@host", "")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             assert_eq!(
-                resolve_credential(&store, &default_id, "alice", "host")
-                    .unwrap()
-                    .expose_secret(),
+                resolve_credential(
+                    &store,
+                    &default_id,
+                    "alice",
+                    "host",
+                    FallbackMode::KeyringThenEnv,
+                )
+                .unwrap()
+                .0
+                .expose_secret(),
                 "from_env"
             );
         });
@@ -390,5 +456,57 @@ mod tests {
         let p = SecretString::from("hunter2".to_string());
         let formatted = format!("{p:?}");
         assert!(!formatted.contains("hunter2"));
+    }
+
+    #[test]
+    fn strict_mode_skips_env_var() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::default();
+        temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
+            let err = resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringOnly)
+                .unwrap_err();
+            assert!(matches!(err, ConfigError::NoCredential { .. }));
+        });
+    }
+
+    #[test]
+    fn permissive_mode_still_uses_env_var() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::default();
+        temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
+            let (password, source) =
+                resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringThenEnv)
+                    .unwrap();
+            assert_eq!(password.expose_secret(), "from_env");
+            assert_eq!(source, rimap_core::CredentialSource::EnvVar);
+        });
+    }
+
+    #[test]
+    fn keyring_hit_reports_keyring_source() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::with(&[("work/alice@host", "secret")]);
+        temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
+            let (_p, source) =
+                resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringOnly)
+                    .unwrap();
+            assert_eq!(source, rimap_core::CredentialSource::Keyring);
+        });
+    }
+
+    #[test]
+    fn legacy_keyring_hit_reports_legacy_source() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::with(&[("alice@host", "secret")]);
+        temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
+            let (_p, source) =
+                resolve_credential(&store, &id, "alice", "host", FallbackMode::KeyringOnly)
+                    .unwrap();
+            assert_eq!(source, rimap_core::CredentialSource::LegacyKeyring);
+        });
     }
 }

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -5,6 +5,7 @@
 //!   2. Environment variable `RUSTY_IMAP_MCP_PASSWORD`.
 //!   3. Clear, actionable error naming both.
 
+use rimap_core::account::AccountId;
 use secrecy::{ExposeSecret, SecretString};
 use sha2::{Digest, Sha256};
 
@@ -34,9 +35,13 @@ pub trait CredentialStore: Send + Sync {
     fn set_password(&self, account: &str, password: &str) -> Result<(), ConfigError>;
 }
 
-/// Build the `<username>@<host>` account key used for keychain lookups.
+/// Build the keyring account key for `(account_id, username, host)`.
+///
+/// Returns the **legacy** `<username>@<host>` form for compatibility with
+/// stored credentials. Task 3 introduces the new `<account-id>/<username>@<host>`
+/// form and a back-compat read path.
 #[must_use]
-pub fn account_key(username: &str, host: &str) -> String {
+pub fn account_key(_account_id: &AccountId, username: &str, host: &str) -> String {
     format!("{username}@{host}")
 }
 
@@ -82,10 +87,11 @@ fn split_account_for_error(account: &str) -> (String, String) {
 /// - `ConfigError::NoCredential` if neither source had a value.
 pub fn resolve_credential(
     store: &dyn CredentialStore,
+    account_id: &AccountId,
     username: &str,
     host: &str,
 ) -> Result<SecretString, ConfigError> {
-    let account = account_key(username, host);
+    let account = account_key(account_id, username, host);
     if let Some(p) = store.get_password(&account)?
         && !p.expose_secret().is_empty()
     {
@@ -165,6 +171,8 @@ mod tests {
 
     use secrecy::{ExposeSecret, SecretString};
 
+    use rimap_core::account::AccountId;
+
     use crate::credential::{CredentialStore, PASSWORD_ENV_VAR, account_key, resolve_credential};
     use crate::error::ConfigError;
 
@@ -242,18 +250,20 @@ mod tests {
     }
 
     #[test]
-    fn account_key_is_username_at_host() {
-        assert_eq!(
-            account_key("alice", "mail.example.test"),
-            "alice@mail.example.test"
-        );
+    fn account_key_signature_accepts_account_id() {
+        let id = AccountId::default_account();
+        // Old format still returned in this task; task 3 changes to
+        // "<id>/<user>@<host>".
+        let key = account_key(&id, "alice", "mail.example.test");
+        assert_eq!(key, "alice@mail.example.test");
     }
 
     #[test]
     fn keychain_hit_wins_over_env() {
         let store = MockStore::with(&[("alice@host", "from_keychain")]);
+        let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
-            let got = resolve_credential(&store, "alice", "host").unwrap();
+            let got = resolve_credential(&store, &default_id, "alice", "host").unwrap();
             assert_eq!(got.expose_secret(), "from_keychain");
         });
     }
@@ -261,8 +271,9 @@ mod tests {
     #[test]
     fn env_used_when_keychain_empty() {
         let store = MockStore::default();
+        let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
-            let got = resolve_credential(&store, "alice", "host").unwrap();
+            let got = resolve_credential(&store, &default_id, "alice", "host").unwrap();
             assert_eq!(got.expose_secret(), "from_env");
         });
     }
@@ -270,8 +281,9 @@ mod tests {
     #[test]
     fn missing_everywhere_returns_no_credential() {
         let store = MockStore::default();
+        let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
-            let err = resolve_credential(&store, "alice", "host").unwrap_err();
+            let err = resolve_credential(&store, &default_id, "alice", "host").unwrap_err();
             match err {
                 ConfigError::NoCredential {
                     host,
@@ -291,8 +303,9 @@ mod tests {
     #[test]
     fn keychain_error_propagates() {
         let store = MockStore::failing();
+        let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("unused"), || {
-            let err = resolve_credential(&store, "alice", "host").unwrap_err();
+            let err = resolve_credential(&store, &default_id, "alice", "host").unwrap_err();
             assert!(matches!(err, ConfigError::Keychain { .. }));
         });
     }
@@ -300,9 +313,10 @@ mod tests {
     #[test]
     fn empty_keychain_value_falls_through_to_env() {
         let store = MockStore::with(&[("alice@host", "")]);
+        let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             assert_eq!(
-                resolve_credential(&store, "alice", "host")
+                resolve_credential(&store, &default_id, "alice", "host")
                     .unwrap()
                     .expose_secret(),
                 "from_env"

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -1,7 +1,9 @@
 //! Credential resolution.
 //!
-//! Order of precedence (design spec §4):
-//!   1. OS keychain (service = `rusty-imap-mcp`, account = `<username>@<host>`).
+//! Order of precedence (design spec §4, updated for #77):
+//!   1. OS keychain (service = `rusty-imap-mcp`,
+//!      account = `<account-id>/<username>@<host>`), with a back-compat read
+//!      on the legacy `<username>@<host>` form that logs a migration hint.
 //!   2. Environment variable `RUSTY_IMAP_MCP_PASSWORD`.
 //!   3. Clear, actionable error naming both.
 
@@ -37,11 +39,19 @@ pub trait CredentialStore: Send + Sync {
 
 /// Build the keyring account key for `(account_id, username, host)`.
 ///
-/// Returns the **legacy** `<username>@<host>` form for compatibility with
-/// stored credentials. Task 3 introduces the new `<account-id>/<username>@<host>`
-/// form and a back-compat read path.
+/// New format: `<account-id>/<username>@<host>`. Added in #77 to prevent
+/// collisions when two accounts share a `<username>@<host>` tuple. Use
+/// [`legacy_account_key`] only for the read-fallback path during migration.
 #[must_use]
-pub fn account_key(_account_id: &AccountId, username: &str, host: &str) -> String {
+pub fn account_key(account_id: &AccountId, username: &str, host: &str) -> String {
+    format!("{}/{username}@{host}", account_id.as_str())
+}
+
+/// Legacy keyring key format (`<username>@<host>`) — retained for the
+/// back-compat read path in [`resolve_credential`]. New code MUST call
+/// [`account_key`].
+#[must_use]
+pub fn legacy_account_key(username: &str, host: &str) -> String {
     format!("{username}@{host}")
 }
 
@@ -91,24 +101,45 @@ pub fn resolve_credential(
     username: &str,
     host: &str,
 ) -> Result<SecretString, ConfigError> {
-    let account = account_key(account_id, username, host);
-    if let Some(p) = store.get_password(&account)?
+    let new_key = account_key(account_id, username, host);
+    if let Some(p) = store.get_password(&new_key)?
         && !p.expose_secret().is_empty()
     {
         return Ok(p);
     }
+
+    // Back-compat: before #77 the keyring key was <username>@<host>, with no
+    // account-id prefix. If the new key lookup missed, try the legacy key and
+    // warn the operator to run `rusty-imap-mcp migrate-keyring`.
+    let legacy_key = legacy_account_key(username, host);
+    if let Some(p) = store.get_password(&legacy_key)?
+        && !p.expose_secret().is_empty()
+    {
+        tracing::warn!(
+            account_id = %account_id.as_str(),
+            host = %host,
+            "credential resolved via legacy keyring key format; \
+             run `rusty-imap-mcp migrate-keyring --account {}` to migrate",
+            account_id.as_str(),
+        );
+        return Ok(p);
+    }
+
     if let Ok(env) = std::env::var(PASSWORD_ENV_VAR)
         && !env.is_empty()
     {
         return Ok(SecretString::from(env));
     }
+
     Err(ConfigError::NoCredential {
         host: host.to_string(),
         account_tag: hash_account_tag(username, host),
         reason: format!(
-            "no entry in keychain service `{KEYCHAIN_SERVICE}` and \
-             `{PASSWORD_ENV_VAR}` is unset or empty; run `rusty-imap-mcp login` \
-             or set the environment variable"
+            "no entry in keychain service `{KEYCHAIN_SERVICE}` (under key \
+             `{new_key}` or legacy `{legacy_key}`) and `{PASSWORD_ENV_VAR}` \
+             is unset or empty; run `rusty-imap-mcp login --account \
+             {}` or set the environment variable",
+            account_id.as_str(),
         ),
     })
 }
@@ -250,18 +281,48 @@ mod tests {
     }
 
     #[test]
-    fn account_key_signature_accepts_account_id() {
-        let id = AccountId::default_account();
-        // Old format still returned in this task; task 3 changes to
-        // "<id>/<user>@<host>".
+    fn account_key_uses_namespaced_format() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
         let key = account_key(&id, "alice", "mail.example.test");
+        assert_eq!(key, "work/alice@mail.example.test");
+    }
+
+    #[test]
+    fn legacy_account_key_returns_bare_form() {
+        let key = super::legacy_account_key("alice", "mail.example.test");
         assert_eq!(key, "alice@mail.example.test");
     }
 
     #[test]
+    fn resolve_credential_reads_new_key_format_first() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::with(&[
+            ("work/alice@host", "from_new_key"),
+            ("alice@host", "from_legacy_key"),
+        ]);
+        temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
+            let got = resolve_credential(&store, &id, "alice", "host").unwrap();
+            assert_eq!(got.expose_secret(), "from_new_key");
+        });
+    }
+
+    #[test]
+    fn resolve_credential_falls_back_to_legacy_key() {
+        use rimap_core::account::AccountId;
+        let id = AccountId::new("work").unwrap();
+        let store = MockStore::with(&[("alice@host", "from_legacy_key")]);
+        temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
+            let got = resolve_credential(&store, &id, "alice", "host").unwrap();
+            assert_eq!(got.expose_secret(), "from_legacy_key");
+        });
+    }
+
+    #[test]
     fn keychain_hit_wins_over_env() {
-        let store = MockStore::with(&[("alice@host", "from_keychain")]);
         let default_id = AccountId::default_account();
+        let store = MockStore::with(&[("default/alice@host", "from_keychain")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             let got = resolve_credential(&store, &default_id, "alice", "host").unwrap();
             assert_eq!(got.expose_secret(), "from_keychain");
@@ -312,8 +373,8 @@ mod tests {
 
     #[test]
     fn empty_keychain_value_falls_through_to_env() {
-        let store = MockStore::with(&[("alice@host", "")]);
         let default_id = AccountId::default_account();
+        let store = MockStore::with(&[("default/alice@host", "")]);
         temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
             assert_eq!(
                 resolve_credential(&store, &default_id, "alice", "host")

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -6,6 +6,7 @@
 //!   3. Clear, actionable error naming both.
 
 use secrecy::{ExposeSecret, SecretString};
+use sha2::{Digest, Sha256};
 
 use crate::error::ConfigError;
 
@@ -39,6 +40,36 @@ pub fn account_key(username: &str, host: &str) -> String {
     format!("{username}@{host}")
 }
 
+/// Return a short (16 hex chars) SHA-256 hash of `"{username}@{host}"` suitable
+/// for correlating error/audit log lines without disclosing the username.
+///
+/// 16 hex chars = 64 bits of prefix — collision probability is negligible at
+/// the scale of "accounts a single deployment's error chain correlates".
+/// The hash is not a keyring key — `account_key` remains distinct and uses the
+/// full unhashed identifiers.
+#[must_use]
+pub fn hash_account_tag(username: &str, host: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(username.as_bytes());
+    hasher.update(b"@");
+    hasher.update(host.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(16);
+    for byte in &digest[..8] {
+        use core::fmt::Write;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+/// Split a `username@host` account key back into `(host, account_tag)` for
+/// building error records. If the input has no `@` (malformed), treat the
+/// whole string as host and use an empty username for hashing.
+fn split_account_for_error(account: &str) -> (String, String) {
+    let (username, host) = account.split_once('@').unwrap_or(("", account));
+    (host.to_string(), hash_account_tag(username, host))
+}
+
 /// Resolve a credential: try the store first, then env var, then fail.
 ///
 /// Accepts `&dyn CredentialStore` so callers that hold an
@@ -66,7 +97,8 @@ pub fn resolve_credential(
         return Ok(SecretString::from(env));
     }
     Err(ConfigError::NoCredential {
-        account,
+        host: host.to_string(),
+        account_tag: hash_account_tag(username, host),
         reason: format!(
             "no entry in keychain service `{KEYCHAIN_SERVICE}` and \
              `{PASSWORD_ENV_VAR}` is unset or empty; run `rusty-imap-mcp login` \
@@ -82,33 +114,45 @@ pub struct KeyringStore;
 
 impl CredentialStore for KeyringStore {
     fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
-        let entry =
-            keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|e| ConfigError::Keychain {
-                account: account.to_string(),
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|e| {
+            let (host, account_tag) = split_account_for_error(account);
+            ConfigError::Keychain {
+                host,
+                account_tag,
                 source: Box::new(e),
-            })?;
+            }
+        })?;
         match entry.get_password() {
             Ok(p) => Ok(Some(SecretString::from(p))),
             Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(ConfigError::Keychain {
-                account: account.to_string(),
-                source: Box::new(e),
-            }),
+            Err(e) => {
+                let (host, account_tag) = split_account_for_error(account);
+                Err(ConfigError::Keychain {
+                    host,
+                    account_tag,
+                    source: Box::new(e),
+                })
+            }
         }
     }
 
     fn set_password(&self, account: &str, password: &str) -> Result<(), ConfigError> {
-        let entry =
-            keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|e| ConfigError::Keychain {
-                account: account.to_string(),
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|e| {
+            let (host, account_tag) = split_account_for_error(account);
+            ConfigError::Keychain {
+                host,
+                account_tag,
                 source: Box::new(e),
-            })?;
-        entry
-            .set_password(password)
-            .map_err(|e| ConfigError::Keychain {
-                account: account.to_string(),
+            }
+        })?;
+        entry.set_password(password).map_err(|e| {
+            let (host, account_tag) = split_account_for_error(account);
+            ConfigError::Keychain {
+                host,
+                account_tag,
                 source: Box::new(e),
-            })
+            }
+        })
     }
 }
 
@@ -123,6 +167,25 @@ mod tests {
 
     use crate::credential::{CredentialStore, PASSWORD_ENV_VAR, account_key, resolve_credential};
     use crate::error::ConfigError;
+
+    #[test]
+    fn hash_account_tag_is_16_hex_and_deterministic() {
+        let a = super::hash_account_tag("alice", "mail.example.com");
+        let b = super::hash_account_tag("alice", "mail.example.com");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_account_tag_differs_on_different_inputs() {
+        let a = super::hash_account_tag("alice", "mail.example.com");
+        let b = super::hash_account_tag("bob", "mail.example.com");
+        let c = super::hash_account_tag("alice", "other.example.com");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
 
     #[derive(Default)]
     struct MockStore {
@@ -153,8 +216,10 @@ mod tests {
     impl CredentialStore for MockStore {
         fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
             if self.fail_on_get {
+                let (host, account_tag) = super::split_account_for_error(account);
                 return Err(ConfigError::Keychain {
-                    account: account.to_string(),
+                    host,
+                    account_tag,
                     source: "simulated failure".into(),
                 });
             }
@@ -208,8 +273,13 @@ mod tests {
         temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
             let err = resolve_credential(&store, "alice", "host").unwrap_err();
             match err {
-                ConfigError::NoCredential { account, reason } => {
-                    assert_eq!(account, "alice@host");
+                ConfigError::NoCredential {
+                    host,
+                    account_tag,
+                    reason,
+                } => {
+                    assert_eq!(host, "host");
+                    assert_eq!(account_tag.len(), 16);
                     assert!(reason.contains("rusty-imap-mcp login"));
                     assert!(reason.contains("RUSTY_IMAP_MCP_PASSWORD"));
                 }

--- a/crates/rimap-config/src/error.rs
+++ b/crates/rimap-config/src/error.rs
@@ -88,19 +88,33 @@ pub enum ConfigError {
         reason: String,
     },
     /// No credential could be found in keychain or environment.
-    #[error("no credential found for `{account}`: {reason}")]
+    ///
+    /// Display never includes the username. `host` is the IMAP/SMTP host
+    /// (public DNS in practice). `account_tag` is `hash_account_tag(username,
+    /// host)` — operators can correlate logs without seeing the username.
+    #[error("no credential for host `{host}` (account_tag {account_tag}): {reason}")]
     NoCredential {
-        /// `<username>@<host>` style account.
-        account: String,
+        /// IMAP/SMTP host (public DNS, safe to log).
+        host: String,
+        /// Short hash of `username@host` for log correlation.
+        account_tag: String,
         /// What we tried and what the user should do next.
         reason: String,
     },
     /// Keychain access error (not "not found" — that becomes `NoCredential`).
-    #[error("keychain error for `{account}`: {source}")]
+    ///
+    /// Display never includes the username. See `NoCredential` for the rules
+    /// on `host` and `account_tag`. The underlying source error is accessible
+    /// via the error chain (e.g. `#[source]` / traversal by `anyhow` or similar),
+    /// never interpolated into the Display string.
+    #[error("keychain error for host `{host}` (account_tag {account_tag})")]
     Keychain {
-        /// `<username>@<host>` style account.
-        account: String,
-        /// Underlying keyring error.
+        /// IMAP/SMTP host (public DNS, safe to log).
+        host: String,
+        /// Short hash of `username@host` for log correlation.
+        account_tag: String,
+        /// Underlying keyring error. Not included in Display to prevent
+        /// leaking username-bearing content from the keyring crate.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -151,4 +165,46 @@ pub enum ConfigError {
     /// Multi-account config has an empty `[[accounts]]` array.
     #[error("no accounts defined in [[accounts]] array")]
     NoAccounts,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_credential_display_omits_username() {
+        let err = ConfigError::NoCredential {
+            host: "mail.example.com".to_string(),
+            account_tag: "deadbeefcafef00d".to_string(),
+            reason: "nothing in keyring".to_string(),
+        };
+        let display = format!("{err}");
+        let full = format!("{err:#}");
+        assert!(
+            !display.contains("alice"),
+            "display leaked username: {display}"
+        );
+        assert!(
+            !full.contains("alice"),
+            "full chain leaked username: {full}"
+        );
+        assert!(display.contains("mail.example.com"));
+        assert!(display.contains("deadbeefcafef00d"));
+    }
+
+    #[test]
+    fn keychain_display_omits_username() {
+        let err = ConfigError::Keychain {
+            host: "mail.example.com".to_string(),
+            account_tag: "deadbeefcafef00d".to_string(),
+            source: "underlying kernel error for alice@something".into(),
+        };
+        let display = format!("{err}");
+        assert!(
+            !display.contains("alice"),
+            "display leaked username: {display}"
+        );
+        assert!(display.contains("mail.example.com"));
+        assert!(display.contains("deadbeefcafef00d"));
+    }
 }

--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -17,9 +17,9 @@ pub use crate::error::ConfigError;
 pub use crate::loader::{CONFIG_ENV_VAR, load_and_validate, load_from_path, resolve_config_path};
 pub use crate::login::{run_login, tty_prompt};
 pub use crate::model::{
-    AttachmentsConfig, AuditConfig, Config, DefaultsConfig, ImapConfig, LimitsConfig,
-    LookalikeConfig, MultiAccountConfig, RawAccountConfig, SecurityConfig, SmtpConfig,
-    SmtpEncryption, Verdict,
+    AttachmentsConfig, AuditConfig, Config, CredentialsConfig, DefaultsConfig, FallbackMode,
+    ImapConfig, LimitsConfig, LookalikeConfig, MultiAccountConfig, RawAccountConfig,
+    SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
 };
 pub use crate::validate::{
     ValidatedAccountConfig, ValidatedMultiConfig, validate_legacy_as_multi, validate_multi,

--- a/crates/rimap-config/src/login.rs
+++ b/crates/rimap-config/src/login.rs
@@ -19,11 +19,12 @@ use crate::error::ConfigError;
 /// prompt failed (e.g. non-interactive terminal).
 pub fn run_login<S: CredentialStore>(
     store: &S,
+    account_id: &rimap_core::account::AccountId,
     username: &str,
     host: &str,
     prompt: impl FnOnce(&str) -> std::io::Result<String>,
 ) -> Result<(), ConfigError> {
-    let account = account_key(username, host);
+    let account = account_key(account_id, username, host);
     let prompt_text = format!("Password for {account}: ");
     let password = prompt(&prompt_text).map_err(|e| ConfigError::NoCredential {
         host: host.to_string(),
@@ -58,6 +59,8 @@ mod tests {
 
     use secrecy::{ExposeSecret, SecretString};
 
+    use rimap_core::account::AccountId;
+
     use crate::credential::{CredentialStore, account_key};
     use crate::error::ConfigError;
     use crate::login::run_login;
@@ -89,9 +92,13 @@ mod tests {
     #[test]
     fn login_writes_prompted_password_to_store() {
         let store = MockStore::default();
-        run_login(&store, "alice", "host", |_| Ok("hunter2".to_string())).unwrap();
+        let default_id = AccountId::default_account();
+        run_login(&store, &default_id, "alice", "host", |_| {
+            Ok("hunter2".to_string())
+        })
+        .unwrap();
         let got = store
-            .get_password(&account_key("alice", "host"))
+            .get_password(&account_key(&default_id, "alice", "host"))
             .unwrap()
             .unwrap();
         assert_eq!(got.expose_secret(), "hunter2");
@@ -100,14 +107,17 @@ mod tests {
     #[test]
     fn empty_password_is_rejected() {
         let store = MockStore::default();
-        let err = run_login(&store, "alice", "host", |_| Ok(String::new())).unwrap_err();
+        let default_id = AccountId::default_account();
+        let err =
+            run_login(&store, &default_id, "alice", "host", |_| Ok(String::new())).unwrap_err();
         assert!(matches!(err, ConfigError::NoCredential { .. }));
     }
 
     #[test]
     fn prompt_error_is_surfaced() {
         let store = MockStore::default();
-        let err = run_login(&store, "alice", "host", |_| {
+        let default_id = AccountId::default_account();
+        let err = run_login(&store, &default_id, "alice", "host", |_| {
             Err(std::io::Error::other("no tty"))
         })
         .unwrap_err();

--- a/crates/rimap-config/src/login.rs
+++ b/crates/rimap-config/src/login.rs
@@ -5,7 +5,7 @@
 //! reserved for MCP transport. Uses `rpassword::prompt_password` which opens
 //! `/dev/tty` on Unix and the console on Windows.
 
-use crate::credential::{CredentialStore, account_key};
+use crate::credential::{CredentialStore, account_key, hash_account_tag};
 use crate::error::ConfigError;
 
 /// Run the `login` flow against the provided store. The caller is responsible
@@ -26,12 +26,14 @@ pub fn run_login<S: CredentialStore>(
     let account = account_key(username, host);
     let prompt_text = format!("Password for {account}: ");
     let password = prompt(&prompt_text).map_err(|e| ConfigError::NoCredential {
-        account: account.clone(),
+        host: host.to_string(),
+        account_tag: hash_account_tag(username, host),
         reason: format!("interactive prompt failed: {e}"),
     })?;
     if password.is_empty() {
         return Err(ConfigError::NoCredential {
-            account,
+            host: host.to_string(),
+            account_tag: hash_account_tag(username, host),
             reason: "empty password not accepted".to_string(),
         });
     }

--- a/crates/rimap-config/src/model.rs
+++ b/crates/rimap-config/src/model.rs
@@ -62,6 +62,34 @@ fn default_connect_timeout() -> u32 {
     10
 }
 
+/// How credential resolution falls back when the keyring has no entry.
+///
+/// - `KeyringThenEnv` (default) — try the keyring, then
+///   `RUSTY_IMAP_MCP_PASSWORD`, then fail. Suitable for CI/test and
+///   single-account deployments.
+/// - `KeyringOnly` — keyring only; a miss returns `NoCredential` without
+///   consulting the env var. Recommended for multi-account deployments
+///   where a shared env-var fallback would silently send one account's
+///   password to another account's server (see #78).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FallbackMode {
+    /// Keyring, then env var, then fail.
+    #[default]
+    KeyringThenEnv,
+    /// Keyring only; no env-var fallback.
+    KeyringOnly,
+}
+
+/// `[defaults.credentials]` / `[[accounts.credentials]]` block.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CredentialsConfig {
+    /// Fallback policy.
+    #[serde(default)]
+    pub fallback: FallbackMode,
+}
+
 /// SMTP encryption mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -359,6 +387,9 @@ pub struct DefaultsConfig {
     /// Default numeric limits.
     #[serde(default)]
     pub limits: LimitsConfig,
+    /// Default credential policy inherited by accounts that omit it.
+    #[serde(default)]
+    pub credentials: CredentialsConfig,
 }
 
 /// A single account entry in `[[accounts]]`.
@@ -378,6 +409,9 @@ pub struct RawAccountConfig {
     /// Per-account limit overrides; `None` inherits from `[defaults]`.
     #[serde(default)]
     pub limits: Option<LimitsConfig>,
+    /// Per-account credential policy; `None` inherits from `[defaults.credentials]`.
+    #[serde(default)]
+    pub credentials: Option<CredentialsConfig>,
 }
 
 #[cfg(test)]
@@ -449,5 +483,32 @@ mod tests {
             let back: W = toml::from_str(&s).unwrap();
             assert_eq!(back.v, v);
         }
+    }
+
+    #[test]
+    fn fallback_mode_defaults_to_keyring_then_env() {
+        assert_eq!(FallbackMode::default(), FallbackMode::KeyringThenEnv);
+    }
+
+    #[test]
+    fn fallback_mode_round_trips_via_toml() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct W {
+            v: FallbackMode,
+        }
+        for v in [FallbackMode::KeyringOnly, FallbackMode::KeyringThenEnv] {
+            let s = toml::to_string(&W { v }).unwrap();
+            let back: W = toml::from_str(&s).unwrap();
+            assert_eq!(back.v, v);
+        }
+    }
+
+    #[test]
+    fn credentials_config_deserializes_with_fallback_key() {
+        let toml_str = r#"
+fallback = "keyring-only"
+"#;
+        let cfg: CredentialsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.fallback, FallbackMode::KeyringOnly);
     }
 }

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -897,6 +897,7 @@ path = "/tmp/audit.jsonl"
             smtp: None,
             security: None,
             limits: None,
+            credentials: None,
         }
     }
 

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -18,8 +18,8 @@ use rimap_core::tool::ToolName;
 
 use crate::error::ConfigError;
 use crate::model::{
-    AttachmentsConfig, AuditConfig, Config, ImapConfig, LimitsConfig, MultiAccountConfig,
-    SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
+    AttachmentsConfig, AuditConfig, Config, FallbackMode, ImapConfig, LimitsConfig,
+    MultiAccountConfig, SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
 };
 
 /// Validated per-account config with resolved overrides and fingerprint.
@@ -39,6 +39,8 @@ pub struct ValidatedAccountConfig {
     pub tool_overrides: BTreeMap<ToolName, Verdict>,
     /// Parsed pinned TLS fingerprint.
     pub tls_fingerprint: Option<TlsFingerprint>,
+    /// Credential fallback policy (see #78).
+    pub fallback_mode: FallbackMode,
 }
 
 /// Validated multi-account config — the canonical output of config loading.
@@ -72,8 +74,18 @@ pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig
             .security
             .unwrap_or_else(|| config.defaults.security.clone());
         let limits = raw.limits.unwrap_or_else(|| config.defaults.limits.clone());
+        let fallback_mode = raw
+            .credentials
+            .map_or(config.defaults.credentials.fallback, |c| c.fallback);
 
-        let validated = validate_account(id.clone(), raw.imap, raw.smtp, security, limits)?;
+        let validated = validate_account(
+            id.clone(),
+            raw.imap,
+            raw.smtp,
+            security,
+            limits,
+            fallback_mode,
+        )?;
         accounts.insert(id, validated);
     }
 
@@ -102,6 +114,7 @@ pub fn validate_legacy_as_multi(config: Config) -> Result<ValidatedMultiConfig, 
         config.smtp,
         config.security,
         config.limits,
+        FallbackMode::default(),
     )?;
     validate_audit_config(&config.audit)?;
     validate_paths_multi(&config.audit, &config.attachments)?;
@@ -123,6 +136,7 @@ fn validate_account(
     smtp: Option<SmtpConfig>,
     security: SecurityConfig,
     limits: LimitsConfig,
+    fallback_mode: FallbackMode,
 ) -> Result<ValidatedAccountConfig, ConfigError> {
     let tls_fingerprint = parse_fingerprint(imap.tls_fingerprint_sha256.as_deref())?;
     validate_imap_username(&imap.username)?;
@@ -143,6 +157,7 @@ fn validate_account(
         limits,
         tool_overrides,
         tls_fingerprint,
+        fallback_mode,
     })
 }
 
@@ -432,8 +447,8 @@ mod tests {
 
     use crate::error::ConfigError;
     use crate::model::{
-        AttachmentsConfig, AuditConfig, Config, ImapConfig, LimitsConfig, SecurityConfig,
-        SmtpEncryption, Verdict,
+        AttachmentsConfig, AuditConfig, Config, CredentialsConfig, FallbackMode, ImapConfig,
+        LimitsConfig, SecurityConfig, SmtpEncryption, Verdict,
     };
     use crate::validate::{ValidatedAccountConfig, validate_legacy_as_multi};
     use rimap_core::account::AccountId;
@@ -986,6 +1001,48 @@ allowed_base_dir = "{}"
         let cfg = base_multi_config(dir.path(), vec![raw_account("bad name")]);
         let err = validate_multi(cfg).unwrap_err();
         assert!(matches!(err, ConfigError::InvalidAccountName(_)));
+    }
+
+    #[test]
+    fn multi_fallback_defaults_to_keyring_then_env() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![raw_account("work")]);
+        let v = validate_multi(cfg).unwrap();
+        let acct = &v.accounts[&AccountId::new("work").unwrap()];
+        assert_eq!(acct.fallback_mode, FallbackMode::KeyringThenEnv);
+    }
+
+    #[test]
+    fn multi_account_inherits_defaults_fallback() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = base_multi_config(dir.path(), vec![raw_account("work")]);
+        cfg.defaults.credentials.fallback = FallbackMode::KeyringOnly;
+        let v = validate_multi(cfg).unwrap();
+        let acct = &v.accounts[&AccountId::new("work").unwrap()];
+        assert_eq!(acct.fallback_mode, FallbackMode::KeyringOnly);
+    }
+
+    #[test]
+    fn multi_account_override_beats_defaults_fallback() {
+        let dir = TempDir::new().unwrap();
+        let mut acct = raw_account("work");
+        acct.credentials = Some(CredentialsConfig {
+            fallback: FallbackMode::KeyringOnly,
+        });
+        let mut cfg = base_multi_config(dir.path(), vec![acct]);
+        cfg.defaults.credentials.fallback = FallbackMode::KeyringThenEnv;
+        let v = validate_multi(cfg).unwrap();
+        let validated = &v.accounts[&AccountId::new("work").unwrap()];
+        assert_eq!(validated.fallback_mode, FallbackMode::KeyringOnly);
+    }
+
+    #[test]
+    fn legacy_fallback_defaults_to_keyring_then_env() {
+        let dir = TempDir::new().unwrap();
+        let cfg = base_config(dir.path());
+        let v = validate_legacy_as_multi(cfg).unwrap();
+        let id = AccountId::default_account();
+        assert_eq!(v.accounts[&id].fallback_mode, FallbackMode::KeyringThenEnv);
     }
 
     #[test]

--- a/crates/rimap-core/src/credential.rs
+++ b/crates/rimap-core/src/credential.rs
@@ -1,0 +1,35 @@
+//! Credential provenance types. Referenced by `rimap-config` (returned from
+//! `resolve_credential`) and by `rimap-audit::record::Auth` (recorded per
+//! auth attempt). Kept here so neither crate has to depend on the other.
+
+use serde::{Deserialize, Serialize};
+
+/// Where a successfully resolved credential came from. Recorded in `Auth`
+/// records so post-incident analysis can detect silent fallbacks (e.g. an
+/// operator's keyring entry went missing and the process started using the
+/// global env-var fallback).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialSource {
+    /// Resolved from the new namespaced keyring key.
+    Keyring,
+    /// Resolved from the legacy unnamespaced keyring key — indicates the
+    /// operator still needs to run `migrate-keyring`.
+    LegacyKeyring,
+    /// Resolved from `RUSTY_IMAP_MCP_PASSWORD`.
+    EnvVar,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::CredentialSource;
+
+    #[test]
+    fn credential_source_serializes_as_snake_case() {
+        let j = serde_json::to_string(&CredentialSource::LegacyKeyring).unwrap();
+        assert_eq!(j, "\"legacy_keyring\"");
+        let back: CredentialSource = serde_json::from_str(&j).unwrap();
+        assert_eq!(back, CredentialSource::LegacyKeyring);
+    }
+}

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(missing_docs)]
 
 pub mod account;
+pub mod credential;
+pub use credential::CredentialSource;
 pub mod error;
 pub mod posture;
 pub mod posture_matrix;

--- a/crates/rimap-imap/src/auth.rs
+++ b/crates/rimap-imap/src/auth.rs
@@ -20,6 +20,9 @@ pub(crate) struct AuthContext<'a> {
     pub pinned: Option<TlsFingerprint>,
     /// Fingerprint the server actually presented, if handshake reached cert verification.
     pub observed: Option<TlsFingerprint>,
+    /// Source of the resolved credential. `None` before `resolve_credential`
+    /// runs (e.g. a TLS failure) or when resolution itself failed.
+    pub credential_source: Option<rimap_core::CredentialSource>,
 }
 
 impl AuthContext<'_> {
@@ -46,6 +49,7 @@ pub(crate) fn auth_success(ctx: &AuthContext<'_>) -> Auth {
         tls_fingerprint_sha256: ctx.observed_hex(),
         fingerprint_match: ctx.fingerprint_match(),
         error_code: None,
+        credential_source: ctx.credential_source,
     }
 }
 
@@ -60,6 +64,7 @@ pub(crate) fn auth_failure(ctx: &AuthContext<'_>, error_code: rimap_core::ErrorC
         tls_fingerprint_sha256: ctx.observed_hex(),
         fingerprint_match: ctx.fingerprint_match(),
         error_code: Some(error_code),
+        credential_source: ctx.credential_source,
     }
 }
 
@@ -83,6 +88,7 @@ mod tests {
             username: "u",
             pinned: Some(pin),
             observed: Some(pin),
+            credential_source: None,
         };
         let rec = auth_success(&ctx);
         assert_eq!(rec.result, AuthResult::Success);
@@ -102,6 +108,7 @@ mod tests {
             username: "u",
             pinned: Some(pin),
             observed: Some(observed),
+            credential_source: None,
         };
         let rec = auth_failure(&ctx, rimap_core::ErrorCode::Tls);
         assert_eq!(rec.result, AuthResult::Failure);
@@ -119,6 +126,7 @@ mod tests {
             username: "u",
             pinned: None,
             observed: Some(observed),
+            credential_source: None,
         };
         let rec = auth_success(&ctx);
         assert_eq!(rec.fingerprint_match, None);
@@ -139,6 +147,7 @@ mod tests {
             username: "u",
             pinned: Some(pin),
             observed: None,
+            credential_source: None,
         };
         let rec = auth_failure(&ctx, rimap_core::ErrorCode::ConnectionLost);
         assert_eq!(rec.result, AuthResult::Failure);

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -45,6 +45,9 @@ pub struct ConnectionConfig {
     /// single-account `"default"` deployment; `Some(name)` in multi-account
     /// configs. Populated into `Auth` audit records.
     pub account: Option<String>,
+    /// Account id used for keyring lookups. Always set — the default account
+    /// uses `AccountId::default_account()`.
+    pub account_id: rimap_core::account::AccountId,
     /// IMAP server host.
     pub host: String,
     /// IMAP server port (typically 993 for IMAPS).
@@ -322,10 +325,15 @@ impl Connection {
         // map it to ERR_AUTH so retry logic and operator messages stay
         // accurate.
         let cfg = &self.inner.cfg;
-        let password = resolve_credential(&*self.inner.credentials, &cfg.username, &cfg.host)
-            .map_err(|e| ImapError::Auth {
-                reason: AuthFailure::CredentialUnavailable(e.to_string()),
-            })?;
+        let password = resolve_credential(
+            &*self.inner.credentials,
+            &cfg.account_id,
+            &cfg.username,
+            &cfg.host,
+        )
+        .map_err(|e| ImapError::Auth {
+            reason: AuthFailure::CredentialUnavailable(e.to_string()),
+        })?;
 
         // Attempt LOGIN. On NO response the server rejected the credentials.
         // Expose the secret only at the moment of use; the borrow ends

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -48,6 +48,9 @@ pub struct ConnectionConfig {
     /// Account id used for keyring lookups. Always set — the default account
     /// uses `AccountId::default_account()`.
     pub account_id: rimap_core::account::AccountId,
+    /// Credential fallback policy: whether to consult the env var when the
+    /// keyring has no entry.
+    pub fallback_mode: rimap_config::model::FallbackMode,
     /// IMAP server host.
     pub host: String,
     /// IMAP server port (typically 993 for IMAPS).
@@ -173,22 +176,23 @@ impl Connection {
         let cfg = &self.inner.cfg;
         let bundle = build_tls_config(cfg.pinned_fingerprint)?;
 
-        // Run the connect flow. If it failed with a TLS handshake error AND
-        // we have a pinned fingerprint, enrich the error into ImapError::Tls
-        // with the structured observed/expected fields by reading the
-        // bundle's last_observed slot.
+        // Run the connect flow. The return type carries `credential_source` for
+        // both the success and post-resolve-failure paths.  Pre-resolve failures
+        // (TLS, connect, greeting, CAPABILITY) return `None`; post-resolve
+        // failures (LoginRejected) and success both return `Some(source)`.
         let raw_outcome = self.connect_with_bundle(&bundle).await;
-        let outcome = match raw_outcome {
-            Ok(session) => Ok(session),
-            Err(ImapError::TlsHandshake(inner)) => {
-                match (cfg.pinned_fingerprint, bundle.last_observed.get().copied()) {
+        let (outcome, credential_source) = match raw_outcome {
+            Ok((session, src)) => (Ok(session), Some(src)),
+            Err((ImapError::TlsHandshake(inner), src)) => {
+                let enriched = match (cfg.pinned_fingerprint, bundle.last_observed.get().copied()) {
                     (Some(expected), Some(observed)) if expected != observed => {
-                        Err(ImapError::Tls { observed, expected })
+                        ImapError::Tls { observed, expected }
                     }
-                    (Some(_) | None, _) => Err(ImapError::TlsHandshake(inner)),
-                }
+                    (Some(_) | None, _) => ImapError::TlsHandshake(inner),
+                };
+                (Err(enriched), src)
             }
-            Err(other) => Err(other),
+            Err((other, src)) => (Err(other), src),
         };
 
         let observed = bundle.last_observed.get().copied();
@@ -199,6 +203,7 @@ impl Connection {
             username: &cfg.username,
             pinned: cfg.pinned_fingerprint,
             observed,
+            credential_source,
         };
 
         match &outcome {
@@ -227,43 +232,61 @@ impl Connection {
         outcome
     }
 
+    /// Returns `Ok((session, credential_source))` on success, or
+    /// `Err((error, Option<credential_source>))` on failure. The
+    /// `credential_source` in the `Err` variant is `Some` when the failure
+    /// occurred after `resolve_credential` succeeded (e.g. server rejected
+    /// the credentials), and `None` for pre-resolve failures (TLS, connect,
+    /// greeting, CAPABILITY).
     async fn connect_with_bundle(
         &self,
         bundle: &TlsConfigBundle,
-    ) -> Result<ImapSession, ImapError> {
+    ) -> Result<
+        (ImapSession, rimap_core::CredentialSource),
+        (ImapError, Option<rimap_core::CredentialSource>),
+    > {
         let cfg = &self.inner.cfg;
         let total_deadline = cfg.connect_timeout;
         let started = std::time::Instant::now();
 
-        // Step 1: TCP connect.
+        // Step 1: TCP connect. Pre-resolve; failures carry `None`.
         let tcp = timeout(
             total_deadline,
             TcpStream::connect((cfg.host.as_str(), cfg.port)),
         )
         .await
-        .map_err(|_| ImapError::Timeout { op: "tcp_connect" })?
-        .map_err(ImapError::Connect)?;
+        .map_err(|_| (ImapError::Timeout { op: "tcp_connect" }, None))?
+        .map_err(|e| (ImapError::Connect(e), None))?;
 
-        // Step 2: TLS handshake.
+        // Step 2: TLS handshake. Pre-resolve; failures carry `None`.
         let server_name = ServerName::try_from(cfg.host.clone()).map_err(|_| {
-            ImapError::Connect(std::io::Error::other("invalid server name for TLS"))
+            (
+                ImapError::Connect(std::io::Error::other("invalid server name for TLS")),
+                None,
+            )
         })?;
         let connector = TlsConnector::from(bundle.config.clone());
         let elapsed = started.elapsed();
         let remaining = total_deadline.saturating_sub(elapsed);
         let tls_stream = timeout(remaining, connector.connect(server_name, tcp))
             .await
-            .map_err(|_| ImapError::Timeout {
-                op: "tls_handshake",
+            .map_err(|_| {
+                (
+                    ImapError::Timeout {
+                        op: "tls_handshake",
+                    },
+                    None,
+                )
             })?
-            .map_err(|e| map_tls_handshake_error(&e))?;
+            .map_err(|e| (map_tls_handshake_error(&e), None))?;
 
-        // Step 3: IMAP greeting + capability check + login.
+        // Step 3: IMAP greeting + capability check + login. The login step
+        // may return a credential source on both success and certain failures.
         let elapsed = started.elapsed();
         let remaining = total_deadline.saturating_sub(elapsed);
         timeout(remaining, self.imap_login(tls_stream))
             .await
-            .map_err(|_| ImapError::Timeout { op: "imap_login" })?
+            .map_err(|_| (ImapError::Timeout { op: "imap_login" }, None))?
     }
 
     /// Run the IMAP greeting + CAPABILITY probe + LOGIN sequence.
@@ -277,64 +300,93 @@ impl Connection {
     ///      and drain the unsolicited channel for `Other(ResponseData)` items
     ///      containing `Response::Capabilities` data.
     ///   3. Call `client.login(user, pass)`.
-    async fn imap_login(&self, tls_stream: TlsStream<TcpStream>) -> Result<ImapSession, ImapError> {
+    ///
+    /// Returns `Ok((session, credential_source))` on success.
+    /// Returns `Err((error, Some(source)))` when the failure occurred after
+    /// `resolve_credential` succeeded (e.g. server rejected the credentials).
+    /// Returns `Err((error, None))` for pre-resolve failures (greeting, CAPABILITY).
+    async fn imap_login(
+        &self,
+        tls_stream: TlsStream<TcpStream>,
+    ) -> Result<
+        (ImapSession, rimap_core::CredentialSource),
+        (ImapError, Option<rimap_core::CredentialSource>),
+    > {
         let mut client = async_imap::Client::new(tls_stream);
 
         // Read the server greeting. An absent greeting (EOF) or BYE status
-        // means the server immediately rejected us.
+        // means the server immediately rejected us. Pre-resolve; carry `None`.
         let greeting = client
             .read_response()
             .await
-            .map_err(ImapError::Connect)?
-            .ok_or(ImapError::Auth {
-                reason: AuthFailure::ServerRejected,
-            })?;
+            .map_err(|e| (ImapError::Connect(e), None))?
+            .ok_or((
+                ImapError::Auth {
+                    reason: AuthFailure::ServerRejected,
+                },
+                None,
+            ))?;
 
         if let Response::Data {
             status: Status::Bye,
             ..
         } = greeting.parsed()
         {
-            return Err(ImapError::Auth {
-                reason: AuthFailure::ServerRejected,
-            });
+            return Err((
+                ImapError::Auth {
+                    reason: AuthFailure::ServerRejected,
+                },
+                None,
+            ));
         }
 
         // Issue CAPABILITY and scan responses for LOGINDISABLED.
         // We create a bounded channel so intermediate untagged responses
         // (including `* CAPABILITY ...`) are routed through it rather than
-        // being silently discarded.
+        // being silently discarded. Pre-resolve; carry `None`.
         let (tx, rx) = async_channel::bounded::<UnsolicitedResponse>(32);
         client
             .run_command_and_check_ok("CAPABILITY", Some(tx))
             .await
-            .map_err(ImapError::Protocol)?;
+            .map_err(|e| (ImapError::Protocol(e), None))?;
 
         // Drain whatever arrived on the channel (non-blocking; the command
         // has already completed). A `Response::Capabilities` list containing
-        // LOGINDISABLED means LOGIN is prohibited.
+        // LOGINDISABLED means LOGIN is prohibited. Pre-resolve; carry `None`.
         let logindisabled = drain_for_logindisabled(&rx);
         if logindisabled {
-            return Err(ImapError::Auth {
-                reason: AuthFailure::CapabilityMissing { needed: "LOGIN" },
-            });
+            return Err((
+                ImapError::Auth {
+                    reason: AuthFailure::CapabilityMissing { needed: "LOGIN" },
+                },
+                None,
+            ));
         }
 
         // Resolve the password from the credential store. A missing
         // credential is an authentication failure, not a network failure —
         // map it to ERR_AUTH so retry logic and operator messages stay
-        // accurate.
+        // accurate. Pre-resolve; carry `None`.
         let cfg = &self.inner.cfg;
-        let password = resolve_credential(
+        let (password, credential_source) = resolve_credential(
             &*self.inner.credentials,
             &cfg.account_id,
             &cfg.username,
             &cfg.host,
+            cfg.fallback_mode,
         )
-        .map_err(|e| ImapError::Auth {
-            reason: AuthFailure::CredentialUnavailable(e.to_string()),
+        .map_err(|e| {
+            (
+                ImapError::Auth {
+                    reason: AuthFailure::CredentialUnavailable(e.to_string()),
+                },
+                None,
+            )
         })?;
 
+        // From here on, all errors carry `Some(credential_source)` because
+        // resolution succeeded.
+        //
         // Attempt LOGIN. On NO response the server rejected the credentials.
         // Expose the secret only at the moment of use; the borrow ends
         // when `client.login` returns.
@@ -342,10 +394,13 @@ impl Connection {
             Ok(session) => session,
             Err((err, _client)) => {
                 return match err {
-                    async_imap::error::Error::No(_) => Err(ImapError::Auth {
-                        reason: AuthFailure::LoginRejected,
-                    }),
-                    other => Err(ImapError::Protocol(other)),
+                    async_imap::error::Error::No(_) => Err((
+                        ImapError::Auth {
+                            reason: AuthFailure::LoginRejected,
+                        },
+                        Some(credential_source),
+                    )),
+                    other => Err((ImapError::Protocol(other), Some(credential_source))),
                 };
             }
         };
@@ -366,7 +421,7 @@ impl Connection {
         self.inner.has_move.store(has_move, Ordering::Relaxed);
         self.inner.has_uidplus.store(has_uidplus, Ordering::Relaxed);
 
-        Ok(session)
+        Ok((session, credential_source))
     }
 
     /// Emit an `Auth` audit record. Runs `AuditWriter::log_auth` inside

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -131,6 +131,7 @@ async fn case_04_login_rejected_emits_audit() {
     };
     let cfg = ConnectionConfig {
         account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),
@@ -264,6 +265,7 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
     };
     let cfg = ConnectionConfig {
         account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -132,6 +132,7 @@ async fn case_04_login_rejected_emits_audit() {
     let cfg = ConnectionConfig {
         account: None,
         account_id: rimap_core::account::AccountId::default_account(),
+        fallback_mode: rimap_config::model::FallbackMode::KeyringThenEnv,
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),
@@ -266,6 +267,7 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
     let cfg = ConnectionConfig {
         account: None,
         account_id: rimap_core::account::AccountId::default_account(),
+        fallback_mode: rimap_config::model::FallbackMode::KeyringThenEnv,
         host: DovecotHarness::host().to_string(),
         port: h.harness.port(),
         username: DovecotHarness::username().to_string(),

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -73,6 +73,7 @@ fn build_connection(cfg: &ProtonConfig) -> Connection {
     let conn_cfg = ConnectionConfig {
         account: None,
         account_id: rimap_core::account::AccountId::default_account(),
+        fallback_mode: rimap_config::model::FallbackMode::KeyringThenEnv,
         host: cfg.host.clone(),
         port: cfg.port,
         username: cfg.user.clone(),

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -72,6 +72,7 @@ fn build_connection(cfg: &ProtonConfig) -> Connection {
     .unwrap();
     let conn_cfg = ConnectionConfig {
         account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
         host: cfg.host.clone(),
         port: cfg.port,
         username: cfg.user.clone(),

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -536,6 +536,7 @@ impl ConnectedHarness {
 
         let cfg = ConnectionConfig {
             account: None,
+            account_id: rimap_core::account::AccountId::default_account(),
             host: DovecotHarness::host().to_string(),
             port: harness.port(),
             username: DovecotHarness::username().to_string(),

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -537,6 +537,7 @@ impl ConnectedHarness {
         let cfg = ConnectionConfig {
             account: None,
             account_id: rimap_core::account::AccountId::default_account(),
+            fallback_mode: rimap_config::model::FallbackMode::KeyringThenEnv,
             host: DovecotHarness::host().to_string(),
             port: harness.port(),
             username: DovecotHarness::username().to_string(),

--- a/crates/rimap-server/src/cli/migrate_keyring.rs
+++ b/crates/rimap-server/src/cli/migrate_keyring.rs
@@ -1,0 +1,147 @@
+//! `rusty-imap-mcp migrate-keyring` subcommand.
+//!
+//! Migrates a single credential from the legacy key `<username>@<host>` to
+//! the new `<account-id>/<username>@<host>` key format (see #77).
+
+use rimap_config::credential::{
+    CredentialStore, account_key, hash_account_tag, legacy_account_key,
+};
+use rimap_config::error::ConfigError;
+use rimap_core::account::AccountId;
+use secrecy::ExposeSecret;
+
+/// Migrate one credential. Returns `Ok(true)` if migration happened,
+/// `Ok(false)` if the legacy key was absent (nothing to migrate).
+///
+/// # Errors
+/// `ConfigError::NoCredential` or `ConfigError::Keychain` on I/O errors.
+///
+/// # Operator-visible side effect
+///
+/// The legacy entry is emptied via `set_password("")`, not deleted. Operators
+/// auditing the keyring (e.g. `secret-tool search`, macOS Keychain Access)
+/// will still see the legacy account entry with an empty secret until they
+/// clear it manually. `CredentialStore` has no delete method; adding one is
+/// tracked for a future refactor.
+pub fn migrate_one<S: CredentialStore>(
+    store: &S,
+    account_id: &AccountId,
+    username: &str,
+    host: &str,
+) -> Result<bool, ConfigError> {
+    let legacy = legacy_account_key(username, host);
+    let Some(password) = store.get_password(&legacy)? else {
+        return Ok(false);
+    };
+    let new_key = account_key(account_id, username, host);
+    store.set_password(&new_key, password.expose_secret())?;
+    // Overwrite the legacy entry with an empty value so subsequent
+    // `resolve_credential` calls no longer find it. CredentialStore has no
+    // delete method; an empty string is treated as "no credential" by the
+    // `!p.expose_secret().is_empty()` guard in resolve_credential.
+    store.set_password(&legacy, "")?;
+    tracing::info!(
+        account_id = %account_id.as_str(),
+        host = %host,
+        account_tag = %hash_account_tag(username, host),
+        "migrated keyring entry from legacy key",
+    );
+    Ok(true)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use rimap_config::credential::{CredentialStore, account_key, legacy_account_key};
+    use rimap_config::error::ConfigError;
+    use rimap_core::account::AccountId;
+    use secrecy::{ExposeSecret, SecretString};
+
+    use super::migrate_one;
+
+    #[derive(Default)]
+    struct MockStore {
+        entries: Mutex<HashMap<String, String>>,
+    }
+
+    impl CredentialStore for MockStore {
+        fn get_password(&self, account: &str) -> Result<Option<SecretString>, ConfigError> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .get(account)
+                .cloned()
+                .map(SecretString::from))
+        }
+        fn set_password(&self, account: &str, password: &str) -> Result<(), ConfigError> {
+            self.entries
+                .lock()
+                .unwrap()
+                .insert(account.to_string(), password.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn migrate_copies_legacy_to_new_and_empties_legacy() {
+        let store = MockStore::default();
+        let id = AccountId::new("work").unwrap();
+        store
+            .set_password(&legacy_account_key("alice", "host"), "hunter2")
+            .unwrap();
+
+        let migrated = migrate_one(&store, &id, "alice", "host").unwrap();
+        assert!(migrated);
+
+        let new = store
+            .get_password(&account_key(&id, "alice", "host"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(new.expose_secret(), "hunter2");
+
+        let legacy = store
+            .get_password(&legacy_account_key("alice", "host"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(legacy.expose_secret(), "", "legacy entry should be empty");
+    }
+
+    #[test]
+    fn migrate_returns_false_when_no_legacy_entry() {
+        let store = MockStore::default();
+        let id = AccountId::new("work").unwrap();
+        let migrated = migrate_one(&store, &id, "alice", "host").unwrap();
+        assert!(!migrated);
+    }
+
+    #[test]
+    fn migrate_overwrites_preexisting_new_key_entry() {
+        // Pins current behavior: if both legacy and new-key entries exist,
+        // the legacy value wins and clobbers the new-key entry. Acceptable
+        // for the migration-once-per-upgrade workflow, but operators who
+        // manually `login --account <id>` BEFORE migrating will lose the
+        // new password. Task 4 review flagged this as a deliberate YAGNI;
+        // a future MigrationOutcome::AlreadyMigrated variant can refine it.
+        let store = MockStore::default();
+        let id = AccountId::new("work").unwrap();
+        store
+            .set_password(&account_key(&id, "alice", "host"), "preexisting")
+            .unwrap();
+        store
+            .set_password(&legacy_account_key("alice", "host"), "from_legacy")
+            .unwrap();
+
+        let migrated = migrate_one(&store, &id, "alice", "host").unwrap();
+        assert!(migrated);
+
+        let new = store
+            .get_password(&account_key(&id, "alice", "host"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(new.expose_secret(), "from_legacy");
+    }
+}

--- a/crates/rimap-server/src/cli/mod.rs
+++ b/crates/rimap-server/src/cli/mod.rs
@@ -10,6 +10,7 @@
 
 pub(crate) mod audit_merge;
 pub(crate) mod dry_run;
+pub(crate) mod migrate_keyring;
 
 use std::path::PathBuf;
 
@@ -52,6 +53,21 @@ pub enum Command {
         #[arg(long)]
         host: String,
         /// IMAP username (e.g. `alice@example.com`).
+        #[arg(long)]
+        username: String,
+    },
+    /// Migrate a credential from the legacy keyring key format
+    /// (`<username>@<host>`) to the new namespaced format
+    /// (`<account-id>/<username>@<host>`). Run once per account after
+    /// upgrading across #77.
+    MigrateKeyring {
+        /// Account name from config.
+        #[arg(long)]
+        account: String,
+        /// IMAP host.
+        #[arg(long)]
+        host: String,
+        /// IMAP username.
         #[arg(long)]
         username: String,
     },

--- a/crates/rimap-server/src/cli/mod.rs
+++ b/crates/rimap-server/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod dry_run;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use rimap_core::account::DEFAULT_ACCOUNT_NAME;
 
 /// Top-level CLI.
 #[derive(Debug, Parser)]
@@ -43,6 +44,10 @@ pub struct Cli {
 pub enum Command {
     /// Interactively store IMAP credentials in the OS keychain.
     Login {
+        /// Account name from config. Defaults to `default`, matching the
+        /// synthetic account used for legacy single-account configs.
+        #[arg(long, default_value_t = String::from(DEFAULT_ACCOUNT_NAME))]
+        account: String,
         /// IMAP host (e.g. `127.0.0.1` for Proton Bridge).
         #[arg(long)]
         host: String,
@@ -92,6 +97,7 @@ pub enum AuditAction {
 #[expect(clippy::panic, reason = "tests")]
 mod tests {
     use clap::Parser;
+    use rimap_core::account::DEFAULT_ACCOUNT_NAME;
 
     use crate::cli::{Cli, Command};
 
@@ -119,7 +125,39 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Some(Command::Login { host, username }) => {
+            Some(Command::Login {
+                account,
+                host,
+                username,
+            }) => {
+                assert_eq!(account, DEFAULT_ACCOUNT_NAME);
+                assert_eq!(host, "127.0.0.1");
+                assert_eq!(username, "alice");
+            }
+            other => panic!("expected Login, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_login_subcommand_with_explicit_account() {
+        let cli = Cli::try_parse_from([
+            "rusty-imap-mcp",
+            "login",
+            "--account",
+            "work",
+            "--host",
+            "127.0.0.1",
+            "--username",
+            "alice",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Login {
+                account,
+                host,
+                username,
+            }) => {
+                assert_eq!(account, "work");
                 assert_eq!(host, "127.0.0.1");
                 assert_eq!(username, "alice");
             }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -215,11 +215,12 @@ fn build_smtp_client(
     let Some(ref smtp_cfg) = acfg.smtp else {
         return Ok(None);
     };
-    let smtp_password = rimap_config::resolve_credential(
+    let (smtp_password, _src) = rimap_config::resolve_credential(
         &**credentials,
         &acfg.id,
         &smtp_cfg.username,
         &smtp_cfg.host,
+        acfg.fallback_mode,
     )
     .with_context(|| format!("resolving SMTP credential for account {}", acfg.id.as_str()))?;
     let client = rimap_smtp::SmtpClient::new(smtp_cfg, smtp_password.expose_secret())
@@ -261,6 +262,7 @@ fn build_account_connection(
     ConnectionConfig {
         account,
         account_id: id.clone(),
+        fallback_mode: acfg.fallback_mode,
         host: acfg.imap.host.clone(),
         port: acfg.imap.port,
         username: acfg.imap.username.clone(),

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -41,9 +41,16 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> anyhow::Result<()> {
-    if let Some(Command::Login { host, username }) = &cli.command {
+    if let Some(Command::Login {
+        account,
+        host,
+        username,
+    }) = &cli.command
+    {
         let store = KeyringStore;
-        run_login(&store, username, host, tty_prompt)
+        let account_id = rimap_core::account::AccountId::new(account)
+            .with_context(|| format!("invalid account name `{account}`"))?;
+        run_login(&store, &account_id, username, host, tty_prompt)
             .with_context(|| format!("storing credential for {username}@{host}"))?;
         let mut stdout = std::io::stdout().lock();
         writeln!(stdout, "credential stored for {username}@{host}")?;
@@ -199,11 +206,13 @@ fn build_smtp_client(
     let Some(ref smtp_cfg) = acfg.smtp else {
         return Ok(None);
     };
-    let smtp_password =
-        rimap_config::resolve_credential(&**credentials, &smtp_cfg.username, &smtp_cfg.host)
-            .with_context(|| {
-                format!("resolving SMTP credential for account {}", acfg.id.as_str())
-            })?;
+    let smtp_password = rimap_config::resolve_credential(
+        &**credentials,
+        &acfg.id,
+        &smtp_cfg.username,
+        &smtp_cfg.host,
+    )
+    .with_context(|| format!("resolving SMTP credential for account {}", acfg.id.as_str()))?;
     let client = rimap_smtp::SmtpClient::new(smtp_cfg, smtp_password.expose_secret())
         .with_context(|| format!("building SMTP client for account {}", acfg.id.as_str()))?;
     drop(smtp_password);
@@ -242,6 +251,7 @@ fn build_account_connection(
     };
     ConnectionConfig {
         account,
+        account_id: id.clone(),
         host: acfg.imap.host.clone(),
         port: acfg.imap.port,
         username: acfg.imap.username.clone(),

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -57,6 +57,15 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if let Some(Command::MigrateKeyring {
+        account,
+        host,
+        username,
+    }) = &cli.command
+    {
+        return run_migrate_keyring(account, username, host);
+    }
+
     if let Some(Command::Audit {
         action:
             AuditAction::Merge {
@@ -299,6 +308,25 @@ fn resolve_download_dir_multi(
             .with_context(|| format!("setting 0700 perms on {}", dir.display()))?;
     }
     Ok(dir)
+}
+
+/// Handle the `migrate-keyring` subcommand.
+fn run_migrate_keyring(account: &str, username: &str, host: &str) -> anyhow::Result<()> {
+    let store = KeyringStore;
+    let account_id = rimap_core::account::AccountId::new(account)
+        .with_context(|| format!("invalid account name `{account}`"))?;
+    let migrated = cli::migrate_keyring::migrate_one(&store, &account_id, username, host)
+        .with_context(|| format!("migrating credential for account `{account}`, host `{host}`"))?;
+    let mut stdout = std::io::stdout().lock();
+    if migrated {
+        writeln!(stdout, "migrated credential for account `{account}`")?;
+    } else {
+        writeln!(
+            stdout,
+            "no legacy credential found for account `{account}` (host `{host}`); nothing to migrate"
+        )?;
+    }
+    Ok(())
 }
 
 #[cfg(all(test, unix))]

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -316,6 +316,7 @@ fn test_account_config(harness: &DovecotHarness) -> ValidatedAccountConfig {
 fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection {
     let conn_cfg = ConnectionConfig {
         account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
         host: "127.0.0.1".into(),
         port: harness.port,
         username: "rimap-test".into(),

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -310,6 +310,7 @@ fn test_account_config(harness: &DovecotHarness) -> ValidatedAccountConfig {
         limits: LimitsConfig::default(),
         tool_overrides: BTreeMap::new(),
         tls_fingerprint: Some(harness.fingerprint),
+        fallback_mode: rimap_config::model::FallbackMode::default(),
     }
 }
 

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -318,6 +318,7 @@ fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection 
     let conn_cfg = ConnectionConfig {
         account: None,
         account_id: rimap_core::account::AccountId::default_account(),
+        fallback_mode: rimap_config::model::FallbackMode::KeyringThenEnv,
         host: "127.0.0.1".into(),
         port: harness.port,
         username: "rimap-test".into(),

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -164,34 +164,52 @@ All accounts share a single audit log file. Every record includes an
 
 Each account resolves its IMAP (and SMTP) password via:
 
-1. **OS keyring** keyed by `<username>@<host>`, service `rusty-imap-mcp`.
-2. **Environment variable** `RUSTY_IMAP_MCP_PASSWORD` (single global value).
-3. Failure (`ERR_CONFIG`) if neither is set.
+1. **OS keyring** keyed by `<account-id>/<username>@<host>`, service
+   `rusty-imap-mcp`. A back-compat read on the legacy `<username>@<host>` form
+   applies until `migrate-keyring` runs (see below).
+2. **Environment variable** `RUSTY_IMAP_MCP_PASSWORD` (single global value) —
+   consulted only when `fallback = "keyring-then-env"` (the default).
+3. Failure (`ERR_CONFIG`) if no source yields a credential.
 
 ### Keyring Collision (Multi-Account)
 
-The keyring key is `<username>@<host>`, NOT `<account>/<username>@<host>`. If two
-accounts share a `username@host` tuple (e.g., the same email configured for two
-logical accounts), they share a keyring entry — the last `rusty-imap-mcp login`
-wins.
-
-**Workaround:** Give each account a distinct IMAP username (include `+alias`
-suffixes if your provider supports them), or use the environment variable
-fallback for one of the two.
+Keyring entries are namespaced by account id: `<account-id>/<username>@<host>`.
+Two accounts that share a `<username>@<host>` tuple no longer collide. After
+upgrading across #77, run `rusty-imap-mcp migrate-keyring --account <id>
+--host <h> --username <u>` once per account to rewrite the legacy key.
+Until migration completes, `resolve_credential` transparently falls back to
+the legacy key and emits a `tracing::warn!` pointing at the migrate command.
 
 ### Env-var Fallback (Multi-Account)
 
-`RUSTY_IMAP_MCP_PASSWORD` is a single global fallback. In multi-account configs,
-if the keyring lookup fails for account A, every subsequent account falls back
-to the same env-var value. This can send account B's password to account A's
-server.
+`RUSTY_IMAP_MCP_PASSWORD` is a single global fallback. In multi-account
+configs, if the keyring lookup fails for account A every subsequent account
+falls back to the same env-var value, which can send account B's password to
+account A's server.
 
-**Recommendation:** In multi-account deployments, use the keyring for every
-account. Do not set `RUSTY_IMAP_MCP_PASSWORD` in production. The fallback exists
-for CI/test automation only.
+To disable the fallback globally:
 
-Tracking issues for per-account keyring namespacing and per-account env vars
-are linked in the v1.x roadmap.
+```toml
+[defaults.credentials]
+fallback = "keyring-only"
+```
+
+Or per-account:
+
+```toml
+[[accounts]]
+name = "work"
+
+[accounts.credentials]
+fallback = "keyring-only"
+```
+
+With `fallback = "keyring-only"`, a missing keyring entry produces
+`ERR_CONFIG` without consulting `RUSTY_IMAP_MCP_PASSWORD`.
+
+The default is `"keyring-then-env"` (back-compat). Audit records include a
+`credential_source` field (`keyring` / `legacy_keyring` / `env_var`) so
+post-incident analysis can detect silent downgrades.
 
 ## Threat model
 


### PR DESCRIPTION
## Summary

Closes roadmap sub-group 4 (`docs/superpowers/specs/2026-04-19-open-issues-roadmap-design.md` §3): three credential-path issues landed as one coherent sweep across `rimap-core`, `rimap-audit`, `rimap-config`, `rimap-imap`, and `rimap-server`.

- **#76** — `ConfigError::NoCredential` / `::Keychain` Display strings no longer interpolate the username. They now show `host` and a 16-hex-char SHA-256 `account_tag` derived from `username@host`, so log correlation works without username enumeration. `Keychain`'s Display no longer interpolates `{source}` — the underlying error stays reachable via `#[source]` / anyhow chain rendering at the operator sink.
- **#77** — Keyring entries are namespaced by account id (`<account-id>/<username>@<host>`) to prevent collisions between accounts that share a `username@host` tuple. `resolve_credential` transparently falls back to the legacy `<username>@<host>` key and emits a `tracing::warn!` recommending `rusty-imap-mcp migrate-keyring`. New `migrate-keyring` CLI subcommand rewrites legacy entries under the new key. `rusty-imap-mcp login` gains `--account <id>` (default `default`) — single-account invocations remain unchanged.
- **#78** — New `[defaults.credentials]` / `[[accounts.credentials]]` TOML section with a `fallback` knob (`keyring-then-env` default, `keyring-only` strict). `KeyringOnly` disables the `RUSTY_IMAP_MCP_PASSWORD` env-var fallback for multi-account deployments where a shared fallback would cross account boundaries. `auth` audit records gain `credential_source: Option<CredentialSource>` (`keyring` / `legacy_keyring` / `env_var`) so post-incident analysis can detect silent downgrades. `CredentialSource` lives in `rimap-core` to keep `rimap-config → rimap-audit` from becoming a dep cycle.

Eight focused commits, TDD-shaped, each reviewed against the plan in `docs/superpowers/plans/2026-04-19-credential-hardening.md`.

## Breaking changes

- **Keyring key format** — existing `<username>@<host>` entries are read via transparent fallback, but operators should run `rusty-imap-mcp migrate-keyring --account <id> --host <h> --username <u>` once per account to migrate. The CHANGELOG entry documents the migration path.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo deny check advisories bans licenses sources` — clean
- [x] `typos` — no findings
- [ ] Manual sanity: `rusty-imap-mcp login --account default --host ... --username ...` writes under the new key format
- [ ] Manual sanity: `rusty-imap-mcp migrate-keyring --account ... --host ... --username ...` on a legacy-format entry migrates and the second run reports "nothing to migrate"
- [ ] Manual sanity: audit log from a successful auth contains `"credential_source": "keyring"`
- [ ] Manual sanity: setting `[defaults.credentials]` `fallback = "keyring-only"` causes a missing keyring entry to fail without consulting `RUSTY_IMAP_MCP_PASSWORD`

Closes #76
Closes #77
Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)