### PR TITLE
refactor: parse config TOML once instead of twice (#74)

### DIFF
--- a/crates/rimap-config/src/loader.rs
+++ b/crates/rimap-config/src/loader.rs
@@ -72,33 +72,35 @@ pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigErro
         source,
     })?;
 
-    // Parse once into `toml::Table` to classify the format. A TOML document
-    // is always a table at the top level, so `toml::from_str::<Table>` will
-    // succeed for any syntactically valid TOML. Format-specific deserialization
-    // is a second pass below — still cheaper and more correct than a
-    // substring match over the raw text.
-    let table: toml::Table = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+    // Parse once. The top level of any syntactically valid TOML document is
+    // a table, so deserialization into `toml::Value` gives us a structured
+    // view for format classification. Format-specific deserialization
+    // reuses the parsed value instead of re-parsing the raw string.
+    let value: toml::Value = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source,
     })?;
 
-    let has_accounts = table.get("accounts").and_then(|v| v.as_array()).is_some();
-    let has_flat_imap = table.contains_key("imap");
+    let (has_accounts, has_flat_imap) = match &value {
+        toml::Value::Table(t) => (
+            t.get("accounts").and_then(toml::Value::as_array).is_some(),
+            t.contains_key("imap"),
+        ),
+        _ => (false, false),
+    };
 
     if has_accounts && has_flat_imap {
         return Err(ConfigError::MixedConfigFormat);
     }
 
     if has_accounts {
-        let config = toml::from_str::<MultiAccountConfig>(&contents).map_err(|source| {
-            ConfigError::Parse {
-                path: path.to_path_buf(),
-                source,
-            }
+        let config: MultiAccountConfig = value.try_into().map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
         })?;
         validate_multi(config)
     } else {
-        let config = toml::from_str::<Config>(&contents).map_err(|source| ConfigError::Parse {
+        let config: Config = value.try_into().map_err(|source| ConfigError::Parse {
             path: path.to_path_buf(),
             source,
         })?;


### PR DESCRIPTION
## Summary

Closes roadmap sub-group 6 (`docs/superpowers/specs/2026-04-19-open-issues-roadmap-design.md` §3): the standalone single-file refactor of `load_and_validate` in `crates/rimap-config/src/loader.rs`.

**Before:** parsed `contents` twice — once as `toml::Table` for format classification (`[imap]` vs `[[accounts]]` vs both), then again via `toml::from_str::<MultiAccountConfig>` or `toml::from_str::<Config>` for typed deserialization.

**After:** parses once into `toml::Value`, pattern-matches the top-level table for format classification, and reuses the same `Value` via `value.try_into()` for the typed deserialization step.

Preserves:
- `ConfigError::Parse` shape (same path + `toml::de::Error` source on both parse failures)
- `ConfigError::MixedConfigFormat` when both `[imap]` and `[[accounts]]` are present
- All three existing format-detection tests (`load_and_validate_legacy_format`, `load_and_validate_multi_format`, `load_and_validate_mixed_format_rejected`)
- `load_from_path` (a separate public function that the CLI's `dry-run` path still calls) is unchanged

One file, 16 insertions / 14 deletions. No API surface change.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all suites pass (93 passing in `rimap-config` alone, including the 10 `loader::tests`)
- [x] `cargo deny check` — clean
- [x] `typos` — no findings

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)