### PR TITLE
fix: --dry-run infrastructure-tool output + Proton quickstart openssl/STARTTLS/headless

### DIFF
--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -6,8 +6,10 @@
 //! the matrix to stdout is both acceptable and the most useful destination
 //! (it can be piped to `less`, etc.).
 //!
-//! Output format is stable text: one header line and one row per tool, in
-//! declaration order. Sample:
+//! Output format is stable text: one header line and one row per content
+//! tool in declaration order, followed by a separate section listing
+//! infrastructure tools (which bypass the posture matrix at runtime and
+//! are always available). Sample:
 //!
 //! ```text
 //! Effective matrix (posture = draft-safe)
@@ -15,6 +17,9 @@
 //!   [ok ] search
 //!   [deny] search.advanced_query
 //!   ...
+//! Infrastructure tools (always available):
+//!   [ok ] use_account
+//!   [ok ] list_accounts
 //! ```
 
 use std::io::Write;
@@ -24,6 +29,7 @@ use anyhow::Context;
 use rimap_audit::{AuditOptions, AuditWriter};
 use rimap_authz::matrix::EffectiveMatrix;
 use rimap_config::loader::load_and_validate;
+use rimap_core::tool::ToolName;
 
 /// Load `path`, validate, acquire an exclusive audit lock, build the effective
 /// matrix, print to `out`, and return. The audit lock is held for the duration
@@ -57,8 +63,18 @@ pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
         }
         writeln!(out, "Effective matrix (posture = {})", matrix.posture())?;
         for (tool, allowed) in matrix.rows() {
+            if tool.is_infrastructure() {
+                continue;
+            }
             let tag = if allowed { "[ok ]" } else { "[deny]" };
             writeln!(out, "  {tag} {tool}")?;
+        }
+        writeln!(out, "Infrastructure tools (always available):")?;
+        for tool in ToolName::all()
+            .into_iter()
+            .filter(|t| t.is_infrastructure())
+        {
+            writeln!(out, "  [ok ] {tool}")?;
         }
     }
     Ok(())
@@ -142,6 +158,40 @@ allowed_base_dir = "{}"
         assert!(
             chain.contains("already locked") || chain.contains("opening audit log"),
             "unexpected error chain: {chain}",
+        );
+    }
+
+    #[test]
+    fn dry_run_lists_infrastructure_tools_separately() {
+        // Infrastructure tools (use_account, list_accounts) bypass the posture
+        // matrix at runtime, so printing them as `[deny]` alongside content
+        // tools misleads users into thinking the tools are unavailable. They
+        // should appear in their own "always available" section instead.
+        let dir = TempDir::new().unwrap();
+        let path = write_minimal_config(&dir);
+        let mut out = Vec::new();
+        run(&path, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+
+        assert!(
+            !text.contains("[deny] use_account"),
+            "use_account must not appear as denied in the matrix:\n{text}"
+        );
+        assert!(
+            !text.contains("[deny] list_accounts"),
+            "list_accounts must not appear as denied in the matrix:\n{text}"
+        );
+        assert!(
+            text.contains("Infrastructure tools (always available)"),
+            "expected infrastructure section header:\n{text}"
+        );
+        assert!(
+            text.contains("use_account"),
+            "use_account must still be listed somewhere:\n{text}"
+        );
+        assert!(
+            text.contains("list_accounts"),
+            "list_accounts must still be listed somewhere:\n{text}"
         );
     }
 

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -36,13 +36,19 @@ system trust store. Pin the certificate fingerprint so the server can
 verify it.
 
 ```bash
-openssl s_client -connect 127.0.0.1:1143 < /dev/null 2>/dev/null \
+openssl s_client -connect 127.0.0.1:1143 -starttls imap < /dev/null 2>/dev/null \
   | openssl x509 -outform DER \
   | openssl dgst -sha256 -hex \
   | awk '{print $2}'
 ```
 
 This prints a 64-character hex string. Copy it for the next step.
+
+Bridge's IMAP port uses STARTTLS rather than implicit TLS, so `-starttls imap`
+is required — without it, `openssl` returns no certificate and the pipeline
+silently hashes empty bytes to the well-known constant
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+If you see that value, you forgot the flag.
 
 The fingerprint changes when Proton Bridge regenerates its certificate
 (after a Bridge update or reinstall). If the server later fails with
@@ -210,3 +216,53 @@ Bridge is slow to start or your mailbox is large, increase
 The fingerprint changes when Bridge regenerates its certificate (after
 updates or reinstalls). If you get `ERR_TLS` after a Bridge update,
 re-run the openssl command from Step 2 and update the config.
+
+### Running headless or over SSH
+
+Proton Bridge and `rusty-imap-mcp` both resolve credentials through the
+Linux Secret Service API (`libsecret` / gnome-keyring or KWallet). In a
+graphical session, PAM unlocks the login keyring automatically at sign-in;
+in a TTY or SSH session it does not, and Bridge fails to start with:
+
+```text
+Proton Mail Bridge is not able to detect a supported password manager
+(secret-service or pass). Please install and set up a supported password
+manager and restart the application.
+```
+
+Pick one of the following.
+
+**A. Log in graphically at least once.** Sign in via your display manager
+so `pam_gnome_keyring` unlocks the login keyring, then launch Bridge from a
+terminal inside that graphical session. SSH sessions spawned afterward also
+need `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus` exported so
+they can reach the running daemon.
+
+**B. Use `pass` as Bridge's backend (recommended for headless hosts).**
+Bridge tries `pass` after Secret Service fails, so a working `pass` store
+is sufficient on its own:
+
+```bash
+# 1. If you don't already have one, generate a local-use GPG key
+chmod 700 ~/.gnupg
+gpg --batch --quick-gen-key "bridge-local <you@localhost>" default default never
+
+# 2. Get the key fingerprint
+gpg --list-secret-keys --keyid-format=long
+
+# 3. Initialize the password store with that fingerprint
+pass init <KEY_FINGERPRINT>
+
+# 4. Re-launch Bridge
+protonmail-bridge -c
+```
+
+Bridge will store its own credentials under `pass` automatically. You can
+then store the Bridge password for `rusty-imap-mcp` the usual way
+(Step 4 above) — `rusty-imap-mcp` itself does not require `pass`, only
+Bridge does.
+
+**C. Capture the fingerprint from a TTY.** The `openssl` pipeline in
+Step 2 works over SSH as long as you can reach `127.0.0.1:1143` from
+the shell where Bridge is running. The `-starttls imap` flag is
+required regardless of session type.


### PR DESCRIPTION
## Summary

Two small, independent fixes surfaced while setting up rusty-imap-mcp against Proton Bridge:

- **`--dry-run` output** — infrastructure tools (`use_account`, `list_accounts`) printed as `[deny]` in the posture matrix even though they bypass the matrix at runtime. Users read that as "these tools are unavailable," which is wrong. Split them into a dedicated `Infrastructure tools (always available):` section. Added a regression test.
- **Proton quickstart docs** — Step 2's `openssl s_client` command omitted `-starttls imap`, so on Bridge's STARTTLS-only port 1143 it returned no certificate and the pipeline silently hashed empty bytes to the well-known constant `e3b0c442…2b855`. Added the flag, documented the failure mode, and added a new *Running headless or over SSH* subsection covering PAM keyring unlock vs. using `pass` as Bridge's backend (encountered this while setting up on a Fedora TTY).

## Changes

- `crates/rimap-server/src/cli/dry_run.rs` — skip infrastructure tools in the matrix loop, append dedicated section; module doc + sample updated; one new test (`dry_run_lists_infrastructure_tools_separately`)
- `docs/quickstart-proton-bridge.md` — `-starttls imap` on Step 2 openssl; empty-hash trap warning; new Known-quirks subsection for headless / SSH setup

## Before / after `--dry-run`

Before (misleading):
```
  [deny] use_account
  [deny] list_accounts
```

After:
```
Infrastructure tools (always available):
  [ok ] use_account
  [ok ] list_accounts
```

## Test plan

- [x] `cargo test --workspace --locked` — all tests pass (163 + others)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `./target/release/rusty-imap-mcp --dry-run` against a multi-account config renders the new section for each account
- [x] `openssl s_client -connect 127.0.0.1:1143 -starttls imap` produces a real 64-char fingerprint; without the flag it yields the empty-bytes constant (as the doc now warns)
- [ ] Review Known-quirks *Running headless or over SSH* prose for accuracy against your own setups

## Related

Filed separately for larger follow-up work discovered during setup:
- #117 — `--dry-run` should actually perform the TLS preflight it claims to (phantom feature in current docs)
- #118 — `rimap-imap` needs STARTTLS support so Proton Bridge works in its default connection mode without requiring users to flip to SSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)