### PR TITLE
Tier 2 backlog: AccountId normalize, dedupe test helpers, aarch64 SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
           targets: aarch64-unknown-linux-gnu
       - name: Install cross
         run: cargo install cross --locked --version 0.2.5
-      # TODO: embed SBOM via cargo-auditable for cross builds. Requires
-      # installing cargo-auditable inside the cross container (e.g. via a
-      # Cross.toml pre-build hook or custom image). Tracked as follow-up.
-      - run: cross build --release --locked --target aarch64-unknown-linux-gnu
+      # Cross.toml at the repo root installs cargo-auditable inside the
+      # cross container via a pre-build hook, so `cross auditable build`
+      # emits an SBOM identical to the native and QEMU targets.
+      - run: cross auditable build --release --locked --target aarch64-unknown-linux-gnu
       - name: Rename binary
         run: cp target/aarch64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} ${{ env.BINARY_NAME }}-aarch64-unknown-linux-gnu
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "proptest",
+ "rimap-content",
  "rimap-core",
  "scraper",
  "serde",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+# Cross configuration for the aarch64-unknown-linux-gnu release build.
+# Installs cargo-auditable inside the cross container so the release
+# binary embeds an SBOM identical to the four other targets. See issue
+# #79 and .github/workflows/release.yml.
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config",
+    "cargo install cargo-auditable --locked --version 0.7.4",
+]

--- a/crates/rimap-config/src/validate.rs
+++ b/crates/rimap-config/src/validate.rs
@@ -988,6 +988,19 @@ allowed_base_dir = "{}"
     }
 
     #[test]
+    fn case_variant_account_names_collide() {
+        // Regression (#75): AccountId normalizes to lowercase, so a config
+        // naming both "Work" and "work" is rejected as a duplicate.
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![raw_account("Work"), raw_account("work")]);
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DuplicateAccountName { .. }),
+            "expected DuplicateAccountName, got {err:?}",
+        );
+    }
+
+    #[test]
     fn no_accounts_rejected() {
         let dir = TempDir::new().unwrap();
         let cfg = base_multi_config(dir.path(), vec![]);

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -36,10 +36,25 @@ phf = { workspace = true }
 [build-dependencies]
 phf_codegen = { workspace = true }
 
+[features]
+# Test/diagnostic helpers exposed via `rimap_content::testutil`. Enable
+# for the epvme_runner binary and when depending on this crate from
+# integration tests.
+test-util = []
+
+[[bin]]
+name = "epvme_runner"
+path = "src/bin/epvme_runner.rs"
+required-features = ["test-util"]
+
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
+
+[dev-dependencies.rimap-content]
+path = "."
+features = ["test-util"]
 
 # `phf` is consumed by the `include!`-expanded output of `build.rs`, so
 # static analyzers like cargo-machete cannot see the direct usage.

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -54,6 +54,7 @@ tempfile = { workspace = true }
 
 [dev-dependencies.rimap-content]
 path = "."
+version = "1.0.0"
 features = ["test-util"]
 
 # `phf` is consumed by the `include!`-expanded output of `build.rs`, so

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -285,13 +285,17 @@ where
             SampleOutcome::Ok(content) => {
                 summary.ok_count += 1;
                 for warning in content.security_warnings {
-                    let label = warning_code_to_label(warning.code).to_string();
+                    let label = rimap_content::testutil::warning_code_label(warning.code)
+                        .unwrap_or_else(|| unknown_warning_code_label(warning.code))
+                        .to_string();
                     *summary.warning_counts.entry(label).or_insert(0) += 1;
                 }
             }
             SampleOutcome::ParseError(err) => {
                 summary.parse_error_count += 1;
-                let label = error_kind_label(&err).to_string();
+                let label = rimap_content::testutil::error_kind_label(&err)
+                    .unwrap_or("Unknown")
+                    .to_string();
                 *summary.parse_error_counts.entry(label.clone()).or_insert(0) += 1;
                 record_failure(&mut summary, path, label, err.to_string());
             }
@@ -422,41 +426,6 @@ fn write_json_report(path: &Path, summary: &RunSummary) -> RunnerResult<()> {
 
 fn is_success(summary: &RunSummary) -> bool {
     summary.parse_error_count == 0 && summary.read_failure_count == 0 && summary.panic_count == 0
-}
-
-fn warning_code_to_label(code: WarningCode) -> &'static str {
-    match code {
-        WarningCode::UnicodeZeroWidthStripped => "unicode_zero_width_stripped",
-        WarningCode::UnicodeBidiOverrideStripped => "unicode_bidi_override_stripped",
-        WarningCode::UnicodeC0C1Stripped => "unicode_c0_c1_stripped",
-        WarningCode::ParseHeaderSmugglingBlocked => "parse_header_smuggling_blocked",
-        WarningCode::ParseMimeTypeMismatch => "parse_mime_type_mismatch",
-        WarningCode::ParseAttachmentPolyglot => "parse_attachment_polyglot",
-        WarningCode::ParseBodyTruncated => "parse_body_truncated",
-        WarningCode::ParseMimeDepthExceeded => "parse_mime_depth_exceeded",
-        WarningCode::ParseMimePartCountExceeded => "parse_mime_part_count_exceeded",
-        WarningCode::ParseHeaderCountExceeded => "parse_header_count_exceeded",
-        WarningCode::ParseAttachmentFilenameRewritten => "parse_attachment_filename_rewritten",
-        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
-        WarningCode::HtmlLinkTextHrefMismatch => "html_link_text_href_mismatch",
-        WarningCode::HtmlScriptStripped => "html_script_stripped",
-        WarningCode::HtmlStyleStripped => "html_style_stripped",
-        WarningCode::HtmlRemoteImageStripped => "html_remote_image_stripped",
-        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
-        WarningCode::LookalikeMixedScript => "lookalike_mixed_script",
-        WarningCode::LookalikeHomographDomain => "lookalike_homograph_domain",
-        WarningCode::LookalikeIdnPunycode => "lookalike_idn_punycode",
-        WarningCode::LookalikeFilenameExtensionSpoof => "lookalike_filename_extension_spoof",
-        _ => unknown_warning_code_label(code),
-    }
-}
-
-fn error_kind_label(err: &ContentError) -> &'static str {
-    match err {
-        ContentError::Malformed { .. } => "Malformed",
-        ContentError::LimitExceeded { .. } => "LimitExceeded",
-        _ => "Unknown",
-    }
 }
 
 #[cfg(test)]

--- a/crates/rimap-content/src/lib.rs
+++ b/crates/rimap-content/src/lib.rs
@@ -16,6 +16,9 @@ pub mod unicode;
 mod html;
 mod lookalike;
 
+#[cfg(any(test, feature = "test-util"))]
+pub mod testutil;
+
 pub use error::ContentError;
 pub use output::{
     AttachmentMeta, Content, ContentMeta, MailingListInfo, SecurityWarning, Untrusted, WarningCode,

--- a/crates/rimap-content/src/testutil.rs
+++ b/crates/rimap-content/src/testutil.rs
@@ -1,0 +1,161 @@
+//! Test/diagnostic label helpers. Gated on the `test-util` feature so the
+//! mappings are not part of the regular public API surface.
+//!
+//! Callers decide how to treat unknown variants (both enums are
+//! `#[non_exhaustive]`): the helpers return `None` for anything not in
+//! the known set. The runner surfaces `None` as a severity-keyed label;
+//! the corpus test harness panics on `None` (a new variant = a harness
+//! gap that must fail loudly).
+
+use crate::{ContentError, WarningCode};
+
+/// Map a known `WarningCode` variant to its stable audit-label string.
+/// Returns `None` for variants added after this function was written.
+#[must_use]
+pub fn warning_code_label(code: WarningCode) -> Option<&'static str> {
+    let label = match code {
+        WarningCode::UnicodeZeroWidthStripped => "unicode_zero_width_stripped",
+        WarningCode::UnicodeBidiOverrideStripped => "unicode_bidi_override_stripped",
+        WarningCode::UnicodeC0C1Stripped => "unicode_c0_c1_stripped",
+        WarningCode::ParseHeaderSmugglingBlocked => "parse_header_smuggling_blocked",
+        WarningCode::ParseMimeTypeMismatch => "parse_mime_type_mismatch",
+        WarningCode::ParseBodystructureTypeMismatch => "parse_bodystructure_type_mismatch",
+        WarningCode::ParseAttachmentPolyglot => "parse_attachment_polyglot",
+        WarningCode::ParseBodyTruncated => "parse_body_truncated",
+        WarningCode::ParseMimeDepthExceeded => "parse_mime_depth_exceeded",
+        WarningCode::ParseMimePartCountExceeded => "parse_mime_part_count_exceeded",
+        WarningCode::ParseHeaderCountExceeded => "parse_header_count_exceeded",
+        WarningCode::ParseAttachmentFilenameRewritten => "parse_attachment_filename_rewritten",
+        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
+        WarningCode::HtmlLinkTextHrefMismatch => "html_link_text_href_mismatch",
+        WarningCode::HtmlScriptStripped => "html_script_stripped",
+        WarningCode::HtmlStyleStripped => "html_style_stripped",
+        WarningCode::HtmlRemoteImageStripped => "html_remote_image_stripped",
+        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
+        WarningCode::LookalikeMixedScript => "lookalike_mixed_script",
+        WarningCode::LookalikeHomographDomain => "lookalike_homograph_domain",
+        WarningCode::LookalikeIdnPunycode => "lookalike_idn_punycode",
+        WarningCode::LookalikeFilenameExtensionSpoof => "lookalike_filename_extension_spoof",
+        WarningCode::ServerNonAtomicMoveFallback => "server_non_atomic_move_fallback",
+        _ => return None,
+    };
+    Some(label)
+}
+
+/// Map a known `ContentError` variant to its kind string. Returns `None`
+/// for variants added after this function was written.
+#[must_use]
+#[expect(
+    unreachable_patterns,
+    reason = "ContentError is #[non_exhaustive]; _ arm is unreachable within the defining crate \
+              but required for forward-compatibility with new variants added externally"
+)]
+pub fn error_kind_label(err: &ContentError) -> Option<&'static str> {
+    let label = match err {
+        ContentError::Malformed { .. } => "Malformed",
+        ContentError::LimitExceeded { .. } => "LimitExceeded",
+        _ => return None,
+    };
+    Some(label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{error_kind_label, warning_code_label};
+    use crate::{ContentError, WarningCode};
+
+    #[test]
+    fn all_known_warning_codes_have_stable_labels() {
+        let cases = [
+            (
+                WarningCode::UnicodeZeroWidthStripped,
+                "unicode_zero_width_stripped",
+            ),
+            (
+                WarningCode::UnicodeBidiOverrideStripped,
+                "unicode_bidi_override_stripped",
+            ),
+            (WarningCode::UnicodeC0C1Stripped, "unicode_c0_c1_stripped"),
+            (
+                WarningCode::ParseHeaderSmugglingBlocked,
+                "parse_header_smuggling_blocked",
+            ),
+            (
+                WarningCode::ParseMimeTypeMismatch,
+                "parse_mime_type_mismatch",
+            ),
+            (
+                WarningCode::ParseBodystructureTypeMismatch,
+                "parse_bodystructure_type_mismatch",
+            ),
+            (
+                WarningCode::ParseAttachmentPolyglot,
+                "parse_attachment_polyglot",
+            ),
+            (WarningCode::ParseBodyTruncated, "parse_body_truncated"),
+            (
+                WarningCode::ParseMimeDepthExceeded,
+                "parse_mime_depth_exceeded",
+            ),
+            (
+                WarningCode::ParseMimePartCountExceeded,
+                "parse_mime_part_count_exceeded",
+            ),
+            (
+                WarningCode::ParseHeaderCountExceeded,
+                "parse_header_count_exceeded",
+            ),
+            (
+                WarningCode::ParseAttachmentFilenameRewritten,
+                "parse_attachment_filename_rewritten",
+            ),
+            (
+                WarningCode::HtmlHiddenContentDetected,
+                "html_hidden_content_detected",
+            ),
+            (
+                WarningCode::HtmlLinkTextHrefMismatch,
+                "html_link_text_href_mismatch",
+            ),
+            (WarningCode::HtmlScriptStripped, "html_script_stripped"),
+            (WarningCode::HtmlStyleStripped, "html_style_stripped"),
+            (
+                WarningCode::HtmlRemoteImageStripped,
+                "html_remote_image_stripped",
+            ),
+            (
+                WarningCode::HtmlAnchorUnparsableHref,
+                "html_anchor_unparsable_href",
+            ),
+            (WarningCode::LookalikeMixedScript, "lookalike_mixed_script"),
+            (
+                WarningCode::LookalikeHomographDomain,
+                "lookalike_homograph_domain",
+            ),
+            (WarningCode::LookalikeIdnPunycode, "lookalike_idn_punycode"),
+            (
+                WarningCode::LookalikeFilenameExtensionSpoof,
+                "lookalike_filename_extension_spoof",
+            ),
+            (
+                WarningCode::ServerNonAtomicMoveFallback,
+                "server_non_atomic_move_fallback",
+            ),
+        ];
+        for (code, expected) in cases {
+            assert_eq!(
+                warning_code_label(code),
+                Some(expected),
+                "label for {code:?} changed",
+            );
+        }
+    }
+
+    #[test]
+    fn error_kind_label_stable_for_known_variants() {
+        let malformed = ContentError::Malformed {
+            reason: "x".to_string(),
+        };
+        assert_eq!(error_kind_label(&malformed), Some("Malformed"));
+    }
+}

--- a/crates/rimap-content/tests/injection_corpus.rs
+++ b/crates/rimap-content/tests/injection_corpus.rs
@@ -10,12 +10,17 @@
 #![expect(clippy::unwrap_used, reason = "test code may unwrap on fixture I/O")]
 #![expect(clippy::expect_used, reason = "test code may expect on fixture I/O")]
 #![expect(clippy::panic, reason = "test failures are reported via panic")]
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "corpus harness panics on unclassified variants inside Result-returning helpers; \
+              this is intentional — an unknown variant is a harness gap, not a recoverable error"
+)]
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use rimap_content::{Content, ContentError, WarningCode, parse_message};
+use rimap_content::{Content, ContentError, parse_message};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -99,47 +104,6 @@ fn load_fixtures() -> BTreeMap<String, (PathBuf, Expected)> {
     out
 }
 
-fn warning_code_to_label(code: WarningCode) -> &'static str {
-    match code {
-        WarningCode::UnicodeZeroWidthStripped => "unicode_zero_width_stripped",
-        WarningCode::UnicodeBidiOverrideStripped => "unicode_bidi_override_stripped",
-        WarningCode::UnicodeC0C1Stripped => "unicode_c0_c1_stripped",
-        WarningCode::ParseHeaderSmugglingBlocked => "parse_header_smuggling_blocked",
-        WarningCode::ParseMimeTypeMismatch => "parse_mime_type_mismatch",
-        WarningCode::ParseAttachmentPolyglot => "parse_attachment_polyglot",
-        WarningCode::ParseBodyTruncated => "parse_body_truncated",
-        WarningCode::ParseMimeDepthExceeded => "parse_mime_depth_exceeded",
-        WarningCode::ParseMimePartCountExceeded => "parse_mime_part_count_exceeded",
-        WarningCode::ParseHeaderCountExceeded => "parse_header_count_exceeded",
-        WarningCode::ParseAttachmentFilenameRewritten => "parse_attachment_filename_rewritten",
-        WarningCode::HtmlHiddenContentDetected => "html_hidden_content_detected",
-        WarningCode::HtmlLinkTextHrefMismatch => "html_link_text_href_mismatch",
-        WarningCode::HtmlScriptStripped => "html_script_stripped",
-        WarningCode::HtmlStyleStripped => "html_style_stripped",
-        WarningCode::HtmlRemoteImageStripped => "html_remote_image_stripped",
-        WarningCode::HtmlAnchorUnparsableHref => "html_anchor_unparsable_href",
-        WarningCode::LookalikeMixedScript => "lookalike_mixed_script",
-        WarningCode::LookalikeHomographDomain => "lookalike_homograph_domain",
-        WarningCode::LookalikeIdnPunycode => "lookalike_idn_punycode",
-        WarningCode::LookalikeFilenameExtensionSpoof => "lookalike_filename_extension_spoof",
-        // Required because WarningCode is #[non_exhaustive] (exhaustive
-        // match is not allowed outside the defining crate). Any future
-        // variant reaching this arm is a test-harness gap and should
-        // cause the corpus run to fail loudly.
-        _ => panic!("corpus harness encountered unclassified WarningCode variant {code:?}"),
-    }
-}
-
-fn error_kind_label(err: &ContentError) -> &'static str {
-    match err {
-        ContentError::Malformed { .. } => "Malformed",
-        ContentError::LimitExceeded { .. } => "LimitExceeded",
-        // Required because ContentError is #[non_exhaustive]. Any
-        // future variant reaching this arm should fail the corpus run.
-        _ => panic!("corpus harness encountered unclassified ContentError variant {err:?}"),
-    }
-}
-
 fn assert_fixture(name: &str, dir: &Path, expected: &Expected) -> Result<(), String> {
     let input_path = dir.join("input.eml");
     let raw = fs::read(&input_path).map_err(|e| format!("read {}: {e}", input_path.display()))?;
@@ -185,7 +149,14 @@ fn assert_warning_codes(
 ) -> Result<(), String> {
     let observed: Vec<&'static str> = warnings
         .iter()
-        .map(|w| warning_code_to_label(w.code))
+        .map(|w| {
+            rimap_content::testutil::warning_code_label(w.code).unwrap_or_else(|| {
+                panic!(
+                    "corpus harness encountered unclassified WarningCode variant {:?}",
+                    w.code
+                )
+            })
+        })
         .collect();
     for required in &expected.warning_codes {
         if !observed.contains(&required.as_str()) {
@@ -243,7 +214,9 @@ fn assert_err_kind(name: &str, err: &ContentError, expected: &Expected) -> Resul
     let Some(want) = expected.error_kind.as_deref() else {
         return Err(format!("{name}: expect=error requires error_kind field"));
     };
-    let got = error_kind_label(err);
+    let got = rimap_content::testutil::error_kind_label(err).unwrap_or_else(|| {
+        panic!("corpus harness encountered unclassified ContentError variant {err:?}")
+    });
     if got == want {
         Ok(())
     } else {

--- a/crates/rimap-core/src/account.rs
+++ b/crates/rimap-core/src/account.rs
@@ -18,6 +18,10 @@ pub struct AccountId(String);
 impl AccountId {
     /// Parse and validate an account name.
     ///
+    /// Validation accepts ASCII alphanumerics and hyphens, 1–64 characters.
+    /// The stored value is normalized to ASCII lowercase, so `AccountId`
+    /// equality is case-insensitive (`Work` and `work` are the same account).
+    ///
     /// # Errors
     ///
     /// Returns [`InvalidAccountName`] if the name is empty, longer than
@@ -48,7 +52,7 @@ impl AccountId {
                 ),
             });
         }
-        Ok(Self(name.to_string()))
+        Ok(Self(name.to_ascii_lowercase()))
     }
 
     /// The built-in default account name.
@@ -83,14 +87,22 @@ pub struct InvalidAccountName {
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "tests")]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
 
     #[test]
     fn valid_names() {
-        for name in ["work", "personal-2", "default", "a", "A-1-b"] {
-            let id = AccountId::new(name).expect("should be valid");
-            assert_eq!(id.as_str(), name);
+        // Each tuple is (input, expected stored form after lowercasing).
+        for (input, expected) in [
+            ("work", "work"),
+            ("personal-2", "personal-2"),
+            ("default", "default"),
+            ("a", "a"),
+            ("A-1-b", "a-1-b"),
+        ] {
+            let id = AccountId::new(input).expect("should be valid");
+            assert_eq!(id.as_str(), expected);
         }
     }
 
@@ -141,5 +153,38 @@ mod tests {
     fn default_account_valid() {
         let id = AccountId::default_account();
         assert_eq!(id.as_str(), DEFAULT_ACCOUNT_NAME);
+    }
+
+    #[test]
+    fn new_lowercases_inner_string() {
+        // Regression (#75): casing is presentation, not identity.
+        assert_eq!(AccountId::new("Work").unwrap().as_str(), "work");
+        assert_eq!(AccountId::new("WORK").unwrap().as_str(), "work");
+        assert_eq!(
+            AccountId::new("PersonalAccount-2").unwrap().as_str(),
+            "personalaccount-2"
+        );
+    }
+
+    #[test]
+    fn case_variants_are_equal() {
+        // Regression (#75): AccountId("Work") == AccountId("work") so that
+        // the multi-account registry deduplicates them via BTreeMap insert.
+        assert_eq!(
+            AccountId::new("Work").unwrap(),
+            AccountId::new("work").unwrap()
+        );
+        assert_eq!(
+            AccountId::new("WORK").unwrap(),
+            AccountId::new("work").unwrap()
+        );
+    }
+
+    #[test]
+    fn display_prints_normalized_lowercase() {
+        // Regression (#75): Display follows the inner string, so users see
+        // the canonical lowercase form in error messages.
+        let id = AccountId::new("Work").unwrap();
+        assert_eq!(format!("{id}"), "work");
     }
 }

--- a/crates/rimap-core/src/error.rs
+++ b/crates/rimap-core/src/error.rs
@@ -200,6 +200,11 @@ pub enum RimapError {
     #[error("ERR_INTERNAL: {0}")]
     Internal(String),
     /// Multiple accounts configured but none selected.
+    ///
+    /// The `available` list is surfaced in the Display form. This is a
+    /// deliberate usability choice for v1 stdio-only deployments — see
+    /// `docs/security-model.md` §"Account-name exposure in errors"
+    /// (issue #81). Revisit before any non-stdio transport ships.
     #[error(
         "multiple accounts configured; call `use_account` or pass \
          `account` parameter. Available: {}",
@@ -210,6 +215,10 @@ pub enum RimapError {
         available: Vec<String>,
     },
     /// Named account not found in registry.
+    ///
+    /// The `available` list is surfaced in the Display form — see the
+    /// `NoAccount` variant and `docs/security-model.md` for the posture
+    /// decision (issue #81).
     #[error("account '{name}' not found. Available: {}", available.join(", "))]
     UnknownAccount {
         /// The name that was looked up.

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -447,6 +447,7 @@ mod tests {
         preflight_size_check, project_size,
     };
     use crate::error::ImapError;
+    use crate::types::tests::uid;
     use async_imap::imap_proto::{
         BodyContentCommon, BodyContentSinglePart, BodyStructure as ImapProtoBodyStructure,
         ContentEncoding, ContentType,
@@ -679,11 +680,6 @@ mod tests {
             Err(ImapError::SizeLimit { limit }) => assert_eq!(limit, 1000),
             other => panic!("expected SizeLimit, got {other:?}"),
         }
-    }
-
-    #[expect(clippy::unwrap_used, reason = "tests")]
-    fn uid(n: u32) -> crate::types::Uid {
-        crate::types::Uid::new(n).unwrap()
     }
 
     #[test]

--- a/crates/rimap-imap/src/ops/move_message.rs
+++ b/crates/rimap-imap/src/ops/move_message.rs
@@ -216,13 +216,9 @@ fn build_results(uids: &[Uid]) -> Vec<MoveResult> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "tests")]
 mod tests {
     use super::*;
-
-    fn uid(n: u32) -> Uid {
-        Uid::new(n).expect("non-zero")
-    }
+    use crate::types::tests::uid;
 
     #[test]
     fn build_results_is_empty_for_empty_input() {

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -429,7 +429,7 @@ impl FolderAttribute {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::FolderAttribute;
 
     #[test]
@@ -543,5 +543,28 @@ mod tests {
             special_use: None,
         };
         assert!(f.selectable());
+    }
+
+    /// Test-only UID constructor shared by the crate's unit tests. Panics
+    /// on `0`; callers pass pre-validated non-zero literals.
+    #[expect(clippy::expect_used, reason = "tests")]
+    pub(crate) fn uid(n: u32) -> super::Uid {
+        super::Uid::new(n).expect("non-zero")
+    }
+
+    #[test]
+    fn uid_helper_constructs_non_zero() {
+        // Regression: the shared test helper (#93) must accept any non-zero
+        // u32 and round-trip through Uid::get.
+        assert_eq!(uid(1).get(), 1);
+        assert_eq!(uid(u32::MAX).get(), u32::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-zero")]
+    fn uid_helper_panics_on_zero() {
+        // Regression: the shared helper preserves the NonZeroU32 invariant
+        // by panicking on 0 (callers are test code).
+        let _ = uid(0);
     }
 }

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -14,6 +14,31 @@ Multi-account introduces a cross-account exfiltration vector: a
 compromised agent could read from one account and send via another.
 Per-account posture gates, rate limits, and audit logging mitigate this.
 
+**Account-name exposure in errors.** `ERR_NO_ACCOUNT` and
+`ERR_UNKNOWN_ACCOUNT` include the full list of configured account
+names in their user-facing message (see
+`RimapError::NoAccount` / `UnknownAccount`). This is deliberate: an
+agent that hits one of these errors can learn the available accounts
+and recover on its next call without operator intervention.
+
+For v1.0 (stdio-only, single trusted client) this is the right
+trade-off. Operators who run the server over stdio own both sides of
+the pipe, and the enumeration value is zero.
+
+**When this must be revisited:** if and when an HTTP/SSE/WebSocket
+transport ships, authenticated clients may have different trust
+levels, and one bad call would reveal every configured account name
+to any client that can reach the endpoint. Before that transport
+lands, one of the following changes is required:
+
+1. Narrow the disclosure — include only `count: N` in the user
+   message; move the full list to a debug-log-only path.
+2. Gate the disclosure on a config flag
+   (`expose_account_names_in_errors = true`, default off for
+   non-stdio transports).
+
+Issue #81 tracks this commitment.
+
 **The server does not trust:** email bodies, headers, sender addresses,
 display names, attachment filenames, link targets, or any
 server-provided content. All of these are treated as untrusted input


### PR DESCRIPTION
## Summary

Bundles the five remaining Tier 2 roadmap issues into one PR.

- **#75** — `AccountId::new` now lowercases the stored inner string; casing is presentation, not identity. `validate_multi` becomes case-insensitive via the existing duplicate check. Validation still runs on the original spelling so non-ASCII errors surface with the user-supplied form.
- **#79** — aarch64-linux release binary embeds a cargo-auditable SBOM via a `Cross.toml` pre-build hook; all five release targets now ship identical SBOM metadata.
- **#81** — Explicit posture decision (option 1): keep account-name disclosure in `NoAccount`/`UnknownAccount` errors for v1 stdio-only. Documented in `docs/security-model.md` with committed revisit triggers before any non-stdio transport ships.
- **#93** — Dedupe `fn uid(n: u32) -> Uid` test helper across `ops/fetch.rs` and `ops/move_message.rs`; single `pub(crate)` helper now lives in `types.rs` behind `#[cfg(test)]`.
- **#94** — Share `warning_code_label` / `error_kind_label` between `epvme_runner.rs` and `injection_corpus.rs` via a new feature-gated `rimap_content::testutil` module. Shared helpers return `Option<&'static str>`; each caller preserves its on-unknown behavior (runner falls back to a severity-keyed label; corpus harness panics). Also restored two missing variants (`ParseBodystructureTypeMismatch`, `ServerNonAtomicMoveFallback`) that were absent from the pre-dedupe copies.

Closes #75
Closes #79
Closes #81
Closes #93
Closes #94

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo deny check` (advisories, bans, licenses, sources all ok)
- [x] `cargo test --workspace --lib`
- [x] `cargo build -p rimap-content` (no features) — `epvme_runner` correctly skipped via `required-features`
- [x] `cargo build -p rimap-content --features test-util --bins` — `epvme_runner` builds
- [x] Pre-push `just test` suite (cargo nextest + container pruning) — green
- [ ] CI aarch64 release build emits non-empty `cargo audit bin` output on the uploaded artifact (verified at next tag push)