### PR TITLE
docs: polish release spec + Wave A plans

### DIFF
--- a/docs/superpowers/plans/2026-04-23-polish-pr07-process-end-aggregator.md
+++ b/docs/superpowers/plans/2026-04-23-polish-pr07-process-end-aggregator.md
@@ -1,0 +1,270 @@
+# Polish PR 7 — `process_end.total_tool_calls` aggregator
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #135. `process_end` currently emits `total_tool_calls: 0` as a placeholder. Thread a daemon-scoped `AtomicU64` counter through `DaemonState`, increment it from `emit_session_end` with each session's tool-call count, and read it in `daemon_main` before writing the `process_end` record.
+
+**Architecture:** One new `AtomicU64` field on `DaemonState`. `emit_session_end` already loads the per-session `tool_call_count`; add a `fetch_add` on the daemon-level counter with the same value. `daemon_main` reads the daemon-level counter with `Relaxed` before logging `process_end`. Two non-primary call sites that currently also emit `total_tool_calls: 0` (`boot/audit_init.rs:181` and `:230`, both in the boot-failure path before the daemon loop starts) stay at `0` — no sessions have run, so the value is correct.
+
+**Tech Stack:** Rust, `std::sync::atomic::AtomicU64`, `Ordering::Relaxed`.
+
+---
+
+## Files
+
+- Modify: `crates/rimap-server/src/daemon/state.rs` — add `total_tool_calls` field to `DaemonState`.
+- Modify: `crates/rimap-server/src/daemon/run.rs:321-340` — bump daemon-level counter in `emit_session_end`.
+- Modify: `crates/rimap-server/src/main.rs:202-211` — read counter in `daemon_main` before `log_process_end`.
+- Test: `crates/rimap-server/tests/audit_process_end_aggregator.rs` (new integration test).
+
+## Task 1: Add the daemon-level counter field
+
+**Files:**
+- Modify: `crates/rimap-server/src/daemon/state.rs`
+
+- [ ] **Step 1: Add a failing unit test**
+
+Append to the `#[cfg(test)]` module at the bottom of `crates/rimap-server/src/daemon/state.rs` (keep the existing `#[expect(clippy::unwrap_used, ...)]` attribute):
+
+```rust
+#[test]
+fn daemon_state_has_total_tool_calls_counter_starting_at_zero() {
+    // Constructed via struct literal (not a helper) to mirror daemon_main().
+    // We only assert the counter starts at 0 — the other fields are stubbed
+    // with placeholder values that are never observed by this test.
+    use std::sync::atomic::Ordering;
+    // A minimal DaemonState cannot be built without the full stack; we
+    // instead assert via a direct field access on a value we do construct
+    // in a real test. This placeholder is elevated into a real integration
+    // test in Task 3; for now, just assert the field exists via a compile
+    // check.
+    fn _assert_field_exists(state: &super::DaemonState) -> u64 {
+        state
+            .total_tool_calls
+            .load(Ordering::Relaxed)
+    }
+    let _ = _assert_field_exists;
+}
+```
+
+(This is a compile-time check, not a runtime assertion. `DaemonState` cannot be constructed outside `daemon_main` without considerable plumbing; the runtime check lives in Task 3.)
+
+- [ ] **Step 2: Run the test to confirm it fails to compile**
+
+Run: `cargo test -p rimap-server --lib daemon::state::tests::daemon_state_has_total_tool_calls_counter_starting_at_zero`
+Expected: compile error — `no field 'total_tool_calls' on type 'DaemonState'`.
+
+- [ ] **Step 3: Add the field**
+
+Edit `crates/rimap-server/src/daemon/state.rs`. Update the `use` block at the top:
+
+```rust
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::Instant;
+```
+
+Inside `pub struct DaemonState { ... }`, add the new field at the end (after `session_permits`):
+
+```rust
+    /// Daemon-wide aggregate of completed tool calls across all sessions.
+    /// Incremented in `emit_session_end` with each session's final count.
+    /// Read in `daemon_main` to populate `process_end.total_tool_calls`.
+    pub total_tool_calls: AtomicU64,
+```
+
+- [ ] **Step 4: Initialise the field in `daemon_main`**
+
+Edit `crates/rimap-server/src/main.rs`, inside `daemon_main` where `DaemonState` is constructed (line 186-193). Add the initialiser:
+
+```rust
+    let state = Arc::new(DaemonState {
+        registry: Arc::new(registry),
+        audit: audit.clone(),
+        download_dir,
+        cancellation_tx,
+        started_at: std::time::Instant::now(),
+        session_permits,
+        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
+    });
+```
+
+- [ ] **Step 5: Run the compile-check test**
+
+Run: `cargo test -p rimap-server --lib daemon::state::tests::daemon_state_has_total_tool_calls_counter_starting_at_zero`
+Expected: pass (the field now exists).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/daemon/state.rs crates/rimap-server/src/main.rs
+git commit -m "feat(rimap-server): add DaemonState.total_tool_calls counter (#135)"
+```
+
+## Task 2: Bump the counter in `emit_session_end`
+
+**Files:**
+- Modify: `crates/rimap-server/src/daemon/run.rs:321-340`
+
+- [ ] **Step 1: Update `emit_session_end`**
+
+In `crates/rimap-server/src/daemon/run.rs`, find `emit_session_end` (starts at line 322). Immediately after the `let total = session.tool_call_count.load(...)` line (line 329-331), add:
+
+```rust
+    state
+        .total_tool_calls
+        .fetch_add(total, std::sync::atomic::Ordering::Relaxed);
+```
+
+The full block should now read:
+
+```rust
+    let total = session
+        .tool_call_count
+        .load(std::sync::atomic::Ordering::Relaxed);
+    state
+        .total_tool_calls
+        .fetch_add(total, std::sync::atomic::Ordering::Relaxed);
+    let end = rimap_audit::record::SessionEnd {
+        session_id: session.id,
+        reason,
+        duration_ms,
+        total_tool_calls: total,
+        last_error,
+    };
+```
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+Run: `cargo build -p rimap-server`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/src/daemon/run.rs
+git commit -m "feat(rimap-server): aggregate per-session tool counts into DaemonState (#135)"
+```
+
+## Task 3: Read the counter in `daemon_main` and add an integration test
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs:202-211`
+- Create: `crates/rimap-server/tests/audit_process_end_aggregator.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `crates/rimap-server/tests/audit_process_end_aggregator.rs`:
+
+```rust
+//! Integration test for issue #135: `process_end.total_tool_calls` must
+//! aggregate across all sessions, not emit 0.
+
+#![expect(clippy::unwrap_used, reason = "tests")]
+
+mod common;
+
+use common::daemon_harness::TestDaemon;
+use serde_json::Value;
+use std::time::Duration;
+
+/// Spawn a daemon, run two sessions each making N tool calls, shut the
+/// daemon down, and assert `process_end.total_tool_calls == 2 * N`.
+#[tokio::test(flavor = "multi_thread")]
+async fn process_end_aggregates_tool_calls_across_sessions() {
+    let daemon = TestDaemon::spawn().await;
+    let audit_path = daemon.audit_path().to_path_buf();
+
+    // Two sessions, two tool calls each. Use the harness's existing
+    // connect + list_tools helper; list_tools is an infrastructure call
+    // that counts toward tool_call_count.
+    for _ in 0..2 {
+        let mut client = daemon.connect().await;
+        client.list_tools().await.unwrap();
+        client.list_tools().await.unwrap();
+        drop(client);
+    }
+
+    daemon.shutdown_and_wait(Duration::from_secs(5)).await;
+
+    // Scan the audit log for the process_end record.
+    let body = std::fs::read_to_string(&audit_path).unwrap();
+    let mut total = None;
+    for line in body.lines() {
+        let v: Value = serde_json::from_str(line).unwrap();
+        if v.get("kind").and_then(Value::as_str) == Some("process_end") {
+            total = v.get("total_tool_calls").and_then(Value::as_u64);
+        }
+    }
+    assert_eq!(total, Some(4), "expected 4 tool calls, got {total:?}");
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `cargo test -p rimap-server --test audit_process_end_aggregator`
+Expected: FAIL with `assertion failed: expected 4 tool calls, got Some(0)`.
+
+- [ ] **Step 3: Update `daemon_main` to read the counter**
+
+In `crates/rimap-server/src/main.rs`, replace lines 204–209:
+
+```rust
+    if let Err(e) = audit.log_process_end(rimap_audit::ProcessEnd {
+        reason,
+        // Aggregation across sessions is a follow-up — leave 0 for v1.
+        total_tool_calls: 0,
+    }) {
+```
+
+with:
+
+```rust
+    let total_tool_calls = state
+        .total_tool_calls
+        .load(std::sync::atomic::Ordering::Relaxed);
+    if let Err(e) = audit.log_process_end(rimap_audit::ProcessEnd {
+        reason,
+        total_tool_calls,
+    }) {
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cargo test -p rimap-server --test audit_process_end_aggregator`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full daemon test suite to confirm no regression**
+
+Run: `cargo test -p rimap-server --tests`
+Expected: all existing daemon tests pass (especially `daemon_happy_path` and `daemon_graceful_shutdown`).
+
+- [ ] **Step 6: Run clippy with zero-warnings policy**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs crates/rimap-server/tests/audit_process_end_aggregator.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): wire process_end.total_tool_calls aggregator (#135)
+
+daemon_main reads the new DaemonState counter populated from
+emit_session_end. Adds an integration test that runs two sessions
+making two tool calls each and asserts process_end reports 4.
+
+Closes #135.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Self-review
+
+- TDD discipline: failing test in Task 3 step 2 before the fix in step 3.
+- `Ordering::Relaxed` used consistently — no cross-thread ordering is required because the counter is only read after every session has finished (`drainer_handle.await` happens before the load in Task 3 step 3).
+- The two non-primary `total_tool_calls: 0` call sites in `boot/audit_init.rs` (line 181 and 230) are intentionally untouched: they fire only on boot-failure paths where no sessions ever ran. Acceptance criterion in the spec is satisfied because #135's target was the daemon success/error exit path in `daemon_main`.
+- Three commits, each independently reviewable; only the final commit changes observable behaviour.

--- a/docs/superpowers/plans/2026-04-23-polish-pr08-dry-run-preflight.md
+++ b/docs/superpowers/plans/2026-04-23-polish-pr08-dry-run-preflight.md
@@ -1,0 +1,445 @@
+# Polish PR 8 — `--dry-run` TLS preflight + CAPABILITY check
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #117. The docs (`docs/quickstart-gmail.md`, `docs/quickstart-proton-bridge.md`) claim `--dry-run` performs a TLS handshake and reports server capabilities. In fact, `--dry-run` today only loads+validates the config and prints the posture matrix. This PR adds a real TLS handshake and pre-auth `CAPABILITY` probe per account and updates the quickstart docs to describe exactly what landed (TLS handshake + capabilities; no fingerprint claim).
+
+**Architecture:** Add a new `probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, ImapError>` free function in `rimap-imap` that runs TCP connect → TLS handshake → IMAP greeting → pre-auth `CAPABILITY` command, returning the capability list. `cli::dry_run::run` becomes `async` and invokes the probe once per account, printing capabilities alongside the existing posture matrix. Tests exercise the probe against the project's existing Mailpit-backed integration fixture (gated on `RIMAP_REQUIRE_LIVE_IMAP=1`) and assert the `--dry-run` text output includes a "Capabilities:" section.
+
+**Tech Stack:** Rust, `tokio`, `async-imap`, `tokio-rustls`. The existing private helpers `build_tls_config`, `tls_handshake`, `starttls_upgrade` in `crates/rimap-imap/src/connection.rs` and the greeting/CAPABILITY blocks of `imap_login` (lines 383–436) are the reference implementation.
+
+---
+
+## Files
+
+- Create: `crates/rimap-imap/src/preflight.rs` — new module exporting `probe_preflight` and `PreflightInfo`.
+- Modify: `crates/rimap-imap/src/lib.rs` — add `pub mod preflight;` and re-exports.
+- Modify: `crates/rimap-imap/src/connection.rs` — make `build_tls_config`, `tls_handshake`, `starttls_upgrade`, `drain_for_logindisabled` visible to the new module (either `pub(crate)` or move into a shared module).
+- Modify: `crates/rimap-server/src/cli/dry_run.rs` — make `run` async; call `probe_preflight` per account; print capabilities.
+- Modify: `crates/rimap-server/src/main.rs:96-100` — `.await` the newly async `dry_run::run`.
+- Modify: `crates/rimap-server/tests/dry_run_cli.rs` — add capability-output assertion (gated on `RIMAP_REQUIRE_LIVE_IMAP`).
+- Modify: `docs/quickstart-gmail.md:73` and `docs/quickstart-proton-bridge.md:114-115` — describe the actual landed behavior (no fingerprint).
+
+## Task 1: Extract a shared module for TLS primitives
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs` — elevate the four helpers listed above from private to `pub(crate)`.
+
+- [ ] **Step 1: Run clippy before any change to baseline**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: clean exit. This confirms the starting state compiles.
+
+- [ ] **Step 2: Make `build_tls_config`, `tls_handshake`, `starttls_upgrade`, and `drain_for_logindisabled` `pub(crate)`**
+
+In `crates/rimap-imap/src/connection.rs`, change:
+
+```rust
+fn build_tls_config(...) -> ... { ... }
+fn tls_handshake(...) -> ... { ... }
+fn starttls_upgrade(...) -> ... { ... }
+fn drain_for_logindisabled(...) -> bool { ... }
+```
+
+to:
+
+```rust
+pub(crate) fn build_tls_config(...) -> ... { ... }
+pub(crate) async fn tls_handshake(...) -> ... { ... }
+pub(crate) async fn starttls_upgrade(...) -> ... { ... }
+pub(crate) fn drain_for_logindisabled(...) -> bool { ... }
+```
+
+(Use `rg -n 'fn build_tls_config|fn tls_handshake|fn starttls_upgrade|fn drain_for_logindisabled' crates/rimap-imap/src/connection.rs` to find the exact signatures; the visibility is the only edit — do not rename or rearrange.)
+
+- [ ] **Step 3: Compile-check**
+
+Run: `cargo check -p rimap-imap`
+Expected: clean — visibility widening is strictly non-breaking.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-imap/src/connection.rs
+git commit -m "refactor(rimap-imap): widen TLS primitives to pub(crate) for preflight reuse (#117)"
+```
+
+## Task 2: Implement `probe_preflight` against a real Mailpit fixture
+
+**Files:**
+- Create: `crates/rimap-imap/src/preflight.rs`
+- Modify: `crates/rimap-imap/src/lib.rs`
+- Create: `crates/rimap-imap/tests/preflight_live.rs` — integration test gated on `RIMAP_REQUIRE_LIVE_IMAP`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+The repo has a Dovecot-backed live fixture under `crates/rimap-imap/tests/integration/`; the test goes in that area so it can share the fixture harness. Create `crates/rimap-imap/tests/preflight_live.rs`:
+
+```rust
+//! Live integration test for `probe_preflight` (#117). Gated on
+//! `RIMAP_REQUIRE_LIVE_IMAP=1` like the other live tests in this crate.
+
+#![expect(clippy::unwrap_used, reason = "tests")]
+
+#[path = "integration/common/mod.rs"]
+mod common;
+
+use rimap_imap::preflight::probe_preflight;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preflight_returns_capabilities_against_live_dovecot() {
+    let Some(fx) = common::LiveFixture::spawn().await else {
+        return; // RIMAP_REQUIRE_LIVE_IMAP not set; skip silently.
+    };
+    let cfg = fx.connection_config();
+    let info = probe_preflight(&cfg).await.unwrap();
+    assert!(!info.capabilities.is_empty(), "capabilities list empty");
+    assert!(
+        info.capabilities.iter().any(|c| c.eq_ignore_ascii_case("IMAP4REV1")),
+        "expected IMAP4REV1 capability, got {:?}",
+        info.capabilities,
+    );
+}
+```
+
+(If `common::LiveFixture::spawn().await` and `connection_config()` are not the exact names in the existing harness, adapt to match. The important thing is: construct a `ConnectionConfig`, then call `probe_preflight`, then assert `IMAP4REV1` appears.)
+
+- [ ] **Step 2: Run the test to confirm it fails to compile**
+
+Run: `RIMAP_REQUIRE_LIVE_IMAP=1 cargo test -p rimap-imap --test preflight_live`
+Expected: compile error — `unresolved import 'rimap_imap::preflight'`.
+
+- [ ] **Step 3: Create the `preflight` module**
+
+Create `crates/rimap-imap/src/preflight.rs`:
+
+```rust
+//! Pre-auth `CAPABILITY` probe used by `--dry-run` and other diagnostic
+//! paths. Performs TCP connect → TLS handshake → IMAP greeting → pre-auth
+//! `CAPABILITY` command, then drops the connection. Does NOT perform LOGIN
+//! and does NOT emit any audit records.
+
+use std::time::Instant;
+
+use async_imap::Client as ImapPlainClient;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+use crate::connection::{
+    build_tls_config, drain_for_logindisabled, starttls_upgrade, tls_handshake,
+};
+use crate::error::ImapError;
+use crate::types::{ConnectionConfig, ImapEncryption};
+
+/// Result of a successful preflight probe.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PreflightInfo {
+    /// Capability atoms returned by the server's pre-auth `CAPABILITY`
+    /// response, upper-case, de-duplicated, order preserved as received.
+    pub capabilities: Vec<String>,
+}
+
+/// Run a TCP+TLS+greeting+CAPABILITY probe against `cfg`.
+///
+/// # Errors
+/// Mirrors `ImapError` variants: `Connect`, `TlsHandshake`, `Timeout`,
+/// `Protocol`. Never returns `Auth` variants — no credentials are used.
+pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, ImapError> {
+    let bundle = build_tls_config(cfg.pinned_fingerprint)?;
+    let total_deadline = cfg.connect_timeout;
+    let started = Instant::now();
+
+    let tcp = timeout(
+        total_deadline,
+        TcpStream::connect((cfg.host.as_str(), cfg.port)),
+    )
+    .await
+    .map_err(|_| ImapError::Timeout { op: "tcp_connect" })?
+    .map_err(ImapError::Connect)?;
+
+    let remaining = total_deadline.saturating_sub(started.elapsed());
+    let (tls_stream, already_greeted) = match cfg.encryption {
+        ImapEncryption::Tls => {
+            let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout { op: "tls_handshake" })??;
+            (s, false)
+        }
+        ImapEncryption::Starttls => {
+            let s = timeout(remaining, starttls_upgrade(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout { op: "starttls_upgrade" })??;
+            (s, true)
+        }
+    };
+
+    // Capabilities collection reuses async-imap's client + unsolicited channel
+    // exactly as imap_login does at connection.rs:383-436.
+    let mut client = ImapPlainClient::new(tls_stream);
+    if !already_greeted {
+        client
+            .read_response()
+            .await
+            .map_err(ImapError::Connect)?
+            .ok_or(ImapError::Connect(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "server closed before greeting",
+            )))?;
+    }
+    let (tx, rx) = async_channel::bounded::<async_imap::imap_proto::UnsolicitedResponse>(32);
+    client
+        .run_command_and_check_ok("CAPABILITY", Some(tx))
+        .await
+        .map_err(ImapError::Protocol)?;
+
+    let mut caps = Vec::new();
+    while let Ok(u) = rx.try_recv() {
+        if let async_imap::imap_proto::UnsolicitedResponse::Capabilities(list) = u {
+            for c in list {
+                let s = format!("{c:?}").to_ascii_uppercase();
+                if !caps.contains(&s) {
+                    caps.push(s);
+                }
+            }
+        }
+    }
+    // `drain_for_logindisabled` is informational for the caller only; not
+    // an error for preflight. We don't use it here, but the import stays
+    // so a future caller can inspect LOGINDISABLED without re-draining.
+    let _ = drain_for_logindisabled;
+
+    Ok(PreflightInfo { capabilities: caps })
+}
+```
+
+**Implementer note:** the exact shape of `async_imap::imap_proto::UnsolicitedResponse::Capabilities(list)` in the installed `async-imap` version may require small adjustment (the variant name/fields can drift between 0.11 and 0.12). If the match arm doesn't compile, `cargo doc --open -p async-imap` and look up the `imap_proto::UnsolicitedResponse` enum. The printed-debug conversion `format!("{c:?}")` is a deliberate simplification — the existing code in `connection.rs` does the same because async-imap's capability atoms don't impl `Display`. A more structured `Vec<Capability>` type is a follow-up, not PR 8 scope.
+
+- [ ] **Step 4: Re-export from the crate root**
+
+Edit `crates/rimap-imap/src/lib.rs`. Add:
+
+```rust
+pub mod preflight;
+```
+
+Place the line with the other `pub mod` declarations (follow existing alphabetical/convention).
+
+- [ ] **Step 5: Run the live test**
+
+Start the Mailpit/Dovecot fixture first (see `justfile` / `README.md` for the exact command — likely `just test-live` or similar).
+
+Run: `RIMAP_REQUIRE_LIVE_IMAP=1 cargo test -p rimap-imap --test preflight_live`
+Expected: PASS. `IMAP4REV1` should appear in the capability list.
+
+- [ ] **Step 6: Also confirm the non-live flow is unaffected**
+
+Run: `cargo test -p rimap-imap` (without the env var)
+Expected: `preflight_live` returns early (no-op); other tests pass as before.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-imap/src/preflight.rs crates/rimap-imap/src/lib.rs crates/rimap-imap/tests/preflight_live.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-imap): add probe_preflight for TLS+CAPABILITY probing (#117)
+
+Runs TCP+TLS+greeting+CAPABILITY with no credentials and no audit
+emission. Used by `--dry-run` to match the quickstart docs, which
+claim a TLS preflight happens.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 3: Wire the preflight into `--dry-run`
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/dry_run.rs`
+- Modify: `crates/rimap-server/src/main.rs:99`
+
+- [ ] **Step 1: Make `dry_run::run` async and invoke the probe**
+
+In `crates/rimap-server/src/cli/dry_run.rs`, change the signature:
+
+```rust
+pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
+```
+
+to:
+
+```rust
+pub async fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
+```
+
+Then inside the `for (id, acfg) in &multi.accounts` loop, after the existing `writeln!(out, "Infrastructure tools (always available):")` block (line 72–78), add:
+
+```rust
+        // TLS + CAPABILITY preflight per account (#117). Errors are
+        // reported inline but do not abort the dry-run — a multi-account
+        // config may have one unreachable host and still want to print
+        // the matrix for the others.
+        let cfg = rimap_imap::types::ConnectionConfig {
+            host: acfg.imap.host.clone(),
+            port: acfg.imap.port,
+            username: acfg.imap.username.clone(),
+            account: Some(id.as_str().to_owned()),
+            account_id: id.clone(),
+            encryption: acfg.imap.encryption,
+            pinned_fingerprint: acfg.imap.pinned_fingerprint,
+            connect_timeout: std::time::Duration::from_secs(10),
+        };
+        match rimap_imap::preflight::probe_preflight(&cfg).await {
+            Ok(info) => {
+                writeln!(out, "Capabilities ({}:{}):", cfg.host, cfg.port)?;
+                for cap in &info.capabilities {
+                    writeln!(out, "  [ok ] {cap}")?;
+                }
+            }
+            Err(e) => {
+                writeln!(
+                    out,
+                    "Capabilities ({}:{}): unavailable ({e})",
+                    cfg.host, cfg.port,
+                )?;
+            }
+        }
+```
+
+**Implementer note:** `ConnectionConfig`'s exact field names may differ — use `rg -n 'pub struct ConnectionConfig' crates/rimap-imap/src/ -A 30` to confirm. If construction requires fields not present on `ValidatedMultiConfig::accounts`, follow the same pattern used by `boot::registry::build_account_connection`. Do NOT fabricate values for fields that affect TLS (pinned_fingerprint) — copy them from the config.
+
+- [ ] **Step 2: Update the caller to `.await`**
+
+In `crates/rimap-server/src/main.rs`, line 99:
+
+```rust
+    if cli.dry_run {
+        let path = resolve_cli_config_path(&cli)?;
+        let mut stdout = std::io::stdout().lock();
+        return cli::dry_run::run(&path, &mut stdout);
+    }
+```
+
+Change to:
+
+```rust
+    if cli.dry_run {
+        let path = resolve_cli_config_path(&cli)?;
+        let mut stdout = std::io::stdout().lock();
+        return cli::dry_run::run(&path, &mut stdout).await;
+    }
+```
+
+- [ ] **Step 3: Update the existing unit tests in `dry_run.rs`**
+
+The tests at `crates/rimap-server/src/cli/dry_run.rs:113-211` call `run(&path, &mut out).unwrap()` synchronously. Because they use a non-reachable IP (`127.0.0.1:1143`), adding `.await` will cause the preflight to fail — which the test output handles gracefully (prints `unavailable`), so the existing assertions still pass.
+
+Convert each `#[test]` to `#[tokio::test]` and each call site to `run(...).await`:
+
+```rust
+#[tokio::test]
+async fn dry_run_prints_matrix_with_default_posture() {
+    let dir = TempDir::new().unwrap();
+    let path = write_minimal_config(&dir);
+    let mut out = Vec::new();
+    run(&path, &mut out).await.unwrap();
+    // ... rest unchanged
+}
+```
+
+Apply this to all four tests in that module.
+
+- [ ] **Step 4: Run the unit tests**
+
+Run: `cargo test -p rimap-server --lib cli::dry_run::tests`
+Expected: all four tests pass. The `Capabilities (127.0.0.1:1143): unavailable ...` line will appear in stdout; no existing assertion checks for its absence.
+
+- [ ] **Step 5: Update the integration test**
+
+Add an assertion for the new section header in `crates/rimap-server/tests/dry_run_cli.rs` inside the `dry_run_exits_zero_and_prints_matrix` test (after line 47):
+
+```rust
+        .stdout(predicate::str::contains("Capabilities"));
+```
+
+Do NOT assert a specific capability list — the integration test uses `127.0.0.1:1143` which isn't reachable. `"Capabilities"` will match either the success or the "unavailable" form.
+
+- [ ] **Step 6: Run the integration test**
+
+Run: `cargo test -p rimap-server --test dry_run_cli`
+Expected: all three tests pass.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/dry_run.rs crates/rimap-server/src/main.rs crates/rimap-server/tests/dry_run_cli.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): --dry-run does TLS preflight + CAPABILITY probe (#117)
+
+dry_run::run becomes async and invokes probe_preflight per account,
+printing the capability list alongside the posture matrix. Unreachable
+hosts are reported inline as unavailable rather than aborting.
+
+Closes #117.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 4: Update quickstart docs to match landed behavior
+
+**Files:**
+- Modify: `docs/quickstart-gmail.md:73`
+- Modify: `docs/quickstart-proton-bridge.md:114-115`
+
+- [ ] **Step 1: Read the current docs to see what they overstate**
+
+Run: `rg -n 'dry-run|dry run|TLS fingerprint' docs/quickstart-gmail.md docs/quickstart-proton-bridge.md`
+Expected: hits around line 73 (Gmail) and 114-115 (Proton Bridge) claiming TLS fingerprint verification.
+
+- [ ] **Step 2: Rewrite the Gmail quickstart claim**
+
+In `docs/quickstart-gmail.md`, locate the paragraph describing `--dry-run`. Replace the sentence that mentions "TLS fingerprint verification" with:
+
+```markdown
+A successful run prints the posture matrix, the active tool allowlist, and
+the IMAP server's capability list (after a TLS handshake), then exits. It
+does not authenticate.
+```
+
+- [ ] **Step 3: Rewrite the Proton Bridge quickstart claim**
+
+Apply the same rewrite to `docs/quickstart-proton-bridge.md` near line 114–115.
+
+- [ ] **Step 4: Confirm no other docs still claim fingerprint printing**
+
+Run: `rg -n 'TLS fingerprint|fingerprint verification' docs/`
+Expected: no hits in quickstart / user-facing docs. Hits in design specs are acceptable if they refer to the `pinned_fingerprint` config field (a separate feature).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/quickstart-gmail.md docs/quickstart-proton-bridge.md
+git commit -m "docs: align quickstart --dry-run description with landed behavior (#117)"
+```
+
+## Self-review
+
+- TDD discipline: live test in Task 2 step 1 before the impl in step 3.
+- Live test is gated on `RIMAP_REQUIRE_LIVE_IMAP` so standard CI isn't affected.
+- Existing `dry_run.rs` unit tests (which use unreachable host:port) will exercise the `Err` branch of `probe_preflight` — graceful fallback is part of the design.
+- Docs updated to describe actually-landed behavior: no claim of TLS fingerprint printing (that would need a custom `ServerCertVerifier` and is a separate enhancement).
+- Four commits, each shippable on its own. If the live test fixture is unavailable locally, task 2 step 5 can be deferred to CI; `cargo check` is sufficient before committing the probe code.
+- `async_imap::imap_proto::UnsolicitedResponse::Capabilities` variant shape is an assumption; if the installed async-imap version differs, the implementer adjusts the match arm before step 5. The risk is low because the same pattern is used in `imap_login` at `connection.rs:428`.

--- a/docs/superpowers/plans/2026-04-23-polish-pr09-doc-sweep.md
+++ b/docs/superpowers/plans/2026-04-23-polish-pr09-doc-sweep.md
@@ -1,0 +1,82 @@
+# Polish PR 9 — Doc sweep: stale `AccountRegistry.active` references
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove stale `registry.active` references from the sprint-3 design spec; point readers at `SessionState.active_account` instead.
+
+**Architecture:** Docs-only. Two inline edits to `docs/superpowers/specs/2026-04-13-sprint-3-design.md` (lines 206 and 214). After editing, verify no stale references remain in any doc under `docs/`.
+
+**Tech Stack:** Markdown only.
+
+---
+
+## Files
+
+- Modify: `docs/superpowers/specs/2026-04-13-sprint-3-design.md` (lines 205–220)
+
+## Task 1: Rewrite account-resolution pseudocode to name the correct field
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-13-sprint-3-design.md:205-220`
+
+- [ ] **Step 1: Read the current section for full context**
+
+Run: read lines 195–230 of `docs/superpowers/specs/2026-04-13-sprint-3-design.md` so the surrounding paragraphs inform the rewrite. The stale field is named on lines 206 and 214.
+
+- [ ] **Step 2: Edit line 206 (`### Account Resolution` bullet)**
+
+Replace:
+
+```markdown
+2. Else if `registry.active` is set — use the session default.
+```
+
+With:
+
+```markdown
+2. Else if `SessionState.active_account` is set — use the session default.
+```
+
+- [ ] **Step 3: Edit line 214 (`use_account` tool description)**
+
+Replace:
+
+```markdown
+- Sets `registry.active` to the named account.
+```
+
+With:
+
+```markdown
+- Sets `SessionState.active_account` on the calling session to the named account.
+```
+
+- [ ] **Step 4: Verify no further stale references remain anywhere under `docs/`**
+
+Run:
+```bash
+rg -n 'registry\.active|AccountRegistry\.active|AccountRegistry::active' docs/
+```
+Expected: no hits, or only hits inside an explicit "superseded / historical" callout. If any remain, repeat step 2/3 on those files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-13-sprint-3-design.md
+git commit -m "$(cat <<'EOF'
+docs: rename stale registry.active to SessionState.active_account (#139)
+
+Task 15 of the multi-client daemon work moved the session-default
+account slot off AccountRegistry onto per-session state. Update the
+sprint-3 design spec accordingly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Self-review
+
+- Every step has complete content (no TBDs).
+- `rg` grep in step 4 confirms coverage across all docs.
+- Single commit, docs-only.

--- a/docs/superpowers/plans/2026-04-23-polish-pr10-config-path-dry.md
+++ b/docs/superpowers/plans/2026-04-23-polish-pr10-config-path-dry.md
@@ -1,0 +1,177 @@
+# Polish PR 10 — Config-path DRY (`resolve_or_default`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the repeated `override.or_else(|| resolve_config_path(None)).ok_or_else(...)` pattern into a single helper used by both `daemon_main` and `resolve_cli_config_path` in `crates/rimap-server/src/main.rs`.
+
+**Architecture:** Pure mechanical refactor. One private helper, two call sites rewritten to call it. No behavior change.
+
+**Tech Stack:** Rust, `anyhow`, `rimap-config::loader::resolve_config_path`.
+
+---
+
+## Files
+
+- Modify: `crates/rimap-server/src/main.rs` (add helper; update `daemon_main` @ line 131; update `resolve_cli_config_path` @ line 217)
+
+## Task 1: Add the helper and unit-test it
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs` — add `resolve_or_default` helper, plus a `#[cfg(test)]` unit test section.
+
+- [ ] **Step 1: Add a failing unit test**
+
+Append this module to the end of `crates/rimap-server/src/main.rs`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod resolve_or_default_tests {
+    use super::resolve_or_default;
+    use std::path::PathBuf;
+
+    #[test]
+    fn override_path_wins_over_env() {
+        let explicit = PathBuf::from("/tmp/custom.toml");
+        let got = resolve_or_default(Some(explicit.clone())).unwrap();
+        assert_eq!(got, explicit);
+    }
+
+    #[test]
+    fn no_override_and_no_env_is_error() {
+        // SAFETY: test is single-threaded in this file; we clear the var
+        // for just this scope. If the env var is set, honour it by skipping.
+        let had = std::env::var_os("RUSTY_IMAP_MCP_CONFIG");
+        unsafe { std::env::remove_var("RUSTY_IMAP_MCP_CONFIG"); }
+        let err = resolve_or_default(None).unwrap_err();
+        assert!(err.to_string().contains("no config path"));
+        if let Some(v) = had {
+            unsafe { std::env::set_var("RUSTY_IMAP_MCP_CONFIG", v); }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails to compile**
+
+Run: `cargo test -p rimap-server --lib resolve_or_default_tests`
+Expected: compile error — `cannot find function 'resolve_or_default'`.
+
+- [ ] **Step 3: Add the helper**
+
+Insert this function immediately above `fn resolve_cli_config_path` at `crates/rimap-server/src/main.rs:217`:
+
+```rust
+/// Resolve a config-file path from an explicit `--config` override, falling
+/// back to the `RUSTY_IMAP_MCP_CONFIG` environment variable via
+/// [`resolve_config_path`]. Errors with the same "no config path" message
+/// used by the previous inline implementations.
+fn resolve_or_default(override_: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    override_
+        .or_else(|| resolve_config_path(None))
+        .ok_or_else(|| {
+            anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
+        })
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cargo test -p rimap-server --lib resolve_or_default_tests`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "refactor(rimap-server): add resolve_or_default config-path helper (#138)"
+```
+
+## Task 2: Replace both call sites with the helper
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs` — `daemon_main` (lines 131–135) and `resolve_cli_config_path` (lines 217–224).
+
+- [ ] **Step 1: Update `daemon_main` to use the helper**
+
+In `crates/rimap-server/src/main.rs`, replace:
+
+```rust
+    let config_path = config_override
+        .or_else(|| resolve_config_path(None))
+        .ok_or_else(|| {
+            anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
+        })?;
+```
+
+with:
+
+```rust
+    let config_path = resolve_or_default(config_override)?;
+```
+
+- [ ] **Step 2: Update `resolve_cli_config_path` to use the helper**
+
+Replace:
+
+```rust
+/// Resolve the config file path from `--config` or the
+/// `RUSTY_IMAP_MCP_CONFIG` environment variable, erroring if neither is set.
+fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
+    cli.config
+        .clone()
+        .or_else(|| resolve_config_path(None))
+        .ok_or_else(|| {
+            anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
+        })
+}
+```
+
+with:
+
+```rust
+/// Resolve the config file path from `--config` or the
+/// `RUSTY_IMAP_MCP_CONFIG` environment variable, erroring if neither is set.
+fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
+    resolve_or_default(cli.config.clone())
+}
+```
+
+- [ ] **Step 3: Verify `resolve_config_path` is still imported but no longer called directly**
+
+Run: `rg -n 'resolve_config_path' crates/rimap-server/src/main.rs`
+
+Expected: one hit on the `use rimap_config::loader::{load_and_validate, resolve_config_path};` line (used inside `resolve_or_default`). If the grep shows more hits, repeat step 1 or 2 on the remaining call site.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cargo test -p rimap-server`
+Expected: all tests pass, including the existing `dry_run_cli` tests which exercise the `resolve_cli_config_path` path end-to-end.
+
+- [ ] **Step 5: Run clippy with the project's zero-warnings policy**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: clean exit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "$(cat <<'EOF'
+refactor(rimap-server): route daemon_main through resolve_or_default (#138)
+
+Closes #138. Both daemon_main and resolve_cli_config_path now share the
+same one-line helper. Behaviour unchanged; the error message matches the
+original wording.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Self-review
+
+- Every step has concrete code, not a prose description.
+- Tests added before the helper (TDD), runs-and-fails step included.
+- Both call sites rewritten; `rg` check in task 2 step 3 confirms coverage.
+- `clippy -D warnings` gate before the second commit catches any stray warnings.

--- a/docs/superpowers/specs/2026-04-23-polish-release-design.md
+++ b/docs/superpowers/specs/2026-04-23-polish-release-design.md
@@ -1,0 +1,368 @@
+# Polish release — post-daemon cleanup
+
+Ship-16-issues plan targeting correctness, code quality, and test-infrastructure
+gaps identified during and after the multi-client daemon merge (PR #150). No new
+features. No scope expansion.
+
+## Goals
+
+1. Close all bug-labeled and doc-mismatch issues filed against the freshly-merged
+   daemon work.
+2. Land the 9 code-review follow-ups from the post-merge `/simplify` pass
+   (#141–#149).
+3. Complete the two test-infrastructure items that were deferred during the
+   daemon implementation (#134, #136).
+4. Explicitly defer the 12 scope-expansion, platform, and ergonomic items with
+   documented rationale.
+
+## Non-goals
+
+- Scope B (multi-UID), scope C1 (HTTP/SSE), scope C2 (remote clients).
+- Windows FFI work (peer-identity, DACL, SCM service). These need a dedicated
+  plan that extracts unsafe code into a quarantined crate.
+- IMAP connection pool depth > 1. Gated on observed contention.
+- Daemon idle-timeout / lazy-spawn. Revisit only if user-started workflow
+  proves friction.
+- New features of any kind.
+
+## In-scope issues (16)
+
+### Bugs / docs (4)
+
+| Issue | Title | Why it's in |
+|-------|-------|-------------|
+| [#117](https://github.com/randomparity/rusty-imap-mcp/issues/117) | `--dry-run`: add TLS preflight + CAPABILITY check to match documented behavior | Docs claim behavior the code doesn't implement |
+| [#135](https://github.com/randomparity/rusty-imap-mcp/issues/135) | `process_end.total_tool_calls` aggregator (currently emits 0) | Bug: audit record always shows 0 |
+| [#137](https://github.com/randomparity/rusty-imap-mcp/issues/137) | `session_end(DaemonShutdown)` missing for sessions aborted during 5s drain | Bug: design-spec contract violated on graceful shutdown |
+| [#139](https://github.com/randomparity/rusty-imap-mcp/issues/139) | Doc sweep: stale `AccountRegistry.active` references in old spec | Docs contradict the code after task-15 of the daemon work |
+
+### Code-review cleanups (9)
+
+| Issue | Title |
+|-------|-------|
+| [#141](https://github.com/randomparity/rusty-imap-mcp/issues/141) | Hoist `RedactionSalt` from per-session to `DaemonState` |
+| [#142](https://github.com/randomparity/rusty-imap-mcp/issues/142) | Move `log_session_start` / `log_session_end` onto `spawn_blocking` |
+| [#143](https://github.com/randomparity/rusty-imap-mcp/issues/143) | Replace `RwLock<Option<AccountId>>` on `SessionState` with `ArcSwapOption` |
+| [#144](https://github.com/randomparity/rusty-imap-mcp/issues/144) | Parallelize `registry::build` per-account setup |
+| [#145](https://github.com/randomparity/rusty-imap-mcp/issues/145) | Tighten `DaemonState` field visibility + narrow `raw_writer` accessor |
+| [#146](https://github.com/randomparity/rusty-imap-mcp/issues/146) | Share a `UlidNewtype<Tag>` macro/helper for `SessionId` + `ProcessId` |
+| [#147](https://github.com/randomparity/rusty-imap-mcp/issues/147) | Share `ensure_tight_dir` helper between `socket_setup` and audit writer |
+| [#148](https://github.com/randomparity/rusty-imap-mcp/issues/148) | Cache `list_tools` result as `Arc<Vec<Tool>>` on `AccountRegistry` |
+| [#149](https://github.com/randomparity/rusty-imap-mcp/issues/149) | Avoid full arg-map clone in audit envelope: accept `&Map` in redact / hash APIs |
+
+### Test infrastructure (2)
+
+| Issue | Title |
+|-------|-------|
+| [#134](https://github.com/randomparity/rusty-imap-mcp/issues/134) | Shim end-to-end test: align harness with resolver path |
+| [#136](https://github.com/randomparity/rusty-imap-mcp/issues/136) | Full Dovecot-backed integration test suite for daemon scenarios |
+
+### Small refactor (1)
+
+| Issue | Title |
+|-------|-------|
+| [#138](https://github.com/randomparity/rusty-imap-mcp/issues/138) | Config path resolution: deduplicate `daemon_main` and `resolve_cli_config_path` (`good first issue`) |
+
+## Deferred issues (12) — explicit rationale
+
+| Issue | Title | Deferral rationale |
+|-------|-------|--------------------|
+| [#105](https://github.com/randomparity/rusty-imap-mcp/issues/105) | Wire LIST-STATUS extended LIST | Blocked on `async-imap` upstream |
+| [#107](https://github.com/randomparity/rusty-imap-mcp/issues/107) | Wire COPYUID capture | Blocked on `async-imap` upstream exposing `ResponseCode::CopyUid` |
+| [#124](https://github.com/randomparity/rusty-imap-mcp/issues/124) | Multi-UID daemon support (scope B) | Scope expansion — needs its own spec |
+| [#125](https://github.com/randomparity/rusty-imap-mcp/issues/125) | HTTP/SSE listener (scope C1) | Scope expansion — needs its own spec |
+| [#126](https://github.com/randomparity/rusty-imap-mcp/issues/126) | Socket path configuration override | Primary use case is multi-UID (#124); defer with #124 |
+| [#127](https://github.com/randomparity/rusty-imap-mcp/issues/127) | SIGHUP config reload | Ergonomic — non-trivial (rate-limit state preservation). Revisit post-polish |
+| [#128](https://github.com/randomparity/rusty-imap-mcp/issues/128) | IMAP connection pool depth > 1 | Gated on observed contention |
+| [#129](https://github.com/randomparity/rusty-imap-mcp/issues/129) | Windows Service (SCM) integration | Needs unsafe-FFI quarantine crate — own plan |
+| [#130](https://github.com/randomparity/rusty-imap-mcp/issues/130) | Daemon idle-timeout / lazy-spawn | Revisit only if user-started workflow proves friction |
+| [#131](https://github.com/randomparity/rusty-imap-mcp/issues/131) | Provenance ring buffer scoping knob | Revisit if forensics want tighter granularity |
+| [#132](https://github.com/randomparity/rusty-imap-mcp/issues/132) | Real Windows peer-identity capture | Needs unsafe-FFI quarantine crate — own plan |
+| [#133](https://github.com/randomparity/rusty-imap-mcp/issues/133) | Custom DACL on Windows named pipe for scope B | Blocks on #124 + unsafe-FFI quarantine |
+
+## PR structure (12 PRs)
+
+File-overlap forces coupling in three groups; the remaining 9 PRs are
+independent.
+
+### Merged PRs (file-overlap driven)
+
+**PR 1 — `daemon/state.rs` cleanup (#141 + #143 + #145)**
+
+- Files: `crates/rimap-server/src/daemon/state.rs`,
+  `crates/rimap-server/src/mcp/server.rs`
+- Three coupled changes on the same struct:
+  - Hoist `RedactionSalt` from per-session onto `DaemonState` (#141) — one
+    random salt for the daemon lifetime rather than per-accept.
+  - Replace `SessionState.active_account: RwLock<Option<AccountId>>` with
+    `arc-swap::ArcSwapOption<AccountId>` (#143) — removes a pointless async
+    lock on a single-writer field.
+  - Tighten `DaemonState` field visibility to `pub(crate)` and narrow the
+    `raw_writer` accessor (#145).
+- Acceptance criteria:
+  - `RedactionSalt::new_random()` called exactly once in `DaemonState::new`.
+  - `active_account` reads/writes are `compare_and_swap` / `load_full`, no
+    `.await`.
+  - No public fields on `DaemonState`; `raw_writer` exposed only where needed.
+  - Existing `dispatch_ticket`, `daemon_happy_path` tests continue to pass.
+- Rollback risk: low. Three mechanical changes on one struct.
+
+**PR 2 — Session-end reliability (#137 + #142)**
+
+- Files: `crates/rimap-server/src/daemon/run.rs`,
+  `crates/rimap-server/tests/daemon_graceful_shutdown.rs`
+- Two coupled changes on the session-end path:
+  - Move `log_session_start` / `log_session_end` onto `spawn_blocking` (#142)
+    to keep audit writes off the async accept loop.
+  - Fix `session_end(DaemonShutdown)` emission for sessions aborted during
+    the 5s graceful drain (#137). `drain_sessions` must issue `session_end`
+    for every tracked session before `JoinSet::shutdown().await`; the fix
+    must await the `spawn_blocking` introduced in #142.
+- Acceptance criteria:
+  - New test: graceful shutdown with N active sessions produces N
+    `session_end(reason=DaemonShutdown)` records in the audit log.
+  - Existing `daemon_graceful_shutdown` test extended to assert the count.
+  - No regression in `daemon_happy_path` / `daemon_max_sessions` timing.
+- Rollback risk: medium. Graceful-shutdown path is concurrency-sensitive.
+  Mitigated by the new test.
+
+**PR 3 — Registry perf (#144 + #148)**
+
+- Files: `crates/rimap-server/src/boot/registry.rs`,
+  `crates/rimap-server/src/mcp/server.rs`
+- Two coupled perf changes in `AccountRegistry::build`:
+  - Parallelize per-account setup using `futures::future::join_all` over the
+    `multi.accounts` loop (#144). `resolve_special_use` does network I/O per
+    account — currently serialized.
+  - Cache `list_tools` result as `Arc<Vec<Tool>>` on `AccountRegistry` (#148)
+    since output depends only on registered accounts, not session state.
+- Acceptance criteria:
+  - Startup with N accounts runs account setup concurrently (verify via
+    tracing spans in tests).
+  - `list_tools` returns the same `Arc<Vec<Tool>>` across calls within a
+    registry generation.
+  - No behavioral change for `use_account` / `tools/list_changed` semantics.
+- Rollback risk: low. Both changes are pure perf; behavior unchanged.
+
+### Standalone PRs
+
+**PR 4 — Shared `UlidNewtype<Tag>` helper (#146)**
+
+- Files: `crates/rimap-core/src/session.rs`,
+  `crates/rimap-audit/src/record/ids.rs`, likely a new module in
+  `rimap-core` or `rimap-audit` for the shared helper.
+- A declarative macro (`ulid_newtype!`) or a generic `UlidNewtype<T>` type
+  covers both `SessionId` and `ProcessId`.
+- Acceptance criteria:
+  - Both types defined via the shared helper.
+  - Public API of both types unchanged (`Display`, `FromStr`, `new`,
+    `new_now`, `Default`, `#[serde(transparent)]`).
+  - No duplicated bodies between the two files.
+- Rollback risk: low. Structural change with identical behavior.
+
+**PR 5 — Shared `ensure_tight_dir` helper (#147)**
+
+- Files: `crates/rimap-server/src/daemon/socket_setup.rs`,
+  `crates/rimap-audit/src/writer/mod.rs`, new shared location (likely
+  `rimap-audit` since it's the lower-level crate).
+- The TOCTOU-safe version from `socket_setup` becomes the shared
+  implementation. `set_parent_mode_0700` in the audit writer calls it.
+- Acceptance criteria:
+  - Single implementation covers both call sites.
+  - Symlink-refusal and uid-check enforcement applied to the audit writer
+    path (strictly tighter than before — catches a previously-ignored
+    symlink hazard).
+  - Existing socket-path and audit-writer tests pass.
+- Rollback risk: low-medium. The audit writer now rejects more edge cases
+  (symlinks); confirm no legitimate setup was relying on symlinked audit
+  dirs.
+
+**PR 6 — `&Map`-taking APIs in audit envelope (#149)**
+
+- Files: `crates/rimap-server/src/mcp/audit_envelope.rs`,
+  `crates/rimap-audit/src/` (redact, hash APIs).
+- Change `Redactor::apply` and `hash_arguments` to accept
+  `&serde_json::Map<String, Value>` directly. Eliminates the per-tool-call
+  `Value::Object(args.clone())` deep-clone.
+- Acceptance criteria:
+  - No `Value::Object(args.clone())` wrapper in `run_with_audit_envelope`.
+  - Redact and hash outputs byte-identical to current behavior
+    (property test or fixture comparison).
+  - No public API breakage for external users of `rimap-audit` (check
+    re-exports).
+- Rollback risk: low.
+
+**PR 7 — `process_end.total_tool_calls` aggregator (#135)**
+
+- Files: `crates/rimap-server/src/main.rs`,
+  `crates/rimap-server/src/daemon/state.rs` (aggregator counter).
+- Add a daemon-level `AtomicU64` incremented in `emit_session_end`;
+  `daemon_main` reads it for `process_end.total_tool_calls`.
+- Acceptance criteria:
+  - New test: N sessions each making M tool calls yields `total_tool_calls
+    = N * M` in `process_end`.
+  - Existing per-session `session_end.tool_call_count` untouched.
+- Rollback risk: low.
+
+**PR 8 — `--dry-run` TLS+CAPA preflight (#117)**
+
+- Files: `crates/rimap-server/src/cli/dry_run.rs`, likely
+  `crates/rimap-imap/src/connection.rs` for a capability-inspection
+  helper if one doesn't exist.
+- Make `--dry-run` actually perform a TLS handshake and `CAPABILITY`
+  command per account, printing the TLS fingerprint and capability list
+  as the docs claim.
+- Acceptance criteria:
+  - `--dry-run` against Mailpit fixture prints server capabilities and
+    TLS fingerprint.
+  - Doc pages (`docs/quickstart-gmail.md`, `docs/quickstart-proton-bridge.md`)
+    no longer overstate behavior.
+  - New test: `--dry-run` against a reachable fixture succeeds; against an
+    unreachable host fails with a clear error.
+- Rollback risk: low. New behavior, opt-in via the existing flag.
+
+**PR 9 — Doc sweep (#139)**
+
+- Files: `docs/superpowers/specs/2026-04-13-sprint-3-design.md` (or other
+  stale specs identified during the sweep).
+- Remove / update references to the removed `AccountRegistry.active`
+  field; point at `SessionState.active_account` instead.
+- Acceptance criteria:
+  - `rg 'registry\.active'` returns zero hits in docs (outside of historic
+    context notes with explicit "superseded" markers).
+- Rollback risk: none (docs only).
+
+**PR 10 — Config-path DRY (#138)**
+
+- Files: `crates/rimap-server/src/main.rs` (possibly a new small module
+  `cli/config_path.rs`).
+- Extract `resolve_or_default(override_: Option<PathBuf>) -> Result<PathBuf>`
+  used by both `daemon_main` and non-daemon subcommands.
+- Acceptance criteria:
+  - Single helper; both call sites updated.
+  - Existing CLI tests pass without modification.
+- Rollback risk: none. Pure mechanical refactor (`good first issue`).
+
+### Test-infra PRs
+
+**PR 11 — Shim e2e resolver-path harness (#134)**
+
+- Files: `crates/rimap-server/tests/common/daemon_harness.rs`,
+  `crates/rimap-server/tests/shim_*.rs`, possibly
+  `crates/rimap-server/src/daemon/socket_path.rs` (env-var hook).
+- `TestDaemon` either (a) binds at the path the resolver produces under a
+  controlled `$XDG_RUNTIME_DIR`/`$TMPDIR` or (b) the shim grows a
+  test-only `RIMAP_DAEMON_SOCKET` env var. Option (a) preferred.
+- Acceptance criteria:
+  - New test: happy-path `mcp/initialize` → `tools/list` → `tools/call` →
+    clean exit via the actual shim binary.
+  - No production code path changes (or one carefully-scoped env-var
+    hook, cfg-gated).
+- Rollback risk: low. Tests only, or a narrowly-scoped production hook.
+
+**PR 12 — Dovecot-backed daemon integration suite (#136)**
+
+- Files: `crates/rimap-server/tests/daemon_*_live.rs` (new), possibly
+  extensions to `crates/rimap-imap/tests/integration/common/` fixtures.
+- Build on the existing Dovecot fixture under
+  `crates/rimap-imap/tests/integration/`. Gate new tests behind
+  `RIMAP_REQUIRE_LIVE_IMAP=1`.
+- Five target scenarios (from phase 5 of the daemon plan): graceful
+  shutdown under load, max-sessions enforcement, audit completeness under
+  failures, peer-identity capture round-trip, shim reconnect after daemon
+  restart.
+- Acceptance criteria:
+  - Five new tests under the `RIMAP_REQUIRE_LIVE_IMAP` gate.
+  - CI job invokes them against the Dovecot fixture.
+  - Documentation in the test file(s) explains what each scenario covers.
+- Rollback risk: low. Test-only additions. Larger scope — may land in
+  multiple sub-PRs if review bandwidth is tight.
+
+## Sequencing
+
+Four waves. Within a wave, PRs are parallelizable; between waves, later
+waves depend on earlier ones.
+
+**Wave A — low-risk, no cross-deps:**
+
+- PR 9 (doc sweep)
+- PR 7 (`process_end` aggregator)
+- PR 8 (`--dry-run` TLS+CAPA)
+- PR 10 (config-path DRY)
+
+**Wave B — code-review cleanups:**
+
+- PR 1 (`daemon/state.rs` cleanup)
+- PR 4 (`UlidNewtype` helper)
+- PR 5 (`ensure_tight_dir` helper)
+- PR 6 (`&Map` audit APIs)
+
+**Wave C — depends on wave B:**
+
+- PR 2 (session-end reliability) — aligns with PR 6's audit-API changes
+  and PR 1's `DaemonState` shape
+- PR 3 (registry perf) — expects PR 1's `DaemonState` visibility
+
+**Wave D — test infra:**
+
+- PR 11 (shim e2e)
+- PR 12 (Dovecot suite)
+
+Waves D and C are order-independent and can run in parallel with each
+other once wave B lands.
+
+## Verification
+
+Every PR must pass before merge:
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --workspace` (unit + integration tests that don't require
+  live IMAP)
+- `cargo deny check` where dependencies change (#144, #146 may pull in
+  `futures` or `arc-swap` if not already present)
+
+PRs introducing new behavior (#117, #134, #135, #136, #137) must include
+a test that fails before the change and passes after. Pure-refactor PRs
+(#138, #139, #141, #143, #144, #145, #146, #147, #148, #149) rely on
+existing tests to prove behavior preservation — if a test breaks, the
+refactor is wrong.
+
+The polish release is "done" when all 12 PRs are merged to `main` and
+all 16 issues are closed.
+
+## Merge policy
+
+- One PR per day on Wave A / B items is the realistic throughput target.
+- Wave C and D PRs may need multiple days each.
+- No release-branch tag. Polish items land on `main` incrementally; if a
+  tagged release is wanted at the end, it can happen as a separate,
+  mechanical step after PR 12 merges.
+
+## Risks
+
+- **#137 + #142 interaction** (PR 2) is the highest-risk item. The
+  graceful-shutdown drain path is concurrency-sensitive. Mitigation: the
+  new test asserting N session_end records is mandatory before merge.
+- **#147** (PR 5) adds symlink-refusal to a path that previously
+  tolerated symlinks. If any user setup scripts symlink the audit dir,
+  they will break. Mitigation: document in CHANGELOG; confirm the
+  project's own packaging scripts (systemd unit, launchd plist) create
+  real directories.
+- **#144** (PR 3) changes the failure mode of startup — one account
+  failing no longer stops the others from setting up. Confirm the
+  existing error-handling policy still matches expectations (fail-fast
+  vs. partial registry).
+
+## References
+
+- `docs/superpowers/plans/2026-04-22-multi-client-daemon-followups.md` —
+  narrative registry of items 1–25 (what exists, why). This plan
+  sequences a subset of those items plus the four bug-labeled issues
+  (#117, #135, #137, #139) and `good first issue` #138.
+- `docs/superpowers/specs/2026-04-22-multi-client-daemon-design.md` —
+  design spec for the daemon work that introduced most of these
+  follow-ups.
+- `docs/superpowers/plans/2026-04-22-multi-client-daemon.md` — the
+  original implementation plan (tasks 28, 29, phase 5 tests) whose
+  deferrals are closed out by PRs 2, 3, 11, 12.

--- a/docs/superpowers/specs/2026-04-23-polish-release-design.md
+++ b/docs/superpowers/specs/2026-04-23-polish-release-design.md
@@ -79,6 +79,7 @@ features. No scope expansion.
 | [#131](https://github.com/randomparity/rusty-imap-mcp/issues/131) | Provenance ring buffer scoping knob | Revisit if forensics want tighter granularity |
 | [#132](https://github.com/randomparity/rusty-imap-mcp/issues/132) | Real Windows peer-identity capture | Needs unsafe-FFI quarantine crate — own plan |
 | [#133](https://github.com/randomparity/rusty-imap-mcp/issues/133) | Custom DACL on Windows named pipe for scope B | Blocks on #124 + unsafe-FFI quarantine |
+| [#151](https://github.com/randomparity/rusty-imap-mcp/issues/151) | Display server TLS cert fingerprint during `--dry-run` | Blocks on #117; implemented as a follow-up on the same preflight path |
 
 ## PR structure (12 PRs)
 


### PR DESCRIPTION
## Summary

Adds the design spec for a post-daemon polish release and the first four implementation plans (Wave A). The spec scopes 16 in-scope issues and documents the rationale for deferring 12 others.

## What's included

### Spec: `docs/superpowers/specs/2026-04-23-polish-release-design.md`

Scopes the polish release:
- **In:** 4 bugs/docs (#117, #135, #137, #139), 9 code-review follow-ups (#141–#149), 2 test-infra items (#134, #136), 1 good-first-issue (#138).
- **Deferred (with rationale):** #105, #107, #124, #125, #126, #127, #128, #129, #130, #131, #132, #133, #151.

Groups the 16 issues into 12 PRs: three merged groups where file overlap forces coupling (`daemon/state.rs` cleanup, session-end reliability, registry perf), plus nine standalone PRs.

Four-wave sequencing:
- **Wave A** (no deps): PR 7 (#135), PR 8 (#117), PR 9 (#139), PR 10 (#138)
- **Wave B** (code-review cleanups): PR 1, PR 4, PR 5, PR 6
- **Wave C** (depends on Wave B): PR 2, PR 3
- **Wave D** (test infra): PR 11, PR 12

### Wave A implementation plans

Per-PR TDD-structured plans with concrete code in every step:
- `docs/superpowers/plans/2026-04-23-polish-pr07-process-end-aggregator.md` — #135
- `docs/superpowers/plans/2026-04-23-polish-pr08-dry-run-preflight.md` — #117
- `docs/superpowers/plans/2026-04-23-polish-pr09-doc-sweep.md` — #139
- `docs/superpowers/plans/2026-04-23-polish-pr10-config-path-dry.md` — #138

### Follow-up issue filed

Issue #151 — surface the observed TLS cert fingerprint during `--dry-run` to help users configure `pinned_fingerprint`. Noted in the spec's deferred table as blocking on #117.

## Out of scope for this PR

Wave B / C / D implementation plans (8 more files) will land in a second planning PR once Wave A starts executing — the post-Wave-B plans benefit from referencing actual code shape rather than guessing it.

## Test plan

Docs-only. `typos` and `trim trailing whitespace` pre-commit hooks passed.