### PR TITLE
fix: address review findings for issues #110-#113

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "rimap-content",
  "rimap-core",
  "rimap-imap",
+ "rimap-server",
  "rimap-smtp",
  "rmcp",
  "schemars",

--- a/crates/rimap-audit/src/redact/mod.rs
+++ b/crates/rimap-audit/src/redact/mod.rs
@@ -493,8 +493,14 @@ fn list_labels_schema(tool: ToolName) -> RedactionSchema {
 }
 
 fn use_account_schema(tool: ToolName) -> RedactionSchema {
-    use FieldPolicy::Verbatim;
-    RedactionSchema::new(tool, &[("account", Verbatim)])
+    // `account` is redacted — NOT verbatim — because the handler's
+    // bidi/zero-width pre-check runs AFTER `tool_start` is emitted,
+    // so a spoofed name would otherwise land in the audit log verbatim.
+    // Operators reviewing audit records see `<redacted:N>`; the handler
+    // still returns `ERR_INVALID_INPUT` for spoofed input so downstream
+    // correlation via `tool_end.code` is unaffected (#111).
+    use FieldPolicy::RedactString;
+    RedactionSchema::new(tool, &[("account", RedactString)])
 }
 
 fn list_accounts_schema(tool: ToolName) -> RedactionSchema {
@@ -746,6 +752,22 @@ mod tests {
         assert!(
             !schema.policies.contains_key("in_reply_to_folder"),
             "in_reply_to_folder is not a spec field",
+        );
+    }
+
+    #[test]
+    fn use_account_schema_redacts_account_field() {
+        // MCP-INJ-03 / MAIL-AUD-02: `account` must be RedactString so
+        // spoofed bidi/zero-width codepoints cannot reach the JSONL
+        // audit log before the handler's pre-check runs.
+        let table = crate::redact::schemas();
+        let schema = table
+            .iter()
+            .find(|s| s.tool == ToolName::UseAccount)
+            .expect("use_account schema exists");
+        assert_eq!(
+            schema.policies.get("account").copied(),
+            Some(FieldPolicy::RedactString),
         );
     }
 

--- a/crates/rimap-core/src/folder_name.rs
+++ b/crates/rimap-core/src/folder_name.rs
@@ -137,7 +137,7 @@ fn validate(raw: &str) -> Result<(), FolderNameError> {
     // These have no legitimate use in client-supplied folder names and
     // are a common spoofing vector (e.g., `INBOX\u{202e}txt.exe`).
     for c in raw.chars() {
-        if is_rejected_codepoint(c) {
+        if is_rejected_display_codepoint(c) {
             return Err(FolderNameError::new(
                 "folder name contains disallowed Unicode character",
             ));
@@ -169,7 +169,7 @@ fn validate(raw: &str) -> Result<(), FolderNameError> {
 /// style forbids `_ =>` in normal `match` expressions). Adding a new
 /// codepoint is a single-line edit either way.
 #[must_use]
-pub(crate) fn is_rejected_codepoint(c: char) -> bool {
+pub fn is_rejected_display_codepoint(c: char) -> bool {
     matches!(
         c,
         '\u{202a}'..='\u{202e}'    // bidi embedding / override
@@ -321,7 +321,7 @@ mod proptests {
 
     use proptest::prelude::*;
 
-    use super::{FolderName, is_rejected_codepoint};
+    use super::{FolderName, is_rejected_display_codepoint};
 
     /// Reference implementation: an independent re-derivation of the
     /// rules from the [`super::FolderName::new`] doc comment, used to
@@ -353,7 +353,7 @@ mod proptests {
             }
         }
         for c in s.chars() {
-            if is_rejected_codepoint(c) {
+            if is_rejected_display_codepoint(c) {
                 return false;
             }
         }
@@ -402,7 +402,7 @@ mod proptests {
 
         /// Every codepoint in the Unicode Tag Characters block
         /// (U+E0000..=U+E007F) is rejected, independent of the shared
-        /// [`is_rejected_codepoint`] predicate — if the predicate is
+        /// [`is_rejected_display_codepoint`] predicate — if the predicate is
         /// silently edited to drop the Tag range, this test fails.
         #[test]
         fn any_unicode_tag_codepoint_is_rejected(

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod warning;
 pub use crate::auth_event::{AuthEvent, AuthResult};
 pub use crate::auth_sink::{AuthEventSink, AuthSinkError};
 pub use crate::error::{ErrorCode, RimapError};
-pub use crate::folder_name::{FolderName, FolderNameError};
+pub use crate::folder_name::{FolderName, FolderNameError, is_rejected_display_codepoint};
 pub use crate::posture::{Posture, UnknownPosture};
 pub use crate::posture_matrix::base_allows;
 pub use crate::tls::{FingerprintParseError, TlsFingerprint};

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -11,6 +11,13 @@ description = "Rusty IMAP MCP server: security-first MCP server for IMAP email a
 [lints]
 workspace = true
 
+[features]
+default = []
+# Gated entry points for integration tests that need to exercise the
+# full dispatch pipeline (posture → breaker → rate → audit envelope →
+# handler) without re-implementing the composition in each test.
+test-support = []
+
 [lib]
 name = "rimap_server"
 path = "src/lib.rs"
@@ -52,5 +59,9 @@ predicates = { workspace = true }
 mail-parser = { workspace = true }
 rimap-audit = { path = "../rimap-audit", version = "1.0.0", features = ["test-injection"] }
 rimap-config = { path = "../rimap-config", version = "1.0.0", features = ["test-support"] }
+# Self dev-dep enables the `test-support` feature unconditionally for
+# integration tests, so `ImapMcpServer::execute_tool_for_test` is in
+# scope without every test harness passing `--features test-support`.
+rimap-server = { path = ".", version = "1.0.0", features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -18,7 +18,7 @@ use rimap_audit::{CancelledToolEndSender, ToolEndInputs, ToolStartInputs};
 use rimap_core::tool::ToolName;
 use rmcp::model::{CallToolResult, ErrorData};
 
-use crate::mcp::dispatch::PostureContext;
+use crate::mcp::dispatch::{DispatchTicket, PostureContext};
 use crate::mcp::server::ImapMcpServer;
 
 impl ImapMcpServer {
@@ -26,7 +26,7 @@ impl ImapMcpServer {
     /// redact+hash args, emit `tool_start`, time the body, emit
     /// `tool_end` with the status/error code derived from the body's
     /// result. Returns the MCP-shaped `CallToolResult` or `ErrorData`.
-    pub(super) async fn run_with_audit_envelope<F>(
+    pub(super) async fn run_with_audit_envelope<F, Fut>(
         &self,
         tool: ToolName,
         audit_account: Option<String>,
@@ -35,7 +35,8 @@ impl ImapMcpServer {
         body: F,
     ) -> Result<CallToolResult, ErrorData>
     where
-        F: std::future::Future<Output = Result<serde_json::Value, rimap_core::RimapError>>,
+        F: FnOnce(DispatchTicket) -> Fut,
+        Fut: std::future::Future<Output = Result<serde_json::Value, rimap_core::RimapError>>,
     {
         let args_value = serde_json::Value::Object(args.clone());
         let redacted = self.redact_tool_args(tool, &args_value);
@@ -54,7 +55,11 @@ impl ImapMcpServer {
             self.cancellation_sender.clone(),
         );
 
-        let result = body.await;
+        // Mint a `DispatchTicket` only now that the envelope is open.
+        // Consuming it by value inside `dispatch_tool` makes "forgot
+        // the envelope" a compile error.
+        let ticket = DispatchTicket::new();
+        let result = body(ticket).await;
 
         // Body completed normally. Disarm before any further await points so
         // a drop of THIS future between here and emit_tool_end does not cause

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -10,12 +10,48 @@
 //! [`rimap_core::RimapError`] codes to [`rimap_authz::breaker::FailureReason`]
 //! used to drive the per-account circuit breaker.
 
+use std::marker::PhantomData;
+
 use rmcp::model::{CallToolResult, ErrorData};
 
 use crate::boot::registry::AccountState;
 use crate::mcp::server::ImapMcpServer;
 use crate::mcp::tool_catalog::{parse_args, ser};
 use rimap_core::tool::ToolName;
+
+/// Proof that the audit envelope is open and the pre-dispatch checks
+/// (posture, breaker, rate limit) have already run. Construction is
+/// module-private; the only way to obtain one is via the `body`
+/// closure of [`ImapMcpServer::run_with_audit_envelope`] (or the
+/// sibling [`ImapMcpServer::dispatch_infrastructure`]). Because
+/// [`ImapMcpServer::dispatch_tool`] consumes the ticket by value,
+/// forgetting to wrap a dispatch in the envelope becomes a compile
+/// error rather than a silent audit-log gap (#110).
+///
+/// Deliberately neither `Clone` nor `Copy`: a ticket is single-use,
+/// scoped to one envelope. Kept `Send` so the dispatch future can
+/// cross `await` boundaries inside the tokio-based MCP handler.
+///
+/// Note on marker choice: the original design sketched
+/// `PhantomData<*const ()>` to kill `Send`/`Sync` auto-traits as a
+/// further reuse barrier. `rmcp::ServerHandler::call_tool` returns a
+/// `MaybeSendFuture`-bound future, and non-`Send` types held across
+/// `.await` boundaries inside that future fail to compile. Since the
+/// ticket is a ZST with no interior state, the weaker `PhantomData<()>`
+/// is as safe as `*const ()` would be — the `Send`/`Sync` auto-traits
+/// have nothing to leak — and the single-use guarantee still holds via
+/// absence of `Clone`/`Copy` and module-private construction.
+#[must_use]
+pub(crate) struct DispatchTicket(PhantomData<()>);
+
+impl DispatchTicket {
+    /// Mint a new ticket. Callable only from within this module, so
+    /// every ticket is necessarily produced by the audit-envelope
+    /// machinery that opens a `tool_start` record.
+    pub(super) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
 
 /// Posture context recorded in audit envelope headers.
 ///
@@ -76,9 +112,16 @@ impl ImapMcpServer {
     /// Dispatch to the tool handler for `tool`. Each arm serializes its
     /// typed response to `serde_json::Value` before returning, so the
     /// audit envelope works with a single future type.
-    #[doc(hidden)]
-    pub async fn dispatch_tool(
+    ///
+    /// The [`DispatchTicket`] is consumed by value — its construction is
+    /// module-private and only `run_with_audit_envelope` /
+    /// `dispatch_infrastructure` mint one, so any caller must first open
+    /// the audit envelope. This closes the bypass where a direct
+    /// `dispatch_tool` call would skip posture gating, breaker updates,
+    /// rate limits, and the `tool_start`/`tool_end` envelope (#110).
+    pub(crate) async fn dispatch_tool(
         &self,
+        _ticket: DispatchTicket,
         account: &AccountState,
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
@@ -173,48 +216,56 @@ impl ImapMcpServer {
         // Infrastructure tools have no per-account posture; record an
         // explicit sentinel so log readers can distinguish these from
         // per-account dispatches.
-        self.run_with_audit_envelope(tool, None, PostureContext::Infrastructure, args, async {
-            // Infrastructure tools bypass posture + breaker, but still
-            // enforce a process-wide rate limit.
-            self.registry.check_infrastructure_rate()?;
-            match tool {
-                ToolName::UseAccount => {
-                    let input = parse_args::<crate::tools::admin::accounts::UseAccountInput>(args)?;
-                    ser(
-                        crate::tools::admin::accounts::handle_use_account(&self.registry, input)
-                            .await?,
-                    )
+        self.run_with_audit_envelope(
+            tool,
+            None,
+            PostureContext::Infrastructure,
+            args,
+            |_ticket| async move {
+                // Infrastructure tools bypass posture + breaker, but still
+                // enforce a process-wide rate limit.
+                self.registry.check_infrastructure_rate()?;
+                match tool {
+                    ToolName::UseAccount => {
+                        let input =
+                            parse_args::<crate::tools::admin::accounts::UseAccountInput>(args)?;
+                        ser(crate::tools::admin::accounts::handle_use_account(
+                            &self.registry,
+                            input,
+                        )
+                        .await?)
+                    }
+                    ToolName::ListAccounts => ser(
+                        crate::tools::admin::accounts::handle_list_accounts(&self.registry).await?,
+                    ),
+                    ToolName::ListFolders
+                    | ToolName::Search
+                    | ToolName::SearchAdvanced
+                    | ToolName::FetchMessage
+                    | ToolName::FetchMessageHtml
+                    | ToolName::ListAttachments
+                    | ToolName::DownloadAttachment
+                    | ToolName::MarkRead
+                    | ToolName::MarkUnread
+                    | ToolName::Flag
+                    | ToolName::Unflag
+                    | ToolName::AddLabel
+                    | ToolName::RemoveLabel
+                    | ToolName::ListLabels
+                    | ToolName::MoveMessage
+                    | ToolName::CreateDraft
+                    | ToolName::SendEmail
+                    | ToolName::DeleteMessage
+                    | ToolName::Expunge
+                    | ToolName::CreateFolder
+                    | ToolName::RenameFolder
+                    | ToolName::DeleteFolder => Err(rimap_core::RimapError::Internal(format!(
+                        "not an infrastructure tool: {}",
+                        tool.as_str(),
+                    ))),
                 }
-                ToolName::ListAccounts => {
-                    ser(crate::tools::admin::accounts::handle_list_accounts(&self.registry).await?)
-                }
-                ToolName::ListFolders
-                | ToolName::Search
-                | ToolName::SearchAdvanced
-                | ToolName::FetchMessage
-                | ToolName::FetchMessageHtml
-                | ToolName::ListAttachments
-                | ToolName::DownloadAttachment
-                | ToolName::MarkRead
-                | ToolName::MarkUnread
-                | ToolName::Flag
-                | ToolName::Unflag
-                | ToolName::AddLabel
-                | ToolName::RemoveLabel
-                | ToolName::ListLabels
-                | ToolName::MoveMessage
-                | ToolName::CreateDraft
-                | ToolName::SendEmail
-                | ToolName::DeleteMessage
-                | ToolName::Expunge
-                | ToolName::CreateFolder
-                | ToolName::RenameFolder
-                | ToolName::DeleteFolder => Err(rimap_core::RimapError::Internal(format!(
-                    "not an infrastructure tool: {}",
-                    tool.as_str(),
-                ))),
-            }
-        })
+            },
+        )
         .await
     }
 }

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -23,7 +23,7 @@ use rmcp::model::{
 };
 use rmcp::service::RequestContext;
 
-use crate::boot::registry::AccountRegistry;
+use crate::boot::registry::{AccountRegistry, AccountState};
 use crate::mcp::dispatch::{PostureContext, rimap_error_to_breaker_reason};
 use crate::mcp::tool_catalog::TOOL_DEFS;
 use crate::mcp::tool_name::{
@@ -63,6 +63,129 @@ impl ImapMcpServer {
             redaction_salt: Arc::new(RedactionSalt::new_random()),
         }
     }
+
+    /// Run an account-scoped tool through the full dispatch pipeline:
+    /// posture header + breaker / rate-limit guard + audit envelope +
+    /// handler. Returns the MCP-shaped `CallToolResult`.
+    ///
+    /// Single source of truth for the account-scoped dispatch
+    /// composition. Used by the real [`ServerHandler::call_tool`] trait
+    /// method and by `execute_tool_for_test`, so the two paths cannot
+    /// drift.
+    pub(crate) async fn dispatch_account_scoped(
+        &self,
+        account: &AccountState,
+        tool: ToolName,
+        args: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Legacy single-account `"default"` records `None`; multi-account
+        // records the account name.
+        let audit_account: Option<String> =
+            if account.id.as_str() == rimap_core::account::DEFAULT_ACCOUNT_NAME {
+                None
+            } else {
+                Some(account.id.as_str().to_string())
+            };
+        let posture = PostureContext::Account(account.guard.matrix().posture());
+
+        self.run_with_audit_envelope(tool, audit_account, posture, args, |ticket| async move {
+            account.guard.pre_dispatch(tool)?;
+            let result = Box::pin(self.dispatch_tool(ticket, account, tool, args)).await;
+            match &result {
+                Ok(_) => account.guard.on_success(),
+                Err(e) => {
+                    if let Some(reason) = rimap_error_to_breaker_reason(e) {
+                        account.guard.on_failure(reason);
+                    }
+                }
+            }
+            result
+        })
+        .await
+    }
+}
+
+/// Integration-test entry point. Exposed under `#[cfg(any(test, feature =
+/// "test-support"))]` so tests exercise the exact same pipeline (account
+/// resolve → `pre_dispatch` → audit envelope → `dispatch_tool`) as real
+/// MCP clients, instead of re-implementing the composition and drifting
+/// from the production path. Production builds without the feature
+/// cannot see this method, and `dispatch_tool` itself is `pub(crate)`.
+#[cfg(any(test, feature = "test-support"))]
+impl ImapMcpServer {
+    /// Execute `tool` through the full dispatch pipeline. Mirrors
+    /// [`ServerHandler::call_tool`] but takes a pre-parsed `ToolName`
+    /// and a raw JSON args value; returns the handler's JSON body
+    /// (the `structured_content` of the MCP `CallToolResult`).
+    ///
+    /// # Errors
+    ///
+    /// Any pipeline failure — unknown account, posture denial, rate
+    /// limit, breaker open, handler error — is returned as a
+    /// [`rimap_core::RimapError`] (the MCP `ErrorData` shape is
+    /// bridged back).
+    pub async fn execute_tool_for_test(
+        &self,
+        account_name: Option<&str>,
+        tool: ToolName,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value, rimap_core::RimapError> {
+        if account_name.is_some() && tool.is_infrastructure() {
+            return Err(rimap_core::RimapError::invalid_input(
+                "execute_tool_for_test: account_name must be None for infrastructure tools",
+            ));
+        }
+
+        let args_map = match args {
+            serde_json::Value::Object(m) => m,
+            serde_json::Value::Null => serde_json::Map::new(),
+            other => {
+                return Err(rimap_core::RimapError::invalid_input(format!(
+                    "execute_tool_for_test expects a JSON object or null, got {other}"
+                )));
+            }
+        };
+
+        let call_tool_result = if tool.is_infrastructure() {
+            Box::pin(self.dispatch_infrastructure(tool, &args_map))
+                .await
+                .map_err(|e| error_data_to_rimap_error(&e))?
+        } else {
+            let account = self.registry.resolve(account_name)?;
+            Box::pin(self.dispatch_account_scoped(account, tool, &args_map))
+                .await
+                .map_err(|e| error_data_to_rimap_error(&e))?
+        };
+
+        Ok(extract_json_from_call_tool_result(call_tool_result))
+    }
+}
+
+/// Extract the structured JSON body from a [`CallToolResult`]. Prefers
+/// the `structured_content` field (populated by `CallToolResult::structured`),
+/// falling back to parsing the first text content item. Returns
+/// `serde_json::Value::Null` when neither is available.
+#[cfg(any(test, feature = "test-support"))]
+fn extract_json_from_call_tool_result(result: CallToolResult) -> serde_json::Value {
+    if let Some(value) = result.structured_content {
+        return value;
+    }
+    result
+        .content
+        .into_iter()
+        .next()
+        .and_then(|content| content.as_text().map(|t| t.text.clone()))
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+/// Bridge an MCP `ErrorData` back to a `RimapError` for the test
+/// helper's uniform `Result<_, RimapError>` surface. The original
+/// message is preserved; the JSON-RPC / MCP code is surfaced as a
+/// prefix so test assertions can still match on it.
+#[cfg(any(test, feature = "test-support"))]
+fn error_data_to_rimap_error(err: &ErrorData) -> rimap_core::RimapError {
+    rimap_core::RimapError::Internal(format!("mcp error {}: {}", err.code.0, err.message))
 }
 
 impl ServerHandler for ImapMcpServer {
@@ -287,29 +410,7 @@ impl ServerHandler for ImapMcpServer {
             .resolve(explicit_account.as_deref())
             .map_err(|e| crate::mcp::error::to_mcp_error(&e))?;
 
-        // Compute the account field for audit records. Legacy single-account
-        // `"default"` records `None`; multi-account records the account name.
-        let audit_account: Option<String> =
-            if account.id.as_str() == rimap_core::account::DEFAULT_ACCOUNT_NAME {
-                None
-            } else {
-                Some(account.id.as_str().to_string())
-            };
-        let posture = PostureContext::Account(account.guard.matrix().posture());
-
-        self.run_with_audit_envelope(tool_name, audit_account, posture, &args, async {
-            account.guard.pre_dispatch(tool_name)?;
-            let result = Box::pin(self.dispatch_tool(account, tool_name, &args)).await;
-            match &result {
-                Ok(_) => account.guard.on_success(),
-                Err(e) => {
-                    if let Some(reason) = rimap_error_to_breaker_reason(e) {
-                        account.guard.on_failure(reason);
-                    }
-                }
-            }
-            result
-        })
-        .await
+        self.dispatch_account_scoped(account, tool_name, &args)
+            .await
     }
 }

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -159,6 +159,39 @@ impl ImapMcpServer {
 
         Ok(extract_json_from_call_tool_result(call_tool_result))
     }
+
+    /// Drive `run_with_audit_envelope` with a caller-supplied async
+    /// factory. The factory receives no ticket (infrastructure posture,
+    /// no account) and returns a future that can suspend at will.
+    ///
+    /// Used in integration tests that need a body that actually yields
+    /// at an `.await` point — e.g. to verify the `AuditEnvelopeGuard`
+    /// fires when the dispatch future is aborted mid-body. Real tool
+    /// handlers complete synchronously so the abort never lands mid-body;
+    /// this method lets the test inject a never-resolving body instead.
+    pub async fn run_envelope_with_body_for_test<Fut>(
+        &self,
+        tool: ToolName,
+        body_fut: Fut,
+    ) -> Result<CallToolResult, ErrorData>
+    where
+        Fut: std::future::Future<Output = Result<serde_json::Value, rimap_core::RimapError>>,
+    {
+        debug_assert!(
+            tool.is_infrastructure(),
+            "run_envelope_with_body_for_test only supports infrastructure tools; \
+             use execute_tool_for_test for account-scoped tools"
+        );
+        let args = serde_json::Map::new();
+        self.run_with_audit_envelope(
+            tool,
+            None,
+            crate::mcp::dispatch::PostureContext::Infrastructure,
+            &args,
+            |_ticket| body_fut,
+        )
+        .await
+    }
 }
 
 /// Extract the structured JSON body from a [`CallToolResult`]. Prefers

--- a/crates/rimap-server/src/tools/admin/accounts.rs
+++ b/crates/rimap-server/src/tools/admin/accounts.rs
@@ -44,7 +44,8 @@ pub struct ListAccountsMeta {
 /// # Errors
 ///
 /// Returns `RimapError::Authz { code: InvalidInput, ... }` if
-/// `input.account` is not a valid account-name shape. Returns
+/// `input.account` contains bidi-control, zero-width, or Unicode Tag
+/// codepoints, or if it is not a valid account-name shape. Returns
 /// `RimapError::UnknownAccount { ... }` if the name does not match a
 /// configured account.
 #[expect(
@@ -55,8 +56,19 @@ pub async fn handle_use_account(
     registry: &AccountRegistry,
     input: UseAccountInput,
 ) -> Result<ToolResponse<UseAccountMeta>, rimap_core::RimapError> {
-    // Validate the account-name shape first so invalid input cannot be
-    // echoed into error messages or reach `set_active`'s lookup code.
+    // Validate the account-name defense-in-depth: reject display-spoofing
+    // codepoints first (so the audit record's error carries a specific
+    // diagnostic), then delegate shape validation to AccountId::new, which
+    // also enforces the ASCII-only constraint.
+    if input
+        .account
+        .chars()
+        .any(rimap_core::is_rejected_display_codepoint)
+    {
+        return Err(rimap_core::RimapError::invalid_input(
+            "account: disallowed bidi/zero-width/tag codepoint in name",
+        ));
+    }
     rimap_core::account::AccountId::new(&input.account)
         .map_err(|_| rimap_core::RimapError::invalid_input("invalid account name"))?;
     let previous = registry.set_active(&input.account)?;
@@ -194,5 +206,40 @@ mod tests {
         let resp = handle_list_accounts(&reg).await.expect("infallible");
         assert_eq!(resp.meta.count, 0);
         assert!(resp.meta.accounts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn use_account_rejects_bidi_override_in_name() {
+        let registry = empty_registry();
+        let input = UseAccountInput {
+            account: "work\u{202e}cnyS".to_string(),
+        };
+        let err = handle_use_account(&registry, input)
+            .await
+            .expect_err("must reject");
+        assert_invalid_input(&err);
+        // Pin the pre-check as the rejecting layer, not AccountId::new's ASCII
+        // gate. If the pre-check is removed, AccountId::new still rejects but
+        // with a different message — this assertion catches that regression.
+        assert!(
+            err.to_string().contains("bidi"),
+            "expected bidi-specific rejection, got: {err}",
+        );
+    }
+
+    #[tokio::test]
+    async fn use_account_rejects_zero_width_space_in_name() {
+        let registry = empty_registry();
+        let input = UseAccountInput {
+            account: "work\u{200b}mail".to_string(),
+        };
+        let err = handle_use_account(&registry, input)
+            .await
+            .expect_err("must reject");
+        assert_invalid_input(&err);
+        assert!(
+            err.to_string().contains("zero-width"),
+            "expected zero-width-specific rejection, got: {err}",
+        );
     }
 }

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -1,5 +1,7 @@
 //! `list_folders` tool handler.
 
+use std::fmt::Write as _;
+
 use rimap_content::output::SecurityWarning;
 use serde::Serialize;
 
@@ -8,18 +10,45 @@ use crate::mcp::response::ToolResponse;
 
 const MAX_FOLDER_NAME_BYTES: usize = 1024;
 
-/// Sanitize a single `Folder` entry, returning the cleaned name and flag
-/// list while appending any security warnings to `warnings`.
+/// Escape a folder name as a JSON-safe Unicode-escape string. Each
+/// non-ASCII-printable codepoint becomes `\u{H..}` (one or more
+/// lowercase hex digits); ASCII printables in 0x20..0x7E (excluding
+/// backslash) are emitted literally. Clients round-trip by applying
+/// the inverse of this escape convention. Backslash is always escaped
+/// so the output can be safely embedded in a JSON string.
+fn escape_wire_name(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        if (c as u32) >= 0x20 && (c as u32) < 0x7f && c != '\\' {
+            out.push(c);
+        } else {
+            let _ = write!(out, "\\u{{{:x}}}", c as u32);
+        }
+    }
+    out
+}
+
+/// Sanitize a single `Folder` entry, returning the cleaned name, optional
+/// wire name, and flag list while appending any security warnings to
+/// `warnings`.
 fn sanitize_folder_entry(
     folder: &rimap_imap::types::Folder,
     warnings: &mut Vec<SecurityWarning>,
-) -> (String, Vec<String>) {
+) -> (String, Option<String>, Vec<String>) {
     let (clean_name, name_warnings) = rimap_content::unicode::sanitize(
         folder.name.as_bytes(),
         None,
         MAX_FOLDER_NAME_BYTES,
         "folder.name",
     );
+    // NFKC normalization, bidi stripping, or any sanitize transform counts
+    // as a "name change" — the server owns the canonical wire bytes, so
+    // the client must round-trip `name_wire` for subsequent commands.
+    let name_wire = if clean_name == folder.name {
+        None
+    } else {
+        Some(escape_wire_name(&folder.name))
+    };
     warnings.extend(name_warnings);
 
     let flags: Vec<String> = folder
@@ -38,14 +67,22 @@ fn sanitize_folder_entry(
         })
         .collect();
 
-    (clean_name, flags)
+    (clean_name, name_wire, flags)
 }
 
 /// A single folder entry in a `list_folders` response.
 #[derive(Debug, Serialize)]
 pub struct FolderEntry {
-    /// Folder name.
+    /// Sanitized, display-safe folder name. Bidi / zero-width / Unicode
+    /// Tag codepoints are stripped before this reaches the client.
     pub name: String,
+    /// Raw wire form of the folder name encoded as `\u{H..}` Unicode
+    /// escape sequences (see `escape_wire_name`), populated only when
+    /// `name` differs from what the server sent. Clients pass this back
+    /// for SELECT / STATUS / MOVE / FETCH when `name_wire` is `Some(_)`;
+    /// otherwise they pass `name` directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_wire: Option<String>,
     /// Hierarchy delimiter character reported by the server.
     pub delimiter: Option<char>,
     /// IMAP folder attribute flags (e.g. `"\\HasNoChildren"`).
@@ -86,10 +123,11 @@ pub(crate) fn sanitize_folder_entries(
     let mut warnings: Vec<SecurityWarning> = Vec::new();
 
     for folder in folders {
-        let (clean_name, flags) = sanitize_folder_entry(&folder, &mut warnings);
+        let (clean_name, name_wire, flags) = sanitize_folder_entry(&folder, &mut warnings);
 
         entries.push(FolderEntry {
             name: clean_name,
+            name_wire,
             delimiter: folder.delimiter,
             flags,
             exists: None,
@@ -122,10 +160,11 @@ pub async fn handle(
     let mut warnings: Vec<SecurityWarning> = Vec::new();
 
     for (folder, status) in pairs {
-        let (clean_name, flags) = sanitize_folder_entry(&folder, &mut warnings);
+        let (clean_name, name_wire, flags) = sanitize_folder_entry(&folder, &mut warnings);
 
         entries.push(FolderEntry {
             name: clean_name,
+            name_wire,
             delimiter: folder.delimiter,
             flags,
             exists: status.as_ref().and_then(|s| s.messages),
@@ -180,6 +219,60 @@ mod tests {
         assert!(
             warnings.is_empty(),
             "clean name should produce no warnings, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn escape_wire_name_passes_ascii_printables_literally() {
+        assert_eq!(super::escape_wire_name("INBOX/Sent"), "INBOX/Sent");
+    }
+
+    #[test]
+    fn escape_wire_name_escapes_backslash() {
+        assert_eq!(
+            super::escape_wire_name("Archive\\2024"),
+            "Archive\\u{5c}2024"
+        );
+    }
+
+    #[test]
+    fn escape_wire_name_escapes_supplementary_codepoint() {
+        // U+1F4E7 ENVELOPE — supplementary plane. Confirms variable-width
+        // hex output, not fixed four-digit HHHH.
+        assert_eq!(super::escape_wire_name("\u{1f4e7}"), "\\u{1f4e7}");
+    }
+
+    #[test]
+    fn wire_name_preserved_when_sanitizer_modifies_name() {
+        let folders = vec![Folder {
+            name: "Inbox\u{202e}gnilleS".to_string(),
+            attributes: vec![FolderAttribute::HasNoChildren],
+            delimiter: Some('/'),
+            special_use: None,
+        }];
+        let (entries, _warnings) = sanitize_folder_entries(folders);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].name_wire.as_deref(),
+            Some("Inbox\\u{202e}gnilleS"),
+            "wire name should preserve the original codepoints as escapes",
+        );
+    }
+
+    #[test]
+    fn wire_name_absent_for_clean_folder_name() {
+        let folders = vec![Folder {
+            name: "INBOX".to_string(),
+            attributes: vec![FolderAttribute::HasNoChildren],
+            delimiter: Some('/'),
+            special_use: None,
+        }];
+        let (entries, _warnings) = sanitize_folder_entries(folders);
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0].name_wire.is_none(),
+            "clean name should have no wire-name field, got: {:?}",
+            entries[0].name_wire,
         );
     }
 }

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -44,10 +44,18 @@ fn sanitize_folder_entry(
     // NFKC normalization, bidi stripping, or any sanitize transform counts
     // as a "name change" — the server owns the canonical wire bytes, so
     // the client must round-trip `name_wire` for subsequent commands.
+    //
+    // Cap raw input before escape. A hostile IMAP server can send a
+    // multi-MB mailbox name; `clean_name` is already capped by
+    // sanitize, but `folder.name` is not. Without this cap a 100 MB
+    // name with bidi codepoints could force a ~270 MB allocation in
+    // `escape_wire_name` (MCP-PRIV-04 / MAIL-DOS-04).
     let name_wire = if clean_name == folder.name {
         None
     } else {
-        Some(escape_wire_name(&folder.name))
+        let capped =
+            rimap_content::unicode::truncate_graphemes(&folder.name, MAX_FOLDER_NAME_BYTES * 4);
+        Some(escape_wire_name(&capped))
     };
     warnings.extend(name_warnings);
 
@@ -273,6 +281,42 @@ mod tests {
             entries[0].name_wire.is_none(),
             "clean name should have no wire-name field, got: {:?}",
             entries[0].name_wire,
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test assertion — None is a hard failure"
+    )]
+    fn name_wire_is_bounded_for_oversized_raw_name() {
+        // Construct a 100 KiB folder name. Sanitize will truncate the
+        // display form to MAX_FOLDER_NAME_BYTES (1024 bytes), so the
+        // inequality branch fires and `escape_wire_name` runs on whatever
+        // raw slice we forward. The cap in `sanitize_folder_entry` bounds
+        // that input to at most MAX_FOLDER_NAME_BYTES * 4 bytes of raw
+        // input, which at worst-case ~10x expansion produces a bounded
+        // wire name.
+        let oversized: String = "A\u{202e}".repeat(20_000); // ~80 KB
+        let folders = vec![Folder {
+            name: oversized,
+            attributes: vec![FolderAttribute::HasNoChildren],
+            delimiter: Some('/'),
+            special_use: None,
+        }];
+        let (entries, _warnings) = sanitize_folder_entries(folders);
+        assert_eq!(entries.len(), 1);
+        // Worst-case cap: 4 * MAX_FOLDER_NAME_BYTES raw bytes, each
+        // expanding to at most ~10 chars in the escape, plus a small
+        // margin for format overhead.
+        let wire = entries[0]
+            .name_wire
+            .as_ref()
+            .expect("sanitizer-modified name should have name_wire");
+        assert!(
+            wire.len() <= 50 * 1024,
+            "name_wire grew to {} bytes; cap not enforced",
+            wire.len(),
         );
     }
 }

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -80,6 +80,7 @@ fn sanitize_folder_entry(
 
 /// A single folder entry in a `list_folders` response.
 #[derive(Debug, Serialize)]
+#[non_exhaustive]
 pub struct FolderEntry {
     /// Sanitized, display-safe folder name. Bidi / zero-width / Unicode
     /// Tag codepoints are stripped before this reaches the client.

--- a/crates/rimap-server/src/tools/compose/send_email.rs
+++ b/crates/rimap-server/src/tools/compose/send_email.rs
@@ -19,6 +19,12 @@ pub struct SentCopyInfo {
     pub uid: Option<u32>,
     /// `true` if the APPEND failed (best-effort; send itself succeeded).
     pub failed: bool,
+    /// Error code classifying why the APPEND failed. Present only when
+    /// `failed` is `true`. Clients use this to decide whether to retry
+    /// (e.g. `Timeout`, `ConnectionLost`) or surface an operator action
+    /// (e.g. `InvalidInput`, `ImapProtocol`, `AttachmentTooLarge`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<rimap_core::ErrorCode>,
 }
 
 /// Trusted metadata for a `send_email` response.
@@ -73,10 +79,12 @@ pub async fn handle(
     // by this point — any failure (including a malformed resolved folder
     // name) must route through `sent_copy.failed` so the response does
     // not misleadingly report delivery failure. Each error is logged at
-    // the failure site, then collapsed to `()` so the pure helper that
-    // builds `SentCopyInfo` stays non-generic and trivially testable.
+    // the failure site. The error code is forwarded to the helper so
+    // clients can distinguish transient from permanent failures; the
+    // helper stays pure and directly testable without an AccountState
+    // fixture.
     let sent_folder: &str = account.special_use.sent().unwrap_or("Sent");
-    let append_outcome: Option<Result<Option<u32>, ()>> =
+    let append_outcome: Option<Result<Option<u32>, rimap_core::ErrorCode>> =
         if let Err(e) = rimap_authz::folder_name::FolderName::new(sent_folder) {
             // Stable warn fields go in the structured record; the full
             // Display goes to DEBUG so it is available when tracing is
@@ -97,13 +105,14 @@ pub async fn handle(
             {
                 Ok(result) => Some(Ok(result.uid.map(rimap_imap::types::Uid::get))),
                 Err(e) => {
+                    let code = e.code();
                     tracing::warn!(
                         tool = "send_email",
-                        error_code = %e.code(),
+                        error_code = %code,
                         "failed to append to Sent folder",
                     );
                     tracing::debug!(error = %e, "sent-folder append detail");
-                    Some(Err(()))
+                    Some(Err(code))
                 }
             }
         };
@@ -132,20 +141,18 @@ pub async fn handle(
 /// `AccountState` fixture.
 fn build_sent_copy_info(
     sent_folder: &str,
-    append_outcome: Option<Result<Option<u32>, ()>>,
+    append_outcome: Option<Result<Option<u32>, rimap_core::ErrorCode>>,
 ) -> SentCopyInfo {
-    // `if let` (rather than `match`) keeps the two failure shapes
-    // (`None`, `Some(Err(()))`) on the same `else` branch without
-    // tripping the workspace's no-wildcard-arm policy via `_ =>`.
-    let (uid, failed) = if let Some(Ok(uid)) = append_outcome {
-        (uid, false)
-    } else {
-        (None, true)
+    let (uid, failed, failure_code) = match append_outcome {
+        Some(Ok(uid)) => (uid, false, None),
+        Some(Err(code)) => (None, true, Some(code)),
+        None => (None, true, Some(rimap_core::ErrorCode::InvalidInput)),
     };
     SentCopyInfo {
         folder: sent_folder.to_string(),
         uid,
         failed,
+        failure_code,
     }
 }
 
@@ -233,6 +240,7 @@ mod tests {
         assert_eq!(info.folder, "Sent");
         assert!(info.failed);
         assert_eq!(info.uid, None);
+        assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::InvalidInput));
     }
 
     #[test]
@@ -256,10 +264,11 @@ mod tests {
 
     #[test]
     fn sent_copy_marks_failed_when_append_errored() {
-        let info = build_sent_copy_info("Sent", Some(Err(())));
+        let info = build_sent_copy_info("Sent", Some(Err(rimap_core::ErrorCode::ImapProtocol)));
         assert_eq!(info.folder, "Sent");
         assert!(info.failed);
         assert_eq!(info.uid, None);
+        assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::ImapProtocol));
     }
 
     #[test]
@@ -270,5 +279,20 @@ mod tests {
         // SPECIAL-USE mappings like "[Gmail]/Sent Mail".
         let info = build_sent_copy_info("[Gmail]/Sent Mail", Some(Ok(Some(7))));
         assert_eq!(info.folder, "[Gmail]/Sent Mail");
+    }
+
+    #[test]
+    fn sent_copy_carries_failure_code_when_append_errored() {
+        let info = build_sent_copy_info("Sent", Some(Err(rimap_core::ErrorCode::Timeout)));
+        assert!(info.failed);
+        assert_eq!(info.uid, None);
+        assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::Timeout));
+    }
+
+    #[test]
+    fn sent_copy_omits_failure_code_on_success() {
+        let info = build_sent_copy_info("Sent", Some(Ok(Some(42))));
+        assert!(!info.failed);
+        assert_eq!(info.failure_code, None);
     }
 }

--- a/crates/rimap-server/src/tools/compose/send_email.rs
+++ b/crates/rimap-server/src/tools/compose/send_email.rs
@@ -12,6 +12,7 @@ pub type SendEmailInput = ComposeInput;
 
 /// Copy-to-Sent result included in a `send_email` response.
 #[derive(Debug, Serialize)]
+#[non_exhaustive]
 pub struct SentCopyInfo {
     /// Folder the copy was appended to.
     pub folder: String,

--- a/crates/rimap-server/tests/dispatch_ticket.rs
+++ b/crates/rimap-server/tests/dispatch_ticket.rs
@@ -167,3 +167,95 @@ async fn use_account_rejected_spoof_is_not_in_audit_log() {
         "account field must be redacted placeholder, got: {account_field:?}",
     );
 }
+
+/// Drop the outer dispatch future while a tool body is still awaiting.
+/// The `AuditEnvelopeGuard::Drop` path must fire, enqueue a synthetic
+/// cancellation `tool_end`, and the drainer must persist it to disk.
+///
+/// Regression test for the closure form of `run_with_audit_envelope`:
+/// the guard lives inside the closure's future, so if a future refactor
+/// disarms the guard above the `body(ticket).await`, cancellation would
+/// silently lose its `tool_end` — the unit test at `audit_envelope.rs`
+/// only exercises the guard in isolation, not the closure wiring.
+#[tokio::test]
+async fn drop_during_body_enqueues_cancellation_tool_end() {
+    use rimap_audit::spawn_drainer;
+    use std::sync::Arc;
+    use tokio::time::Duration;
+
+    let audit_dir = tempfile::TempDir::new().expect("audit tempdir");
+    let audit_path = audit_dir.path().join("audit.jsonl");
+    let audit = rimap_audit::AuditWriter::open(&rimap_audit::AuditOptions {
+        path: audit_path.clone(),
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: rimap_audit::Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let registry =
+        rimap_server::boot::registry::AccountRegistry::new(std::collections::BTreeMap::new());
+    let (cancellation_sender, cancellation_rx) = rimap_audit::cancellation_channel();
+    let drainer = spawn_drainer(cancellation_rx, audit.clone());
+    let server = Arc::new(rimap_server::mcp::server::ImapMcpServer::new(
+        registry,
+        audit,
+        cancellation_sender,
+    ));
+
+    // Use a never-resolving body so the abort reliably lands mid-body.
+    // Real infrastructure tools (ListAccounts) complete synchronously —
+    // no yield point exists between guard creation and `guard.disarm()`,
+    // so aborting at a yield point always lands outside the guarded
+    // window. Injecting `std::future::pending()` guarantees the abort
+    // fires while the body is suspended, which is exactly the state
+    // where `AuditEnvelopeGuard::drop` must enqueue the cancellation
+    // `tool_end`.
+    //
+    // The invariant: every `tool_start` must be paired with a `tool_end`.
+    // Aborting mid-body exercises the cancellation path: the guard's
+    // `Drop` fires and enqueues the `tool_end` via the drainer channel.
+    // A bad refactor that disarms the guard ABOVE `body(ticket).await`
+    // breaks this: the `Drop` is a no-op, no `tool_end` is enqueued,
+    // and counts diverge.
+    let server_clone = Arc::clone(&server);
+    let task = tokio::spawn(async move {
+        server_clone
+            .run_envelope_with_body_for_test(
+                ToolName::ListAccounts,
+                std::future::pending::<Result<serde_json::Value, rimap_core::RimapError>>(),
+            )
+            .await
+    });
+
+    // Give the envelope time to emit `tool_start` and enter the body's
+    // pending await before aborting. The `spawn_blocking` for `tool_start`
+    // is the only real work before the body; 50ms gives comfortable headroom
+    // on loaded CI runners without approaching the test's total budget.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    task.abort();
+    let _ = task.await; // wait for the abort to settle
+
+    // Give the drainer time to flush the queued cancellation record.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    drop(server);
+    // Await the drainer after dropping server (which drops the last sender)
+    // so it exits cleanly after flushing remaining records.
+    drainer.await.expect("drainer task should not panic");
+
+    let records = read_audit_records(&audit_path);
+
+    let starts = records.iter().filter(|r| r["kind"] == "tool_start").count();
+    let ends = records.iter().filter(|r| r["kind"] == "tool_end").count();
+
+    assert_eq!(
+        starts, ends,
+        "tool_start count must equal tool_end count (no orphans); records={records:#?}",
+    );
+    assert!(
+        starts >= 1,
+        "at least one dispatch envelope must have fired; records={records:#?}",
+    );
+}

--- a/crates/rimap-server/tests/dispatch_ticket.rs
+++ b/crates/rimap-server/tests/dispatch_ticket.rs
@@ -1,0 +1,105 @@
+//! Compile-time enforcement of the audit envelope (#110).
+//!
+//! `execute_tool_for_test` composes the full dispatch pipeline
+//! (posture → `pre_dispatch` → audit envelope → handler). This test
+//! invokes it against the `list_accounts` infrastructure tool — no
+//! IMAP connection is required — and asserts that both the
+//! `tool_start` and `tool_end` envelope records landed in the audit
+//! log. If a future refactor lets a caller bypass
+//! `run_with_audit_envelope`, these records are absent and the test
+//! fails.
+
+#![expect(clippy::expect_used, reason = "tests")]
+
+use std::collections::BTreeMap;
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_core::tool::ToolName;
+use rimap_server::boot::registry::AccountRegistry;
+use rimap_server::mcp::server::ImapMcpServer;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct TestFixture {
+    server: ImapMcpServer,
+    audit_path: std::path::PathBuf,
+    _audit_dir: TempDir,
+}
+
+fn build_test_server() -> TestFixture {
+    let audit_dir = TempDir::new().expect("audit tempdir");
+    let audit_path = audit_dir.path().join("audit.jsonl");
+    let audit = AuditWriter::open(&AuditOptions {
+        path: audit_path.clone(),
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let registry = AccountRegistry::new(BTreeMap::new());
+    let (cancellation_sender, _cancellation_rx) = rimap_audit::cancellation_channel();
+    let server = ImapMcpServer::new(registry, audit, cancellation_sender);
+
+    TestFixture {
+        server,
+        audit_path,
+        _audit_dir: audit_dir,
+    }
+}
+
+fn read_audit_records(path: &std::path::Path) -> Vec<serde_json::Value> {
+    let contents = std::fs::read_to_string(path).expect("read audit log");
+    contents
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parse record"))
+        .collect()
+}
+
+#[tokio::test]
+async fn execute_tool_for_test_emits_audit_envelope() {
+    let fixture = build_test_server();
+
+    // `list_accounts` is an infrastructure tool and needs no IMAP
+    // connection. If the envelope were bypassed, the tool_start /
+    // tool_end records below would be missing.
+    let _result = fixture
+        .server
+        .execute_tool_for_test(None, ToolName::ListAccounts, json!({}))
+        .await
+        .expect("execute_tool_for_test should succeed");
+
+    // Drop the server to flush the audit writer.
+    drop(fixture.server);
+
+    let records = read_audit_records(&fixture.audit_path);
+
+    assert!(
+        records
+            .iter()
+            .any(|r| r["kind"] == "tool_start" && r["tool"] == "list_accounts"),
+        "tool_start record missing; dispatch must not bypass the envelope. records={records:#?}",
+    );
+    assert!(
+        records
+            .iter()
+            .any(|r| r["kind"] == "tool_end" && r["tool"] == "list_accounts"),
+        "tool_end record missing. records={records:#?}",
+    );
+
+    let start = records
+        .iter()
+        .find(|r| r["kind"] == "tool_start" && r["tool"] == "list_accounts")
+        .expect("tool_start record");
+    let end = records
+        .iter()
+        .find(|r| r["kind"] == "tool_end" && r["tool"] == "list_accounts")
+        .expect("tool_end record");
+
+    assert_eq!(
+        start["seq"], end["start_seq"],
+        "tool_end.start_seq must correlate back to tool_start.seq; otherwise the envelope's pairing guarantee is broken",
+    );
+}

--- a/crates/rimap-server/tests/dispatch_ticket.rs
+++ b/crates/rimap-server/tests/dispatch_ticket.rs
@@ -103,3 +103,67 @@ async fn execute_tool_for_test_emits_audit_envelope() {
         "tool_end.start_seq must correlate back to tool_start.seq; otherwise the envelope's pairing guarantee is broken",
     );
 }
+
+#[tokio::test]
+async fn use_account_rejected_spoof_is_not_in_audit_log() {
+    let fixture = build_test_server();
+
+    // Spoofed account name containing RLO (U+202E) and ZWSP (U+200B).
+    // After rejection, the audit log must contain neither the raw
+    // account string nor the JSON-escaped form of the spoof codepoints —
+    // only the `<redacted:N>` placeholder.
+    let _ = fixture
+        .server
+        .execute_tool_for_test(
+            None,
+            ToolName::UseAccount,
+            serde_json::json!({ "account": "work\u{202e}\u{200b}cnyS" }),
+        )
+        .await;
+
+    drop(fixture.server);
+
+    let raw = std::fs::read_to_string(&fixture.audit_path).expect("read audit log");
+
+    // serde_json may or may not escape non-ASCII as \uXXXX depending on
+    // configuration. Check both the literal UTF-8 bytes AND the JSON-escape
+    // forms so a regression is caught regardless of serializer behavior.
+    assert!(
+        !raw.contains('\u{202e}'),
+        "RTL-override literal codepoint leaked into audit log: {raw}",
+    );
+    assert!(
+        !raw.contains('\u{200b}'),
+        "zero-width-space literal codepoint leaked into audit log: {raw}",
+    );
+    assert!(
+        !raw.contains("\\u202e"),
+        "RTL-override escape form leaked into audit log: {raw}",
+    );
+    assert!(
+        !raw.contains("\\u200b"),
+        "zero-width-space escape form leaked into audit log: {raw}",
+    );
+    assert!(
+        !raw.contains("\"work"),
+        "raw account string prefix leaked into audit log: {raw}",
+    );
+
+    // Walk the structured records. The `tool_start` for `use_account`
+    // must carry the redacted placeholder in `arguments_redacted.account`,
+    // proving the `RedactString` policy is active.
+    let start = raw
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|r| r["kind"] == "tool_start" && r["tool"] == "use_account")
+        .expect("tool_start record for use_account");
+    let account_field = start
+        .pointer("/arguments_redacted/account")
+        .expect("tool_start must expose arguments_redacted.account")
+        .as_str()
+        .expect("arguments_redacted.account must be a string");
+    assert!(
+        account_field.starts_with("<redacted:"),
+        "account field must be redacted placeholder, got: {account_field:?}",
+    );
+}

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -360,17 +360,7 @@ async fn call_tool(
     let tool = std::str::FromStr::from_str(tool_name).map_err(
         |e: rimap_core::tool::ParseToolNameError| rimap_core::RimapError::Internal(e.to_string()),
     )?;
-
-    let account = server.registry.resolve(None)?;
-
-    account.guard.pre_dispatch(tool)?;
-
-    let args_map = match args {
-        serde_json::Value::Object(m) => m,
-        _ => serde_json::Map::new(),
-    };
-
-    server.dispatch_tool(account, tool, &args_map).await
+    server.execute_tool_for_test(None, tool, args).await
 }
 
 /// Extract a u32 from a JSON value (safe truncation check).

--- a/docs/superpowers/plans/2026-04-20-issues-110-113-followup.md
+++ b/docs/superpowers/plans/2026-04-20-issues-110-113-followup.md
@@ -1,0 +1,1092 @@
+# Issues #110–#113 Review Follow-up Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address every finding from the four post-implementation reviews (MCP-security, email-IMAP-security, rust-safety, supply-chain) of branch `fix/issues-110-113` — including medium, low, and info-level items.
+
+**Architecture:** Eight tasks as new commits on top of `fix/issues-110-113` (branch is unpushed; linear history preferred over amending mid-branch). Tasks are ordered most-important → least-important so the branch can be stopped partway and still land a stronger cut than today. Tasks 1–3 close real gaps (audit-log spoofing, escape amplification, cancellation-test coverage). Tasks 4–7 are hygiene (non_exhaustive, doc sanitization, cross-crate co-maintenance notes). Task 8 is CI.
+
+**Tech Stack:** Same as branch — Rust stable, `tokio`, `serde` + `schemars`, `thiserror`, `tracing`, `rimap-content::unicode` for filtering/truncation, `rimap-audit` for redaction/writer.
+
+**Base branch:** `fix/issues-110-113` at commit `c67686b`. All task commits land on top.
+
+**Self-review notes (controller):** Verified `FieldPolicy::RedactString` behavior (replaces value with `"<redacted:N>"`), `rimap_content::unicode::truncate_graphemes` signature (`&str, usize -> String`), and the external test callers of `ImapMcpServer::registry` in `tests/e2e.rs:424, 518` that must migrate before Task 5 can narrow visibility.
+
+---
+
+## Task 1: Close the `use_account` audit-log spoofing gap (#111 follow-up)
+
+`handle_use_account` rejects spoofed codepoints, but `run_with_audit_envelope` emits `tool_start` **before** the handler runs, and `use_account_schema` declares `account` as `Verbatim`. So `"work\u{202e}cnyS"` still lands in the JSONL audit record. The original issue body explicitly says *"the audit log should not carry unsanitized input either"* — the current fix doesn't meet that bar. Fix by switching the schema to `RedactString`; pin with a test that reads the audit log and asserts no spoofed bytes.
+
+**Files:**
+- Modify: `crates/rimap-audit/src/redact/mod.rs:495-498` (`use_account_schema`)
+- Test: `crates/rimap-server/tests/dispatch_ticket.rs` (new `#[tokio::test]` at end of file)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `crates/rimap-server/tests/dispatch_ticket.rs`:
+
+```rust
+#[tokio::test]
+async fn use_account_rejected_spoof_is_not_in_audit_log() {
+    let fixture = build_test_server();
+
+    // Spoofed account name containing RLO (U+202E) and ZWSP (U+200B).
+    // The handler rejects it, but we want to confirm the audit log's
+    // redacted arguments do NOT carry these codepoints either.
+    let _ = fixture
+        .server
+        .execute_tool_for_test(
+            None,
+            ToolName::UseAccount,
+            serde_json::json!({ "account": "work\u{202e}\u{200b}cnyS" }),
+        )
+        .await;
+
+    drop(fixture.server);
+
+    let raw = std::fs::read_to_string(&fixture.audit_path).expect("read audit log");
+    assert!(
+        !raw.contains('\u{202e}'),
+        "RTL-override codepoint leaked into the audit log: {raw}",
+    );
+    assert!(
+        !raw.contains('\u{200b}'),
+        "zero-width space codepoint leaked into the audit log: {raw}",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test — it should fail**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp/.worktrees/issues-110-113
+cargo test -p rimap-server --test dispatch_ticket --features test-support
+```
+
+Expected: FAIL. The assertion reports `RTL-override codepoint leaked into the audit log: ...` because the current `Verbatim` policy echoes the raw account string into `tool_start.arguments_redacted.account`.
+
+- [ ] **Step 3: Switch the schema to `RedactString`**
+
+Edit `crates/rimap-audit/src/redact/mod.rs:495-498`:
+
+Before:
+```rust
+fn use_account_schema(tool: ToolName) -> RedactionSchema {
+    use FieldPolicy::Verbatim;
+    RedactionSchema::new(tool, &[("account", Verbatim)])
+}
+```
+
+After:
+```rust
+fn use_account_schema(tool: ToolName) -> RedactionSchema {
+    // `account` is redacted — NOT verbatim — because the handler's
+    // bidi/zero-width pre-check runs AFTER `tool_start` is emitted,
+    // so a spoofed name would otherwise land in the audit log verbatim.
+    // Operators reviewing audit records see `<redacted:N>`; the handler
+    // still returns `ERR_INVALID_INPUT` for spoofed input so downstream
+    // correlation via `tool_end.code` is unaffected (#111).
+    use FieldPolicy::RedactString;
+    RedactionSchema::new(tool, &[("account", RedactString)])
+}
+```
+
+- [ ] **Step 4: Run the test — it should pass**
+
+```bash
+cargo test -p rimap-server --test dispatch_ticket --features test-support
+```
+
+Expected: all `dispatch_ticket` tests PASS.
+
+- [ ] **Step 5: Check other use_account tests still pass**
+
+```bash
+cargo test -p rimap-audit --lib
+cargo test -p rimap-server --lib -- tools::admin::accounts
+```
+
+Expected: all PASS. If any existing rimap-audit test asserts `account` appears verbatim in a redacted record, update its expectation to `<redacted:N>` — this is the intended behavior change.
+
+- [ ] **Step 6: Update the plan doc with a "review follow-up" note**
+
+Edit `docs/superpowers/plans/2026-04-20-issues-110-113.md`. In the Task 1 section, add a note at the top acknowledging the scope correction:
+
+```markdown
+> **Review follow-up (2026-04-20):** the original Task 1 landed the handler
+> pre-check but left the audit-log verbatim echo intact. The audit-log gap
+> was closed in a follow-up commit by switching `use_account_schema`'s
+> `account` field from `Verbatim` to `RedactString`; see
+> `2026-04-20-issues-110-113-followup.md` Task 1.
+```
+
+- [ ] **Step 7: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace --all-features
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-audit/src/redact/mod.rs \
+        crates/rimap-server/tests/dispatch_ticket.rs \
+        docs/superpowers/plans/2026-04-20-issues-110-113.md
+git commit -m "$(cat <<'EOF'
+fix(audit): redact use_account account arg to close MCP-INJ-03 audit gap
+
+Follow-up to #111. The handler pre-check in a8b7a6a rejects spoofed
+bidi/zero-width account names, but `run_with_audit_envelope` emits
+`tool_start` before the handler runs, and `use_account_schema` declared
+`account` as `Verbatim` — so the spoofed string still landed in the
+audit log.
+
+Switch the policy to `RedactString`. Operators reviewing audit records
+see `<redacted:N>`; the `tool_end` record still carries
+`code: "ERR_INVALID_INPUT"` so correlation and triage are unaffected.
+Flagged as MCP-INJ-03/MCP-AUD-05 (mcp-security-reviewer) and
+MAIL-AUD-02 (email-imap-security-reviewer) on the post-fix review pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Cap `escape_wire_name` input to prevent memory amplification (#113 follow-up)
+
+A malicious IMAP server (or MITM past TLS pinning) can return a multi-MB folder name. `sanitize` truncates `clean_name` to 1024 bytes, but the `clean_name != folder.name` comparison then sends the full un-capped raw name to `escape_wire_name`, which can expand worst-case ~10× per codepoint. Cap the raw name to a multiple of `MAX_FOLDER_NAME_BYTES` before escaping.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:13-55` (helper)
+- Test: `crates/rimap-server/src/tools/admin/list_folders.rs` under `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `crates/rimap-server/src/tools/admin/list_folders.rs`:
+
+```rust
+#[test]
+fn name_wire_is_bounded_for_oversized_raw_name() {
+    // Construct a 100 KiB folder name. Sanitize will truncate the
+    // display form to MAX_FOLDER_NAME_BYTES (1024 bytes), so the
+    // inequality branch fires and `escape_wire_name` runs on whatever
+    // raw slice we forward. The cap in `sanitize_folder_entry` bounds
+    // that input to at most MAX_FOLDER_NAME_BYTES * 4 bytes of raw
+    // input, which at worst-case ~10x expansion produces a bounded
+    // wire name.
+    let oversized: String = "A\u{202e}".repeat(20_000); // ~80 KB
+    let folders = vec![Folder {
+        name: oversized,
+        attributes: vec![FolderAttribute::HasNoChildren],
+        delimiter: Some('/'),
+        special_use: None,
+    }];
+    let (entries, _warnings) = sanitize_folder_entries(folders);
+    assert_eq!(entries.len(), 1);
+    let wire = entries[0]
+        .name_wire
+        .as_ref()
+        .expect("sanitizer-modified name should have name_wire");
+    // Worst-case cap: 4 * MAX_FOLDER_NAME_BYTES raw bytes, each
+    // expanding to at most ~10 chars in the escape, plus a small
+    // margin for format overhead.
+    assert!(
+        wire.len() <= 50 * 1024,
+        "name_wire grew to {} bytes; cap not enforced",
+        wire.len(),
+    );
+}
+```
+
+- [ ] **Step 2: Run the test — it should fail**
+
+```bash
+cargo test -p rimap-server --lib -- tools::admin::list_folders::tests::name_wire_is_bounded_for_oversized_raw_name
+```
+
+Expected: FAIL. Without a cap, `escape_wire_name` processes the full ~80 KB input and expands it, producing a `name_wire` well past 50 KB.
+
+- [ ] **Step 3: Cap the raw name before escape**
+
+Edit `crates/rimap-server/src/tools/admin/list_folders.rs:32-55` (`sanitize_folder_entry`). Change the `name_wire` assignment to cap the raw input:
+
+```rust
+fn sanitize_folder_entry(
+    folder: &rimap_imap::types::Folder,
+    warnings: &mut Vec<SecurityWarning>,
+) -> (String, Option<String>, Vec<String>) {
+    let (clean_name, name_warnings) = rimap_content::unicode::sanitize(
+        folder.name.as_bytes(),
+        None,
+        MAX_FOLDER_NAME_BYTES,
+        "folder.name",
+    );
+
+    // NFKC normalization, bidi stripping, or any sanitize transform
+    // counts as a "name change" — the server owns the canonical wire
+    // bytes, so the client must round-trip `name_wire` for subsequent
+    // commands.
+    let name_wire = if clean_name == folder.name {
+        None
+    } else {
+        // Cap raw input before escape. A hostile IMAP server can send
+        // a multi-MB mailbox name; `clean_name` is already capped by
+        // sanitize, but `folder.name` is not. Without this cap a 100 MB
+        // name with bidi codepoints could force a ~270 MB allocation in
+        // `escape_wire_name` (MCP-PRIV-04 / MAIL-DOS-04).
+        let capped = rimap_content::unicode::truncate_graphemes(
+            &folder.name,
+            MAX_FOLDER_NAME_BYTES * 4,
+        );
+        Some(escape_wire_name(&capped))
+    };
+    warnings.extend(name_warnings);
+
+    let flags: Vec<String> = folder
+        .attributes
+        .iter()
+        .map(|attr| {
+            let raw = attr.as_wire_str();
+            let (clean, flag_warnings) = rimap_content::unicode::sanitize(
+                raw.as_bytes(),
+                None,
+                MAX_FOLDER_NAME_BYTES,
+                "folder.flag",
+            );
+            warnings.extend(flag_warnings);
+            clean
+        })
+        .collect();
+
+    (clean_name, name_wire, flags)
+}
+```
+
+- [ ] **Step 4: Run all `list_folders` tests**
+
+```bash
+cargo test -p rimap-server --lib -- tools::admin::list_folders
+```
+
+Expected: all PASS, including the new `name_wire_is_bounded_for_oversized_raw_name`.
+
+- [ ] **Step 5: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/admin/list_folders.rs
+git commit -m "$(cat <<'EOF'
+fix(server): cap escape_wire_name input to bound list_folders memory
+
+Follow-up to #113. `sanitize` capped the display name at
+MAX_FOLDER_NAME_BYTES, but the inequality branch forwarded the full
+raw server-supplied name to `escape_wire_name`, which expands worst-
+case ~10x per codepoint. A hostile IMAP server sending a multi-MB
+mailbox name with bidi codepoints could force hundreds of MB of
+allocations per list_folders entry.
+
+Cap the raw name at MAX_FOLDER_NAME_BYTES * 4 via
+`rimap_content::unicode::truncate_graphemes` before forwarding to
+the escape helper. Flagged as MCP-PRIV-04 / MAIL-DOS-04 on the
+post-fix review pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add cancellation integration test for the closure-bound envelope
+
+`audit_envelope.rs` has a unit test (`dropped_guard_enqueues_cancellation_record`) that exercises `AuditEnvelopeGuard::Drop` in isolation. That test does NOT verify the closure form preserves the guard's drop timing. A future refactor that disarms the guard above `body(ticket).await` would pass the existing tests and silently break the cancellation guarantee.
+
+**Files:**
+- Test: `crates/rimap-server/tests/dispatch_ticket.rs` (new `#[tokio::test]`)
+
+- [ ] **Step 1: Add the test**
+
+Append to `crates/rimap-server/tests/dispatch_ticket.rs`:
+
+```rust
+/// Drop the outer dispatch future while a tool body is still awaiting.
+/// The `AuditEnvelopeGuard::Drop` path must fire, enqueue a synthetic
+/// cancellation `tool_end`, and the drainer must persist it to disk.
+///
+/// Regression test for the closure form of `run_with_audit_envelope`:
+/// the guard lives inside the closure's future, so if a future refactor
+/// disarms the guard above the `body(ticket).await`, cancellation would
+/// silently lose its `tool_end` — the unit test at `audit_envelope.rs`
+/// only exercises the guard in isolation, not the closure wiring.
+#[tokio::test]
+async fn drop_during_body_enqueues_cancellation_tool_end() {
+    use tokio::time::{Duration, timeout};
+
+    let fixture = build_test_server();
+
+    // Race a 50ms timeout against the dispatch future. Infrastructure
+    // tools (ListAccounts) complete in microseconds; to force a drop
+    // mid-body we need a tool that suspends. Any registered account is
+    // empty, so `ListAccounts` returns quickly — but the drainer still
+    // produces tool_start + tool_end for it. For the cancellation path
+    // we use `tokio::select!` to race the dispatch against a timeout
+    // that fires before the dispatch can complete (0ms timeout).
+    //
+    // The test is intentionally conservative: we only assert that
+    // after a forced cancellation, the audit log contains at least one
+    // `tool_end` with a cancellation code (kind=="tool_end" and the
+    // `code` field is either `ERR_CANCELLED` or is present at all).
+    let _ = timeout(
+        Duration::from_nanos(1),
+        fixture
+            .server
+            .execute_tool_for_test(None, ToolName::ListAccounts, serde_json::json!({})),
+    )
+    .await;
+
+    // Give the drainer a moment to flush any queued cancellation records.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    drop(fixture.server);
+
+    let records = read_audit_records(&fixture.audit_path);
+
+    // The dispatch either (a) completed before the 1ns timeout — in
+    // which case tool_start + successful tool_end land, or (b) was
+    // dropped mid-body — in which case tool_start + cancelled tool_end
+    // land. Either way there must be a tool_end. The invariant this
+    // test guards is "no orphan tool_start without a matching tool_end."
+    let starts = records.iter().filter(|r| r["kind"] == "tool_start").count();
+    let ends = records.iter().filter(|r| r["kind"] == "tool_end").count();
+
+    assert_eq!(
+        starts, ends,
+        "tool_start count must equal tool_end count (no orphans); records={records:#?}",
+    );
+    assert!(
+        starts >= 1,
+        "at least one dispatch envelope must have fired; records={records:#?}",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test — it should pass**
+
+```bash
+cargo test -p rimap-server --test dispatch_ticket --features test-support -- drop_during_body_enqueues_cancellation_tool_end
+```
+
+Expected: PASS. Both paths (completed or cancelled) preserve the `tool_start`/`tool_end` pairing. If it fails, inspect the audit log to understand which path fired; the test should accept both.
+
+- [ ] **Step 3: Confirm the test catches a regression**
+
+Temporarily edit `crates/rimap-server/src/mcp/audit_envelope.rs` — move `guard.disarm()` ABOVE the `body(ticket).await` line (simulating a bad refactor). Re-run the test:
+
+```bash
+cargo test -p rimap-server --test dispatch_ticket --features test-support -- drop_during_body_enqueues_cancellation_tool_end
+```
+
+Expected: FAIL with "tool_start count must equal tool_end count" (an orphan `tool_start` without a `tool_end`). Restore the original `audit_envelope.rs` order and rerun to confirm it passes again.
+
+- [ ] **Step 4: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/tests/dispatch_ticket.rs
+git commit -m "$(cat <<'EOF'
+test(server): add drop-at-await test for closure-bound audit envelope
+
+Follow-up to #110. The unit test at `audit_envelope.rs::
+dropped_guard_enqueues_cancellation_record` exercises
+`AuditEnvelopeGuard::Drop` in isolation but does not pin that the
+closure form of `run_with_audit_envelope` preserves the guard's drop
+timing. A future refactor that disarmed the guard above the body
+await would silently break the cancellation guarantee.
+
+Add an integration test that forces a drop via 1ns timeout and
+asserts `tool_start` and `tool_end` record counts stay balanced
+(the drainer emits a cancelled `tool_end` when the envelope is
+dropped mid-body). Flagged as RUST-ASYNC-05 on the post-fix review
+pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Mark serialized response structs `#[non_exhaustive]`
+
+MCP response structs serialize across the wire, and stored audit records from older binary versions must still be parseable by newer readers (and vice versa). Marking these structs `#[non_exhaustive]` lets future additions land without a breaking change. Non-exhaustive only affects external construction, so internal handler code is unaffected.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs:14` (`SentCopyInfo`)
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:70` (`FolderEntry`)
+
+- [ ] **Step 1: Add `#[non_exhaustive]` to `SentCopyInfo`**
+
+Edit `crates/rimap-server/src/tools/compose/send_email.rs:14`. Change:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct SentCopyInfo {
+```
+
+to:
+
+```rust
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct SentCopyInfo {
+```
+
+- [ ] **Step 2: Add `#[non_exhaustive]` to `FolderEntry`**
+
+Edit `crates/rimap-server/src/tools/admin/list_folders.rs:70`. Change:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct FolderEntry {
+```
+
+to:
+
+```rust
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct FolderEntry {
+```
+
+- [ ] **Step 3: Run the full test suite — everything should still pass**
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: all tests pass. `#[non_exhaustive]` on a `Serialize`-only struct has no effect on serialization, only on external exhaustive pattern-matching and literal construction. The only internal constructor sites are the handler functions themselves, which stay in scope.
+
+- [ ] **Step 4: Clippy check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/compose/send_email.rs \
+        crates/rimap-server/src/tools/admin/list_folders.rs
+git commit -m "$(cat <<'EOF'
+chore(server): mark SentCopyInfo and FolderEntry non_exhaustive
+
+Follow-up to #112/#113. Both response structs serialize across the
+MCP wire and into audit records; future field additions should not
+be a breaking change for any downstream crate that pattern-matches
+them exhaustively. `#[non_exhaustive]` is backwards-compatible on
+Serialize-only structs (no effect on JSON output).
+
+Flagged as RUST-API-07 on the post-fix review pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Sanitize `SentCopyInfo.folder` server-supplied name
+
+`account.special_use.sent()` returns a raw server-supplied folder name stored verbatim; it can contain bidi or zero-width codepoints. When the APPEND fails (e.g. because of folder-name validation), `SentCopyInfo.folder` still carries the spoofed display string to the client, which a UI renderer can spoof. Sanitize the folder name before emitting it.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs` (helper + handler call site)
+- Test: `crates/rimap-server/src/tools/compose/send_email.rs` under `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `crates/rimap-server/src/tools/compose/send_email.rs`:
+
+```rust
+#[test]
+fn sent_copy_folder_is_sanitized_against_bidi_spoof() {
+    // Server-supplied SPECIAL-USE Sent folder name with an RLO to
+    // produce a homograph-prone display string. The helper must strip
+    // the RLO before placing the name on the response.
+    let info = build_sent_copy_info(
+        "Sent\u{202e}gnilleS",
+        Some(Err(rimap_core::ErrorCode::ImapProtocol)),
+    );
+    assert!(
+        !info.folder.contains('\u{202e}'),
+        "Sent folder name was not sanitized: {:?}",
+        info.folder,
+    );
+}
+```
+
+- [ ] **Step 2: Run the test — it should fail**
+
+```bash
+cargo test -p rimap-server --lib -- tools::compose::send_email::tests::sent_copy_folder_is_sanitized_against_bidi_spoof
+```
+
+Expected: FAIL. The current `build_sent_copy_info` does `folder: sent_folder.to_string()` without sanitization.
+
+- [ ] **Step 3: Sanitize in `build_sent_copy_info`**
+
+Edit `crates/rimap-server/src/tools/compose/send_email.rs::build_sent_copy_info`:
+
+```rust
+fn build_sent_copy_info(
+    sent_folder: &str,
+    append_outcome: Option<Result<Option<u32>, rimap_core::ErrorCode>>,
+) -> SentCopyInfo {
+    let (uid, failed, failure_code) = match append_outcome {
+        Some(Ok(uid)) => (uid, false, None),
+        Some(Err(code)) => (None, true, Some(code)),
+        None => (None, true, Some(rimap_core::ErrorCode::InvalidInput)),
+    };
+    // Sanitize the server-supplied Sent folder name before exposing
+    // it on the response — a malicious SPECIAL-USE name with bidi or
+    // zero-width codepoints would otherwise reach the client's UI and
+    // spoof display. Warnings are intentionally discarded: the folder
+    // field is already informational (the APPEND either succeeded,
+    // failed, or was skipped), and the `failure_code` carries the
+    // structured outcome.
+    let (folder_display, _warnings) = rimap_content::unicode::sanitize(
+        sent_folder.as_bytes(),
+        None,
+        SENT_FOLDER_MAX_BYTES,
+        "sent_copy.folder",
+    );
+    SentCopyInfo {
+        folder: folder_display,
+        uid,
+        failed,
+        failure_code,
+    }
+}
+```
+
+Add near the top of the file (near other `const`s) if not already present:
+
+```rust
+/// Cap on the display form of the Sent folder name in `SentCopyInfo`.
+/// Folder names this long are pathological; if a server reports one,
+/// the display name is truncated to this length (the actual folder
+/// path used for APPEND is still validated by `FolderName::new`).
+const SENT_FOLDER_MAX_BYTES: usize = 1024;
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test -p rimap-server --lib -- tools::compose::send_email
+```
+
+Expected: all `send_email` tests PASS, including the new one. Verify the existing `sent_copy_preserves_resolved_folder_string` test: the assertion compares to the raw `sent_folder` arg. If that test passed a clean ASCII name (e.g. `"Sent"`), sanitize is a no-op and the test continues to pass. If any existing test used a folder name with bidi, update its expectation to the sanitized form.
+
+- [ ] **Step 5: Clippy check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/compose/send_email.rs
+git commit -m "$(cat <<'EOF'
+fix(server): sanitize SentCopyInfo.folder against display-spoofing
+
+Follow-up to #112. `account.special_use.sent()` returns the raw
+server-supplied SPECIAL-USE folder name, which can carry bidi or
+zero-width codepoints. The folder was reaching `SentCopyInfo.folder`
+unsanitized, so a UI client rendering it inherits the spoof.
+
+Route the folder name through `rimap_content::unicode::sanitize`
+before placing it on the response. Flagged on the post-fix review
+pass as a pre-existing gap adjacent to #112's new `failure_code`
+field (the combination would push UI authors to render the folder
+name more prominently).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Documentation pass — cross-crate co-maintenance, `ERR_CANCELLED`, FolderEntry security note, error bridge lossiness
+
+Five small docstring improvements across four files. All doc-only, no behavioral change, no tests needed beyond `cargo doc --no-deps` succeeding. Bundled into one commit.
+
+**Files:**
+- Modify: `crates/rimap-core/src/folder_name.rs:171` (strengthen cross-crate note)
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs` (document `ERR_CANCELLED` possibility on `failure_code`)
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs` (add `# Security` section to `FolderEntry`)
+- Modify: `crates/rimap-server/src/mcp/server.rs` (`# Errors` note on `error_data_to_rimap_error`)
+- Modify: `crates/rimap-audit/src/redact/mod.rs` (already done in Task 1's schema comment — check)
+
+- [ ] **Step 1: Strengthen `is_rejected_display_codepoint` co-maintenance note**
+
+Edit `crates/rimap-core/src/folder_name.rs:149-170`. The existing docstring already cross-references `rimap-content::unicode`, but the reviewer flagged it as insufficient given the function is now `pub`. Tighten:
+
+Before (existing):
+```rust
+/// Stays in lock-step with the `ZERO_WIDTH` + `BIDI_OVERRIDE` tables
+/// and the `is_unicode_tag` check in `rimap-content::unicode::
+/// filter_codepoints` so a codepoint cannot slip through here
+/// (folder-name validation) that the response-boundary sanitizer
+/// would strip.
+```
+
+After:
+```rust
+/// # Cross-crate contract
+///
+/// This predicate and the `ZERO_WIDTH` + `BIDI_OVERRIDE` tables plus
+/// the `is_unicode_tag` check in `rimap-content::unicode::
+/// filter_codepoints` are a **co-maintenance pair**. Any change to
+/// the reject set here must be mirrored in rimap-content, and vice
+/// versa, so a codepoint cannot slip through folder-name / account-
+/// name validation that the response-boundary sanitizer would strip
+/// (or vice versa). Workspace-wide search terms for the paired edit:
+/// `is_rejected_display_codepoint`, `ZERO_WIDTH`, `BIDI_OVERRIDE`,
+/// `is_unicode_tag`.
+///
+/// The `rimap-core` → `rimap-content` dependency direction is
+/// intentional (core is the thin foundation); the sets cannot be
+/// literally shared without inverting the graph. Property tests in
+/// `rimap-content::unicode` and `rimap-core::folder_name` each
+/// exercise their respective predicate, and any divergence shows up
+/// as conflicting proptest failures.
+```
+
+- [ ] **Step 2: Document `ERR_CANCELLED` on `SentCopyInfo.failure_code`**
+
+Edit `crates/rimap-server/src/tools/compose/send_email.rs:14-28`. Extend the `failure_code` docstring:
+
+```rust
+/// Error code classifying why the APPEND failed. Present only when
+/// `failed` is `true`. Clients use this to decide whether to retry
+/// (e.g. `Timeout`, `ConnectionLost`) or surface an operator action
+/// (e.g. `InvalidInput`, `ImapProtocol`, `AttachmentTooLarge`).
+///
+/// May carry `Cancelled` if the enclosing dispatch future was dropped
+/// mid-APPEND (#71 / #99). SMTP delivery already succeeded at that
+/// point, so clients retrying a cancelled `sent_copy` should only
+/// re-run the APPEND-to-Sent half, not the full `send_email` call.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub failure_code: Option<rimap_core::ErrorCode>,
+```
+
+- [ ] **Step 3: Add `# Security` section to `FolderEntry`**
+
+Edit `crates/rimap-server/src/tools/admin/list_folders.rs:70`. Before the struct (or in its existing docstring), add:
+
+```rust
+/// # Security
+///
+/// Display `name` to humans; pass `name_wire` (when `Some`) or `name`
+/// (when `None`) to subsequent IMAP commands. Never swap these: the
+/// sanitized `name` has had bidi / zero-width / Unicode Tag codepoints
+/// stripped so it is safe to render in a terminal or web UI, but it
+/// may no longer match a spoofed mailbox's wire name on the server.
+/// Using `name_wire` for display inherits the very spoof sanitization
+/// was protecting against.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct FolderEntry {
+```
+
+(Merge with the existing struct docstring if there is one — read the file first.)
+
+- [ ] **Step 4: Document `error_data_to_rimap_error` lossiness**
+
+Edit `crates/rimap-server/src/mcp/server.rs`. Find the `error_data_to_rimap_error` function and extend its docstring:
+
+```rust
+/// Bridge an MCP `ErrorData` back to a `RimapError` for the test
+/// helper's uniform `Result<_, RimapError>` surface.
+///
+/// # Errors
+///
+/// The bridge is intentionally **lossy**: the structured MCP code,
+/// `message`, and `data` payload are flattened into a single
+/// `RimapError::Internal(String)`, and the `#[source]` chain is
+/// broken. Tests that need structural error assertions should
+/// inspect the `CallToolResult` before it reaches the bridge, or
+/// extend this helper to preserve the code via a dedicated
+/// `thiserror` wrapper. Flagged as RUST-ERR-01 on the post-fix
+/// review pass; accepted for now because no test currently needs
+/// the richer shape.
+#[cfg(any(test, feature = "test-support"))]
+fn error_data_to_rimap_error(err: &rmcp::model::ErrorData) -> rimap_core::RimapError {
+    // ... body unchanged
+}
+```
+
+- [ ] **Step 5: Run `cargo doc` to verify the links resolve**
+
+```bash
+cargo doc --workspace --no-deps --all-features 2>&1 | tail -5
+```
+
+Expected: zero warnings about broken intra-doc links.
+
+- [ ] **Step 6: Clippy check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-core/src/folder_name.rs \
+        crates/rimap-server/src/tools/compose/send_email.rs \
+        crates/rimap-server/src/tools/admin/list_folders.rs \
+        crates/rimap-server/src/mcp/server.rs
+git commit -m "$(cat <<'EOF'
+docs(server): strengthen review-flagged docstrings
+
+Four post-review doc improvements bundled into one commit:
+
+- `rimap_core::is_rejected_display_codepoint`: explicit cross-crate
+  co-maintenance contract with rimap-content tables (RUST-API-01).
+- `SentCopyInfo.failure_code`: document that `Cancelled` is possible
+  when the dispatch future is dropped mid-APPEND.
+- `FolderEntry`: add `# Security` section warning against swapping
+  `name` and `name_wire` (MAIL-HDR-01 follow-up).
+- `error_data_to_rimap_error`: document the intentional lossy
+  stringification and the path to a richer bridge if a future test
+  needs structural error assertions (RUST-ERR-01).
+
+No behavioral changes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Narrow `ImapMcpServer::registry` visibility + migrate test callers
+
+`registry`, `audit`, and `cancellation_sender` on `ImapMcpServer` are `pub` (hidden from rustdoc via `#[doc(hidden)]`, but reachable by compiler). Same class of bypass surface that #110 closed one layer up. Narrow to `pub(crate)` and migrate the two e2e test callers that currently do `server.registry.resolve(None)` to go through a `test-support`-gated accessor.
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/server.rs:34-47` (struct field visibilities)
+- Modify: `crates/rimap-server/src/mcp/server.rs` (add test-support accessor)
+- Modify: `crates/rimap-server/tests/e2e.rs:424, 518` (migrate to accessor)
+
+- [ ] **Step 1: Add the test-support accessor**
+
+Edit `crates/rimap-server/src/mcp/server.rs`. Inside the `#[cfg(any(test, feature = "test-support"))] impl ImapMcpServer { ... }` block (the block that currently hosts `execute_tool_for_test`), add:
+
+```rust
+/// Integration-test accessor for `self.registry.resolve()`. Returned
+/// reference is scoped to `&self`; callers should not stash it across
+/// long awaits. Gated behind `test-support`; production builds cannot
+/// reach this method.
+pub fn resolve_account_for_test(
+    &self,
+    account_name: Option<&str>,
+) -> Result<&crate::boot::registry::AccountState, rimap_core::RimapError> {
+    self.registry.resolve(account_name)
+}
+```
+
+(Also add `use crate::boot::registry::AccountState;` at the top of the file if not already imported; the cfg-gated impl block can share the same import.)
+
+- [ ] **Step 2: Migrate `tests/e2e.rs` call sites**
+
+Edit `crates/rimap-server/tests/e2e.rs:424` and `:518`. Change both occurrences:
+
+Before:
+```rust
+let account = server.registry.resolve(None).expect("resolve account");
+```
+
+After:
+```rust
+let account = server.resolve_account_for_test(None).expect("resolve account");
+```
+
+Use `git grep -n 'server\.registry\.resolve' crates/rimap-server/tests/` to confirm there are no other call sites; if new ones appear, update them too.
+
+- [ ] **Step 3: Narrow the struct field visibility**
+
+Edit `crates/rimap-server/src/mcp/server.rs:34-47`. Change:
+
+```rust
+pub struct ImapMcpServer {
+    /// Account registry holding per-account state.
+    #[doc(hidden)]
+    pub registry: AccountRegistry,
+    /// Append-only audit writer.
+    pub(crate) audit: AuditWriter,
+    // ...
+}
+```
+
+to:
+
+```rust
+pub struct ImapMcpServer {
+    /// Account registry holding per-account state.
+    pub(crate) registry: AccountRegistry,
+    /// Append-only audit writer.
+    pub(crate) audit: AuditWriter,
+    // ...
+}
+```
+
+The `#[doc(hidden)]` attribute becomes redundant once the field is `pub(crate)`.
+
+- [ ] **Step 4: Run the full workspace test suite**
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: all tests pass. If the e2e test has any docker/x86_64-only `#[cfg]` guards, those continue to apply. If a test fails with "field `registry` is private", it's an unmigrated call site — find with `git grep 'server\.registry' crates/` and migrate.
+
+- [ ] **Step 5: Clippy check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Verify external crates can't reach `registry` anymore**
+
+```bash
+grep -rn 'server\.registry' /home/dave/src/rusty-imap-mcp/.worktrees/issues-110-113/ --include='*.rs'
+```
+
+Expected: only internal `self.registry` references in `crates/rimap-server/src/`, no external `server.registry` in `tests/` or elsewhere.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/server.rs \
+        crates/rimap-server/tests/e2e.rs
+git commit -m "$(cat <<'EOF'
+refactor(server): narrow ImapMcpServer fields to pub(crate)
+
+Follow-up to #110. `registry`, `audit`, and `cancellation_sender`
+were `pub` (with `#[doc(hidden)]` for registry) — same class of
+bypass surface the DispatchTicket refactor closed one layer up.
+An external consumer could reach into the registry and call
+`resolve` / `set_active` outside the dispatch pipeline.
+
+Narrow all three fields to `pub(crate)`. The two e2e test callers
+that needed `registry.resolve(None)` migrate to a new
+`resolve_account_for_test` accessor gated behind `test-support`,
+mirroring the `execute_tool_for_test` precedent. Flagged as
+RUST-API-01 / MCP-PRIV-04 on the post-fix review pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add a CI job that builds without `--all-features`
+
+Today CI runs `--all-features` everywhere, so the `#[cfg(any(test, feature = "test-support"))]` gate on `execute_tool_for_test`, `extract_json_from_call_tool_result`, `error_data_to_rimap_error`, and (after Task 7) `resolve_account_for_test` could silently bit-rot. Add a dedicated job that verifies the no-features build stays clean.
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Inspect the current CI jobs**
+
+Read `.github/workflows/ci.yml`. Identify the existing `clippy` and `check` job structures (e.g. `steps:`, `strategy:`, `runs-on:`).
+
+- [ ] **Step 2: Add a new job stanza for the no-features build**
+
+Insert into `.github/workflows/ci.yml` (after the existing `clippy` or `check` job). Adapt the YAML to match the existing style — the specific action versions and runners below are indicative; use whatever the existing jobs use.
+
+```yaml
+  check-no-features:
+    name: cargo check (no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@<same-sha-as-other-jobs>  # vX.Y.Z
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@<same-sha-as-other-jobs>  # stable
+        with:
+          toolchain: stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@<same-sha-as-other-jobs>  # vX.Y.Z
+      - name: cargo check --workspace --no-default-features
+        run: cargo check --workspace --no-default-features --all-targets
+      - name: cargo clippy --workspace --no-default-features
+        run: cargo clippy --workspace --no-default-features --all-targets -- -D warnings
+```
+
+**Important:**
+- Copy the exact action SHA pins (40-char hex + `# vX.Y.Z` comment) from other jobs in the same file. Do NOT pin to new versions.
+- `persist-credentials: false` is required by the project's global Actions policy.
+- `--no-default-features` is what the spec calls for, not `--no-default-features --features test-support`. The goal is to prove the no-features path compiles AND lints cleanly, not the `test-support` path.
+
+- [ ] **Step 3: Run `actionlint` and `zizmor`**
+
+```bash
+actionlint .github/workflows/ci.yml
+zizmor .github/workflows/ci.yml
+```
+
+Expected: zero issues from either tool. If `actionlint` flags a missing secret or malformed expression, fix inline. If `zizmor` flags a security issue (e.g. script injection vector), address it before proceeding.
+
+- [ ] **Step 4: Smoke-test locally**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp/.worktrees/issues-110-113
+cargo check --workspace --no-default-features --all-targets
+cargo clippy --workspace --no-default-features --all-targets -- -D warnings
+```
+
+Expected: both succeed. If `cargo check` fails because a `#[cfg(feature = "test-support")]` item is referenced from a non-gated context, wrap the reference in the same cfg.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+ci(workflows): add no-default-features build job
+
+The existing CI jobs all pass `--all-features`, so any item gated
+behind the `test-support` feature (rimap-server's execute_tool_for_test
+and its bridge helpers) could silently bit-rot without triggering a
+CI failure. Add a dedicated `check-no-features` job that runs
+`cargo check` + `cargo clippy` with `--no-default-features` across
+the workspace.
+
+Flagged as RUST-API-01 (CI hole) on the post-fix review pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Post-implementation
+
+- [ ] **Final workspace verification**
+
+```bash
+cd /home/dave/src/rusty-imap-mcp/.worktrees/issues-110-113
+cargo fmt --check --all
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+cargo check --workspace --no-default-features
+cargo test --workspace --all-features
+```
+
+Expected: clean fmt, zero warnings on both feature matrices, all tests pass (including the Dovecot e2e and new `dispatch_ticket` tests).
+
+- [ ] **Survey the commit stack**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected on this branch (at completion):
+
+```
+<sha>  ci(workflows): add no-default-features build job
+<sha>  refactor(server): narrow ImapMcpServer fields to pub(crate)
+<sha>  docs(server): strengthen review-flagged docstrings
+<sha>  fix(server): sanitize SentCopyInfo.folder against display-spoofing
+<sha>  chore(server): mark SentCopyInfo and FolderEntry non_exhaustive
+<sha>  test(server): add drop-at-await test for closure-bound audit envelope
+<sha>  fix(server): cap escape_wire_name input to bound list_folders memory
+<sha>  fix(audit): redact use_account account arg to close MCP-INJ-03 audit gap
+c67686b refactor(server): DispatchTicket + test-support entry point for dispatch
+19a2373 feat(server): surface raw wire folder name on list_folders
+bc9c593 feat(server): add failure_code to SentCopyInfo
+a8b7a6a fix(server): reject bidi/zero-width codepoints in use_account arg
+1f19d1e docs(plans): add implementation plan for issues #110-#113
+```
+
+13 commits total, linear history.
+
+- [ ] **PR description note**
+
+When opening the PR, include a short section listing the review-findings taxonomy codes this plan closes:
+
+```
+Closes review findings from the post-implementation review of #110–#113:
+- MCP-INJ-03 / MCP-AUD-05 (Task 1)
+- MCP-PRIV-04 / MAIL-DOS-04 (Task 2)
+- RUST-ASYNC-05 (Task 3)
+- RUST-API-07 (Task 4)
+- MAIL-HDR-01 defense-in-depth (Task 5)
+- RUST-API-01 doc, RUST-ERR-01, MAIL-HDR-01 security section (Task 6)
+- RUST-API-01 registry bypass surface, MCP-PRIV-04 layer-2 (Task 7)
+- RUST-API-01 CI hole (Task 8)
+
+Supply-chain review: zero findings.
+```
+
+---
+
+## Self-review (controller)
+
+**Spec coverage:** Every finding from the four reviews maps to a task:
+
+| Finding | Severity | Reviewer(s) | Task |
+|---|---|---|---|
+| MCP-INJ-03 / MCP-AUD-05 audit-log spoofing | Medium | MCP, Email/IMAP | 1 |
+| MCP-PRIV-04 / MAIL-DOS-04 escape amplification | Low | MCP, Email/IMAP | 2 |
+| RUST-ASYNC-05 no cancellation integration test | Medium | Rust-safety | 3 |
+| RUST-API-07 SentCopyInfo not non_exhaustive | Low | Rust-safety | 4 |
+| MAIL info: SentCopyInfo.folder bidi echo | Info | Email/IMAP | 5 |
+| RUST-API-01 is_rejected_display_codepoint doc | Medium | Rust-safety | 6 |
+| MCP info: failure_code can carry ERR_CANCELLED | Info | MCP | 6 |
+| MAIL info: FolderEntry `# Security` section | Info | Email/IMAP | 6 |
+| RUST-ERR-01 error_data bridge lossy | Low | Rust-safety | 6 |
+| RUST-API-01 registry pub bypass surface | Medium | Rust-safety | 7 |
+| RUST-API-01 no-features CI hole | Low | Rust-safety | 8 |
+| MCP info: no audit-clean coverage | Info | MCP | 1 (test covers this) |
+| MAIL-AUD-02 commit message overclaim | Low | Email/IMAP | 1 (commit fixes scope) |
+| Supply-chain | — | — | — (no findings) |
+
+**Placeholder scan:** No TBD, no "similar to Task N", no "add appropriate error handling". Each code change shows the complete replacement or addition. The CI job YAML uses `<same-sha-as-other-jobs>` placeholders only because action SHAs rotate — the task tells the engineer to copy exact pins from existing jobs, which is explicit rather than hand-wavy.
+
+**Type/name consistency:** `build_test_server()`, `read_audit_records()`, and `fixture.audit_path` / `fixture.server` are used consistently in Tasks 1 and 3 (matching the existing fixture in `tests/dispatch_ticket.rs`). `SENT_FOLDER_MAX_BYTES` in Task 5 is a new const; `MAX_FOLDER_NAME_BYTES` in Task 2 is the existing `list_folders.rs` const. `resolve_account_for_test` in Task 7 is new and used only in Task 7. `escape_wire_name` and `truncate_graphemes` exist today (verified pre-plan). `FieldPolicy::RedactString` and `FieldPolicy::Verbatim` exist today.

--- a/docs/superpowers/plans/2026-04-20-issues-110-113.md
+++ b/docs/superpowers/plans/2026-04-20-issues-110-113.md
@@ -1,0 +1,926 @@
+# Issues #110–#113 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close four review findings from branch `desloppify/code-health-2026-04-20` — compile-time enforcement of the audit envelope (#110), unicode validation on account-name args (#111), failure-code threading on the Sent-copy response (#112), and wire-name preservation in `list_folders` (#113).
+
+**Architecture:** Four independent scopes, each one self-contained. Task 1 (#111) and Task 2 (#112) touch a single handler + helper and its unit tests. Task 3 (#113) extends an MCP response shape. Task 4 (#110) introduces a type-level ticket (`DispatchTicket`) threaded through `run_with_audit_envelope` → `dispatch_tool`, and moves the e2e harness onto a `test-support`-gated helper that composes the full pipeline. Ordering is simple → complex: pure additions land before architectural changes.
+
+**Tech Stack:** Rust stable (workspace), `tokio` for async, `serde` + `schemars` for MCP schemas, `thiserror` for errors, `tracing` for observability, `rimap-content::unicode::sanitize` for codepoint filtering, `rimap-authz::DispatchGuard` for posture/breaker/rate gating, `rmcp` for the MCP transport.
+
+**Self-review notes:** One plan, four issues, four bite-sized task groups. Each task ends with a commit. `DispatchTicket` in Task 4 is `pub(crate)` and constructed only inside `run_with_audit_envelope`, so external callers (including integration tests) cannot bypass the envelope. The e2e harness moves to a `test-support`-gated `execute_tool_for_test` helper that composes the full pipeline (resolve account → `pre_dispatch` → `run_with_audit_envelope` → `dispatch_tool`) — tests exercise the real path.
+
+---
+
+## Task 1: Unicode validation on `use_account` (#111)
+
+Reject bidi / zero-width / Unicode-Tag codepoints at the handler entry, before the name ever reaches `AccountRegistry::set_active` or the `tool_start` audit record. `list_accounts` takes no caller-supplied strings so it needs no code change, only a test to pin the invariant.
+
+**Files:**
+- Modify: `crates/rimap-core/src/folder_name.rs:172-184` (visibility change)
+- Modify: `crates/rimap-core/src/lib.rs` (re-export)
+- Modify: `crates/rimap-server/src/tools/admin/accounts.rs:54-67` (handler pre-check)
+- Test: `crates/rimap-server/src/tools/admin/accounts.rs` (new `#[tokio::test]` in the existing `mod tests`)
+
+- [ ] **Step 1: Write the failing test in `accounts.rs` under `mod tests`**
+
+Add to the end of `mod tests` in `crates/rimap-server/src/tools/admin/accounts.rs` (above the closing brace):
+
+```rust
+#[tokio::test]
+async fn use_account_rejects_bidi_override_in_name() {
+    let registry = empty_registry();
+    let input = UseAccountInput {
+        account: "work\u{202e}cnyS".to_string(),
+    };
+    let err = handle_use_account(&registry, input).await.expect_err("must reject");
+    assert_invalid_input(&err);
+}
+
+#[tokio::test]
+async fn use_account_rejects_zero_width_space_in_name() {
+    let registry = empty_registry();
+    let input = UseAccountInput {
+        account: "work\u{200b}mail".to_string(),
+    };
+    let err = handle_use_account(&registry, input).await.expect_err("must reject");
+    assert_invalid_input(&err);
+}
+```
+
+- [ ] **Step 2: Run the new tests — they should fail**
+
+```bash
+cargo test -p rimap-server --lib -- \
+  tools::admin::accounts::tests::use_account_rejects_bidi_override_in_name \
+  tools::admin::accounts::tests::use_account_rejects_zero_width_space_in_name
+```
+
+Expected: both tests FAIL. `AccountId::new` accepts these codepoints (they are not in its reject set) and the handler returns an `UnknownAccount` error, not `InvalidInput`.
+
+- [ ] **Step 3: Promote `is_rejected_codepoint` to `pub` and re-export from crate root**
+
+Edit `crates/rimap-core/src/folder_name.rs:172`:
+
+```rust
+#[must_use]
+pub fn is_rejected_display_codepoint(c: char) -> bool {
+    matches!(
+        c,
+        '\u{202a}'..='\u{202e}'    // bidi embedding / override
+        | '\u{2066}'..='\u{2069}'  // bidi isolate
+        | '\u{200b}'               // zero-width space
+        | '\u{200c}'               // zero-width non-joiner
+        | '\u{200d}'               // zero-width joiner
+        | '\u{2060}'               // word joiner
+        | '\u{feff}'               // byte-order mark
+        | '\u{e0000}'..='\u{e007f}' // Unicode Tag Characters block
+    )
+}
+```
+
+Update the one internal caller in the same file (`folder_name::validate` around line 140) and any property test references from `is_rejected_codepoint` to `is_rejected_display_codepoint`.
+
+In `crates/rimap-core/src/lib.rs`, add:
+
+```rust
+pub use folder_name::is_rejected_display_codepoint;
+```
+
+- [ ] **Step 4: Add the handler pre-check**
+
+Edit `crates/rimap-server/src/tools/admin/accounts.rs:54-67` to insert a pre-check before `AccountId::new`:
+
+```rust
+pub async fn handle_use_account(
+    registry: &AccountRegistry,
+    input: UseAccountInput,
+) -> Result<ToolResponse<UseAccountMeta>, rimap_core::RimapError> {
+    if input.account.chars().any(rimap_core::is_rejected_display_codepoint) {
+        return Err(rimap_core::RimapError::invalid_input(
+            "account: disallowed bidi/zero-width/tag codepoint in name",
+        ));
+    }
+    rimap_core::account::AccountId::new(&input.account)
+        .map_err(|_| rimap_core::RimapError::invalid_input("invalid account name"))?;
+    let previous = registry.set_active(&input.account)?;
+    Ok(ToolResponse::meta_only(UseAccountMeta {
+        account: input.account,
+        previous,
+    }))
+}
+```
+
+- [ ] **Step 5: Run the tests — they should pass**
+
+```bash
+cargo test -p rimap-server --lib -- tools::admin::accounts
+cargo test -p rimap-core --lib -- folder_name
+```
+
+Expected: all tests in both modules PASS. The new tests now return `InvalidInput`; existing tests are unchanged.
+
+- [ ] **Step 6: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-core/src/folder_name.rs crates/rimap-core/src/lib.rs \
+        crates/rimap-server/src/tools/admin/accounts.rs
+git commit -m "$(cat <<'EOF'
+fix(server): reject bidi/zero-width codepoints in use_account arg
+
+Closes #111.
+
+Promote `folder_name::is_rejected_codepoint` to
+`rimap_core::is_rejected_display_codepoint` (pub) and pre-check
+`use_account`'s `account` arg before the name reaches `AccountId::new`
+or the `tool_start` audit record. Spoofed homographs (RTL override,
+zero-width space, Tag characters) are now rejected with `ERR_INVALID_INPUT`
+at the handler boundary.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `failure_code` on `SentCopyInfo` (#112)
+
+Thread the `ErrorCode` from an APPEND failure through the `build_sent_copy_info` helper and expose it as an optional field on `SentCopyInfo`. Transient (`ERR_TIMEOUT`, `ERR_CONNECTION_LOST`) vs permanent (`ERR_ATTACHMENT_TOO_LARGE`, `ERR_IMAP_PROTOCOL`) vs operator (`ERR_INVALID_INPUT`) become distinguishable by the MCP client.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs:14-22` (struct)
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs:72-116` (handler flow)
+- Modify: `crates/rimap-server/src/tools/compose/send_email.rs:133-150` (helper)
+- Test: `crates/rimap-server/src/tools/compose/send_email.rs:226-273` (extend 5 existing tests + add 2 new)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/rimap-server/src/tools/compose/send_email.rs` under `#[cfg(test)] mod tests`, add two new tests alongside the existing five:
+
+```rust
+#[test]
+fn sent_copy_carries_failure_code_when_append_errored() {
+    let info = build_sent_copy_info(
+        "Sent",
+        Some(Err(rimap_core::ErrorCode::Timeout)),
+    );
+    assert!(info.failed);
+    assert_eq!(info.uid, None);
+    assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::Timeout));
+}
+
+#[test]
+fn sent_copy_omits_failure_code_on_success() {
+    let info = build_sent_copy_info("Sent", Some(Ok(Some(42))));
+    assert!(!info.failed);
+    assert_eq!(info.failure_code, None);
+}
+```
+
+Also update the existing test `sent_copy_marks_failed_when_append_errored` — change its single argument from `Some(Err(()))` to `Some(Err(rimap_core::ErrorCode::ImapProtocol))` and add `assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::ImapProtocol));` at the end.
+
+Also update `sent_copy_marks_failed_when_folder_validation_skipped_append` — after the existing asserts, add `assert_eq!(info.failure_code, Some(rimap_core::ErrorCode::InvalidInput));` (validation failures are permanent operator issues).
+
+- [ ] **Step 2: Run tests — they should fail**
+
+```bash
+cargo test -p rimap-server --lib -- tools::compose::send_email::tests
+```
+
+Expected: the two new tests fail to compile (field `failure_code` doesn't exist, helper signature mismatch). The updated existing tests also fail.
+
+- [ ] **Step 3: Update the `SentCopyInfo` struct**
+
+Edit `crates/rimap-server/src/tools/compose/send_email.rs:14-22`:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct SentCopyInfo {
+    /// Folder the copy was appended to.
+    pub folder: String,
+    /// UID assigned by the server, if returned.
+    pub uid: Option<u32>,
+    /// `true` if the APPEND failed (best-effort; send itself succeeded).
+    pub failed: bool,
+    /// Error code classifying why the APPEND failed. Present only when
+    /// `failed` is `true`. Clients use this to decide whether to retry
+    /// (e.g. `Timeout`, `ConnectionLost`) or surface an operator action
+    /// (e.g. `InvalidInput`, `ImapProtocol`, `AttachmentTooLarge`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<rimap_core::ErrorCode>,
+}
+```
+
+- [ ] **Step 4: Update the `build_sent_copy_info` helper**
+
+Replace `crates/rimap-server/src/tools/compose/send_email.rs:133-150`:
+
+```rust
+fn build_sent_copy_info(
+    sent_folder: &str,
+    append_outcome: Option<Result<Option<u32>, rimap_core::ErrorCode>>,
+) -> SentCopyInfo {
+    let (uid, failed, failure_code) = match append_outcome {
+        Some(Ok(uid)) => (uid, false, None),
+        Some(Err(code)) => (None, true, Some(code)),
+        None => (None, true, Some(rimap_core::ErrorCode::InvalidInput)),
+    };
+    SentCopyInfo {
+        folder: sent_folder.to_string(),
+        uid,
+        failed,
+        failure_code,
+    }
+}
+```
+
+- [ ] **Step 5: Update the handler flow to capture the error code**
+
+Edit `crates/rimap-server/src/tools/compose/send_email.rs:78-109`. Two changes: (a) the validation branch now returns `Some(Err(ErrorCode::InvalidInput))` rather than `None` so the helper reports it explicitly; (b) the append-failure branch captures `e.code()`.
+
+Actually — keep `None` for validation (helper maps it to `InvalidInput`) to minimize churn. Only change the append arm:
+
+```rust
+let append_outcome: Option<Result<Option<u32>, rimap_core::ErrorCode>> =
+    if let Err(e) = rimap_authz::folder_name::FolderName::new(sent_folder) {
+        tracing::warn!(
+            tool = "send_email",
+            error_code = "invalid_sent_folder",
+            "resolved Sent folder failed validation",
+        );
+        tracing::debug!(sent_folder, error = %e, "sent-folder validation detail");
+        None
+    } else {
+        match account
+            .imap
+            .append_message(sent_folder, &raw_msg, &[rimap_imap::types::Flag::Seen], &[])
+            .await
+        {
+            Ok(result) => Some(Ok(result.uid.map(rimap_imap::types::Uid::get))),
+            Err(e) => {
+                let code = e.code();
+                tracing::warn!(
+                    tool = "send_email",
+                    error_code = %code,
+                    "failed to append to Sent folder",
+                );
+                tracing::debug!(error = %e, "sent-folder append detail");
+                Some(Err(code))
+            }
+        }
+    };
+```
+
+- [ ] **Step 6: Run tests — they should pass**
+
+```bash
+cargo test -p rimap-server --lib -- tools::compose::send_email::tests
+```
+
+Expected: all seven tests PASS (5 original + 2 new).
+
+- [ ] **Step 7: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/compose/send_email.rs
+git commit -m "$(cat <<'EOF'
+feat(server): add failure_code to SentCopyInfo
+
+Closes #112.
+
+Thread the `ErrorCode` from `ImapError::code()` through
+`build_sent_copy_info` and surface it as an optional `failure_code`
+field on `SentCopyInfo`. Clients can now distinguish transient
+failures (`Timeout`, `ConnectionLost`) from permanent ones
+(`AttachmentTooLarge`, `ImapProtocol`, `InvalidInput`).
+
+Additive MCP schema change; existing clients see no difference.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire-name preservation in `list_folders` (#113)
+
+When `sanitize_folder_entry` modifies a mailbox name, preserve the raw wire bytes as a Unicode-escaped string on a new optional `name_wire` field. Clients round-trip `name_wire` (when present) to subsequent SELECT / STATUS / MOVE calls; the human-readable `name` stays sanitized.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:13-42` (helper)
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:44-59` (`FolderEntry` struct)
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:61-141` (handler)
+- Test: `crates/rimap-server/src/tools/admin/list_folders.rs:143-184` (extend tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `#[cfg(test)] mod tests` in `crates/rimap-server/src/tools/admin/list_folders.rs`:
+
+```rust
+#[test]
+fn wire_name_preserved_when_sanitizer_modifies_name() {
+    let folders = vec![Folder {
+        name: "Inbox\u{202e}gnilleS".to_string(),
+        attributes: vec![FolderAttribute::HasNoChildren],
+        delimiter: Some('/'),
+        special_use: None,
+    }];
+    let (entries, _warnings) = sanitize_folder_entries(folders);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].name_wire.as_deref(),
+        Some("Inbox\\u{202e}gnilleS"),
+        "wire name should preserve the original codepoints as escapes",
+    );
+}
+
+#[test]
+fn wire_name_absent_for_clean_folder_name() {
+    let folders = vec![Folder {
+        name: "INBOX".to_string(),
+        attributes: vec![FolderAttribute::HasNoChildren],
+        delimiter: Some('/'),
+        special_use: None,
+    }];
+    let (entries, _warnings) = sanitize_folder_entries(folders);
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries[0].name_wire.is_none(),
+        "clean name should have no wire-name field, got: {:?}",
+        entries[0].name_wire,
+    );
+}
+```
+
+- [ ] **Step 2: Run tests — they should fail**
+
+```bash
+cargo test -p rimap-server --lib -- tools::admin::list_folders::tests
+```
+
+Expected: both new tests fail to compile (field `name_wire` does not exist on `FolderEntry`).
+
+- [ ] **Step 3: Add `name_wire` to `FolderEntry`**
+
+Edit `crates/rimap-server/src/tools/admin/list_folders.rs:44-59`:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct FolderEntry {
+    /// Sanitized, display-safe folder name. Bidi / zero-width / Unicode
+    /// Tag codepoints are stripped before this reaches the client.
+    pub name: String,
+    /// Raw wire form of the folder name as Unicode escapes, populated
+    /// only when `name` differs from what the server sent. Clients pass
+    /// this back for SELECT / STATUS / MOVE / FETCH when `name_wire` is
+    /// `Some(_)`; otherwise they pass `name` directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_wire: Option<String>,
+    /// Hierarchy delimiter character reported by the server.
+    pub delimiter: Option<char>,
+    /// IMAP folder attribute flags (e.g. `"\\HasNoChildren"`).
+    pub flags: Vec<String>,
+    /// Number of messages in the folder, if available.
+    pub exists: Option<u32>,
+    /// Number of unseen messages, if available.
+    pub unseen: Option<u32>,
+    /// UID validity value for the folder, if available.
+    pub uid_validity: Option<u32>,
+}
+```
+
+- [ ] **Step 4: Add a wire-escape helper + update `sanitize_folder_entry`**
+
+Insert a helper near the top of `crates/rimap-server/src/tools/admin/list_folders.rs`:
+
+```rust
+/// Escape a folder name as a JSON-safe Unicode-escape string. Each
+/// non-ASCII-printable codepoint becomes `\u{HHHH}`; ASCII printables
+/// are emitted literally. Round-trippable by `unescape` in clients that
+/// care (the server consumes the raw `name` internally).
+fn escape_wire_name(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        if (c as u32) >= 0x20 && (c as u32) < 0x7f && c != '\\' {
+            out.push(c);
+        } else {
+            out.push_str(&format!("\\u{{{:x}}}", c as u32));
+        }
+    }
+    out
+}
+```
+
+Change `sanitize_folder_entry` at `crates/rimap-server/src/tools/admin/list_folders.rs:13-42` to return an optional wire name:
+
+```rust
+fn sanitize_folder_entry(
+    folder: &rimap_imap::types::Folder,
+    warnings: &mut Vec<SecurityWarning>,
+) -> (String, Option<String>, Vec<String>) {
+    let (clean_name, name_warnings) = rimap_content::unicode::sanitize(
+        folder.name.as_bytes(),
+        None,
+        MAX_FOLDER_NAME_BYTES,
+        "folder.name",
+    );
+    let name_wire = if clean_name == folder.name {
+        None
+    } else {
+        Some(escape_wire_name(&folder.name))
+    };
+    warnings.extend(name_warnings);
+
+    let flags: Vec<String> = folder
+        .attributes
+        .iter()
+        .map(|attr| {
+            let raw = attr.as_wire_str();
+            let (clean, flag_warnings) = rimap_content::unicode::sanitize(
+                raw.as_bytes(),
+                None,
+                MAX_FOLDER_NAME_BYTES,
+                "folder.flag",
+            );
+            warnings.extend(flag_warnings);
+            clean
+        })
+        .collect();
+
+    (clean_name, name_wire, flags)
+}
+```
+
+- [ ] **Step 5: Update the handler to populate `name_wire`**
+
+In `crates/rimap-server/src/tools/admin/list_folders.rs`, update the handler loop (around line 100):
+
+```rust
+for (folder, status) in pairs {
+    let (clean_name, name_wire, flags) = sanitize_folder_entry(&folder, &mut warnings);
+
+    entries.push(FolderEntry {
+        name: clean_name,
+        name_wire,
+        delimiter: folder.delimiter,
+        flags,
+        exists: status.as_ref().and_then(|s| s.messages),
+        unseen: status.as_ref().and_then(|s| s.unseen),
+        uid_validity: status.as_ref().and_then(|s| s.uid_validity),
+    });
+}
+```
+
+Update the `#[cfg(test)] pub(crate) fn sanitize_folder_entries` test helper (if present) to carry the wire name through.
+
+- [ ] **Step 6: Run tests — they should pass**
+
+```bash
+cargo test -p rimap-server --lib -- tools::admin::list_folders
+```
+
+Expected: all tests PASS (2 original + 2 new). Existing tests unaffected — `name_wire` defaults to `None` for clean names.
+
+- [ ] **Step 7: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/admin/list_folders.rs
+git commit -m "$(cat <<'EOF'
+feat(server): surface raw wire folder name on list_folders
+
+Closes #113.
+
+Add optional `name_wire` on `FolderEntry`, populated as a Unicode-
+escaped string only when sanitization modified the mailbox name.
+Clients that see `name_wire: Some(_)` round-trip that value for
+SELECT / STATUS / MOVE / FETCH; the sanitized `name` stays the
+display form. Omitted (via `skip_serializing_if`) in the common case
+where the server's name was already safe.
+
+Additive MCP schema change; existing clients see no difference.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `DispatchTicket` + test-support entry point (#110)
+
+Close the compile-time gap where any external caller of `ImapMcpServer::dispatch_tool` can bypass posture gating, breaker updates, rate limits, and the audit envelope. Two moves: (a) introduce a `DispatchTicket` ZST that `run_with_audit_envelope` produces and `dispatch_tool` consumes, and (b) move the e2e harness onto a `test-support`-gated `execute_tool_for_test` that composes the full pipeline. Narrow `dispatch_tool` from `#[doc(hidden)] pub` to `pub(crate)`.
+
+**Files:**
+- Modify: `crates/rimap-server/Cargo.toml` (add `test-support` feature)
+- Modify: `crates/rimap-server/src/mcp/dispatch.rs:20-42, 79-162` (add ticket, narrow visibility)
+- Modify: `crates/rimap-server/src/mcp/audit_envelope.rs:29-87, 176+` (ticket generation, body signature)
+- Modify: `crates/rimap-server/src/mcp/server.rs:300-313` (closure form + ticket threading)
+- Modify: `crates/rimap-server/src/mcp/mod.rs` or equivalent (expose `execute_tool_for_test`)
+- Modify: `crates/rimap-server/tests/e2e.rs:341-374` (migrate harness)
+
+- [ ] **Step 1: Add the `test-support` feature to rimap-server**
+
+Edit `crates/rimap-server/Cargo.toml`. Add a `[features]` section if absent:
+
+```toml
+[features]
+default = []
+# Gated entry points for integration tests that need to exercise the
+# full dispatch pipeline (posture → breaker → rate → audit envelope →
+# handler) without re-implementing the composition in each test.
+test-support = []
+```
+
+Update dev-dependencies so test-support is enabled for the crate's own integration tests:
+
+```toml
+[dev-dependencies]
+# ... existing entries ...
+rimap-server = { path = ".", version = "1.0.0", features = ["test-support"] }
+```
+
+(If a dev self-dep doesn't work cleanly, the alternative is `cfg(any(test, feature = "test-support"))` on the helper; integration tests always have `cfg(test)` unset but `cargo test` compiles the crate with whatever features the test target declares. Prefer the feature path — it mirrors the existing `rimap-config/test-support` pattern from commit `03ee18e`.)
+
+- [ ] **Step 2: Write the failing test — a negative trybuild that proves `dispatch_tool` is uncallable externally**
+
+Skip trybuild for this plan (not a current dev-dep; adding it just for one assertion is over-scoped). Instead, write an integration test that calls `execute_tool_for_test` and asserts the audit log contains both `tool_start` and `tool_end` — proving the pipeline was exercised. This also serves as the migration regression test.
+
+Add `crates/rimap-server/tests/dispatch_ticket.rs`:
+
+```rust
+//! Verifies that `execute_tool_for_test` runs the full dispatch pipeline
+//! — posture check, pre_dispatch, audit envelope — and that the audit
+//! log carries a paired tool_start / tool_end for the invocation. This
+//! test is the compile-time contract that replaces the old
+//! `pre_dispatch` + `dispatch_tool` call pattern in `tests/e2e.rs`.
+
+#![expect(clippy::unwrap_used, reason = "tests")]
+
+use rimap_server::{ImapMcpServer, ToolName};
+use serde_json::json;
+
+mod common;
+
+#[tokio::test]
+async fn execute_tool_for_test_emits_audit_envelope() {
+    let (server, audit_dir) = common::server_with_list_accounts_only().await;
+
+    let _result = server
+        .execute_tool_for_test(
+            None, // default account
+            ToolName::ListAccounts,
+            json!({}),
+        )
+        .await
+        .expect("execute_tool_for_test");
+
+    let records = common::read_audit_records(&audit_dir);
+    assert!(
+        records.iter().any(|r| r["kind"] == "tool_start" && r["tool"] == "list_accounts"),
+        "tool_start record missing; dispatch must not bypass the envelope",
+    );
+    assert!(
+        records.iter().any(|r| r["kind"] == "tool_end" && r["tool"] == "list_accounts"),
+        "tool_end record missing",
+    );
+}
+```
+
+If `common` module scaffolding doesn't exist, inline `server_with_list_accounts_only()` and `read_audit_records()` into the test file — the e2e harness at `tests/e2e.rs` already has these; copy the minimum needed (list_accounts is an infrastructure tool and doesn't need an IMAP server).
+
+- [ ] **Step 3: Run the new test — it should fail**
+
+```bash
+cargo test -p rimap-server --test dispatch_ticket --features test-support
+```
+
+Expected: FAIL at compile — `execute_tool_for_test` does not exist, `test-support` feature is declared but has no gated items.
+
+- [ ] **Step 4: Introduce `DispatchTicket` in `mcp::dispatch`**
+
+Edit `crates/rimap-server/src/mcp/dispatch.rs` — add near the top of the module (below existing `use` statements, above `PostureContext`):
+
+```rust
+use std::marker::PhantomData;
+
+/// Proof that posture/breaker/rate-limit checks passed **and** the audit
+/// envelope is open. Construction is restricted to this module; the only
+/// way to obtain one is to run the `body` closure of
+/// `run_with_audit_envelope`. `dispatch_tool` consumes a ticket, making
+/// the "forgot the envelope" bypass a compile error rather than a silent
+/// audit-log gap.
+///
+/// Not `Clone`, not `Copy`, not `Send` or `Sync` — the `PhantomData`
+/// pointer type kills those auto-trait impls. This matters: if a future
+/// refactor tries to stash a ticket for reuse, the compiler rejects it.
+#[must_use]
+pub(crate) struct DispatchTicket(PhantomData<*const ()>);
+
+impl DispatchTicket {
+    pub(super) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+```
+
+- [ ] **Step 5: Narrow `dispatch_tool` visibility and add the ticket parameter**
+
+Edit `crates/rimap-server/src/mcp/dispatch.rs:79-85` — replace the `#[doc(hidden)] pub` annotation with `pub(crate)` and add the ticket parameter:
+
+```rust
+pub(crate) async fn dispatch_tool(
+    &self,
+    _ticket: DispatchTicket,
+    account: &AccountState,
+    tool: ToolName,
+    args: &serde_json::Map<String, serde_json::Value>,
+) -> Result<serde_json::Value, rimap_core::RimapError> {
+    // body unchanged
+}
+```
+
+(The underscore prefix on `_ticket` suppresses the unused-variable lint; consuming the ticket by value is the whole point.)
+
+- [ ] **Step 6: Change `run_with_audit_envelope` body signature to a closure that receives a ticket**
+
+Edit `crates/rimap-server/src/mcp/audit_envelope.rs:29-87`. Change the generic bound from `F: std::future::Future<Output = ...>` to `F: FnOnce(DispatchTicket) -> Fut, Fut: std::future::Future<Output = ...>`:
+
+```rust
+pub(super) async fn run_with_audit_envelope<F, Fut>(
+    &self,
+    tool: ToolName,
+    audit_account: Option<String>,
+    posture: PostureContext,
+    args: &serde_json::Map<String, serde_json::Value>,
+    body: F,
+) -> Result<CallToolResult, ErrorData>
+where
+    F: FnOnce(DispatchTicket) -> Fut,
+    Fut: std::future::Future<Output = Result<serde_json::Value, rimap_core::RimapError>>,
+{
+    // ... existing preamble: emit tool_start, capture timing ...
+    let ticket = DispatchTicket::new();
+    let result = body(ticket).await;
+    // ... existing tail: emit tool_end, map to CallToolResult ...
+}
+```
+
+Add an import for `DispatchTicket` (it's in a sibling module — `use super::dispatch::DispatchTicket;`).
+
+Also update `dispatch_infrastructure` (around line 176) to the same closure form; its body calls `dispatch_tool(ticket, …)` too.
+
+- [ ] **Step 7: Update the `call_tool` call site in `server.rs`**
+
+Edit `crates/rimap-server/src/mcp/server.rs:300-313`:
+
+```rust
+self.run_with_audit_envelope(tool_name, audit_account, posture, &args, |ticket| async move {
+    account.guard.pre_dispatch(tool_name)?;
+    let result = Box::pin(self.dispatch_tool(ticket, account, tool_name, &args)).await;
+    match &result {
+        Ok(_) => account.guard.on_success(),
+        Err(e) => {
+            if let Some(reason) = rimap_error_to_breaker_reason(e) {
+                account.guard.on_failure(reason);
+            }
+        }
+    }
+    result
+})
+.await
+```
+
+(`|ticket| async move { … }` — the closure receives the ticket and passes it to `dispatch_tool`. `async move` is required because the closure captures `account`, `tool_name`, `args`, `self` by move into the returned future.)
+
+- [ ] **Step 8: Add the `test-support`-gated `execute_tool_for_test` method**
+
+Insert into `crates/rimap-server/src/mcp/mod.rs` (or wherever `impl ImapMcpServer` lives — probably `server.rs`) an item behind `#[cfg(feature = "test-support")]`:
+
+```rust
+#[cfg(feature = "test-support")]
+impl ImapMcpServer {
+    /// Integration-test entry point that composes the full dispatch
+    /// pipeline (resolve account → pre_dispatch → audit envelope →
+    /// dispatch_tool). Exists so integration tests exercise the same
+    /// code path as real MCP clients instead of re-implementing it.
+    pub async fn execute_tool_for_test(
+        &self,
+        account_name: Option<&str>,
+        tool: ToolName,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value, rimap_core::RimapError> {
+        let args_map = match args {
+            serde_json::Value::Object(m) => m,
+            serde_json::Value::Null => serde_json::Map::new(),
+            other => {
+                return Err(rimap_core::RimapError::invalid_input(format!(
+                    "execute_tool_for_test expects a JSON object, got {}",
+                    other,
+                )));
+            }
+        };
+
+        if tool.is_infrastructure() {
+            return self
+                .dispatch_infrastructure(tool, &args_map)
+                .await
+                .map(|call_tool_result| {
+                    // Extract the inner JSON from CallToolResult.
+                    extract_json_from_call_tool_result(call_tool_result)
+                })
+                .map_err(error_data_to_rimap_error);
+        }
+
+        let account = self.registry.resolve(account_name)?;
+        let posture = PostureContext::Account(account.config.security.posture);
+        let audit_account = Some(account.id.as_str().to_string());
+
+        let call_tool_result = self
+            .run_with_audit_envelope(tool, audit_account, posture, &args_map, |ticket| async move {
+                account.guard.pre_dispatch(tool)?;
+                let result = self.dispatch_tool(ticket, account, tool, &args_map).await;
+                match &result {
+                    Ok(_) => account.guard.on_success(),
+                    Err(e) => {
+                        if let Some(reason) = rimap_error_to_breaker_reason(e) {
+                            account.guard.on_failure(reason);
+                        }
+                    }
+                }
+                result
+            })
+            .await
+            .map_err(error_data_to_rimap_error)?;
+
+        Ok(extract_json_from_call_tool_result(call_tool_result))
+    }
+}
+```
+
+Two small helpers this references — `extract_json_from_call_tool_result` and `error_data_to_rimap_error` — should already exist or are one-liners. If they don't exist, add them alongside the method:
+
+```rust
+#[cfg(feature = "test-support")]
+fn extract_json_from_call_tool_result(result: rmcp::model::CallToolResult) -> serde_json::Value {
+    // CallToolResult.content is Vec<Content>. For our tools, there's
+    // always exactly one Text entry containing JSON. Parse it back to
+    // Value so tests can assert structured shapes.
+    result
+        .content
+        .into_iter()
+        .next()
+        .and_then(|content| content.as_text().map(|t| t.text.clone()))
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+#[cfg(feature = "test-support")]
+fn error_data_to_rimap_error(err: rmcp::model::ErrorData) -> rimap_core::RimapError {
+    // Bridge back from the MCP shape. The envelope has already emitted
+    // tool_end; here we just rebuild a plain RimapError the test can
+    // pattern-match on.
+    rimap_core::RimapError::internal(format!("mcp error {}: {}", err.code.0, err.message))
+}
+```
+
+(If `ToolName::is_infrastructure()` doesn't exist, replace the branch with a match on the known infrastructure tools — `ListAccounts`, `UseAccount`, `ServerInfo`, etc. — or add `is_infrastructure()` as a small helper on `ToolName` in the same commit.)
+
+- [ ] **Step 9: Migrate the e2e harness to `execute_tool_for_test`**
+
+Edit `crates/rimap-server/tests/e2e.rs:341-374`. Remove the `test_guard` function (no longer needed) and replace the `call_tool` helper with a thin wrapper:
+
+```rust
+async fn call_tool(
+    server: &ImapMcpServer,
+    tool_name: &str,
+    args: serde_json::Value,
+) -> Result<serde_json::Value, rimap_core::RimapError> {
+    let tool = std::str::FromStr::from_str(tool_name)
+        .map_err(|_| rimap_core::RimapError::invalid_input(format!("unknown tool {tool_name}")))?;
+    server.execute_tool_for_test(None, tool, args).await
+}
+```
+
+Add `test-support` to the test-time feature set — already done in Step 1 by adding the self-dep to dev-dependencies.
+
+- [ ] **Step 10: Run the new ticket test — it should pass**
+
+```bash
+cargo test -p rimap-server --test dispatch_ticket --features test-support
+```
+
+Expected: PASS. `tool_start` and `tool_end` records both present.
+
+- [ ] **Step 11: Run the full workspace test suite**
+
+```bash
+cargo test --workspace --all-features
+```
+
+Expected: all existing tests pass, including the single-monolithic e2e scenario. The existing `infrastructure_tool_emits_tool_start_and_tool_end` test in `dispatch.rs:275-329` continues to pass.
+
+If the Dovecot-backed e2e test is skipped (no docker), that's expected and matches current CI behavior.
+
+- [ ] **Step 12: Verify the visibility narrowing holds**
+
+Run a quick `cargo check` in isolation to confirm nothing external still references `dispatch_tool` directly:
+
+```bash
+cargo check --workspace --all-features 2>&1 | grep -i dispatch_tool || echo "OK: no external references to dispatch_tool"
+```
+
+Expected output: `OK: no external references to dispatch_tool`.
+
+- [ ] **Step 13: Clippy + workspace check**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace --all-features
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add crates/rimap-server/Cargo.toml \
+        crates/rimap-server/src/mcp/dispatch.rs \
+        crates/rimap-server/src/mcp/audit_envelope.rs \
+        crates/rimap-server/src/mcp/server.rs \
+        crates/rimap-server/src/mcp/mod.rs \
+        crates/rimap-server/tests/dispatch_ticket.rs \
+        crates/rimap-server/tests/e2e.rs
+git commit -m "$(cat <<'EOF'
+refactor(server): DispatchTicket + test-support entry point for dispatch
+
+Closes #110.
+
+`dispatch_tool` now takes a `DispatchTicket` ZST whose construction is
+module-private and whose only producer is `run_with_audit_envelope`.
+The envelope's body signature becomes a closure that receives the
+ticket, so the "forgot the envelope" bypass is a compile error. Also
+narrow `dispatch_tool` from `#[doc(hidden)] pub` to `pub(crate)`.
+
+For integration tests, expose `execute_tool_for_test` under a new
+`test-support` feature that composes the full pipeline (resolve account
+→ pre_dispatch → audit envelope → dispatch_tool). The e2e harness now
+uses this helper and no longer re-implements the composition.
+
+No MCP-client-visible behavior change. No posture / breaker / rate /
+audit schema change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Post-implementation
+
+- [ ] **Final workspace verification**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+Expected: clean format, zero warnings, all tests pass.
+
+- [ ] **Open four PRs or one combined PR**
+
+Stylistic decision — the four tasks are independent, so four PRs is fine and lets reviewers land them in any order. A single combined PR is also defensible since the scope is ~200–400 lines. Default: one PR titled `fix: address review findings from code-health-2026-04-20 (#110–#113)` with the four commits. If reviewers push back on scope, split.
+
+- [ ] **Close each issue with a commit-ref in the PR body**
+
+`Closes #110`, `Closes #111`, `Closes #112`, `Closes #113` — already embedded in the commit messages above. GitHub auto-closes on merge to main.

--- a/docs/superpowers/plans/2026-04-20-issues-110-113.md
+++ b/docs/superpowers/plans/2026-04-20-issues-110-113.md
@@ -14,6 +14,12 @@
 
 ## Task 1: Unicode validation on `use_account` (#111)
 
+> **Review follow-up (2026-04-20):** the original Task 1 landed the handler
+> pre-check but left the audit-log verbatim echo intact. The audit-log gap
+> was closed in a follow-up commit by switching `use_account_schema`'s
+> `account` field from `Verbatim` to `RedactString`; see
+> `2026-04-20-issues-110-113-followup.md` Task 1.
+
 Reject bidi / zero-width / Unicode-Tag codepoints at the handler entry, before the name ever reaches `AccountRegistry::set_active` or the `tool_start` audit record. `list_accounts` takes no caller-supplied strings so it needs no code change, only a test to pin the invariant.
 
 **Files:**


### PR DESCRIPTION
## Summary

Closes #110, #111, #112, #113 and addresses every finding from the post-implementation review (MCP-security, email-IMAP-security, rust-safety, supply-chain reviewers).

The branch lands in two logical halves:

### Part 1 — the four issues (commits a8b7a6a..c67686b)

- **#111** — `fix(server): reject bidi/zero-width codepoints in use_account arg`. Promotes `rimap_core::is_rejected_display_codepoint` to `pub` and pre-checks the `account` argument at handler entry.
- **#112** — `feat(server): add failure_code to SentCopyInfo`. Threads `ImapError::code()` through `build_sent_copy_info`, so clients can distinguish transient (`Timeout`, `ConnectionLost`) from permanent (`AttachmentTooLarge`, `ImapProtocol`, `InvalidInput`) failures. Additive MCP schema field.
- **#113** — `feat(server): surface raw wire folder name on list_folders`. Adds `FolderEntry.name_wire: Option<String>`, populated as a Unicode-escaped string only when the sanitizer modified the display name. Clients round-trip `name_wire` for SELECT/STATUS/MOVE/FETCH.
- **#110** — `refactor(server): DispatchTicket + test-support entry point for dispatch`. Introduces a `DispatchTicket` ZST whose construction is module-private; `dispatch_tool` is narrowed to `pub(crate)` and consumes the ticket by value, making the "forgot the envelope" bypass a compile error. `execute_tool_for_test` is exposed under a new `test-support` feature so integration tests exercise the same pipeline as real MCP clients.

### Part 2 — review follow-ups (commits b3ac4e5..cb96113)

Eight commits addressing every reviewer finding:

| Commit | Finding | Severity |
|---|---|---|
| `b3ac4e5` fix(audit): redact use_account account arg | MCP-INJ-03 / MAIL-AUD-02: spoofed account names were still landing in `tool_start` verbatim despite the handler pre-check | Medium |
| `0916cd0` fix(server): cap escape_wire_name input | MCP-PRIV-04 / MAIL-DOS-04: hostile IMAP server could amplify memory via multi-MB folder names with bidi codepoints | Low |
| `ca9a49f` test(server): add drop-at-await test | RUST-ASYNC-05: no integration-level test pinned that the closure form of run_with_audit_envelope preserves AuditEnvelopeGuard::Drop timing | Medium |
| `adbf7fd` chore(server): mark SentCopyInfo and FolderEntry non_exhaustive | RUST-API-07: future field additions would be breaking for exhaustive pattern-matches | Low |
| `df90e60` fix(server): sanitize SentCopyInfo.folder | Pre-existing gap: server-supplied SPECIAL-USE Sent folder name could carry bidi codepoints to the client | Info |
| `7e5c5df` docs(server): strengthen review-flagged docstrings | RUST-API-01, RUST-ERR-01, + ERR_CANCELLED / FolderEntry security doc | Low/info |
| `cc0c858` refactor(server): narrow ImapMcpServer fields to pub(crate) | RUST-API-01 / MCP-PRIV-04 layer-2: external crates could reach server.registry and bypass the dispatch pipeline at a lower layer | Medium |
| `cb96113` ci(workflows): add no-default-features build job | RUST-API-01: CI-only-\`--all-features\` coverage left test-support-gated code vulnerable to bit-rot | Low |

Plan docs: \`docs/superpowers/plans/2026-04-20-issues-110-113.md\` (original) and \`docs/superpowers/plans/2026-04-20-issues-110-113-followup.md\` (review follow-up).

## Verification

- \`cargo fmt --check --all\`
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- \`cargo clippy --workspace --all-targets --no-default-features -- -D warnings\` (new coverage from the \`check-no-features\` CI job)
- \`cargo clippy -p rimap-server --no-default-features --lib -- -D warnings\` (catches rimap-server-specific cfg-rot past the self-dev-dep)
- \`cargo test --workspace --all-features\` — all pass, including the Dovecot-backed e2e

## Test plan

- [ ] CI green across all jobs including the new \`check-no-features\`
- [ ] Reviewer spot-check: the audit-log-clean invariant (use_account rejection) — see \`use_account_rejected_spoof_is_not_in_audit_log\` in \`crates/rimap-server/tests/dispatch_ticket.rs\`
- [ ] Reviewer spot-check: the drop-at-await invariant — see \`drop_during_body_enqueues_cancellation_tool_end\`
- [ ] Reviewer spot-check: the \`escape_wire_name\` cap — see \`name_wire_is_bounded_for_oversized_raw_name\`
- [ ] Reviewer spot-check: no external crate can reach \`ImapMcpServer::registry\` (\`grep 'server\.registry'\` across the workspace after checkout; expect no matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)