### PR TITLE
feat: audit cancellation drop-guard + fail_open test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -1461,7 +1461,7 @@ checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.3",
+ "web_atoms 0.2.4",
 ]
 
 [[package]]
@@ -1691,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1955,9 +1955,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2088,7 +2088,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "rimap-audit"
 version = "1.0.0"
 dependencies = [
+ "async-channel 2.5.0",
  "fs4",
+ "futures",
  "hex",
  "libc",
  "proptest",
@@ -2100,6 +2102,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "time",
+ "tokio",
  "tracing",
  "ulid",
 ]
@@ -2261,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2283,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2307,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2944,9 +2947,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3095,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ulid"
@@ -3198,9 +3201,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3235,11 +3238,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3248,7 +3251,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3364,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -3376,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3638,6 +3641,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/crates/rimap-audit/Cargo.toml
+++ b/crates/rimap-audit/Cargo.toml
@@ -11,6 +11,9 @@ description = "Append-only JSONL audit log with exclusive file locking for rusty
 [lints]
 workspace = true
 
+[features]
+test-injection = []
+
 [dependencies]
 rimap-core = { path = "../rimap-core", version = "1.0.0" }
 thiserror = { workspace = true }

--- a/crates/rimap-audit/Cargo.toml
+++ b/crates/rimap-audit/Cargo.toml
@@ -23,6 +23,8 @@ hex = { workspace = true }
 rand = { workspace = true }
 fs4 = { workspace = true }
 tracing = { workspace = true }
+async-channel = { workspace = true }
+tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -30,3 +32,4 @@ libc = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 proptest = { workspace = true }
+futures = "0.3"

--- a/crates/rimap-audit/src/cancellation.rs
+++ b/crates/rimap-audit/src/cancellation.rs
@@ -1,0 +1,176 @@
+//! Cancellation drop-guard plumbing: a bounded channel of `ToolEndInputs`
+//! submitted from `Drop` (sync) and consumed by a dedicated tokio task that
+//! routes each record through the existing `AuditWriter::log_tool_end` path.
+//!
+//! Used by `rimap-server/src/mcp/audit_envelope.rs::AuditEnvelopeGuard` to
+//! close out the `tool_start` / `tool_end` pair when the MCP dispatch future
+//! is dropped mid-call (#71, #99).
+
+use crate::ToolEndInputs;
+use crate::writer::AuditWriter;
+
+/// Channel capacity. 1024 outstanding cancellations is a lot — drops here
+/// only happen on client disconnect / shutdown, not steady-state.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// Clone-cheap handle used by `Drop` implementations to enqueue a
+/// cancellation `ToolEnd`. `try_send` is non-blocking; on `Full` or `Closed`
+/// the caller logs a warning and discards the record.
+#[derive(Clone, Debug)]
+pub struct CancelledToolEndSender {
+    inner: async_channel::Sender<ToolEndInputs>,
+}
+
+impl CancelledToolEndSender {
+    /// Try to enqueue a cancellation record without blocking. Returns an
+    /// error if the channel is full or all receivers have dropped.
+    ///
+    /// # Errors
+    /// Returns `async_channel::TrySendError` on `Full` or `Closed`.
+    pub fn try_send(
+        &self,
+        inputs: ToolEndInputs,
+    ) -> Result<(), Box<async_channel::TrySendError<ToolEndInputs>>> {
+        self.inner.try_send(inputs).map_err(Box::new)
+    }
+}
+
+/// Receiver half. Created once at startup; moved into the drainer task.
+pub struct CancelledToolEndReceiver {
+    inner: async_channel::Receiver<ToolEndInputs>,
+}
+
+/// Build a paired `(sender, receiver)` for cancellation records.
+#[must_use]
+pub fn cancellation_channel() -> (CancelledToolEndSender, CancelledToolEndReceiver) {
+    let (tx, rx) = async_channel::bounded(CHANNEL_CAPACITY);
+    (
+        CancelledToolEndSender { inner: tx },
+        CancelledToolEndReceiver { inner: rx },
+    )
+}
+
+/// Spawn a dedicated tokio task that drains `receiver` and writes each
+/// record via `AuditWriter::log_tool_end` on a `spawn_blocking` thread.
+/// The task exits when all senders are dropped and the channel drains.
+///
+/// The returned `JoinHandle` should be `await`ed on shutdown so the drainer
+/// finishes any remaining queued records before the runtime exits.
+#[must_use]
+pub fn spawn_drainer(
+    receiver: CancelledToolEndReceiver,
+    writer: AuditWriter,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(inputs) = receiver.inner.recv().await {
+            let writer = writer.clone();
+            let join = tokio::task::spawn_blocking(move || writer.log_tool_end(inputs)).await;
+            match join {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        error = %e,
+                        "cancellation tool_end write failed",
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "cancellation drainer spawn_blocking panic",
+                    );
+                }
+            }
+        }
+        tracing::debug!("cancellation drainer exiting — all senders dropped");
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::cancellation_channel;
+    use crate::record::{Provenance, ResultSummary, ToolStatus};
+    use crate::writer::AuditOptions;
+    use crate::{AuditWriter, Seq, ToolEndInputs};
+    use rimap_core::ErrorCode;
+    use rimap_core::tool::ToolName;
+    use tempfile::tempdir;
+
+    fn dummy_inputs(account: &str) -> ToolEndInputs {
+        ToolEndInputs {
+            start_seq: Seq::FIRST,
+            tool: ToolName::Search,
+            account: Some(account.to_string()),
+            status: ToolStatus::Cancelled,
+            error_code: Some(ErrorCode::Cancelled),
+            duration_ms: 42,
+            result_summary: ResultSummary::default(),
+            provenance: Provenance {
+                window_seconds: 60,
+                message_ids_recently_read: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn try_send_and_receive_round_trip() {
+        let (tx, rx) = cancellation_channel();
+        tx.try_send(dummy_inputs("a")).unwrap();
+        tx.try_send(dummy_inputs("b")).unwrap();
+        drop(tx);
+        let received: Vec<_> = futures::executor::block_on(async {
+            let mut out = Vec::new();
+            while let Ok(inputs) = rx.inner.recv().await {
+                out.push(inputs);
+            }
+            out
+        });
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0].account.as_deref(), Some("a"));
+        assert_eq!(received[1].account.as_deref(), Some("b"));
+    }
+
+    #[tokio::test]
+    async fn drainer_writes_records_to_audit_writer() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = AuditWriter::open(&AuditOptions {
+            path: path.clone(),
+            rotate_bytes: 10 * 1024 * 1024,
+            rotate_keep: 5,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap();
+
+        // Prime an earlier tool_start so the tool_end has a plausible start_seq.
+        let start_seq = writer
+            .log_tool_start(
+                ToolName::Search,
+                Some("a"),
+                Some(rimap_core::Posture::DraftSafe),
+                serde_json::Value::Object(serde_json::Map::new()),
+                "0".repeat(64),
+            )
+            .unwrap();
+
+        let (tx, rx) = cancellation_channel();
+        let handle = super::spawn_drainer(rx, writer.clone());
+
+        let mut inputs = dummy_inputs("a");
+        inputs.start_seq = start_seq;
+        tx.try_send(inputs).unwrap();
+        drop(tx); // Signals drainer to exit once drained.
+        handle.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 2, "expected 2 records, got: {contents}");
+        assert!(
+            lines[1].contains(r#""status":"cancelled""#),
+            "last line should be cancellation tool_end: {}",
+            lines[1]
+        );
+    }
+}

--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -2,11 +2,16 @@
 
 #![deny(missing_docs)]
 
+pub mod cancellation;
 pub(crate) mod fs;
 pub mod reader;
 pub mod record;
 pub mod redact;
 pub mod writer;
+
+pub use cancellation::{
+    CancelledToolEndReceiver, CancelledToolEndSender, cancellation_channel, spawn_drainer,
+};
 
 /// Re-export of [`reader::backup_exclude`] so external callers can continue to
 /// use `rimap_audit::backup_exclude::exclude_from_backup` after the split.

--- a/crates/rimap-audit/src/record/mod.rs
+++ b/crates/rimap-audit/src/record/mod.rs
@@ -233,7 +233,8 @@ pub struct ToolStart {
 }
 
 /// Outcome status for a tool call. `Ok` means a structured result was
-/// returned; `Error` means dispatch failed and `error_code` is populated.
+/// returned; `Error` means dispatch failed and `error_code` is populated;
+/// `Cancelled` means the tool call was cancelled (e.g. client disconnect, runtime shutdown).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolStatus {
@@ -241,6 +242,9 @@ pub enum ToolStatus {
     Ok,
     /// Tool call failed.
     Error,
+    /// Tool call was cancelled (e.g. client disconnect, runtime shutdown).
+    /// Written by the cancellation drop-guard on future drop; see #99.
+    Cancelled,
 }
 
 /// A coarse summary of what a tool returned. Structured so reviewers can
@@ -333,7 +337,9 @@ mod tests {
     use rimap_core::{Posture, tool::ToolName};
 
     use crate::record::ids::{ProcessId, Seq, Timestamp};
-    use crate::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason, ProcessStart};
+    use crate::record::{
+        AuditRecord, Payload, ProcessEnd, ProcessEndReason, ProcessStart, ToolStatus,
+    };
 
     fn sample_start() -> AuditRecord {
         AuditRecord {
@@ -528,5 +534,13 @@ mod tests {
             serde_json::to_string(&crate::record::ToolStatus::Error).unwrap(),
             "\"error\"",
         );
+    }
+
+    #[test]
+    fn tool_status_cancelled_serializes_as_snake_case() {
+        let j = serde_json::to_string(&ToolStatus::Cancelled).unwrap();
+        assert_eq!(j, "\"cancelled\"");
+        let back: ToolStatus = serde_json::from_str(&j).unwrap();
+        assert_eq!(back, ToolStatus::Cancelled);
     }
 }

--- a/crates/rimap-audit/src/writer/mod.rs
+++ b/crates/rimap-audit/src/writer/mod.rs
@@ -53,6 +53,17 @@ pub struct AuditOptions {
     pub initial_seq: crate::record::ids::Seq,
 }
 
+/// Test-only failure injection hook. When `fail_next` is set, the next
+/// call to `write_record_inner` returns an injected `AuditError::Write`
+/// without touching the file, then clears the flag.
+#[cfg(any(test, feature = "test-injection"))]
+#[derive(Debug, Default)]
+struct FailureInjection {
+    /// When `true`, the next `write_record_inner` call returns
+    /// `AuditError::Write` without touching the file.
+    fail_next: std::sync::atomic::AtomicBool,
+}
+
 /// Append-only JSONL writer. Construct via [`AuditWriter::open`]. Cheaply
 /// cloneable — the underlying `File` and `BufWriter` live behind an
 /// `Arc<Mutex<_>>`, so all clones write through the same lock.
@@ -66,6 +77,8 @@ pub struct AuditWriter {
     process_id: crate::record::ids::ProcessId,
     suppressed_failures: Arc<AtomicU64>,
     inner: Arc<Mutex<Inner>>,
+    #[cfg(any(test, feature = "test-injection"))]
+    failure_injection: Arc<FailureInjection>,
 }
 
 #[derive(Debug)]
@@ -143,6 +156,8 @@ impl AuditWriter {
                 bytes_written,
                 next_seq: opts.initial_seq,
             })),
+            #[cfg(any(test, feature = "test-injection"))]
+            failure_injection: Arc::new(FailureInjection::default()),
         })
     }
 
@@ -283,6 +298,18 @@ impl AuditWriter {
     }
 
     fn write_record_inner(&self, record: &crate::record::AuditRecord) -> Result<(), AuditError> {
+        #[cfg(any(test, feature = "test-injection"))]
+        if self
+            .failure_injection
+            .fail_next
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+        {
+            return Err(AuditError::Write {
+                path: self.path.clone(),
+                source: std::io::Error::other("injected failure (test)"),
+            });
+        }
+
         let mut bytes = serde_json::to_vec(record).map_err(AuditError::Serialize)?;
         bytes.push(b'\n');
 
@@ -332,6 +359,16 @@ impl AuditWriter {
     #[must_use]
     pub fn suppressed_failures(&self) -> u64 {
         self.suppressed_failures.load(Ordering::Relaxed)
+    }
+
+    /// Test-only: cause the next `write_record_inner` call to fail with
+    /// `AuditError::Write`. Used to exercise `fail_open = true`
+    /// suppression paths without filesystem tricks (#72).
+    #[cfg(any(test, feature = "test-injection"))]
+    pub fn force_next_write_failure(&self) {
+        self.failure_injection
+            .fail_next
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Total bytes written through this writer since `open` (including bytes

--- a/crates/rimap-core/src/error.rs
+++ b/crates/rimap-core/src/error.rs
@@ -48,6 +48,10 @@ pub enum ErrorCode {
     NoAccount,
     /// Named account not found in registry.
     UnknownAccount,
+    /// Operation cancelled before completion (e.g. client disconnect, runtime
+    /// shutdown). Emitted in `tool_end` records synthesized by the cancellation
+    /// drop-guard (#99).
+    Cancelled,
 }
 
 impl ErrorCode {
@@ -73,6 +77,7 @@ impl ErrorCode {
             Self::Internal => "ERR_INTERNAL",
             Self::NoAccount => "ERR_NO_ACCOUNT",
             Self::UnknownAccount => "ERR_UNKNOWN_ACCOUNT",
+            Self::Cancelled => "ERR_CANCELLED",
         }
     }
 }
@@ -111,6 +116,7 @@ impl FromStr for ErrorCode {
             "ERR_INTERNAL" => Ok(Self::Internal),
             "ERR_NO_ACCOUNT" => Ok(Self::NoAccount),
             "ERR_UNKNOWN_ACCOUNT" => Ok(Self::UnknownAccount),
+            "ERR_CANCELLED" => Ok(Self::Cancelled),
             other => Err(ParseErrorCodeError(other.to_string())),
         }
     }
@@ -261,11 +267,19 @@ mod tests {
             (ErrorCode::Internal, "ERR_INTERNAL"),
             (ErrorCode::NoAccount, "ERR_NO_ACCOUNT"),
             (ErrorCode::UnknownAccount, "ERR_UNKNOWN_ACCOUNT"),
+            (ErrorCode::Cancelled, "ERR_CANCELLED"),
         ];
         for (code, expected) in cases {
             assert_eq!(code.as_str(), expected);
             assert_eq!(format!("{code}"), expected);
         }
+    }
+
+    #[test]
+    fn cancelled_round_trips() {
+        assert_eq!(ErrorCode::Cancelled.as_str(), "ERR_CANCELLED");
+        let parsed = "ERR_CANCELLED".parse::<ErrorCode>();
+        assert_eq!(parsed, Ok(ErrorCode::Cancelled));
     }
 
     #[test]

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -50,4 +50,6 @@ tempfile = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 mail-parser = { workspace = true }
+rimap-audit = { path = "../rimap-audit", version = "1.0.0", features = ["test-injection"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -116,15 +116,28 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         let registry = build_registry(&multi, &audit, &credentials, &download_dir)
             .await
             .context("building account registry")?;
-        let mcp_server = server::ImapMcpServer::new(registry, audit);
+
+        let (cancellation_tx, cancellation_rx) = rimap_audit::cancellation_channel();
+        let drainer_handle = rimap_audit::spawn_drainer(cancellation_rx, audit.clone());
+
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
         let transport = rmcp::transport::io::stdio();
         let service = Box::pin(rmcp::serve_server(mcp_server, transport))
             .await
             .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        // waiting() takes ownership of service, consuming it and dropping the
+        // ImapMcpServer (including all cancellation sender clones) when it
+        // returns. The drainer task exits once all senders have dropped.
         service
             .waiting()
             .await
             .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+
+        // All senders dropped above. Wait for the drainer to flush any
+        // remaining queued cancellation records before the runtime exits.
+        if let Err(e) = drainer_handle.await {
+            tracing::error!(error = %e, "cancellation drainer join error");
+        }
         Ok(())
     });
 

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -7,9 +7,14 @@
 //! [`ImapMcpServer::emit_tool_end`] offload the blocking writer calls
 //! onto `spawn_blocking` and surface panics/join errors as
 //! `RimapError::Internal`.
+//!
+//! [`AuditEnvelopeGuard`] is a drop-guard that synthesizes a cancellation
+//! `tool_end` if the enclosing future is dropped between `tool_start`
+//! emission and the normal `emit_tool_end` call (#71, #99).
 
 use rimap_audit::record::{Provenance, ResultSummary, ToolStatus};
 use rimap_audit::redact::{Redactor, hash_arguments};
+use rimap_audit::{CancelledToolEndSender, ToolEndInputs};
 use rimap_core::tool::ToolName;
 use rmcp::model::{CallToolResult, ErrorData};
 
@@ -41,7 +46,20 @@ impl ImapMcpServer {
             .await?;
         let start_time = std::time::Instant::now();
 
+        let mut guard = AuditEnvelopeGuard::new(
+            start_seq,
+            tool,
+            audit_account.clone(),
+            start_time,
+            self.cancellation_sender.clone(),
+        );
+
         let result = body.await;
+
+        // Body completed normally. Disarm before any further await points so
+        // a drop of THIS future between here and emit_tool_end does not cause
+        // double emission.
+        guard.disarm();
 
         let duration_ms = start_time
             .elapsed()
@@ -164,6 +182,84 @@ impl ImapMcpServer {
                 let rimap_err = crate::mcp::spawn_blocking_panic_error(&join_err);
                 tracing::error!(error = %rimap_err, "tool_end join error");
             }
+        }
+    }
+}
+
+/// RAII guard that emits a cancellation `tool_end` record if dropped
+/// undisarmed. Used inside `run_with_audit_envelope` to pair every
+/// `tool_start` with a `tool_end` even when the outer MCP dispatch
+/// future is dropped mid-call (#71, #99).
+struct AuditEnvelopeGuard {
+    inner: Option<GuardInner>,
+}
+
+struct GuardInner {
+    start_seq: rimap_audit::Seq,
+    tool: ToolName,
+    account: Option<String>,
+    start_time: std::time::Instant,
+    sender: CancelledToolEndSender,
+}
+
+impl AuditEnvelopeGuard {
+    fn new(
+        start_seq: rimap_audit::Seq,
+        tool: ToolName,
+        account: Option<String>,
+        start_time: std::time::Instant,
+        sender: CancelledToolEndSender,
+    ) -> Self {
+        Self {
+            inner: Some(GuardInner {
+                start_seq,
+                tool,
+                account,
+                start_time,
+                sender,
+            }),
+        }
+    }
+
+    /// Mark the guard as completed normally. `Drop` becomes a no-op.
+    fn disarm(&mut self) {
+        self.inner = None;
+    }
+}
+
+impl Drop for AuditEnvelopeGuard {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.take() else {
+            return;
+        };
+        let duration_ms = inner
+            .start_time
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        // ToolName is Copy; capture it for the warning log before try_send
+        // consumes the payload.
+        let tool = inner.tool;
+        let cancellation = ToolEndInputs {
+            start_seq: inner.start_seq,
+            tool,
+            account: inner.account,
+            status: rimap_audit::record::ToolStatus::Cancelled,
+            error_code: Some(rimap_core::ErrorCode::Cancelled),
+            duration_ms,
+            result_summary: rimap_audit::record::ResultSummary::default(),
+            provenance: Provenance {
+                window_seconds: 60,
+                message_ids_recently_read: Vec::new(),
+            },
+        };
+        if let Err(e) = inner.sender.try_send(cancellation) {
+            tracing::warn!(
+                error = %e,
+                tool = tool.as_str(),
+                "cancellation tool_end drop: failed to enqueue (channel full or closed)",
+            );
         }
     }
 }

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -263,3 +263,118 @@ impl Drop for AuditEnvelopeGuard {
         }
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use rimap_audit::writer::AuditOptions;
+    use rimap_audit::{AuditWriter, Seq, cancellation_channel, spawn_drainer};
+    use rimap_core::tool::ToolName;
+    use tempfile::tempdir;
+
+    use super::AuditEnvelopeGuard;
+
+    fn test_writer(path: std::path::PathBuf) -> AuditWriter {
+        AuditWriter::open(&AuditOptions {
+            path,
+            rotate_bytes: 10 * 1024 * 1024,
+            rotate_keep: 5,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap()
+    }
+
+    /// Dropping an `AuditEnvelopeGuard` without disarming enqueues a
+    /// cancellation record with `status = cancelled` and
+    /// `error_code = ERR_CANCELLED`. The drainer writes it to the audit file.
+    /// This is the core invariant for #71 and #99.
+    #[tokio::test]
+    async fn dropped_guard_enqueues_cancellation_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer(path.clone());
+
+        // Prime a tool_start so the resulting tool_end references a real seq.
+        let start_seq = writer
+            .log_tool_start(
+                ToolName::Search,
+                Some("test"),
+                Some(rimap_core::Posture::Readonly),
+                serde_json::Value::Object(serde_json::Map::new()),
+                "0".repeat(64),
+            )
+            .unwrap();
+
+        let (tx, rx) = cancellation_channel();
+        let drainer = spawn_drainer(rx, writer.clone());
+
+        {
+            let _guard = AuditEnvelopeGuard::new(
+                start_seq,
+                ToolName::Search,
+                Some("test".to_string()),
+                std::time::Instant::now(),
+                tx.clone(),
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            // Implicit drop of `_guard` here — undisarmed, so cancellation fires.
+        }
+
+        drop(tx); // Close the channel so the drainer can exit.
+        drainer.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "expected >= 2 records (tool_start + cancellation tool_end), got: {contents}",
+        );
+        let last = lines.last().unwrap();
+        assert!(
+            last.contains(r#""status":"cancelled""#),
+            "last record should be cancellation tool_end: {last}",
+        );
+        assert!(
+            last.contains(r#""error_code":"ERR_CANCELLED""#),
+            "last record should carry ERR_CANCELLED: {last}",
+        );
+        assert!(
+            last.contains(&format!(r#""start_seq":{start_seq}"#)),
+            "last record should reference primed tool_start seq {start_seq}: {last}",
+        );
+    }
+
+    /// A disarmed guard's drop is a no-op: no cancellation record is written.
+    #[tokio::test]
+    async fn disarmed_guard_does_not_enqueue() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer(path.clone());
+
+        let (tx, rx) = cancellation_channel();
+        let drainer = spawn_drainer(rx, writer.clone());
+
+        {
+            let mut guard = AuditEnvelopeGuard::new(
+                Seq::FIRST,
+                ToolName::Search,
+                Some("test".to_string()),
+                std::time::Instant::now(),
+                tx.clone(),
+            );
+            guard.disarm();
+            // Drop here — disarmed, so no cancellation is enqueued.
+        }
+
+        drop(tx);
+        drainer.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        assert!(
+            !contents.contains(r#""status":"cancelled""#),
+            "disarmed guard must not write a cancellation record: {contents}",
+        );
+    }
+}

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -66,7 +66,8 @@ pub(super) fn rimap_error_to_breaker_reason(
         | ErrorCode::Config
         | ErrorCode::Internal
         | ErrorCode::NoAccount
-        | ErrorCode::UnknownAccount => None,
+        | ErrorCode::UnknownAccount
+        | ErrorCode::Cancelled => None,
     }
 }
 

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -294,7 +294,8 @@ mod tests {
         .expect("audit open");
 
         let registry = AccountRegistry::new(BTreeMap::new());
-        let server = ImapMcpServer::new(registry, audit);
+        let (cancellation_sender, _cancellation_rx) = rimap_audit::cancellation_channel();
+        let server = ImapMcpServer::new(registry, audit, cancellation_sender);
 
         // list_accounts needs no args and no IMAP connection.
         let args = serde_json::Map::new();

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -52,7 +52,8 @@ pub fn to_mcp_error(err: &RimapError) -> ErrorData {
         | ErrorCode::ConnectionLost
         | ErrorCode::Timeout
         | ErrorCode::Config
-        | ErrorCode::Internal => ErrorData::internal_error(message, None),
+        | ErrorCode::Internal
+        | ErrorCode::Cancelled => ErrorData::internal_error(message, None),
     }
 }
 

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use rimap_audit::AuditWriter;
+use rimap_audit::CancelledToolEndSender;
 use rimap_audit::redact::{RedactionSalt, RedactionSchema, schemas};
 use rimap_core::account::AccountId;
 use rimap_core::tool::ToolName;
@@ -35,6 +36,10 @@ pub struct ImapMcpServer {
     pub registry: AccountRegistry,
     /// Append-only audit writer.
     pub(crate) audit: AuditWriter,
+    /// Channel used by `AuditEnvelopeGuard::drop` to emit synthetic
+    /// cancellation `tool_end` records when the MCP dispatch future is
+    /// dropped mid-call (#71, #99).
+    pub(crate) cancellation_sender: CancelledToolEndSender,
     /// Per-process salt used when applying `Redactor` to tool arguments.
     /// Wrapped in `Arc` so `spawn_blocking` closures can cheaply capture it.
     pub(crate) redaction_salt: Arc<RedactionSalt>,
@@ -47,12 +52,17 @@ impl ImapMcpServer {
     /// Construct a new server. Builds the redaction salt and schema map
     /// from [`rimap_audit::redact::schemas`].
     #[must_use]
-    pub fn new(registry: AccountRegistry, audit: AuditWriter) -> Self {
+    pub fn new(
+        registry: AccountRegistry,
+        audit: AuditWriter,
+        cancellation_sender: CancelledToolEndSender,
+    ) -> Self {
         let schema_map: HashMap<ToolName, RedactionSchema> =
             schemas().into_iter().map(|s| (s.tool, s)).collect();
         Self {
             registry,
             audit,
+            cancellation_sender,
             redaction_salt: Arc::new(RedactionSalt::new_random()),
             redaction_schemas: Arc::new(schema_map),
         }

--- a/crates/rimap-server/tests/audit_fail_open.rs
+++ b/crates/rimap-server/tests/audit_fail_open.rs
@@ -1,0 +1,87 @@
+//! Pin the `fail_open = true` propagation path: when an audit write fails and
+//! the writer was configured with `fail_open = true`, calls that would normally
+//! return an error instead return Ok, and the writer's `suppressed_failures`
+//! counter increments.
+//!
+//! Issue: #72.
+
+#![expect(clippy::unwrap_used, reason = "tests")]
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_core::tool::ToolName;
+use tempfile::tempdir;
+
+#[test]
+fn fail_open_suppresses_write_failure_and_increments_counter() {
+    let dir = tempdir().unwrap();
+    let writer = AuditWriter::open(&AuditOptions {
+        path: dir.path().join("audit.jsonl"),
+        rotate_bytes: 10 * 1024 * 1024,
+        rotate_keep: 5,
+        retention_seconds: None,
+        fail_open: true,
+        initial_seq: Seq::FIRST,
+    })
+    .unwrap();
+
+    // Inject one write failure. The next log_tool_start should encounter
+    // AuditError::Write, which fail_open=true converts to Ok while
+    // incrementing suppressed_failures.
+    writer.force_next_write_failure();
+
+    let result = writer.log_tool_start(
+        ToolName::Search,
+        Some("test"),
+        Some(rimap_core::Posture::Readonly),
+        serde_json::Value::Object(serde_json::Map::new()),
+        "0".repeat(64),
+    );
+
+    assert!(
+        result.is_ok(),
+        "fail_open=true should suppress the write failure, got: {result:?}",
+    );
+    assert_eq!(
+        writer.suppressed_failures(),
+        1,
+        "suppressed_failures counter should have incremented once",
+    );
+}
+
+#[test]
+fn fail_open_false_propagates_write_failure() {
+    // Symmetric control: fail_open=false propagates the write failure as
+    // AuditError::Write. Not strictly required by #72 but pins the
+    // complementary contract so a regression in either direction trips a
+    // test.
+    let dir = tempdir().unwrap();
+    let writer = AuditWriter::open(&AuditOptions {
+        path: dir.path().join("audit.jsonl"),
+        rotate_bytes: 10 * 1024 * 1024,
+        rotate_keep: 5,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .unwrap();
+
+    writer.force_next_write_failure();
+
+    let result = writer.log_tool_start(
+        ToolName::Search,
+        Some("test"),
+        Some(rimap_core::Posture::Readonly),
+        serde_json::Value::Object(serde_json::Map::new()),
+        "0".repeat(64),
+    );
+
+    assert!(
+        result.is_err(),
+        "fail_open=false should propagate the failure, got: {result:?}",
+    );
+    assert_eq!(
+        writer.suppressed_failures(),
+        0,
+        "suppressed_failures counter should not have incremented",
+    );
+}

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -281,7 +281,8 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
     accounts.insert(id, state);
     let registry = rimap_server::boot::registry::AccountRegistry::new(accounts);
 
-    let server = ImapMcpServer::new(registry, audit);
+    let (cancellation_sender, _cancellation_rx) = rimap_audit::cancellation_channel();
+    let server = ImapMcpServer::new(registry, audit, cancellation_sender);
 
     TestEnv {
         _harness: harness,

--- a/docs/superpowers/plans/2026-04-19-audit-cancellation.md
+++ b/docs/superpowers/plans/2026-04-19-audit-cancellation.md
@@ -1,0 +1,1030 @@
+# Audit Cancellation Drop-Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close three audit-durability issues as one sweep — guarantee every `tool_start` record is paired with a `tool_end` even when the MCP handler future is dropped mid-call (#71, #99), and pin `fail_open = true` write-failure propagation with a test (#72).
+
+**Architecture:** Introduce a `CancelledToolEndSender` primitive in `rimap-audit` (bounded async channel) and a dedicated drainer task that consumes it via `spawn_blocking` calls into the existing `AuditWriter`. `run_with_audit_envelope` in `rimap-server/src/mcp/audit_envelope.rs` wraps its body in an `AuditEnvelopeGuard`. On normal completion the guard is disarmed before `emit_tool_end` fires. If the outer future is dropped between `emit_tool_start` and the disarm call, the guard's `Drop` impl synthesizes a `ToolEnd { status: Cancelled, error_code: ERR_CANCELLED, duration_ms: elapsed }` record and enqueues it via the channel. The drainer task drains remaining records on shutdown.
+
+**Tech Stack:** Rust (stable), `tokio` (`task::spawn_blocking`, `JoinHandle`), `async_channel` (bounded), existing `rimap-audit::AuditWriter`.
+
+---
+
+## Prior-Art Context
+
+`crates/rimap-server/src/mcp/audit_envelope.rs` currently implements `run_with_audit_envelope`. It calls `emit_tool_start` (returns a `Seq`), awaits `body`, then calls `emit_tool_end`. Both `emit_tool_start` / `emit_tool_end` offload to `spawn_blocking` and surface audit-write failures (the former as `ErrorData::internal_error`, the latter as `tracing::error!`). There is currently no drop-guard — a dropped outer future leaves an orphan `tool_start`.
+
+Issues #71 and #99 reference the same logical call site at different review cycles. #71's line references (`server.rs:265-315`) predate the refactor that moved the pair into `mcp/audit_envelope.rs`; both are addressed by one guard.
+
+`AuditWriter` (`crates/rimap-audit/src/writer/mod.rs`) already has `fail_open: bool` and a `suppressed_failures: Arc<AtomicU64>` counter. On `fail_open = true`, write errors log via `tracing::error!` and increment the counter; the writer returns `Ok(())` to callers. This is what #72 wants to pin with a test.
+
+---
+
+## File Structure
+
+### New files
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `crates/rimap-audit/src/cancellation.rs` | `CancelledToolEndSender` / `CancelledToolEndReceiver` wrapper types + drainer task helper. |
+
+### Modified files
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/rimap-core/src/error.rs` | Add `ErrorCode::Cancelled` → `"ERR_CANCELLED"`. Update `as_str`, `from_str`, and the `round_trip_pairs` list. |
+| Modify | `crates/rimap-audit/src/record/mod.rs` | Add `ToolStatus::Cancelled` variant (snake_case serde). Round-trip test. |
+| Modify | `crates/rimap-audit/src/lib.rs` | Register `cancellation` module; re-export the public types. |
+| Modify | `crates/rimap-audit/src/writer/mod.rs` | Add a `#[cfg(test)]` failure-injection hook (`force_next_write_failure`) used only by #72's test. |
+| Modify | `crates/rimap-server/src/mcp/audit_envelope.rs` | `AuditEnvelopeGuard` struct + `Drop` impl + wiring into `run_with_audit_envelope`. |
+| Modify | `crates/rimap-server/src/mcp/server.rs` | `ImapMcpServer` holds the `CancelledToolEndSender`; construction accepts it. |
+| Modify | `crates/rimap-server/src/main.rs` | Construct sender + drainer at boot, await drainer handle on shutdown. |
+| Create | `crates/rimap-server/tests/audit_cancellation.rs` | Integration test for the drop-induced cancellation. |
+| Create | `crates/rimap-server/tests/audit_fail_open.rs` | Integration test for #72 (fail_open=true + write failure). |
+
+---
+
+## Task 1: Add `ErrorCode::Cancelled` variant
+
+**Issue:** prerequisite for the cancellation record's `error_code` field.
+
+**Files:**
+- Modify: `crates/rimap-core/src/error.rs`
+
+### Approach
+
+Add a new variant `Cancelled` that serializes to `"ERR_CANCELLED"`. Keep the existing pattern: `as_str` match arm, `from_str` parse arm, and an entry in the `round_trip_pairs` list used by the tests.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `crates/rimap-core/src/error.rs` tests:
+
+```rust
+    #[test]
+    fn cancelled_round_trips() {
+        assert_eq!(ErrorCode::Cancelled.as_str(), "ERR_CANCELLED");
+        assert_eq!("ERR_CANCELLED".parse::<ErrorCode>().unwrap(), ErrorCode::Cancelled);
+    }
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `cargo test -p rimap-core --lib error::tests::cancelled_round_trips`
+Expected: FAIL — variant undefined.
+
+- [ ] **Step 3: Add the variant**
+
+In `crates/rimap-core/src/error.rs`, add `Cancelled` to the `ErrorCode` enum:
+
+```rust
+    /// Operation cancelled before completion (e.g. client disconnect, runtime
+    /// shutdown). Emitted in `tool_end` records synthesized by the cancellation
+    /// drop-guard (#99).
+    Cancelled,
+```
+
+Add the `as_str` match arm:
+
+```rust
+            Self::Cancelled => "ERR_CANCELLED",
+```
+
+Add the `from_str` parse arm. Find the existing `match s { "ERR_X" => Ok(Self::X), ... }` block and add `"ERR_CANCELLED" => Ok(Self::Cancelled),`.
+
+Add the entry to the `round_trip_pairs` list (or equivalent) used by the existing `every_code_round_trips` test:
+
+```rust
+            (ErrorCode::Cancelled, "ERR_CANCELLED"),
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `cargo test -p rimap-core --lib error::tests`
+Expected: PASS including the new `cancelled_round_trips` and the existing `every_code_round_trips`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-core/src/error.rs
+git commit -m "core: add ErrorCode::Cancelled (#99 prep)
+
+New variant for the cancellation drop-guard: resolves to
+\"ERR_CANCELLED\". Used by the synthesized tool_end record when the
+MCP dispatch future is dropped mid-call."
+```
+
+---
+
+## Task 2: Add `ToolStatus::Cancelled` variant
+
+**Issue:** prerequisite for the cancellation record's `status` field.
+
+**Files:**
+- Modify: `crates/rimap-audit/src/record/mod.rs`
+
+### Approach
+
+Add `Cancelled` to `ToolStatus` with snake_case serde.
+
+- [ ] **Step 1: Write failing test**
+
+In `crates/rimap-audit/src/record/mod.rs`:
+
+```rust
+    #[test]
+    fn tool_status_cancelled_serializes_as_snake_case() {
+        let j = serde_json::to_string(&ToolStatus::Cancelled).unwrap();
+        assert_eq!(j, "\"cancelled\"");
+        let back: ToolStatus = serde_json::from_str(&j).unwrap();
+        assert_eq!(back, ToolStatus::Cancelled);
+    }
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `cargo test -p rimap-audit --lib record::tests::tool_status_cancelled_serializes_as_snake_case`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the variant**
+
+In `crates/rimap-audit/src/record/mod.rs`, find the `ToolStatus` enum and add:
+
+```rust
+pub enum ToolStatus {
+    /// Tool call succeeded.
+    Ok,
+    /// Tool call failed.
+    Error,
+    /// Tool call was cancelled (e.g. client disconnect, runtime shutdown).
+    /// Written by the cancellation drop-guard on future drop; see #99.
+    Cancelled,
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `cargo test -p rimap-audit --lib record::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-audit/src/record/mod.rs
+git commit -m "audit: add ToolStatus::Cancelled variant (#99 prep)
+
+Serializes as \"cancelled\". Used by the tool_end record the
+cancellation drop-guard synthesizes when the MCP dispatch future is
+dropped mid-call."
+```
+
+---
+
+## Task 3: Cancellation channel primitive + drainer task
+
+**Issue:** #71, #99 — the shared mechanism both layers consume.
+
+**Files:**
+- Create: `crates/rimap-audit/src/cancellation.rs`
+- Modify: `crates/rimap-audit/src/lib.rs`
+
+### Approach
+
+Wrap `async_channel::bounded::<ToolEndInputs>(1024)` in a pair of newtypes — `CancelledToolEndSender` (`Clone`, used from sync `Drop`) and `CancelledToolEndReceiver` (used once by the drainer). Provide a `spawn_drainer` helper that returns the tokio `JoinHandle` so `main.rs` can await it at shutdown.
+
+Verify `async_channel` is already a workspace dep (used in `rimap-imap/connection.rs`). If `rimap-audit/Cargo.toml` lacks it, add `async_channel = { workspace = true }`.
+
+- [ ] **Step 1: Write failing unit test**
+
+Create `crates/rimap-audit/src/cancellation.rs`:
+
+```rust
+//! Cancellation drop-guard plumbing: a bounded channel of `ToolEndInputs`
+//! submitted from `Drop` (sync) and consumed by a dedicated tokio task that
+//! routes each record through the existing `AuditWriter::log_tool_end` path.
+//!
+//! Used by `rimap-server/src/mcp/audit_envelope.rs::AuditEnvelopeGuard` to
+//! close out the `tool_start` / `tool_end` pair when the MCP dispatch future
+//! is dropped mid-call (#71, #99).
+
+use crate::ToolEndInputs;
+use crate::writer::AuditWriter;
+
+/// Channel capacity. 1024 outstanding cancellations is a lot — drops here
+/// only happen on client disconnect / shutdown, not steady-state.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// Clone-cheap handle used by `Drop` implementations to enqueue a
+/// cancellation `ToolEnd`. `try_send` is non-blocking; on `Full` or `Closed`
+/// the caller logs a warning and discards the record.
+#[derive(Clone, Debug)]
+pub struct CancelledToolEndSender {
+    inner: async_channel::Sender<ToolEndInputs>,
+}
+
+impl CancelledToolEndSender {
+    /// Try to enqueue a cancellation record without blocking. Returns an
+    /// error if the channel is full or all receivers have dropped.
+    ///
+    /// # Errors
+    /// Returns `async_channel::TrySendError` on `Full` or `Closed`.
+    pub fn try_send(
+        &self,
+        inputs: ToolEndInputs,
+    ) -> Result<(), async_channel::TrySendError<ToolEndInputs>> {
+        self.inner.try_send(inputs)
+    }
+}
+
+/// Receiver half. Created once at startup; moved into the drainer task.
+pub struct CancelledToolEndReceiver {
+    inner: async_channel::Receiver<ToolEndInputs>,
+}
+
+/// Build a paired `(sender, receiver)` for cancellation records.
+#[must_use]
+pub fn cancellation_channel() -> (CancelledToolEndSender, CancelledToolEndReceiver) {
+    let (tx, rx) = async_channel::bounded(CHANNEL_CAPACITY);
+    (
+        CancelledToolEndSender { inner: tx },
+        CancelledToolEndReceiver { inner: rx },
+    )
+}
+
+/// Spawn a dedicated tokio task that drains `receiver` and writes each
+/// record via `AuditWriter::log_tool_end` on a `spawn_blocking` thread.
+/// The task exits when all senders are dropped and the channel drains.
+///
+/// The returned `JoinHandle` should be `await`ed on shutdown so the drainer
+/// finishes any remaining queued records before the runtime exits.
+#[must_use]
+pub fn spawn_drainer(
+    receiver: CancelledToolEndReceiver,
+    writer: AuditWriter,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(inputs) = receiver.inner.recv().await {
+            let writer = writer.clone();
+            let join =
+                tokio::task::spawn_blocking(move || writer.log_tool_end(inputs)).await;
+            match join {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        error = %e,
+                        "cancellation tool_end write failed",
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "cancellation drainer spawn_blocking panic",
+                    );
+                }
+            }
+        }
+        tracing::debug!("cancellation drainer exiting — all senders dropped");
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::cancellation_channel;
+    use crate::record::{Provenance, ResultSummary, ToolStatus};
+    use crate::{AuditWriter, Seq, ToolEndInputs};
+    use rimap_core::ErrorCode;
+    use rimap_core::tool::ToolName;
+    use tempfile::tempdir;
+
+    fn dummy_inputs(account: &str) -> ToolEndInputs {
+        ToolEndInputs {
+            start_seq: Seq::FIRST,
+            tool: ToolName::Search,
+            account: Some(account.to_string()),
+            status: ToolStatus::Cancelled,
+            error_code: Some(ErrorCode::Cancelled),
+            duration_ms: 42,
+            result_summary: ResultSummary::default(),
+            provenance: Provenance {
+                window_seconds: 60,
+                message_ids_recently_read: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn try_send_and_receive_round_trip() {
+        let (tx, rx) = cancellation_channel();
+        tx.try_send(dummy_inputs("a")).unwrap();
+        tx.try_send(dummy_inputs("b")).unwrap();
+        drop(tx);
+        let received: Vec<_> = futures::executor::block_on(async {
+            let mut out = Vec::new();
+            while let Ok(inputs) = rx.inner.recv().await {
+                out.push(inputs);
+            }
+            out
+        });
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0].account.as_deref(), Some("a"));
+        assert_eq!(received[1].account.as_deref(), Some("b"));
+    }
+
+    #[tokio::test]
+    async fn drainer_writes_records_to_audit_writer() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = AuditWriter::new(crate::writer::AuditWriterOpts {
+            path: path.clone(),
+            rotate_bytes: 10 * 1024 * 1024,
+            rotate_keep: 5,
+            retention_seconds: None,
+            provenance_window_seconds: 60,
+            fail_open: false,
+        })
+        .unwrap();
+
+        // Prime an earlier tool_start so the tool_end has a plausible start_seq.
+        let start_seq = writer
+            .log_tool_start(
+                ToolName::Search,
+                Some("a"),
+                rimap_audit::record::PostureEffective::DraftSafe,
+                serde_json::Value::Object(serde_json::Map::new()),
+                "0".repeat(64),
+            )
+            .unwrap();
+
+        let (tx, rx) = cancellation_channel();
+        let handle = super::spawn_drainer(rx, writer.clone());
+
+        let mut inputs = dummy_inputs("a");
+        inputs.start_seq = start_seq;
+        tx.try_send(inputs).unwrap();
+        drop(tx); // Signals drainer to exit once drained.
+        handle.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        // Two JSONL records: the tool_start we primed + the cancellation tool_end.
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 2, "expected 2 records, got: {contents}");
+        assert!(
+            lines[1].contains(r#""status":"cancelled""#),
+            "last line should be cancellation tool_end: {}",
+            lines[1]
+        );
+    }
+}
+```
+
+`rimap-audit/Cargo.toml` needs `async_channel = { workspace = true }` if not already present, plus `futures = { workspace = true }` under `[dev-dependencies]` for `futures::executor::block_on`. Check existing `Cargo.toml` before adding.
+
+- [ ] **Step 2: Register the module**
+
+In `crates/rimap-audit/src/lib.rs`, add:
+
+```rust
+pub mod cancellation;
+pub use cancellation::{cancellation_channel, CancelledToolEndSender, CancelledToolEndReceiver, spawn_drainer};
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+Run: `cargo test -p rimap-audit --lib cancellation::tests`
+Expected: PASS — both tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-audit/src/cancellation.rs crates/rimap-audit/src/lib.rs \
+        crates/rimap-audit/Cargo.toml
+git commit -m "audit: add cancellation channel + drainer task (#71, #99 prep)
+
+Bounded async channel carries ToolEndInputs synthesized by
+Drop-invoked cancellation guards in rimap-server. A dedicated tokio
+task drains the channel and routes each record through
+AuditWriter::log_tool_end via spawn_blocking. Returning the
+JoinHandle lets main.rs await the drainer on shutdown so queued
+records are not lost."
+```
+
+---
+
+## Task 4: `AuditEnvelopeGuard` + `run_with_audit_envelope` integration
+
+**Issue:** #71, #99 — the drop-guard plumbed into the dispatch path.
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/audit_envelope.rs`
+
+### Approach
+
+Build `AuditEnvelopeGuard` as a local struct inside the `audit_envelope` module. The guard owns `Option<GuardInner>` so that `disarm()` swaps the inner to `None` without touching `Drop`. `Drop` checks `take()` — if `Some`, it builds the cancellation `ToolEndInputs` and calls `sender.try_send`.
+
+`run_with_audit_envelope` constructs the guard AFTER `emit_tool_start` returns the `start_seq`. On normal completion (before or after `emit_tool_end`), call `guard.disarm()` so the Drop is a no-op.
+
+One subtlety: `run_with_audit_envelope` currently calls `emit_tool_end` via `.await` — that path may itself be cancelled. The normal-completion code path should therefore be:
+
+1. Construct guard.
+2. Await `body` → `result`.
+3. Construct the `tool_end` inputs on the stack (do NOT call `emit_tool_end` yet).
+4. `guard.disarm()` — we've already committed to emitting a real `tool_end`; the guard's work is done.
+5. Call `emit_tool_end` (await). If cancelled here, the real `tool_end` may be lost — but the cancellation channel will NOT emit (guard already disarmed). That's acceptable: a cancellation during the final audit write leaves a dangling `tool_start`, but the window is now sub-millisecond (a `spawn_blocking` schedule) instead of the full `body` duration.
+
+A more ambitious fix would keep the guard armed past `emit_tool_end` submission, but that risks double-emission if `spawn_blocking` has already sent the normal `tool_end`. Keeping the guard armed only during `body` is the right scope for this PR.
+
+- [ ] **Step 1: Read the current `run_with_audit_envelope`**
+
+Reference: `crates/rimap-server/src/mcp/audit_envelope.rs:24-69`. Note the existing structure:
+
+```rust
+let start_seq = self.emit_tool_start(...).await?;
+let start_time = Instant::now();
+let result = body.await;
+let duration_ms = ...;
+let (status, error_code) = ...;
+self.emit_tool_end(start_seq, tool, audit_account, status, error_code, duration_ms).await;
+match result { ... }
+```
+
+The guard wraps the `body.await` step.
+
+- [ ] **Step 2: Define `AuditEnvelopeGuard`**
+
+Append to `crates/rimap-server/src/mcp/audit_envelope.rs`:
+
+```rust
+use rimap_audit::record::Provenance;
+use rimap_audit::{CancelledToolEndSender, ToolEndInputs};
+
+/// RAII guard that emits a cancellation `tool_end` record if dropped
+/// undisarmed. Used inside `run_with_audit_envelope` to pair every
+/// `tool_start` with a `tool_end`, even when the outer MCP dispatch
+/// future is dropped mid-call (#71, #99).
+struct AuditEnvelopeGuard {
+    inner: Option<GuardInner>,
+}
+
+struct GuardInner {
+    start_seq: rimap_audit::Seq,
+    tool: ToolName,
+    account: Option<String>,
+    start_time: std::time::Instant,
+    sender: CancelledToolEndSender,
+}
+
+impl AuditEnvelopeGuard {
+    fn new(
+        start_seq: rimap_audit::Seq,
+        tool: ToolName,
+        account: Option<String>,
+        start_time: std::time::Instant,
+        sender: CancelledToolEndSender,
+    ) -> Self {
+        Self {
+            inner: Some(GuardInner {
+                start_seq,
+                tool,
+                account,
+                start_time,
+                sender,
+            }),
+        }
+    }
+
+    /// Mark the guard as completed normally. Drop becomes a no-op.
+    fn disarm(&mut self) {
+        self.inner = None;
+    }
+}
+
+impl Drop for AuditEnvelopeGuard {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.take() else {
+            return;
+        };
+        let duration_ms = inner
+            .start_time
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        // `ToolName` is `Copy`; capture it for the warning log before
+        // `try_send` consumes the payload.
+        let tool = inner.tool;
+        let cancellation = ToolEndInputs {
+            start_seq: inner.start_seq,
+            tool,
+            account: inner.account,
+            status: rimap_audit::record::ToolStatus::Cancelled,
+            error_code: Some(rimap_core::ErrorCode::Cancelled),
+            duration_ms,
+            result_summary: rimap_audit::record::ResultSummary::default(),
+            provenance: Provenance {
+                window_seconds: 60,
+                message_ids_recently_read: Vec::new(),
+            },
+        };
+        if let Err(e) = inner.sender.try_send(cancellation) {
+            tracing::warn!(
+                error = %e,
+                tool = tool.as_str(),
+                "cancellation tool_end drop: failed to enqueue (channel full or closed)",
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Wire the guard into `run_with_audit_envelope`**
+
+Update the body of `run_with_audit_envelope` (`crates/rimap-server/src/mcp/audit_envelope.rs:24-69`):
+
+```rust
+    pub(super) async fn run_with_audit_envelope<F>(
+        &self,
+        tool: ToolName,
+        audit_account: Option<String>,
+        posture: PostureContext,
+        args: &serde_json::Map<String, serde_json::Value>,
+        body: F,
+    ) -> Result<CallToolResult, ErrorData>
+    where
+        F: std::future::Future<Output = Result<serde_json::Value, rimap_core::RimapError>>,
+    {
+        let args_value = serde_json::Value::Object(args.clone());
+        let redacted = self.redact_tool_args(tool, &args_value);
+        let hash = hash_arguments(&args_value);
+
+        let start_seq = self
+            .emit_tool_start(tool, audit_account.clone(), posture, redacted, hash)
+            .await?;
+        let start_time = std::time::Instant::now();
+
+        let mut guard = AuditEnvelopeGuard::new(
+            start_seq,
+            tool,
+            audit_account.clone(),
+            start_time,
+            self.cancellation_sender.clone(),
+        );
+
+        let result = body.await;
+
+        // Body completed normally. Disarm the guard before any further await
+        // points so a drop of THIS future between here and emit_tool_end does
+        // not cause double emission.
+        guard.disarm();
+
+        let duration_ms = start_time
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let (status, error_code) = match &result {
+            Ok(_) => (ToolStatus::Ok, None),
+            Err(e) => (ToolStatus::Error, Some(e.code())),
+        };
+        self.emit_tool_end(
+            start_seq,
+            tool,
+            audit_account,
+            status,
+            error_code,
+            duration_ms,
+        )
+        .await;
+
+        match result {
+            Ok(value) => Ok(CallToolResult::structured(value)),
+            Err(e) => Err(crate::mcp::error::to_mcp_error(&e)),
+        }
+    }
+```
+
+Note: this references `self.cancellation_sender` — that field is added in Task 5.
+
+- [ ] **Step 4: Temporarily stub the field access**
+
+Task 4 cannot compile standalone because Task 5 adds the field. Commit Tasks 4 and 5 TOGETHER (see Task 5's commit step). For now, proceed to Task 5 before running any build commands against this task's changes.
+
+- [ ] **Step 5: No separate commit — fold into Task 5's commit**
+
+---
+
+## Task 5: Wire `CancelledToolEndSender` through `ImapMcpServer` and boot
+
+**Issue:** #71, #99 — the end-to-end plumbing.
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/server.rs`
+- Modify: `crates/rimap-server/src/main.rs`
+
+### Approach
+
+`ImapMcpServer` gains `pub(crate) cancellation_sender: CancelledToolEndSender`. `ImapMcpServer::new` takes it as an argument. `main.rs` constructs the `(sender, receiver)` pair at boot, spawns the drainer task with a clone of the `AuditWriter`, keeps the drainer's `JoinHandle` for shutdown, and passes the sender into `ImapMcpServer::new`.
+
+On shutdown after the MCP loop exits, `drop(server)` releases the sender, the drainer's `recv().await` returns `Err`, the drainer task exits. We `await` the drainer handle so the runtime doesn't exit until the drainer finishes.
+
+- [ ] **Step 1: Add the field to `ImapMcpServer`**
+
+In `crates/rimap-server/src/mcp/server.rs`:
+
+```rust
+use rimap_audit::CancelledToolEndSender;
+
+pub struct ImapMcpServer {
+    /// Account registry holding per-account state.
+    #[doc(hidden)]
+    pub registry: AccountRegistry,
+    /// Append-only audit writer.
+    pub(crate) audit: AuditWriter,
+    /// Channel used by `AuditEnvelopeGuard::drop` to emit synthetic
+    /// cancellation `tool_end` records when the MCP dispatch future is
+    /// dropped mid-call (#71, #99).
+    pub(crate) cancellation_sender: CancelledToolEndSender,
+    /// Per-process salt used when applying `Redactor` to tool arguments.
+    pub(crate) redaction_salt: Arc<RedactionSalt>,
+    /// Redaction schemas keyed by tool name.
+    pub(crate) redaction_schemas: Arc<HashMap<ToolName, RedactionSchema>>,
+}
+
+impl ImapMcpServer {
+    #[must_use]
+    pub fn new(
+        registry: AccountRegistry,
+        audit: AuditWriter,
+        cancellation_sender: CancelledToolEndSender,
+    ) -> Self {
+        let schema_map: HashMap<ToolName, RedactionSchema> =
+            schemas().into_iter().map(|s| (s.tool, s)).collect();
+        Self {
+            registry,
+            audit,
+            cancellation_sender,
+            redaction_salt: Arc::new(RedactionSalt::new_random()),
+            redaction_schemas: Arc::new(schema_map),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire boot in `main.rs`**
+
+In `crates/rimap-server/src/main.rs`, update the `rt.block_on` block to construct the channel and drainer:
+
+```rust
+    let mcp_result: anyhow::Result<()> = rt.block_on(async {
+        let registry = build_registry(&multi, &audit, &credentials, &download_dir)
+            .await
+            .context("building account registry")?;
+
+        let (cancellation_tx, cancellation_rx) = rimap_audit::cancellation_channel();
+        let drainer_handle = rimap_audit::spawn_drainer(cancellation_rx, audit.clone());
+
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
+        let transport = rmcp::transport::io::stdio();
+        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+
+        // ImapMcpServer drops here, releasing the cancellation sender. Wait
+        // for the drainer to flush remaining records before the runtime exits.
+        drop(service);
+        if let Err(e) = drainer_handle.await {
+            tracing::error!(error = %e, "cancellation drainer join error");
+        }
+        Ok(())
+    });
+```
+
+The existing `audit_for_shutdown.log_process_end(...)` call further down runs after this block, which is the right order — drainer exits, then `process_end` is written.
+
+- [ ] **Step 3: Run full build — expect PASS**
+
+Run: `cd /home/dave/src/rusty-imap-mcp-audit-cancel && cargo build --workspace`
+Expected: PASS. Task 4's `audit_envelope.rs` reference to `self.cancellation_sender` now resolves.
+
+If the build fails because of other `ImapMcpServer::new` call sites with the old 2-argument signature (tests, maybe), update them to pass a fresh sender (use `rimap_audit::cancellation_channel().0`) or accept `CancelledToolEndSender` via a test helper. Search: `grep -rn "ImapMcpServer::new(" crates/ tests/`.
+
+- [ ] **Step 4: Run tests + clippy**
+
+Run: `cd /home/dave/src/rusty-imap-mcp-audit-cancel && cargo test --workspace && cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS and clean.
+
+- [ ] **Step 5: Commit (Tasks 4 + 5 together)**
+
+```bash
+git add crates/rimap-server/src/mcp/audit_envelope.rs \
+        crates/rimap-server/src/mcp/server.rs \
+        crates/rimap-server/src/main.rs
+# plus any test files updated for the new ImapMcpServer::new signature
+git commit -m "server: guard tool_start with AuditEnvelopeGuard (#71, #99)
+
+run_with_audit_envelope now wraps body.await in a drop-guard. Normal
+completion disarms the guard before emit_tool_end; a dropped future
+synthesizes a tool_end { status: cancelled, error_code:
+ERR_CANCELLED, duration_ms: elapsed } and enqueues it via the
+CancelledToolEndSender channel added in rimap-audit. main.rs spawns
+the drainer task and awaits its JoinHandle on shutdown so queued
+records flush before the runtime exits."
+```
+
+---
+
+## Task 6: Test — drop-induced cancellation emits a paired `tool_end`
+
+**Issue:** #71, #99 — pins the drop-guard behavior.
+
+**Files:**
+- Create: `crates/rimap-server/tests/audit_cancellation.rs`
+
+### Approach
+
+Spawn `run_with_audit_envelope` with a body that is `std::future::pending` (never completes). Drop the outer future. Assert the audit log contains a `tool_end` with `status: "cancelled"` paired to the earlier `tool_start`.
+
+This requires enough of the MCP server to construct `ImapMcpServer`. Look for existing integration-test helpers in `rimap-server/tests/` (probably `e2e.rs` or `dry_run.rs`). Reuse the helpers if possible; otherwise build a minimal fixture.
+
+If `run_with_audit_envelope` is `pub(super)`, the test will need to go through a public tool-dispatch path. Call `call_tool` via `ServerHandler::call_tool` with a mock account. The challenge: the test needs to drop the outer future deterministically, which means wrapping the call in a `tokio::time::timeout` and relying on timeout-drops, or in a pinned future we poll manually.
+
+Simpler pattern:
+
+```rust
+let fut = server.handle_call_tool(...);
+let mut fut = Box::pin(fut);
+// Poll once to get past emit_tool_start.
+let waker = futures::task::noop_waker();
+let mut cx = std::task::Context::from_waker(&waker);
+let _ = fut.as_mut().poll(&mut cx);
+// Now drop the future before body completes.
+drop(fut);
+// Give the drainer task a moment to process.
+tokio::time::sleep(Duration::from_millis(100)).await;
+```
+
+That relies on `handle_call_tool` having an await point inside `emit_tool_start` (it does — `spawn_blocking`). After polling once, the future is suspended awaiting `spawn_blocking`, so `emit_tool_start` will complete on a background thread. Dropping the future here cancels the body future, which triggers `AuditEnvelopeGuard::drop`.
+
+Actually — after poll once, `emit_tool_start` may not have finished yet because `spawn_blocking` is async from the caller's perspective. A more reliable test uses a dispatch body that completes in phases, or uses `tokio::select!` with a cancellation signal. Consider this approach:
+
+```rust
+let start_signal = Arc::new(tokio::sync::Notify::new());
+let start_signal_clone = start_signal.clone();
+
+let inner_fut = server.call_dispatch_with_body(..., async move {
+    start_signal_clone.notify_one();
+    std::future::pending::<Result<_, _>>().await;
+    unreachable!()
+});
+
+let outer = tokio::spawn(inner_fut);
+start_signal.notified().await;  // Body future has started, emit_tool_start is done.
+outer.abort();  // Cancels the outer task → drops the future → fires guard.
+// Await the drainer.
+...
+```
+
+Implementation details depend on what the dispatch path exposes. The implementer should feel free to shape the test mechanism to fit the codebase.
+
+- [ ] **Step 1: Write the integration test scaffolding**
+
+Create `crates/rimap-server/tests/audit_cancellation.rs`:
+
+```rust
+//! Pins the cancellation drop-guard behavior: when an MCP dispatch future is
+//! dropped between emit_tool_start and emit_tool_end, a synthetic tool_end
+//! record with status = "cancelled" is written to the audit log.
+//!
+//! Issue: #71 (server-layer drop-guard), #99 (audit-envelope drop-guard).
+
+// Scaffolding: concrete setup depends on which test helpers already exist
+// in `crates/rimap-server/tests/`. Look for `e2e.rs`, `dry_run.rs`, or a
+// `common.rs` module with reusable fixtures. Reuse what exists; extend only
+// if a new helper is unavoidable.
+
+#[tokio::test]
+async fn dropped_dispatch_future_emits_cancellation_tool_end() {
+    // 1. Build an ImapMcpServer with a temporary audit file.
+    // 2. Construct a dispatch future that is guaranteed to block past
+    //    emit_tool_start but never returns (`std::future::pending`).
+    // 3. Drop the future.
+    // 4. Drop the server to release the cancellation sender; await the drainer.
+    // 5. Parse the audit file; assert the last record has
+    //    status == "cancelled" and error_code == "ERR_CANCELLED".
+    //
+    // Full implementation below — follow existing patterns in e2e.rs for
+    // ImapMcpServer construction.
+
+    todo!("expand using existing rimap-server test helpers");
+}
+```
+
+- [ ] **Step 2: Expand the test with a concrete implementation**
+
+The implementer should:
+
+1. Locate existing test helpers (e.g. `rimap-server/tests/e2e.rs` constructs `ImapMcpServer` — see how it wires the registry and audit writer).
+2. Construct a minimal `ImapMcpServer` with: one account (use `AccountId::default_account()`), a `tempfile::NamedTempFile` for the audit path with `fail_open = false`, the new `cancellation_channel`, and the drainer.
+3. Invoke a dispatch path that goes through `run_with_audit_envelope`. The simplest way is to pick a read-only tool like `list_folders` but with an IMAP connection that never responds. Mock the IMAP connection to block on `std::future::pending`.
+4. Use `tokio::spawn` to run the dispatch, then `handle.abort()` to drop the future.
+5. Drop the server, await the drainer handle, then read the audit file.
+6. Use `rimap-audit::reader` (check `crates/rimap-audit/src/reader/`) to parse records, or just read lines and deserialize as `Payload`.
+7. Assert the last record matches `ToolEnd { status: Cancelled, error_code: Some(ErrorCode::Cancelled), .. }` with `start_seq` matching the earlier `ToolStart.seq`.
+
+Given the complexity of mocking IMAP, an alternative is to test `run_with_audit_envelope` directly by making it `pub(crate)` (or adding a thin `#[cfg(test)]` wrapper) and calling it with a synthetic body future. Adjust visibility only if strictly necessary.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd /home/dave/src/rusty-imap-mcp-audit-cancel && cargo test -p rimap-server --test audit_cancellation`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/audit_cancellation.rs
+# plus any visibility / helper changes needed
+git commit -m "test: pin cancellation tool_end on dropped dispatch future (#71, #99)
+
+Spawns a dispatch with a pending body, drops the outer future after
+emit_tool_start completes, and asserts the audit log contains a
+matching tool_end with status = \"cancelled\" / error_code =
+ERR_CANCELLED. Exercises the AuditEnvelopeGuard → channel → drainer
+→ AuditWriter::log_tool_end path end-to-end."
+```
+
+---
+
+## Task 7: Test — `fail_open = true` propagation on write failure (#72)
+
+**Issue:** #72 — pin the existing `fail_open = true` suppression behavior.
+
+**Files:**
+- Modify: `crates/rimap-audit/src/writer/mod.rs` (add `#[cfg(test)]` failure-injection hook)
+- Create: `crates/rimap-server/tests/audit_fail_open.rs`
+
+### Approach
+
+Add a test-only failure-injection hook on `AuditWriter` that forces the next `write_record_inner` to return `AuditError::Write`. This lets the fail_open path exercise without filesystem tricks (chmod, deleted files) that are platform-sensitive.
+
+- [ ] **Step 1: Add the failure-injection hook**
+
+In `crates/rimap-audit/src/writer/mod.rs`, near the `AuditWriter` definition:
+
+```rust
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct FailureInjection {
+    /// When `true`, the next `write_record_inner` call returns
+    /// `AuditError::Write` without touching the file.
+    fail_next: std::sync::atomic::AtomicBool,
+}
+
+pub struct AuditWriter {
+    // ... existing fields ...
+    #[cfg(test)]
+    failure_injection: Arc<FailureInjection>,
+}
+```
+
+Initialize `failure_injection: Arc::new(FailureInjection::default())` in `AuditWriter::new`.
+
+Add a test-only method:
+
+```rust
+impl AuditWriter {
+    /// Test-only: cause the next `write_record_inner` call to fail.
+    /// Used by #72's test to exercise the `fail_open = true` suppression
+    /// path without filesystem tricks.
+    #[cfg(test)]
+    pub(crate) fn force_next_write_failure(&self) {
+        self.failure_injection
+            .fail_next
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+```
+
+Modify the top of `write_record_inner` (around line 285):
+
+```rust
+fn write_record_inner(&self, record: &crate::record::AuditRecord) -> Result<(), AuditError> {
+    #[cfg(test)]
+    if self
+        .failure_injection
+        .fail_next
+        .swap(false, std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err(AuditError::Write {
+            path: self.path.clone(),
+            source: std::io::Error::other("injected failure (test)"),
+        });
+    }
+
+    // existing body
+    ...
+}
+```
+
+Verify `AuditError::Write`'s structure (check `crates/rimap-audit/src/error.rs` or the module that defines it). Adjust the error construction to match the actual variant.
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `crates/rimap-server/tests/audit_fail_open.rs`:
+
+```rust
+//! Pin the fail_open = true propagation path: when an audit write fails and
+//! the writer was configured with fail_open = true, the tool call succeeds
+//! (no ERR_INTERNAL to the caller) and the writer's suppressed_failures
+//! counter increments.
+//!
+//! Issue: #72.
+
+// Scaffolding. Follow the same pattern as audit_cancellation.rs for server
+// construction, but:
+// 1. Create the AuditWriter with fail_open = true.
+// 2. Call force_next_write_failure() before invoking the dispatch.
+// 3. Run a successful tool call (the body completes normally).
+// 4. Assert the tool result is Ok (not ERR_INTERNAL).
+// 5. Assert `audit.suppressed_failures() == 1`.
+
+#[tokio::test]
+async fn fail_open_suppresses_write_failure_and_increments_counter() {
+    // ... full implementation here ...
+}
+```
+
+The implementer expands this to a concrete test. Visibility: `force_next_write_failure` is `pub(crate)` in `rimap-audit`, so cross-crate tests in `rimap-server/tests/` cannot call it directly. Options:
+
+- (a) Make it `#[cfg(test)] pub` — but `#[cfg(test)]` only applies within the defining crate, not dependent crates. Use `#[cfg(any(test, feature = "test-injection"))]` with a non-default feature, and enable the feature in `rimap-server`'s `[dev-dependencies]` entry for `rimap-audit`.
+- (b) Put the test entirely inside `rimap-audit`'s own `tests/` directory, exercising the writer in isolation without going through `rimap-server`.
+
+Option (a) keeps the test at the integration boundary (where #72 is about end-to-end fail_open behavior). Option (b) is simpler but verifies less.
+
+Recommend (a). In `crates/rimap-audit/Cargo.toml`:
+
+```toml
+[features]
+test-injection = []
+```
+
+Then gate the hook:
+
+```rust
+#[cfg(any(test, feature = "test-injection"))]
+```
+
+And in `crates/rimap-server/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+rimap-audit = { path = "../rimap-audit", features = ["test-injection"] }
+```
+
+- [ ] **Step 3: Run the test — expect PASS**
+
+Run: `cd /home/dave/src/rusty-imap-mcp-audit-cancel && cargo test -p rimap-server --test audit_fail_open`
+Expected: PASS. Tool result is Ok, `suppressed_failures == 1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-audit/src/writer/mod.rs crates/rimap-audit/Cargo.toml \
+        crates/rimap-server/tests/audit_fail_open.rs \
+        crates/rimap-server/Cargo.toml
+git commit -m "test: pin fail_open=true write-failure suppression (#72)
+
+Adds a test-injection hook on AuditWriter (gated by the
+test-injection feature of rimap-audit) that forces the next
+write_record_inner to fail. The new integration test constructs a
+writer with fail_open = true, injects a failure, runs a tool
+dispatch, and asserts that (1) the tool call returns Ok (not
+ERR_INTERNAL) and (2) suppressed_failures increments by 1."
+```
+
+---
+
+## Task 8: Final verification + PR
+
+- [ ] **Step 1: Run the full verification pipeline**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp-audit-cancel
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo deny check advisories bans licenses sources
+typos
+```
+
+All five must pass.
+
+- [ ] **Step 2: Open the PR**
+
+Branch: `feat/audit-cancellation-guard`. Target: `main`. PR body references `Closes #71`, `Closes #72`, `Closes #99`.
+
+- [ ] **Step 3: After merge, update the roadmap spec**
+
+Mark sub-group 3 as closed in `docs/superpowers/specs/2026-04-19-open-issues-roadmap-design.md` (or leave to a roadmap-refresh sweep).


### PR DESCRIPTION
## Summary

Closes roadmap sub-group 3 (`docs/superpowers/specs/2026-04-19-open-issues-roadmap-design.md` §3): three audit-durability issues resolved as one sweep.

- **#71 / #99** — `run_with_audit_envelope` now wraps `body.await` in an `AuditEnvelopeGuard`. Normal completion disarms the guard before `emit_tool_end`. A dropped outer future (client disconnect, runtime shutdown, SIGTERM mid-request) synthesizes a `tool_end { status: \"cancelled\", error_code: \"ERR_CANCELLED\", duration_ms: <elapsed> }` record and enqueues it via a bounded `async_channel::Sender<ToolEndInputs>` in `rimap-audit`. A dedicated drainer task (spawned at boot) consumes the channel and routes each record through the existing `AuditWriter::log_tool_end` path via `spawn_blocking`. `main.rs` awaits the drainer's `JoinHandle` after `service.waiting()` returns so queued records flush before the runtime exits.

- **#72** — `AuditWriter` gained a `#[cfg(any(test, feature = \"test-injection\"))]` hook, `force_next_write_failure()`, that causes the next `write_record_inner` to return `AuditError::Write`. New integration test at `crates/rimap-server/tests/audit_fail_open.rs` constructs a writer with `fail_open = true`, injects a failure, calls `log_tool_start`, and asserts (1) the call returns `Ok` and (2) `suppressed_failures()` returns 1. A symmetric `fail_open = false` test pins the complementary contract.

New public surface in `rimap-audit`: `CancelledToolEndSender`, `CancelledToolEndReceiver`, `cancellation_channel()`, `spawn_drainer()`. New variants: `rimap_core::ErrorCode::Cancelled` (→ `\"ERR_CANCELLED\"`), `rimap_audit::record::ToolStatus::Cancelled` (→ `\"cancelled\"`).

Seven focused commits, TDD-shaped, each verified against the plan in `docs/superpowers/plans/2026-04-19-audit-cancellation.md`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all suites pass; new tests: 2 in `cancellation::tests`, 2 in `audit_envelope::tests`, 2 in `audit_fail_open.rs`
- [x] `cargo deny check` — clean
- [x] `typos` — no findings
- [ ] Manual sanity: SIGTERM the server mid-request — audit log contains `tool_start` paired with `tool_end { status: \"cancelled\" }`
- [ ] Manual sanity: normal tool call does NOT produce a cancellation record (guard disarms correctly)

Closes #71
Closes #72
Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)