### PR TITLE
ci: cap Docker-gated test parallelism via nextest test-groups

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+# nextest configuration.
+#
+# The Dovecot and Proton Bridge integration binaries each spawn Docker/Podman
+# containers per test. Running many in parallel triggers container-daemon
+# contention (port mapping races, mmap failures during dovecot worker startup,
+# volume-mount relabeling under SELinux). Cap those binaries to a small
+# concurrency so the rest of the workspace still runs at full parallelism.
+
+[test-groups]
+container-backed = { max-threads = 4 }
+
+[[profile.default.overrides]]
+filter = 'binary(dovecot) + binary(proton)'
+test-group = 'container-backed'


### PR DESCRIPTION
## Summary
- Adds `.config/nextest.toml` with a `container-backed` test-group limited to 4 threads, scoped to the `dovecot` and `proton` integration binaries.
- The rest of the workspace still runs at full nextest parallelism; only the container-backed binaries are capped.

## Why
`just test` runs the full workspace at default nextest parallelism (~host-core count). The Dovecot integration binary spawns a container per test case (≥20 cases today, 23 once STARTTLS tests land). At ~10+ concurrent container starts, the Podman/Docker daemon occasionally fails to boot Dovecot workers cleanly (mmap failures under load, SELinux relabel contention on shared volume mounts, port-mapping races). These fail as test-level errors that look like regressions but are infrastructure.

Capping just the container-backed tests keeps the unit suite fast while removing the flakiness ceiling.

## Test plan
- [x] `just test` locally — 941/941 pass in 72.9s with the new config (was sporadically 10/941 failing before).
- [x] `cargo nextest show-config test-groups` confirms the `container-backed` group matches all Dovecot + Proton tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)