### PR TITLE
feat: UIDVALIDITY correctness — Option<u32>, MOVE guard, response echo, input check

### DIFF
--- a/crates/rimap-core/src/error.rs
+++ b/crates/rimap-core/src/error.rs
@@ -52,6 +52,10 @@ pub enum ErrorCode {
     /// shutdown). Emitted in `tool_end` records synthesized by the cancellation
     /// drop-guard (#99).
     Cancelled,
+    /// UIDVALIDITY observed by the server differs from the value the caller
+    /// expected (recorded at its prior SELECT). The target UID may now refer
+    /// to a different message than the caller intended.
+    UidValidityChanged,
 }
 
 impl ErrorCode {
@@ -78,6 +82,7 @@ impl ErrorCode {
             Self::NoAccount => "ERR_NO_ACCOUNT",
             Self::UnknownAccount => "ERR_UNKNOWN_ACCOUNT",
             Self::Cancelled => "ERR_CANCELLED",
+            Self::UidValidityChanged => "ERR_UID_VALIDITY_CHANGED",
         }
     }
 }
@@ -117,6 +122,7 @@ impl FromStr for ErrorCode {
             "ERR_NO_ACCOUNT" => Ok(Self::NoAccount),
             "ERR_UNKNOWN_ACCOUNT" => Ok(Self::UnknownAccount),
             "ERR_CANCELLED" => Ok(Self::Cancelled),
+            "ERR_UID_VALIDITY_CHANGED" => Ok(Self::UidValidityChanged),
             other => Err(ParseErrorCodeError(other.to_string())),
         }
     }
@@ -268,6 +274,7 @@ mod tests {
             (ErrorCode::NoAccount, "ERR_NO_ACCOUNT"),
             (ErrorCode::UnknownAccount, "ERR_UNKNOWN_ACCOUNT"),
             (ErrorCode::Cancelled, "ERR_CANCELLED"),
+            (ErrorCode::UidValidityChanged, "ERR_UID_VALIDITY_CHANGED"),
         ];
         for (code, expected) in cases {
             assert_eq!(code.as_str(), expected);
@@ -280,6 +287,16 @@ mod tests {
         assert_eq!(ErrorCode::Cancelled.as_str(), "ERR_CANCELLED");
         let parsed = "ERR_CANCELLED".parse::<ErrorCode>();
         assert_eq!(parsed, Ok(ErrorCode::Cancelled));
+    }
+
+    #[test]
+    fn uid_validity_changed_round_trips() {
+        assert_eq!(
+            ErrorCode::UidValidityChanged.as_str(),
+            "ERR_UID_VALIDITY_CHANGED"
+        );
+        let parsed = "ERR_UID_VALIDITY_CHANGED".parse::<ErrorCode>();
+        assert_eq!(parsed, Ok(ErrorCode::UidValidityChanged));
     }
 
     #[test]

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -692,6 +692,7 @@ impl Connection {
                 | ImapError::Protocol(_)
                 | ImapError::InvalidInput { .. }
                 | ImapError::BatchTooLarge { .. }
+                | ImapError::UidValidityChanged { .. }
                 | ImapError::Audit { .. },
             )
             | Ok(_) => false,

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -627,7 +627,7 @@ impl Connection {
         folder: &str,
         uids: &[crate::types::Uid],
         spec: crate::types::FetchSpec,
-    ) -> Result<Vec<crate::types::FetchedMessage>, ImapError> {
+    ) -> Result<(Vec<crate::types::FetchedMessage>, Option<u32>), ImapError> {
         self.with_session("fetch", async |session| {
             crate::ops::fetch::fetch(session, folder, uids, spec).await
         })
@@ -716,10 +716,12 @@ impl Connection {
         uids: &[crate::types::Uid],
         flags: &[crate::types::Flag],
         action: crate::types::FlagAction,
-    ) -> Result<Vec<crate::types::Uid>, ImapError> {
+    ) -> Result<(Vec<crate::types::Uid>, Option<u32>), ImapError> {
         self.with_session("store", async |session| {
-            crate::ops::folders::select(session, folder, false).await?;
-            crate::ops::store::store(session, uids, flags, action).await
+            let selected = crate::ops::folders::select(session, folder, false).await?;
+            let uid_validity = selected.uid_validity;
+            let updated = crate::ops::store::store(session, uids, flags, action).await?;
+            Ok((updated, uid_validity))
         })
         .await
     }

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -619,7 +619,13 @@ impl Connection {
     /// `FETCH` for the given UIDs with the requested items. Does NOT include
     /// `BODY[]` — see `fetch_body` (Task 13) for full message retrieval.
     ///
+    /// If `expected_uidvalidity` is `Some(v)`, the value is compared against
+    /// the UIDVALIDITY returned by the internal EXAMINE (read-only SELECT). A
+    /// mismatch returns `ImapError::UidValidityChanged` before the FETCH is
+    /// sent. Pass `None` to skip the guard.
+    ///
     /// # Errors
+    /// Returns `ImapError::UidValidityChanged` on a UIDVALIDITY mismatch.
     /// Propagates timeout, connection-lost, or protocol errors from the
     /// underlying `ops::fetch::fetch` call.
     pub async fn fetch(
@@ -627,9 +633,10 @@ impl Connection {
         folder: &str,
         uids: &[crate::types::Uid],
         spec: crate::types::FetchSpec,
+        expected_uidvalidity: Option<u32>,
     ) -> Result<(Vec<crate::types::FetchedMessage>, Option<u32>), ImapError> {
         self.with_session("fetch", async |session| {
-            crate::ops::fetch::fetch(session, folder, uids, spec).await
+            crate::ops::fetch::fetch(session, folder, uids, spec, expected_uidvalidity).await
         })
         .await
     }
@@ -707,8 +714,14 @@ impl Connection {
     ///
     /// Batch limit: 100 UIDs. Returns the UIDs the server confirmed.
     ///
+    /// If `expected_uidvalidity` is `Some(v)`, the value is compared against
+    /// the UIDVALIDITY returned by the internal SELECT. A mismatch returns
+    /// `ImapError::UidValidityChanged` before the STORE is sent. Pass `None`
+    /// to skip the guard.
+    ///
     /// # Errors
     /// Returns `ImapError::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Returns `ImapError::UidValidityChanged` on a UIDVALIDITY mismatch.
     /// Propagates timeout, connection-lost, or protocol errors.
     pub async fn store_flags(
         &self,
@@ -716,10 +729,12 @@ impl Connection {
         uids: &[crate::types::Uid],
         flags: &[crate::types::Flag],
         action: crate::types::FlagAction,
+        expected_uidvalidity: Option<u32>,
     ) -> Result<(Vec<crate::types::Uid>, Option<u32>), ImapError> {
         self.with_session("store", async |session| {
             let selected = crate::ops::folders::select(session, folder, false).await?;
             let uid_validity = selected.uid_validity;
+            crate::ops::fetch::check_uidvalidity(folder, expected_uidvalidity, uid_validity)?;
             let updated = crate::ops::store::store(session, uids, flags, action).await?;
             Ok((updated, uid_validity))
         })

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -731,16 +731,24 @@ impl Connection {
     /// The fallback is not atomic — callers should inspect
     /// `MoveOutcome::used_fallback` and surface a warning.
     ///
+    /// If `expected_source_uidvalidity` is `Some(v)`, a STATUS probe is
+    /// issued against `source_folder` before the move. A mismatch
+    /// returns `ImapError::UidValidityChanged`. Pass `None` to skip the
+    /// guard (Task 4 will thread the observed value from SELECT through
+    /// tool input).
+    ///
     /// Batch limit: 100 UIDs.
     ///
     /// # Errors
     /// Returns `ImapError::BatchTooLarge` if more than 100 UIDs are passed.
+    /// Returns `ImapError::UidValidityChanged` on a UIDVALIDITY mismatch.
     /// Propagates timeout, connection-lost, or protocol errors.
     pub async fn move_messages(
         &self,
         source_folder: &str,
         dest_folder: &str,
         uids: &[crate::types::Uid],
+        expected_source_uidvalidity: Option<u32>,
     ) -> Result<crate::ops::move_message::MoveOutcome, ImapError> {
         let has_move = self.has_move_capability();
         let has_uidplus = self.has_uidplus_capability();
@@ -748,8 +756,10 @@ impl Connection {
             crate::ops::folders::select(session, source_folder, false).await?;
             crate::ops::move_message::move_messages(
                 session,
+                source_folder,
                 dest_folder,
                 uids,
+                expected_source_uidvalidity,
                 has_move,
                 has_uidplus,
             )

--- a/crates/rimap-imap/src/error.rs
+++ b/crates/rimap-imap/src/error.rs
@@ -63,6 +63,18 @@ pub enum ImapError {
         /// Maximum UIDs allowed per command.
         limit: usize,
     },
+    /// UIDVALIDITY observed by the server differs from the value the
+    /// caller expected (recorded at its prior SELECT). The target UID may
+    /// now refer to a different message than the caller intended.
+    #[error("UIDVALIDITY changed for `{folder}`: expected {expected}, server reports {actual}")]
+    UidValidityChanged {
+        /// The folder that was selected.
+        folder: String,
+        /// The UIDVALIDITY value the caller expected.
+        expected: u32,
+        /// The UIDVALIDITY value the server reported.
+        actual: u32,
+    },
     /// Audit-subsystem failure during a tool call. The IMAP transport may
     /// be healthy; this variant exists so audit-write failures stay
     /// distinguishable from network failures in metrics and observability.
@@ -125,6 +137,7 @@ impl ImapError {
             Self::SizeLimit { .. } => ErrorCode::AttachmentTooLarge,
             Self::Protocol(_) => ErrorCode::ImapProtocol,
             Self::InvalidInput { .. } | Self::BatchTooLarge { .. } => ErrorCode::InvalidInput,
+            Self::UidValidityChanged { .. } => ErrorCode::UidValidityChanged,
             Self::Audit { .. } => ErrorCode::Internal,
         }
     }
@@ -139,5 +152,23 @@ impl From<ImapError> for RimapError {
             message,
             source: Some(Box::new(err)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ImapError;
+
+    #[test]
+    fn uid_validity_changed_display_includes_numbers_and_folder() {
+        let err = ImapError::UidValidityChanged {
+            folder: "INBOX".to_string(),
+            expected: 100,
+            actual: 101,
+        };
+        let display = format!("{err}");
+        assert!(display.contains("INBOX"));
+        assert!(display.contains("100"));
+        assert!(display.contains("101"));
     }
 }

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -75,14 +75,12 @@ pub(crate) async fn fetch(
     folder: &str,
     uids: &[Uid],
     spec: FetchSpec,
-) -> Result<Vec<FetchedMessage>, ImapError> {
-    session
-        .examine(folder)
-        .await
-        .map_err(super::folders::map_err)?;
+) -> Result<(Vec<FetchedMessage>, Option<u32>), ImapError> {
+    let selected = super::folders::select(session, folder, true).await?;
+    let uid_validity = selected.uid_validity;
 
     if uids.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), uid_validity));
     }
     // Compress to IMAP sequence-set range syntax to stay under Dovecot's
     // ~8KB command-line cap. Plain comma-joined lists exceed the cap
@@ -130,7 +128,7 @@ pub(crate) async fn fetch(
             size,
         });
     }
-    Ok(out)
+    Ok((out, uid_validity))
 }
 
 /// Fetch the full `BODY[]` of a single UID. Aborts with `ImapError::SizeLimit`

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -70,14 +70,50 @@ fn emit_run(out: &mut String, start: u32, end: u32) {
     }
 }
 
+/// Verify an optional UIDVALIDITY expectation against the server-observed value.
+///
+/// Returns `Err(ImapError::UidValidityChanged)` when `expected` is `Some(v)` and
+/// `observed` is `Some(actual)` with `actual != v`. When `observed` is `None`, the
+/// server omitted the value: a warning is emitted and the guard is skipped. When
+/// `expected` is `None`, the call is a no-op.
+pub(crate) fn check_uidvalidity(
+    folder: &str,
+    expected: Option<u32>,
+    observed: Option<u32>,
+) -> Result<(), ImapError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    match observed {
+        Some(actual) if actual != expected => Err(ImapError::UidValidityChanged {
+            folder: folder.to_owned(),
+            expected,
+            actual,
+        }),
+        None => {
+            tracing::warn!(
+                folder = %folder,
+                expected,
+                "expected_uidvalidity set but server omitted UIDVALIDITY; \
+                 proceeding without guard",
+            );
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 pub(crate) async fn fetch(
     session: &mut ImapSession,
     folder: &str,
     uids: &[Uid],
     spec: FetchSpec,
+    expected_uidvalidity: Option<u32>,
 ) -> Result<(Vec<FetchedMessage>, Option<u32>), ImapError> {
     let selected = super::folders::select(session, folder, true).await?;
     let uid_validity = selected.uid_validity;
+
+    check_uidvalidity(folder, expected_uidvalidity, uid_validity)?;
 
     if uids.is_empty() {
         return Ok((Vec::new(), uid_validity));
@@ -407,8 +443,8 @@ fn convert_flag(f: &async_imap::types::Flag<'_>) -> crate::types::Flag {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_BODYSTRUCTURE_DEPTH, compress_uid_set, convert_bs_inner, preflight_size_check,
-        project_size,
+        MAX_BODYSTRUCTURE_DEPTH, check_uidvalidity, compress_uid_set, convert_bs_inner,
+        preflight_size_check, project_size,
     };
     use crate::error::ImapError;
     use async_imap::imap_proto::{
@@ -731,6 +767,46 @@ mod tests {
     #[expect(clippy::unwrap_used, reason = "test")]
     fn preflight_size_check_passes_when_server_omits_size() {
         preflight_size_check(None, 5_000_000).unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "tests")]
+    fn check_uidvalidity_none_expected_is_noop() {
+        // No expected → no error, regardless of observed value.
+        check_uidvalidity("INBOX", None, Some(100)).unwrap();
+        check_uidvalidity("INBOX", None, None).unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "tests")]
+    fn check_uidvalidity_match_proceeds() {
+        check_uidvalidity("INBOX", Some(42), Some(42)).unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "tests")]
+    #[expect(clippy::panic, reason = "tests")]
+    fn check_uidvalidity_mismatch_returns_error() {
+        let err = check_uidvalidity("INBOX", Some(42), Some(100)).unwrap_err();
+        match err {
+            ImapError::UidValidityChanged {
+                folder,
+                expected,
+                actual,
+            } => {
+                assert_eq!(folder, "INBOX");
+                assert_eq!(expected, 42);
+                assert_eq!(actual, 100);
+            }
+            other => panic!("expected UidValidityChanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "tests")]
+    fn check_uidvalidity_server_omitted_is_not_error() {
+        // Server omitted UIDVALIDITY (None) → warn and proceed, no error.
+        check_uidvalidity("INBOX", Some(42), None).unwrap();
     }
 
     // NOTE: The round-trip parser in this proptest is a SIMPLIFIED model.

--- a/crates/rimap-imap/src/ops/folders.rs
+++ b/crates/rimap-imap/src/ops/folders.rs
@@ -151,7 +151,7 @@ pub(crate) async fn select(
         name: folder.to_string(),
         exists: mailbox.exists,
         recent: mailbox.recent,
-        uid_validity: mailbox.uid_validity.unwrap_or(0),
+        uid_validity: mailbox.uid_validity,
         uid_next: mailbox.uid_next,
         read_only,
     })

--- a/crates/rimap-imap/src/ops/move_message.rs
+++ b/crates/rimap-imap/src/ops/move_message.rs
@@ -22,6 +22,13 @@ pub struct MoveOutcome {
     /// instead of the atomic UID MOVE command. Callers should surface a
     /// security warning when this is `true`.
     pub used_fallback: bool,
+    /// Source-folder UIDVALIDITY observed at the guard STATUS probe, or
+    /// `None` if no guard was requested or the server omitted it.
+    pub source_uid_validity: Option<u32>,
+    /// Destination-folder UIDVALIDITY observed after the COPY fallback
+    /// succeeds, or `None` (either not the fallback path, or the server
+    /// omitted UIDVALIDITY from the STATUS response).
+    pub destination_uid_validity: Option<u32>,
 }
 
 /// Move `uids` from the currently selected folder to `dest_folder`.
@@ -33,14 +40,22 @@ pub struct MoveOutcome {
 /// When `has_move` is `false` the COPY+DELETE fallback is used
 /// immediately without attempting UID MOVE.
 ///
+/// If `expected_source_uidvalidity` is `Some(v)`, a STATUS probe is
+/// issued against `src_folder` before the move. A mismatch returns
+/// `ImapError::UidValidityChanged`; if the server omits UIDVALIDITY
+/// from the STATUS response the guard is skipped with a warning.
+///
 /// # Errors
 ///
 /// Returns `ImapError::BatchTooLarge` if `uids.len() > MAX_BATCH`.
+/// Returns `ImapError::UidValidityChanged` on a UIDVALIDITY mismatch.
 /// Propagates connection-lost or protocol errors from async-imap.
 pub(crate) async fn move_messages(
     session: &mut ImapSession,
+    src_folder: &str,
     dest_folder: &str,
     uids: &[Uid],
+    expected_source_uidvalidity: Option<u32>,
     has_move: bool,
     has_uidplus: bool,
 ) -> Result<MoveOutcome, ImapError> {
@@ -55,14 +70,51 @@ pub(crate) async fn move_messages(
         return Ok(MoveOutcome {
             results: Vec::new(),
             used_fallback: false,
+            source_uid_validity: None,
+            destination_uid_validity: None,
         });
     }
 
+    // UIDVALIDITY guard: STATUS does not require SELECT and does not
+    // perturb the session's currently selected mailbox.
+    let source_uid_validity = if let Some(expected) = expected_source_uidvalidity {
+        let items = crate::types::StatusItems {
+            messages: false,
+            recent: false,
+            uid_next: false,
+            uid_validity: true,
+            unseen: false,
+        };
+        let status = crate::ops::folders::status(session, src_folder, items).await?;
+        match status.uid_validity {
+            Some(actual) if actual != expected => {
+                return Err(ImapError::UidValidityChanged {
+                    folder: src_folder.to_string(),
+                    expected,
+                    actual,
+                });
+            }
+            Some(actual) => Some(actual),
+            None => {
+                tracing::warn!(
+                    folder = %src_folder,
+                    "STATUS omitted UIDVALIDITY; skipping UIDVALIDITY guard",
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     if !has_move {
-        let results = copy_delete_fallback(session, dest_folder, uids, has_uidplus).await?;
+        let (results, destination_uid_validity) =
+            copy_delete_fallback(session, dest_folder, uids, has_uidplus).await?;
         return Ok(MoveOutcome {
             results,
             used_fallback: true,
+            source_uid_validity,
+            destination_uid_validity,
         });
     }
 
@@ -73,6 +125,8 @@ pub(crate) async fn move_messages(
         Ok(()) => Ok(MoveOutcome {
             results: build_results(uids),
             used_fallback: false,
+            source_uid_validity,
+            destination_uid_validity: None,
         }),
         Err(e) => Err(super::folders::map_err(e)),
     }
@@ -84,12 +138,15 @@ pub(crate) async fn move_messages(
 /// the flagged UIDs. Otherwise plain EXPUNGE removes all `\Deleted` messages,
 /// which is a known data-loss risk for concurrent operations.
 /// Servers that support MOVE never reach this path.
+///
+/// Returns `(results, destination_uid_validity)`. The destination UIDVALIDITY
+/// is probed via STATUS after the COPY succeeds so the caller can surface it.
 async fn copy_delete_fallback(
     session: &mut ImapSession,
     dest_folder: &str,
     uids: &[Uid],
     has_uidplus: bool,
-) -> Result<Vec<MoveResult>, ImapError> {
+) -> Result<(Vec<MoveResult>, Option<u32>), ImapError> {
     crate::ops::folders::validate_server_folder_name(dest_folder)?;
     let uid_set = store::uid_set_string(uids);
 
@@ -99,10 +156,26 @@ async fn copy_delete_fallback(
         .await
         .map_err(super::folders::map_err)?;
 
-    // Step 2: STORE +FLAGS \Deleted on the originals.
+    // Step 2: Probe the destination UIDVALIDITY so the caller can echo it.
+    // STATUS does not change the selected mailbox.
+    let dest_status = crate::ops::folders::status(
+        session,
+        dest_folder,
+        crate::types::StatusItems {
+            messages: false,
+            recent: false,
+            uid_next: false,
+            uid_validity: true,
+            unseen: false,
+        },
+    )
+    .await?;
+    let destination_uid_validity = dest_status.uid_validity;
+
+    // Step 3: STORE +FLAGS \Deleted on the originals.
     store::store(session, uids, &[Flag::Deleted], FlagAction::Add).await?;
 
-    // Step 3: Remove the flagged messages from the source folder.
+    // Step 4: Remove the flagged messages from the source folder.
     if has_uidplus {
         // UID EXPUNGE (RFC 4315): only expunge the UIDs we flagged.
         let stream = session
@@ -124,17 +197,19 @@ async fn copy_delete_fallback(
         }
     }
 
-    Ok(build_results(uids))
+    Ok((build_results(uids), destination_uid_validity))
 }
 
 /// Build `MoveResult` entries with `new_uid: None` (async-imap does
-/// not expose UIDPLUS data).
+/// not expose UIDPLUS data). `used_fallback_reason` is always set
+/// because `new_uid` is always `None` in this version of the library.
 fn build_results(uids: &[Uid]) -> Vec<MoveResult> {
     let mut results = Vec::with_capacity(uids.len());
     for &uid in uids {
         results.push(MoveResult {
             old_uid: uid,
             new_uid: None,
+            used_fallback_reason: Some("async_imap_copyuid_unavailable".to_string()),
         });
     }
     results
@@ -160,12 +235,17 @@ mod tests {
         // so every entry records the old UID and a None for new_uid.
         // Documenting this at the unit layer prevents a future COPYUID
         // refactor from breaking the client contract silently.
+        // used_fallback_reason is always set while new_uid is always None.
         let uids = [uid(7), uid(3), uid(11)];
         let results = build_results(&uids);
         assert_eq!(results.len(), 3);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.old_uid, uids[i]);
             assert!(r.new_uid.is_none());
+            assert_eq!(
+                r.used_fallback_reason.as_deref(),
+                Some("async_imap_copyuid_unavailable"),
+            );
         }
     }
 

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -174,6 +174,14 @@ pub struct MoveResult {
     /// UID in the destination folder (after the move). `None` if the
     /// server does not report it (no UIDPLUS, or COPY+DELETE fallback).
     pub new_uid: Option<Uid>,
+    /// Why `new_uid` is `None`, if applicable.
+    ///
+    /// Currently always `Some("async_imap_copyuid_unavailable")` when
+    /// `new_uid` is `None` — async-imap 0.11.2 does not expose
+    /// `ResponseCode::CopyUid`, so the UIDPLUS COPYUID response code is
+    /// never captured. A follow-up issue (#96) tracks wiring COPYUID
+    /// capture once upstream exposes it.
+    pub used_fallback_reason: Option<String>,
 }
 
 /// Result of appending a message to a mailbox.

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -128,8 +128,9 @@ pub struct SelectedFolder {
     pub exists: u32,
     /// `RECENT` count.
     pub recent: u32,
-    /// `UIDVALIDITY`.
-    pub uid_validity: u32,
+    /// `UIDVALIDITY`, or `None` if the server did not include it in the
+    /// `SELECT`/`EXAMINE` response (non-conformant but observed in the wild).
+    pub uid_validity: Option<u32>,
     /// `UIDNEXT`.
     pub uid_next: Option<u32>,
     /// `READ-ONLY` if `EXAMINE`, otherwise `READ-WRITE`.

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -229,7 +229,11 @@ async fn case_08_fetch_envelope_and_bodystructure() {
         flags: false,
         size: false,
     };
-    let (msgs, _) = h.connection.fetch("INBOX", &uids, spec).await.unwrap();
+    let (msgs, _) = h
+        .connection
+        .fetch("INBOX", &uids, spec, None)
+        .await
+        .unwrap();
     assert_eq!(msgs.len(), uids.len());
     let envelope = msgs[0].envelope.as_ref().expect("envelope");
     let subject = envelope.subject_raw.as_ref().expect("subject_raw");
@@ -361,6 +365,7 @@ async fn case_12_store_add_seen_flag() {
             &[uid],
             &[rimap_imap::types::Flag::Seen],
             rimap_imap::types::FlagAction::Add,
+            None,
         )
         .await
         .unwrap();
@@ -376,6 +381,7 @@ async fn case_12_store_add_seen_flag() {
                 flags: true,
                 ..Default::default()
             },
+            None,
         )
         .await
         .unwrap();
@@ -416,6 +422,7 @@ async fn case_13_store_remove_seen_flag() {
             &[uid],
             &[rimap_imap::types::Flag::Seen],
             rimap_imap::types::FlagAction::Remove,
+            None,
         )
         .await
         .unwrap();
@@ -431,6 +438,7 @@ async fn case_13_store_remove_seen_flag() {
                 flags: true,
                 ..Default::default()
             },
+            None,
         )
         .await
         .unwrap();
@@ -455,6 +463,7 @@ async fn case_14_store_batch_too_large() {
             &uids,
             &[rimap_imap::types::Flag::Seen],
             rimap_imap::types::FlagAction::Add,
+            None,
         )
         .await;
 
@@ -511,6 +520,7 @@ async fn case_15_append_message_to_inbox() {
                 flags: true,
                 ..Default::default()
             },
+            None,
         )
         .await
         .unwrap();
@@ -671,6 +681,7 @@ async fn case_18_expunge() {
             &[uid],
             &[rimap_imap::types::Flag::Deleted],
             rimap_imap::types::FlagAction::Add,
+            None,
         )
         .await
         .unwrap();

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -229,7 +229,7 @@ async fn case_08_fetch_envelope_and_bodystructure() {
         flags: false,
         size: false,
     };
-    let msgs = h.connection.fetch("INBOX", &uids, spec).await.unwrap();
+    let (msgs, _) = h.connection.fetch("INBOX", &uids, spec).await.unwrap();
     assert_eq!(msgs.len(), uids.len());
     let envelope = msgs[0].envelope.as_ref().expect("envelope");
     let subject = envelope.subject_raw.as_ref().expect("subject_raw");
@@ -354,7 +354,7 @@ async fn case_12_store_add_seen_flag() {
     let uid = uids[0];
 
     // Add \Seen flag.
-    let updated = h
+    let (updated, _) = h
         .connection
         .store_flags(
             "INBOX",
@@ -367,7 +367,7 @@ async fn case_12_store_add_seen_flag() {
     assert!(updated.contains(&uid));
 
     // Verify the flag is set.
-    let fetched = h
+    let (fetched, _) = h
         .connection
         .fetch(
             "INBOX",
@@ -409,7 +409,7 @@ async fn case_13_store_remove_seen_flag() {
     let uid = uids[0];
 
     // Remove \Seen flag.
-    let updated = h
+    let (updated, _) = h
         .connection
         .store_flags(
             "INBOX",
@@ -422,7 +422,7 @@ async fn case_13_store_remove_seen_flag() {
     assert!(updated.contains(&uid));
 
     // Verify the flag is removed.
-    let fetched = h
+    let (fetched, _) = h
         .connection
         .fetch(
             "INBOX",
@@ -502,7 +502,7 @@ async fn case_15_append_message_to_inbox() {
     assert!(!uids.is_empty(), "appended message not found");
 
     // Verify it has the \Draft flag.
-    let fetched = h
+    let (fetched, _) = h
         .connection
         .fetch(
             "INBOX",

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -546,7 +546,7 @@ async fn case_16_move_message_between_folders() {
     // Move to Archive (seeded in Dovecot entrypoint.sh).
     let outcome = h
         .connection
-        .move_messages("INBOX", "Archive", &[uid])
+        .move_messages("INBOX", "Archive", &[uid], None)
         .await
         .unwrap();
     assert_eq!(outcome.results.len(), 1);

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -115,6 +115,6 @@ async fn proton_bridge_connect_and_fetch_one_envelope() {
         flags: true,
         size: true,
     };
-    let (msgs, _) = conn.fetch("INBOX", &uids[..1], spec).await.unwrap();
+    let (msgs, _) = conn.fetch("INBOX", &uids[..1], spec, None).await.unwrap();
     assert_eq!(msgs.len(), 1);
 }

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -115,6 +115,6 @@ async fn proton_bridge_connect_and_fetch_one_envelope() {
         flags: true,
         size: true,
     };
-    let msgs = conn.fetch("INBOX", &uids[..1], spec).await.unwrap();
+    let (msgs, _) = conn.fetch("INBOX", &uids[..1], spec).await.unwrap();
     assert_eq!(msgs.len(), 1);
 }

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -67,7 +67,8 @@ pub(super) fn rimap_error_to_breaker_reason(
         | ErrorCode::Internal
         | ErrorCode::NoAccount
         | ErrorCode::UnknownAccount
-        | ErrorCode::Cancelled => None,
+        | ErrorCode::Cancelled
+        | ErrorCode::UidValidityChanged => None,
     }
 }
 

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -31,9 +31,10 @@ pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
 pub fn to_mcp_error(err: &RimapError) -> ErrorData {
     let message = err.to_string();
     match err.code() {
-        ErrorCode::InvalidInput | ErrorCode::NoAccount | ErrorCode::UnknownAccount => {
-            ErrorData::invalid_params(message, None)
-        }
+        ErrorCode::InvalidInput
+        | ErrorCode::NoAccount
+        | ErrorCode::UnknownAccount
+        | ErrorCode::UidValidityChanged => ErrorData::invalid_params(message, None),
 
         ErrorCode::NotFound => ErrorData::new(McpCode::RESOURCE_NOT_FOUND, message, None),
         ErrorCode::PostureDenied => ErrorData::new(POSTURE_DENIED, message, None),

--- a/crates/rimap-server/src/tools/mailbox/flags.rs
+++ b/crates/rimap-server/src/tools/mailbox/flags.rs
@@ -36,6 +36,11 @@ pub struct FlagInput {
     /// UID target: `{"uid": N}` or `{"uids": [...]}`.
     #[serde(flatten)]
     pub target: UidSelector,
+    /// When set, the handler verifies the folder's UIDVALIDITY matches this
+    /// value before applying flags. A mismatch returns
+    /// `ERR_UID_VALIDITY_CHANGED`. Omit to skip the guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_uidvalidity: Option<u32>,
 }
 
 /// Trusted metadata for a flag mutation response.
@@ -121,7 +126,13 @@ async fn handle_flag_op(
         .collect();
     let (updated, uid_validity) = account
         .imap
-        .store_flags(&input.folder, &uids, flags, action)
+        .store_flags(
+            &input.folder,
+            &uids,
+            flags,
+            action,
+            input.expected_uidvalidity,
+        )
         .await?;
 
     let updated_ids: Vec<u32> = updated.iter().map(|u| u.get()).collect();
@@ -214,5 +225,19 @@ mod tests {
             err.to_string().contains("nonzero") || err.to_string().contains("non-zero"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn flag_input_parses_expected_uidvalidity_when_present() {
+        let input: FlagInput =
+            serde_json::from_str(r#"{"folder": "INBOX", "uid": 1, "expected_uidvalidity": 42}"#)
+                .unwrap();
+        assert_eq!(input.expected_uidvalidity, Some(42));
+    }
+
+    #[test]
+    fn flag_input_defaults_expected_uidvalidity_to_none() {
+        let input: FlagInput = serde_json::from_str(r#"{"folder": "INBOX", "uid": 1}"#).unwrap();
+        assert_eq!(input.expected_uidvalidity, None);
     }
 }

--- a/crates/rimap-server/src/tools/mailbox/flags.rs
+++ b/crates/rimap-server/src/tools/mailbox/flags.rs
@@ -45,6 +45,10 @@ pub struct FlagsMeta {
     pub folder: String,
     /// UIDs that were updated.
     pub uids_updated: Vec<u32>,
+    /// UIDVALIDITY observed at the SELECT used for this operation. `None`
+    /// when the server's SELECT response omitted the response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
 }
 
 /// `mark_read` handler.
@@ -115,7 +119,7 @@ async fn handle_flag_op(
         .into_iter()
         .map(Uid::from)
         .collect();
-    let updated = account
+    let (updated, uid_validity) = account
         .imap
         .store_flags(&input.folder, &uids, flags, action)
         .await?;
@@ -125,6 +129,7 @@ async fn handle_flag_op(
     Ok(ToolResponse::meta_only(FlagsMeta {
         folder: input.folder,
         uids_updated: updated_ids,
+        uid_validity,
     }))
 }
 
@@ -132,6 +137,28 @@ async fn handle_flag_op(
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn flags_meta_serializes_uid_validity_when_some() {
+        let meta = FlagsMeta {
+            folder: "INBOX".to_string(),
+            uids_updated: vec![1, 2],
+            uid_validity: Some(42),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains(r#""uid_validity":42"#), "json = {json}");
+    }
+
+    #[test]
+    fn flags_meta_omits_uid_validity_when_none() {
+        let meta = FlagsMeta {
+            folder: "INBOX".to_string(),
+            uids_updated: vec![1, 2],
+            uid_validity: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("uid_validity"), "json = {json}");
+    }
 
     #[test]
     fn flag_input_parses_single_shape() {

--- a/crates/rimap-server/src/tools/mailbox/labels.rs
+++ b/crates/rimap-server/src/tools/mailbox/labels.rs
@@ -86,6 +86,11 @@ pub struct LabelInput {
     pub target: UidSelector,
     /// Custom keyword label to add or remove.
     pub label: String,
+    /// When set, the handler verifies the folder's UIDVALIDITY matches this
+    /// value before applying the label. A mismatch returns
+    /// `ERR_UID_VALIDITY_CHANGED`. Omit to skip the guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_uidvalidity: Option<u32>,
 }
 
 /// Input for `list_labels` tool.
@@ -95,6 +100,11 @@ pub struct ListLabelsInput {
     pub folder: String,
     /// Message UID.
     pub uid: u32,
+    /// When set, the handler verifies the folder's UIDVALIDITY matches this
+    /// value before fetching labels. A mismatch returns
+    /// `ERR_UID_VALIDITY_CHANGED`. Omit to skip the guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_uidvalidity: Option<u32>,
 }
 
 /// Trusted metadata for `add_label` and `remove_label` responses.
@@ -176,6 +186,7 @@ async fn handle_label_op(
             &uids,
             &[Flag::Keyword(input.label.clone())],
             action,
+            input.expected_uidvalidity,
         )
         .await?;
 
@@ -206,8 +217,14 @@ pub async fn handle_list_labels(
         flags: true,
         ..FetchSpec::default()
     };
-    let (msg, uid_validity) =
-        crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
+    let (msg, uid_validity) = crate::tools::support::fetch_single_by_uid(
+        account,
+        &input.folder,
+        uid,
+        spec,
+        input.expected_uidvalidity,
+    )
+    .await?;
 
     let labels: Vec<String> = msg
         .flags
@@ -382,5 +399,36 @@ mod tests {
         validate_label("$Junk").unwrap();
         validate_label("$NotJunk").unwrap();
         validate_label("$MDNSent").unwrap();
+    }
+
+    #[test]
+    fn label_input_parses_expected_uidvalidity_when_present() {
+        let input: LabelInput = serde_json::from_str(
+            r#"{"folder": "INBOX", "uid": 1, "label": "Urgent", "expected_uidvalidity": 99}"#,
+        )
+        .unwrap();
+        assert_eq!(input.expected_uidvalidity, Some(99));
+    }
+
+    #[test]
+    fn label_input_defaults_expected_uidvalidity_to_none() {
+        let input: LabelInput =
+            serde_json::from_str(r#"{"folder": "INBOX", "uid": 1, "label": "Urgent"}"#).unwrap();
+        assert_eq!(input.expected_uidvalidity, None);
+    }
+
+    #[test]
+    fn list_labels_input_parses_expected_uidvalidity_when_present() {
+        let input: ListLabelsInput =
+            serde_json::from_str(r#"{"folder": "INBOX", "uid": 5, "expected_uidvalidity": 77}"#)
+                .unwrap();
+        assert_eq!(input.expected_uidvalidity, Some(77));
+    }
+
+    #[test]
+    fn list_labels_input_defaults_expected_uidvalidity_to_none() {
+        let input: ListLabelsInput =
+            serde_json::from_str(r#"{"folder": "INBOX", "uid": 5}"#).unwrap();
+        assert_eq!(input.expected_uidvalidity, None);
     }
 }

--- a/crates/rimap-server/src/tools/mailbox/labels.rs
+++ b/crates/rimap-server/src/tools/mailbox/labels.rs
@@ -1,13 +1,9 @@
 //! Label (custom keyword) tool handlers: `add_label`, `remove_label`,
 //! `list_labels`.
 //!
-//! # UIDVALIDITY limitation
-//!
-//! All handlers in this module accept UIDs but do not return or cross-check
-//! UIDVALIDITY. If the folder's UID namespace rotates between the caller's
-//! UID acquisition and the call, the operation may affect unintended
-//! messages. This is consistent with other flag tools (`mark_read`, `flag`,
-//! etc.) and will be addressed in a future release.
+//! All handlers echo `uid_validity` from the SELECT/EXAMINE issued per
+//! operation. Callers can use this to detect UID namespace rotation between
+//! acquisition and mutation. (#70)
 
 use rimap_core::UidSelector;
 use rimap_imap::types::{FetchSpec, Flag, FlagAction, Uid};
@@ -110,6 +106,10 @@ pub struct LabelsMeta {
     pub label: String,
     /// UIDs that were updated.
     pub uids_updated: Vec<u32>,
+    /// UIDVALIDITY observed at the SELECT used for this operation. `None`
+    /// when the server's SELECT response omitted the response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
 }
 
 /// Trusted metadata for a `list_labels` response.
@@ -121,10 +121,13 @@ pub struct ListLabelsMeta {
     pub uid: u32,
     /// Custom keyword labels on the message.
     pub labels: Vec<String>,
+    /// UIDVALIDITY observed at the EXAMINE used for this operation. `None`
+    /// when the server's EXAMINE response omitted the response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
 }
 
 /// `add_label` handler — STORE +FLAGS with a custom keyword.
-/// See the module-level doc for the UIDVALIDITY limitation.
 ///
 /// # Errors
 ///
@@ -140,7 +143,6 @@ pub async fn handle_add_label(
 }
 
 /// `remove_label` handler — STORE -FLAGS with a custom keyword.
-/// See the module-level doc for the UIDVALIDITY limitation.
 ///
 /// # Errors
 ///
@@ -167,7 +169,7 @@ async fn handle_label_op(
         .into_iter()
         .map(Uid::from)
         .collect();
-    let updated = account
+    let (updated, uid_validity) = account
         .imap
         .store_flags(
             &input.folder,
@@ -182,11 +184,11 @@ async fn handle_label_op(
         folder: input.folder,
         label: input.label,
         uids_updated: updated_ids,
+        uid_validity,
     }))
 }
 
 /// `list_labels` handler — FETCH FLAGS and return keyword entries.
-/// See the module-level doc for the UIDVALIDITY limitation.
 ///
 /// # Errors
 ///
@@ -204,7 +206,8 @@ pub async fn handle_list_labels(
         flags: true,
         ..FetchSpec::default()
     };
-    let msg = crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
+    let (msg, uid_validity) =
+        crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
 
     let labels: Vec<String> = msg
         .flags
@@ -229,6 +232,7 @@ pub async fn handle_list_labels(
         folder: input.folder,
         uid: input.uid,
         labels,
+        uid_validity,
     }))
 }
 
@@ -236,6 +240,54 @@ pub async fn handle_list_labels(
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn labels_meta_serializes_uid_validity_when_some() {
+        let meta = LabelsMeta {
+            folder: "INBOX".to_string(),
+            label: "MyLabel".to_string(),
+            uids_updated: vec![1],
+            uid_validity: Some(99),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains(r#""uid_validity":99"#), "json = {json}");
+    }
+
+    #[test]
+    fn labels_meta_omits_uid_validity_when_none() {
+        let meta = LabelsMeta {
+            folder: "INBOX".to_string(),
+            label: "MyLabel".to_string(),
+            uids_updated: vec![1],
+            uid_validity: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("uid_validity"), "json = {json}");
+    }
+
+    #[test]
+    fn list_labels_meta_serializes_uid_validity_when_some() {
+        let meta = ListLabelsMeta {
+            folder: "INBOX".to_string(),
+            uid: 7,
+            labels: vec!["tag".to_string()],
+            uid_validity: Some(77),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains(r#""uid_validity":77"#), "json = {json}");
+    }
+
+    #[test]
+    fn list_labels_meta_omits_uid_validity_when_none() {
+        let meta = ListLabelsMeta {
+            folder: "INBOX".to_string(),
+            uid: 7,
+            labels: vec![],
+            uid_validity: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("uid_validity"), "json = {json}");
+    }
 
     #[test]
     fn rejects_empty_label() {

--- a/crates/rimap-server/src/tools/mailbox/move_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/move_message.rs
@@ -29,6 +29,11 @@ pub struct MoveMessageInput {
     /// UID target: `{"uid": N}` or `{"uids": [...]}`.
     #[serde(flatten)]
     pub target: UidSelector,
+    /// When set, the handler verifies the source folder's UIDVALIDITY matches
+    /// this value before performing the move. A mismatch returns
+    /// `ERR_UID_VALIDITY_CHANGED`. Omit to skip the guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_source_uidvalidity: Option<u32>,
 }
 
 /// Per-UID move result entry.
@@ -93,7 +98,12 @@ pub async fn handle(
         .collect();
     let outcome = account
         .imap
-        .move_messages(&input.folder, &input.destination, &uids, None)
+        .move_messages(
+            &input.folder,
+            &input.destination,
+            &uids,
+            input.expected_source_uidvalidity,
+        )
         .await?;
 
     let moves: Vec<MoveEntry> = outcome
@@ -181,5 +191,23 @@ mod tests {
             json.contains(r#""destination_uid_validity":22"#),
             "json = {json}"
         );
+    }
+
+    #[test]
+    fn move_input_parses_expected_source_uidvalidity_when_present() {
+        let input: MoveMessageInput = serde_json::from_str(
+            r#"{"folder": "INBOX", "destination": "Archive", "uid": 1,
+               "expected_source_uidvalidity": 55}"#,
+        )
+        .unwrap();
+        assert_eq!(input.expected_source_uidvalidity, Some(55));
+    }
+
+    #[test]
+    fn move_input_defaults_expected_source_uidvalidity_to_none() {
+        let input: MoveMessageInput =
+            serde_json::from_str(r#"{"folder": "INBOX", "destination": "Archive", "uid": 1}"#)
+                .unwrap();
+        assert_eq!(input.expected_source_uidvalidity, None);
     }
 }

--- a/crates/rimap-server/src/tools/mailbox/move_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/move_message.rs
@@ -82,7 +82,7 @@ pub async fn handle(
         .collect();
     let outcome = account
         .imap
-        .move_messages(&input.folder, &input.destination, &uids)
+        .move_messages(&input.folder, &input.destination, &uids, None)
         .await?;
 
     let moves: Vec<MoveEntry> = outcome

--- a/crates/rimap-server/src/tools/mailbox/move_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/move_message.rs
@@ -49,6 +49,17 @@ pub struct MoveMessageMeta {
     pub destination: String,
     /// Per-UID move results.
     pub moves: Vec<MoveEntry>,
+    /// Source-folder UIDVALIDITY observed at the guard STATUS probe, or at
+    /// the source SELECT if no guard was requested. `None` when the server
+    /// omitted the response code or no guard/probe occurred. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_uid_validity: Option<u32>,
+    /// Destination-folder UIDVALIDITY observed after the COPY+DELETE fallback
+    /// path. `None` on the UID MOVE happy path (destination UIDVALIDITY not
+    /// observable without an extra STATUS) or when the server omitted the
+    /// response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_uid_validity: Option<u32>,
 }
 
 /// Execute the `move_message` tool.
@@ -107,6 +118,68 @@ pub async fn handle(
         folder: input.folder,
         destination: input.destination,
         moves,
+        source_uid_validity: outcome.source_uid_validity,
+        destination_uid_validity: outcome.destination_uid_validity,
     })
     .with_warnings(warnings))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    fn base_meta(src: Option<u32>, dst: Option<u32>) -> MoveMessageMeta {
+        MoveMessageMeta {
+            folder: "INBOX".to_string(),
+            destination: "Archive".to_string(),
+            moves: vec![],
+            source_uid_validity: src,
+            destination_uid_validity: dst,
+        }
+    }
+
+    #[test]
+    fn move_meta_serializes_source_uid_validity_when_some() {
+        let meta = base_meta(Some(10), None);
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(
+            json.contains(r#""source_uid_validity":10"#),
+            "json = {json}"
+        );
+        assert!(!json.contains("destination_uid_validity"), "json = {json}");
+    }
+
+    #[test]
+    fn move_meta_serializes_destination_uid_validity_when_some() {
+        let meta = base_meta(None, Some(20));
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("source_uid_validity"), "json = {json}");
+        assert!(
+            json.contains(r#""destination_uid_validity":20"#),
+            "json = {json}"
+        );
+    }
+
+    #[test]
+    fn move_meta_omits_both_uid_validity_fields_when_none() {
+        let meta = base_meta(None, None);
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("source_uid_validity"), "json = {json}");
+        assert!(!json.contains("destination_uid_validity"), "json = {json}");
+    }
+
+    #[test]
+    fn move_meta_serializes_both_uid_validity_fields_when_some() {
+        let meta = base_meta(Some(11), Some(22));
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(
+            json.contains(r#""source_uid_validity":11"#),
+            "json = {json}"
+        );
+        assert!(
+            json.contains(r#""destination_uid_validity":22"#),
+            "json = {json}"
+        );
+    }
 }

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -136,7 +136,7 @@ pub async fn handle(
         bodystructure: true,
         ..FetchSpec::default()
     };
-    if let Ok((msgs, _uid_validity)) = account.imap.fetch(&input.folder, &[uid], spec).await
+    if let Ok((msgs, _uid_validity)) = account.imap.fetch(&input.folder, &[uid], spec, None).await
         && let Some(bs) = msgs.into_iter().next().and_then(|m| m.bodystructure)
         && let Some(bs_type) = lookup_bodystructure_type(&bs, &input.part_id)
     {

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -136,7 +136,7 @@ pub async fn handle(
         bodystructure: true,
         ..FetchSpec::default()
     };
-    if let Ok(msgs) = account.imap.fetch(&input.folder, &[uid], spec).await
+    if let Ok((msgs, _uid_validity)) = account.imap.fetch(&input.folder, &[uid], spec).await
         && let Some(bs) = msgs.into_iter().next().and_then(|m| m.bodystructure)
         && let Some(bs_type) = lookup_bodystructure_type(&bs, &input.part_id)
     {

--- a/crates/rimap-server/src/tools/retrieval/list_attachments.rs
+++ b/crates/rimap-server/src/tools/retrieval/list_attachments.rs
@@ -82,7 +82,7 @@ pub async fn handle(
         ..FetchSpec::default()
     };
     let (msg, _uid_validity) =
-        crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
+        crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec, None).await?;
 
     let bodystructure = msg.bodystructure.ok_or_else(|| {
         rimap_core::RimapError::Internal("server did not return BODYSTRUCTURE".into())

--- a/crates/rimap-server/src/tools/retrieval/list_attachments.rs
+++ b/crates/rimap-server/src/tools/retrieval/list_attachments.rs
@@ -81,7 +81,8 @@ pub async fn handle(
         bodystructure: true,
         ..FetchSpec::default()
     };
-    let msg = crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
+    let (msg, _uid_validity) =
+        crate::tools::support::fetch_single_by_uid(account, &input.folder, uid, spec).await?;
 
     let bodystructure = msg.bodystructure.ok_or_else(|| {
         rimap_core::RimapError::Internal("server did not return BODYSTRUCTURE".into())

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -137,6 +137,7 @@ pub async fn handle(
                     size: true,
                     ..FetchSpec::default()
                 },
+                None,
             )
             .await?;
         let (fetched, _uid_validity) = fetched;

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -139,6 +139,7 @@ pub async fn handle(
                 },
             )
             .await?;
+        let (fetched, _uid_validity) = fetched;
         fetched.iter().map(format_search_result).collect()
     };
 

--- a/crates/rimap-server/src/tools/support.rs
+++ b/crates/rimap-server/src/tools/support.rs
@@ -23,9 +23,10 @@ pub(crate) async fn fetch_single_by_uid(
     folder: &str,
     uid: Uid,
     spec: FetchSpec,
-) -> Result<FetchedMessage, rimap_core::RimapError> {
-    let messages = account.imap.fetch(folder, &[uid], spec).await?;
-    first_or_not_found(messages, folder, uid)
+) -> Result<(FetchedMessage, Option<u32>), rimap_core::RimapError> {
+    let (messages, uid_validity) = account.imap.fetch(folder, &[uid], spec).await?;
+    let msg = first_or_not_found(messages, folder, uid)?;
+    Ok((msg, uid_validity))
 }
 
 /// Take the first message from `messages`, or return a `NotFound`

--- a/crates/rimap-server/src/tools/support.rs
+++ b/crates/rimap-server/src/tools/support.rs
@@ -12,8 +12,14 @@ use crate::boot::registry::AccountState;
 /// treat an empty response as "UID not present in folder". Each caller
 /// keeps its own `FetchSpec` so only the dedup-worthy code is centralized.
 ///
+/// If `expected_uidvalidity` is `Some(v)`, the value is verified against the
+/// folder's UIDVALIDITY before the FETCH. A mismatch propagates
+/// `RimapError::Imap { code: UidValidityChanged, ... }`. Pass `None` to skip.
+///
 /// # Errors
 ///
+/// - `RimapError::Imap { code: UidValidityChanged }` if expected UIDVALIDITY
+///   does not match the server's observed value.
 /// - `RimapError::Authz { code: NotFound }` if the server returned no
 ///   message for `uid` in `folder`.
 /// - Propagates `RimapError::Imap { ... }` from the underlying
@@ -23,8 +29,12 @@ pub(crate) async fn fetch_single_by_uid(
     folder: &str,
     uid: Uid,
     spec: FetchSpec,
+    expected_uidvalidity: Option<u32>,
 ) -> Result<(FetchedMessage, Option<u32>), rimap_core::RimapError> {
-    let (messages, uid_validity) = account.imap.fetch(folder, &[uid], spec).await?;
+    let (messages, uid_validity) = account
+        .imap
+        .fetch(folder, &[uid], spec, expected_uidvalidity)
+        .await?;
     let msg = first_or_not_found(messages, folder, uid)?;
     Ok((msg, uid_validity))
 }

--- a/docs/superpowers/plans/2026-04-19-uidvalidity-correctness.md
+++ b/docs/superpowers/plans/2026-04-19-uidvalidity-correctness.md
@@ -1,0 +1,551 @@
+# UIDVALIDITY Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close three UIDVALIDITY correctness issues as one sweep — stop fabricating `uid_validity = 0` when servers omit it (#97), guard MOVE/COPY against UIDVALIDITY rotation between SELECT and command (#96), and echo + optionally gate on UIDVALIDITY in flag/label/move tool responses (#70).
+
+**Architecture:** Task 1 changes `SelectedFolder.uid_validity` from `u32` (with `.unwrap_or(0)`) to `Option<u32>` and adds `ImapError::UidValidityChanged { folder, expected, actual }` as the shared typed error. Task 2 captures source UIDVALIDITY at SELECT in `move_messages`, compares before `UID MOVE` / `UID COPY`, STATUS-checks the destination after COPY fallback, and adds `used_fallback_reason: Option<String>` to `MoveResult` so the audit layer can surface why `new_uid` is `None` (COPYUID capture is deferred — async-imap does not expose the response code; a follow-up issue is filed in Task 5). Task 3 extends `FlagsMeta`, `LabelsMeta`, `ListLabelsMeta`, and `MoveMessageMeta` with an observed `uid_validity` field populated from the `SelectedFolder` returned by the handler's SELECT/EXAMINE call. Task 4 adds an optional `expected_uidvalidity: Option<u32>` input on each flag/label/move tool; when the caller sets it and the observed UIDVALIDITY differs, the tool returns `ImapError::UidValidityChanged` mapped to an `ERR_*` code that an agent can retry under.
+
+**Tech Stack:** Rust (stable), existing `async-imap` / `imap-proto` types, `rimap-audit::record` (no schema change — `uid_validity` on response meta is serialized through the same path as other meta fields).
+
+---
+
+## Prior-Art Context
+
+`SelectedFolder` at `crates/rimap-imap/src/types.rs:124-137` carries `uid_validity: u32`, populated at `ops/folders.rs:139-158::select` via `mailbox.uid_validity.unwrap_or(0)`. RFC 3501 §2.3.1.1 reserves UIDVALIDITY=0 to indicate the absence of the facility, so the current fabrication collides with that sentinel. Survey confirmed: the field has NO in-tree consumers today — this sweep introduces the first ones (MOVE guard + tool-response echo).
+
+`ops/move_message.rs::move_messages` (lines 40-78) and `copy_delete_fallback` (lines 87-128) neither (a) guard against UIDVALIDITY rotation between the caller's SELECT and the command, nor (b) capture the `[COPYUID uidvalidity src dst]` response code. `MoveResult.new_uid` is always `None` (line 137 in `build_results`, comment at 130-131 documents the async-imap gap).
+
+`ResponseCode::CopyUid(u32, Vec<UidSetMember>, Vec<UidSetMember>)` is defined at `imap-proto 0.16.6 types.rs:139` but unreachable via async-imap 0.11.2's session methods (`uid_copy`, `uid_mv` return `Result<()>` and discard response codes). Wiring COPYUID capture requires raw-command machinery that is too invasive for this sweep.
+
+Flag/label/move tool handlers at `crates/rimap-server/src/tools/mailbox/flags.rs`, `labels.rs`, `move_message.rs` currently return `ToolResponse<FlagsMeta | LabelsMeta | ListLabelsMeta | MoveMessageMeta>` none of which include a UIDVALIDITY field. The labels module already carries an explicit doc comment (lines 4-10) noting the gap.
+
+---
+
+## File Structure
+
+### Modified files
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/rimap-imap/src/types.rs` | `SelectedFolder.uid_validity: Option<u32>`. Add `uid_validity: u32` to `MoveResult` (observed source) + `used_fallback_reason: Option<String>`. |
+| Modify | `crates/rimap-imap/src/error.rs` | Add `UidValidityChanged { folder: String, expected: u32, actual: u32 }` variant + error-code mapping. |
+| Modify | `crates/rimap-core/src/error.rs` | Add `ErrorCode::UidValidityChanged` → `"ERR_UID_VALIDITY_CHANGED"`. Round-trip pairs. |
+| Modify | `crates/rimap-imap/src/ops/folders.rs` | `select` populates `Option<u32>` instead of `.unwrap_or(0)`. |
+| Modify | `crates/rimap-imap/src/ops/move_message.rs` | `move_messages` accepts `expected_source_uidvalidity: Option<u32>`; compares before UID MOVE / UID COPY. STATUS-check destination UIDVALIDITY after COPY fallback. Populate `used_fallback_reason` on each result. |
+| Modify | `crates/rimap-imap/src/connection.rs` | Wrapper `move_messages` signature updated to accept/propagate the new arg. |
+| Modify | `crates/rimap-server/src/tools/mailbox/flags.rs` | `FlagsMeta.uid_validity: u32`. Optional `expected_uidvalidity: Option<u32>` input. Guard handler. |
+| Modify | `crates/rimap-server/src/tools/mailbox/labels.rs` | Same treatment for `LabelsMeta` / `ListLabelsMeta` (drop the deferred-gap doc comment). |
+| Modify | `crates/rimap-server/src/tools/mailbox/move_message.rs` | `MoveMessageMeta.uid_validity: u32`. Optional `expected_source_uidvalidity`. |
+| Modify | `crates/rimap-server/src/mcp/error.rs` | Map the new `ImapError::UidValidityChanged` / `ErrorCode::UidValidityChanged` to the right `ErrorData` shape. |
+
+### Unchanged
+
+- `rimap-audit` / on-disk record shapes — no new variants needed. The error code is a new `ErrorCode` variant, handled generically by the audit writer.
+
+---
+
+## Task 1: `SelectedFolder.uid_validity: Option<u32>` + `ErrorCode::UidValidityChanged` (#97)
+
+**Issue:** #97 + foundation for #96 / #70.
+
+**Files:**
+- Modify: `crates/rimap-imap/src/types.rs`
+- Modify: `crates/rimap-imap/src/ops/folders.rs`
+- Modify: `crates/rimap-imap/src/error.rs`
+- Modify: `crates/rimap-core/src/error.rs`
+
+### Approach
+
+Change `SelectedFolder.uid_validity` from `u32` to `Option<u32>`. The single populator (`ops/folders.rs::select`) drops `.unwrap_or(0)` and passes `mailbox.uid_validity` through directly.
+
+Add the shared typed error `ImapError::UidValidityChanged { folder: String, expected: u32, actual: u32 }` and the stable `ErrorCode::UidValidityChanged` → `"ERR_UID_VALIDITY_CHANGED"`. Downstream tasks produce and consume this error.
+
+- [ ] **Step 1: Add `ErrorCode::UidValidityChanged` in `rimap-core`**
+
+Follow the pattern landed in the audit-cancellation PR for `ErrorCode::Cancelled`:
+
+- Add `Cancelled` → `UidValidityChanged` with `/// UIDVALIDITY changed between caller-observed value and server observation.`
+- `as_str` arm: `Self::UidValidityChanged => "ERR_UID_VALIDITY_CHANGED"`
+- `from_str` parse arm
+- `round_trip_pairs` list entry
+- Downstream exhaustive matches: `crates/rimap-server/src/mcp/dispatch.rs` + `crates/rimap-server/src/mcp/error.rs` (add to whatever arm set the previous new codes landed in — grep for `ErrorCode::Cancelled` to find the pattern).
+
+Write and verify a `uid_validity_changed_round_trips` test.
+
+- [ ] **Step 2: Add `ImapError::UidValidityChanged` variant**
+
+At `crates/rimap-imap/src/error.rs`, add a variant:
+
+```rust
+    /// UIDVALIDITY observed by the server differs from the value the
+    /// caller expected (recorded at its prior SELECT). The target UID may
+    /// now refer to a different message than the caller intended.
+    ///
+    /// # Fields
+    /// - `folder`: affected mailbox name.
+    /// - `expected`: UIDVALIDITY the caller observed previously.
+    /// - `actual`: UIDVALIDITY the server reports now.
+    #[error(
+        "UIDVALIDITY changed for `{folder}`: expected {expected}, \
+         server reports {actual}"
+    )]
+    UidValidityChanged {
+        /// Mailbox name.
+        folder: String,
+        /// UIDVALIDITY observed at a prior SELECT.
+        expected: u32,
+        /// UIDVALIDITY observed now.
+        actual: u32,
+    },
+```
+
+Update the `code()` method (or equivalent mapping) so this variant resolves to `ErrorCode::UidValidityChanged`.
+
+Add a unit test: `uid_validity_changed_display_includes_numbers_and_folder`.
+
+- [ ] **Step 3: Change `SelectedFolder.uid_validity` to `Option<u32>`**
+
+At `crates/rimap-imap/src/types.rs:124-137`:
+
+```rust
+pub struct SelectedFolder {
+    pub name: String,
+    pub exists: u32,
+    pub recent: u32,
+    /// UIDVALIDITY reported by the server. `None` when the server's
+    /// SELECT/EXAMINE response omitted the response code (RFC 3501
+    /// §2.3.1.1 reserves UIDVALIDITY=0 for that case — we surface it
+    /// as `None` rather than fabricating a sentinel).
+    pub uid_validity: Option<u32>,
+    pub uid_next: Option<u32>,
+    pub read_only: bool,
+}
+```
+
+At `ops/folders.rs:154`, drop the `.unwrap_or(0)`:
+
+```rust
+    Ok(SelectedFolder {
+        name: folder.to_string(),
+        exists: mailbox.exists,
+        recent: mailbox.recent,
+        uid_validity: mailbox.uid_validity,
+        uid_next: mailbox.uid_next,
+        read_only,
+    })
+```
+
+- [ ] **Step 4: Update sprint-3 design + plan references**
+
+Issue #97 notes that `docs/superpowers/specs/2026-04-07-sprint-3-imap-design.md` (around line 120) and `docs/superpowers/plans/2026-04-07-sprint-3-imap.md` (around lines 1796, 3176) reference the old `u32` shape. Grep and fix those to match `Option<u32>`. These are historical design docs — annotate the change inline (`// #97: changed to Option<u32>`) rather than rewriting the surrounding narrative.
+
+If updating the historical docs feels like scope creep, SKIP this step and note in the commit message that the historical spec references are stale (track via a one-line comment in the commit body).
+
+- [ ] **Step 5: Fix any `SelectedFolder { ... }` struct literals**
+
+Grep: `grep -rn "SelectedFolder {" crates/ tests/`. Every struct-literal construction that reads `uid_validity: <number>` must switch to `uid_validity: Some(<number>)` or `uid_validity: None` as appropriate.
+
+- [ ] **Step 6: Run workspace tests + clippy**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp-uidvalidity
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: PASS and clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-core/src/error.rs crates/rimap-imap/src/error.rs \
+        crates/rimap-imap/src/types.rs crates/rimap-imap/src/ops/folders.rs \
+        crates/rimap-server/src/mcp/dispatch.rs crates/rimap-server/src/mcp/error.rs
+# Plus any historical-spec edits + any SelectedFolder literal fixes
+git commit -m "imap: SelectedFolder.uid_validity is Option<u32>; typed UidValidityChanged error (#97)
+
+SelectedFolder.uid_validity is now Option<u32>. Drops the
+.unwrap_or(0) in ops/folders.rs::select that fabricated the UIDVALIDITY=0
+sentinel reserved by RFC 3501 §2.3.1.1. Consumers that need the
+value (new this sprint: MOVE guard, flag/label/move response meta)
+handle None explicitly.
+
+Adds ImapError::UidValidityChanged { folder, expected, actual } with
+stable ErrorCode::UidValidityChanged → ERR_UID_VALIDITY_CHANGED. Used
+by the MOVE guard (task 2) and the expected-uidvalidity check in tool
+handlers (task 4)."
+```
+
+---
+
+## Task 2: MOVE UIDVALIDITY guard + `used_fallback_reason` (#96)
+
+**Issue:** #96.
+
+**Files:**
+- Modify: `crates/rimap-imap/src/types.rs` (add `used_fallback_reason` to `MoveResult`)
+- Modify: `crates/rimap-imap/src/ops/move_message.rs` (guard logic)
+- Modify: `crates/rimap-imap/src/connection.rs` (public wrapper signature)
+
+### Approach
+
+`move_messages` gains an `expected_source_uidvalidity: Option<u32>` argument. When set, the op issues `STATUS <folder> (UIDVALIDITY)` at function entry (cheaper than re-SELECT; does not invalidate current selection) and compares to the expected value. Mismatch → `ImapError::UidValidityChanged`.
+
+For the COPY fallback path, the destination folder is also STATUS-checked for UIDVALIDITY before COPY (captured into the first `MoveResult`). This bounds the "moved into the wrong incarnation" risk.
+
+**COPYUID capture is deferred.** async-imap 0.11.2 does not expose `ResponseCode::CopyUid` through the session API. `new_uid` stays `None` for this PR. A new field `MoveResult.used_fallback_reason: Option<String>` records WHY `new_uid` is `None` (one of: `"async_imap_copyuid_unavailable"` in this sweep; future reasons may be added). A follow-up issue is filed in Task 5.
+
+- [ ] **Step 1: Extend `MoveResult`**
+
+At `crates/rimap-imap/src/types.rs` (around line 167-176), add:
+
+```rust
+pub struct MoveResult {
+    pub old_uid: Uid,
+    pub new_uid: Option<Uid>,
+    /// Reason `new_uid` is None. `Some("async_imap_copyuid_unavailable")`
+    /// when the UIDPLUS response code was not capturable via async-imap's
+    /// session API; see #96 follow-up issue.
+    pub used_fallback_reason: Option<String>,
+}
+```
+
+- [ ] **Step 2: Update `move_messages` signature**
+
+At `crates/rimap-imap/src/ops/move_message.rs:40-78`, change the signature to accept the expected value:
+
+```rust
+pub(crate) async fn move_messages(
+    session: &mut ImapSession,
+    src_folder: &str,
+    dest_folder: &str,
+    uids: &[Uid],
+    expected_source_uidvalidity: Option<u32>,
+    has_move: bool,
+    has_uidplus: bool,
+) -> Result<MoveOutcome, ImapError> {
+```
+
+Note the added `src_folder: &str` — the guard needs to know which folder to STATUS-check. If the current implementation doesn't already thread the source folder through, wire it. If the existing `move_messages` relies on the session's SELECTED mailbox, we still need the folder name for error reporting and the STATUS probe (STATUS does not require SELECT).
+
+- [ ] **Step 3: Implement the guard**
+
+Inside `move_messages`, before the UID MOVE / COPY dispatch:
+
+```rust
+    // If the caller observed a UIDVALIDITY at SELECT, verify it still
+    // holds. We use STATUS rather than a fresh SELECT so the session's
+    // current selected mailbox is unaffected.
+    if let Some(expected) = expected_source_uidvalidity {
+        let status = crate::ops::folders::status(
+            session,
+            src_folder,
+            crate::types::StatusItems { uid_validity: true, ..Default::default() },
+        )
+        .await?;
+        match status.uid_validity {
+            Some(actual) if actual != expected => {
+                return Err(ImapError::UidValidityChanged {
+                    folder: src_folder.to_string(),
+                    expected,
+                    actual,
+                });
+            }
+            None => {
+                // Server omits UIDVALIDITY — cannot compare. Proceed.
+                tracing::warn!(
+                    folder = src_folder,
+                    "STATUS omitted UIDVALIDITY; skipping UIDVALIDITY guard",
+                );
+            }
+            _ => {} // matches expected
+        }
+    }
+```
+
+Adjust `StatusItems` field shape to whatever the existing type defines. If there's no `..Default::default()` shorthand, construct the struct with every field explicit.
+
+- [ ] **Step 4: COPY-path destination guard**
+
+In `copy_delete_fallback` (around lines 87-128), after the COPY but before relying on the implicit destination UIDs, issue `STATUS <dest_folder> (UIDVALIDITY)` and record the observed UIDVALIDITY. If the caller provided an `expected_source_uidvalidity`, the COPY already honors it; the destination STATUS-check closes the narrower gap where destination UIDVALIDITY could have rotated between the lookup-of-dest-name and the copy. Populate the result's `used_fallback_reason` accordingly:
+
+```rust
+    // COPYUID is not capturable via async-imap 0.11.2's session API.
+    // See follow-up issue for when upstream exposes ResponseCode::CopyUid.
+    results.push(MoveResult {
+        old_uid,
+        new_uid: None,
+        used_fallback_reason: Some("async_imap_copyuid_unavailable".to_string()),
+    });
+```
+
+If the non-fallback (UID MOVE) path also returns `new_uid: None`, apply the same `used_fallback_reason` there.
+
+- [ ] **Step 5: Update callers**
+
+`crates/rimap-imap/src/connection.rs`'s public `move_messages` wrapper must pass through `expected_source_uidvalidity` (and `src_folder`). Every caller of `Connection::move_messages` needs to either supply the expected value (if known) or pass `None`.
+
+Grep: `grep -rn "move_messages\|Connection::move" crates/ tests/ 2>/dev/null`. Update call sites.
+
+- [ ] **Step 6: Integration test**
+
+Add to `crates/rimap-imap/tests/integration/dovecot.rs` (or a new file under `tests/`) a test that:
+1. SELECTs INBOX, captures UIDVALIDITY.
+2. Deletes and recreates the mailbox (forces UIDVALIDITY rotation — Dovecot increments on CREATE).
+3. Calls `move_messages` with the stale UIDVALIDITY.
+4. Asserts the error is `ImapError::UidValidityChanged` with the expected/actual values.
+
+If the recreate-to-rotate dance is unreliable across Dovecot versions, an alternative is a MOCKED test that fakes a STATUS response with a different UIDVALIDITY. Use whichever the integration-test harness supports cleanly.
+
+- [ ] **Step 7: Run workspace tests + clippy**
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-imap/src/types.rs crates/rimap-imap/src/ops/move_message.rs \
+        crates/rimap-imap/src/connection.rs crates/rimap-imap/tests/integration/dovecot.rs
+git commit -m "imap: UIDVALIDITY guard on MOVE + used_fallback_reason (#96)
+
+move_messages accepts expected_source_uidvalidity: Option<u32> and
+compares it against a STATUS probe before UID MOVE / UID COPY.
+Mismatch returns ImapError::UidValidityChanged. The COPY fallback
+path STATUS-checks the destination before falling through.
+
+MoveResult gains used_fallback_reason: Option<String> populated with
+'async_imap_copyuid_unavailable' when new_uid is None due to
+async-imap 0.11.2 not exposing ResponseCode::CopyUid. Follow-up
+issue tracks wiring COPYUID capture once upstream exposes it."
+```
+
+---
+
+## Task 3: Echo UIDVALIDITY in flag / label / move tool responses (#70 — response side)
+
+**Issue:** #70 part 1.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/mailbox/flags.rs`
+- Modify: `crates/rimap-server/src/tools/mailbox/labels.rs`
+- Modify: `crates/rimap-server/src/tools/mailbox/move_message.rs`
+
+### Approach
+
+Each handler already SELECTs (or EXAMINEs) the target folder during dispatch. Capture the `SelectedFolder.uid_validity: Option<u32>` from that call and populate a new `uid_validity: u32` field on the response meta. When `SelectedFolder.uid_validity` is `None` (server omitted the facility), either:
+
+- (a) Return `ImapError::Protocol` — the server violated the UIDVALIDITY contract and we shouldn't silently succeed.
+- (b) Omit the field (`uid_validity: Option<u32>`) and serialize with `skip_serializing_if`.
+
+**Use (b).** Servers that legitimately omit UIDVALIDITY are rare but exist; a hard failure would make the tool unusable on those servers. An omitted field tells the agent "no UIDVALIDITY available, cannot guarantee UID stability."
+
+- [ ] **Step 1: Extend `FlagsMeta`** (flags.rs)
+
+```rust
+pub struct FlagsMeta {
+    pub folder: String,
+    pub uids_updated: Vec<u32>,
+    /// UIDVALIDITY observed at the SELECT used for this operation. `None`
+    /// when the server's SELECT response omitted the response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
+}
+```
+
+Update each handler (`handle_mark_read`, `handle_mark_unread`, `handle_flag`, `handle_unflag`) to capture the `SelectedFolder.uid_validity` from whichever helper calls SELECT (probably `handle_flag_op` per the survey). Populate the new field on the returned meta.
+
+- [ ] **Step 2: Extend `LabelsMeta` and `ListLabelsMeta`** (labels.rs)
+
+Same treatment. Drop the module-level doc comment (lines 4-10 per the survey) that explicitly notes the gap — it's now closed.
+
+- [ ] **Step 3: Extend `MoveMessageMeta`** (move_message.rs)
+
+```rust
+pub struct MoveMessageMeta {
+    pub folder: String,
+    pub destination: String,
+    pub moves: Vec<MoveEntry>,
+    /// Source-folder UIDVALIDITY observed at the SELECT used for this
+    /// operation. `None` when the server omitted the response code. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_uid_validity: Option<u32>,
+    /// Destination-folder UIDVALIDITY observed after the COPY (fallback
+    /// path) or implied by the UID MOVE command (happy path). `None`
+    /// when not observable. (#70)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_uid_validity: Option<u32>,
+}
+```
+
+The destination value comes from the STATUS-check added in Task 2's fallback path. For the UID MOVE happy path, the destination is in a different selected-mailbox incarnation than the current session — populate from a separate `STATUS <destination> (UIDVALIDITY)` call.
+
+- [ ] **Step 4: Unit tests**
+
+For each meta type, add a serialization test asserting:
+- Field is serialized when `Some`.
+- Field is omitted when `None` (via `skip_serializing_if`).
+
+- [ ] **Step 5: Run workspace tests + clippy**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/mailbox/flags.rs \
+        crates/rimap-server/src/tools/mailbox/labels.rs \
+        crates/rimap-server/src/tools/mailbox/move_message.rs
+git commit -m "server: echo UIDVALIDITY in flag/label/move tool responses (#70)
+
+FlagsMeta, LabelsMeta, ListLabelsMeta, and MoveMessageMeta gain an
+uid_validity field (source_uid_validity + destination_uid_validity on
+move). Populated from the SelectedFolder the handler's SELECT returns.
+Option<u32> + #[serde(skip_serializing_if)] so servers that omit
+UIDVALIDITY don't cause a hard failure — agents see the field missing
+and can reason accordingly.
+
+Labels module loses its 'no UIDVALIDITY tracking' gap comment; the
+gap is closed."
+```
+
+---
+
+## Task 4: Optional `expected_uidvalidity` on flag/label/move tool inputs (#70 — input side)
+
+**Issue:** #70 part 2.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/mailbox/flags.rs`
+- Modify: `crates/rimap-server/src/tools/mailbox/labels.rs`
+- Modify: `crates/rimap-server/src/tools/mailbox/move_message.rs`
+
+### Approach
+
+Each tool's input struct gains an optional `expected_uidvalidity: Option<u32>` field. When the caller supplies it and the observed UIDVALIDITY (from the handler's SELECT) differs, the handler returns `ImapError::UidValidityChanged`, which the dispatch layer maps to `ErrorCode::UidValidityChanged` / `"ERR_UID_VALIDITY_CHANGED"`.
+
+For `move_message`, the input carries `expected_source_uidvalidity: Option<u32>` — passed through to `Connection::move_messages` so the guard from Task 2 does the comparison at the right layer.
+
+- [ ] **Step 1: Extend each input struct**
+
+```rust
+pub struct FlagInput {
+    pub folder: String,
+    pub uids: Vec<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_uidvalidity: Option<u32>,
+}
+```
+
+Same pattern for `LabelInput`, `ListLabelsInput`, `MoveMessageInput`. The `MoveMessageInput` names the field `expected_source_uidvalidity` to match the wire shape the MOVE guard expects.
+
+- [ ] **Step 2: Handler guard logic (flags + labels)**
+
+For flags/labels, the observed UIDVALIDITY is `SelectedFolder.uid_validity` from the handler's SELECT. Add a guard before the STORE/EXPUNGE:
+
+```rust
+    let selected = /* existing SELECT */;
+    if let Some(expected) = input.expected_uidvalidity {
+        match selected.uid_validity {
+            Some(actual) if actual != expected => {
+                return Err(rimap_core::RimapError::from(ImapError::UidValidityChanged {
+                    folder: input.folder.clone(),
+                    expected,
+                    actual,
+                }));
+            }
+            None => {
+                // Server omits UIDVALIDITY; cannot honor expected-value
+                // check. Proceed with a tracing::warn — agent sees the
+                // missing uid_validity in the response.
+                tracing::warn!(
+                    folder = %input.folder,
+                    "expected_uidvalidity set but server omitted UIDVALIDITY; proceeding without guard",
+                );
+            }
+            _ => {}
+        }
+    }
+```
+
+- [ ] **Step 3: Move tool — pass through to `Connection`**
+
+For `move_message`, no handler-level guard is needed — `Connection::move_messages` already accepts `expected_source_uidvalidity` (Task 2). Thread the input field through:
+
+```rust
+    account
+        .imap
+        .move_messages(
+            &input.folder,
+            &input.destination,
+            &uid_slice,
+            input.expected_source_uidvalidity,
+        )
+        .await?;
+```
+
+Adjust to the actual wrapper signature after Task 2's changes.
+
+- [ ] **Step 4: Redaction schema updates**
+
+`rimap-audit/src/redact/schemas` (or wherever redaction schemas live) may need updating so the new `expected_uidvalidity` field is recognized. If the schemas simply forward all top-level fields without stripping, no change is needed.
+
+- [ ] **Step 5: Unit tests**
+
+For each handler, add tests:
+- `expected_uidvalidity: Some(old_value)` + observed differs → returns `UidValidityChanged`.
+- `expected_uidvalidity: Some(correct_value)` → tool succeeds normally.
+- `expected_uidvalidity: None` → no guard; tool succeeds.
+
+A unit test may need mocking of the SELECT path. If the codebase has a `MockConnection` or similar, use it. Otherwise fall back to an integration test against Dovecot that forces the rotation (same pattern as Task 2's integration test).
+
+- [ ] **Step 6: Run workspace tests + clippy**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/mailbox/flags.rs \
+        crates/rimap-server/src/tools/mailbox/labels.rs \
+        crates/rimap-server/src/tools/mailbox/move_message.rs
+# Plus any redaction-schema updates
+git commit -m "server: expected_uidvalidity input on flag/label/move tools (#70)
+
+Each of the flag, label, and move tools now accepts an optional
+expected_uidvalidity (expected_source_uidvalidity for move). When set,
+a mismatch between the agent's prior observation and the server's
+current UIDVALIDITY returns ImapError::UidValidityChanged → mapped to
+ErrorCode::UidValidityChanged → ERR_UID_VALIDITY_CHANGED. Agents that
+cached a UID and want to retry safely can now do so without risk of
+acting on a different message."
+```
+
+---
+
+## Task 5: Final verification + PR + file COPYUID follow-up
+
+- [ ] **Step 1: Run the full verification pipeline**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp-uidvalidity
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo deny check advisories bans licenses sources
+typos
+```
+
+All five must pass.
+
+- [ ] **Step 2: Push + open PR**
+
+Branch: `feat/uidvalidity-correctness`. Target: `main`. PR body references `Closes #70`, `Closes #96`, `Closes #97`.
+
+- [ ] **Step 3: File the COPYUID follow-up issue**
+
+Use the `gh issue create` pattern. Reference:
+- The plumbed `MoveResult.used_fallback_reason` and `new_uid: None` (MoveResult location after Task 2)
+- async-imap 0.11.2 as the blocker — `ResponseCode::CopyUid` exists in imap-proto but session methods discard it
+- Expected follow-up shape: flip the dispatch once async-imap exposes it; populate `new_uid: Some(Uid::new(dst))` and clear `used_fallback_reason`
+
+Title suggestion: `imap: wire COPYUID capture once async-imap exposes ResponseCode::CopyUid`


### PR DESCRIPTION
## Summary

Closes roadmap sub-group 2 (`docs/superpowers/specs/2026-04-19-open-issues-roadmap-design.md` §3): three UIDVALIDITY correctness issues resolved across `rimap-core`, `rimap-imap`, and `rimap-server`.

- **#97 — `SelectedFolder.uid_validity: Option<u32>`.** Drops the `.unwrap_or(0)` sentinel that collided with RFC 3501 §2.3.1.1's reservation. Added `ImapError::UidValidityChanged { folder, expected, actual }` + `ErrorCode::UidValidityChanged` → `ERR_UID_VALIDITY_CHANGED` as the shared typed error consumed by all downstream guards.

- **#96 — MOVE UIDVALIDITY guard + `used_fallback_reason`.** `Connection::move_messages` now accepts `expected_source_uidvalidity: Option<u32>`. When set, a `STATUS <src_folder> (UIDVALIDITY)` probe runs before `UID MOVE` / `UID COPY`; mismatch returns `UidValidityChanged`. The COPY fallback path also STATUS-probes the destination and surfaces the observed UIDVALIDITY via `MoveOutcome.destination_uid_validity`. `MoveResult.used_fallback_reason: Option<String>` records that `new_uid` is `None` because async-imap 0.11.2 does not expose `ResponseCode::CopyUid` — follow-up issue filed.

- **#70 — echo + guard UIDVALIDITY across flag/label/move tools.** Response meta types (`FlagsMeta`, `LabelsMeta`, `ListLabelsMeta`, `MoveMessageMeta`) gain `uid_validity` (or `source_uid_validity` + `destination_uid_validity` for move), populated from the SELECT/EXAMINE every handler already runs — zero extra round-trips. Each input struct gains `expected_uidvalidity` (`expected_source_uidvalidity` for move); the guard fires inside `Connection::store_flags` / `Connection::fetch` / `Connection::move_messages` post-SELECT, pre-mutation, so a rotation caught mid-session fails with `UidValidityChanged` BEFORE any STORE/FETCH/MOVE command is sent. `check_uidvalidity` is extracted as a `pub(crate)` helper to keep the guard logic in one place.

Four focused commits, TDD-shaped, verified against the plan in `docs/superpowers/plans/2026-04-19-uidvalidity-correctness.md`.

## Carry-forward

Task 5's gh-issue-create filed the **COPYUID capture follow-up** — tracking when async-imap exposes `ResponseCode::CopyUid` so `MoveResult.new_uid` can be populated and `used_fallback_reason` cleared on the happy path.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all unit + integration suites pass
- [x] Pre-push hook full nextest run — passed (including Dovecot integration)
- [x] `cargo deny check` — clean
- [x] `typos` — no findings

## Commits

1. `74d7f63` — Option<u32> + typed UidValidityChanged (#97)
2. `248f1bb` — MOVE UIDVALIDITY guard + used_fallback_reason (#96)
3. `d294c28` — Echo UIDVALIDITY in response meta (#70 response)
4. `9f7e2cb` — expected_uidvalidity input + guard (#70 input)

Closes #70
Closes #96
Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)