### PR TITLE
docs: rename stale registry.active to SessionState.active_account (#139)

### DIFF
--- a/docs/superpowers/specs/2026-04-13-sprint-3-design.md
+++ b/docs/superpowers/specs/2026-04-13-sprint-3-design.md
@@ -203,7 +203,7 @@ fields.
 On every tool call (except `use_account` and `list_accounts`):
 
 1. If the tool arguments contain `"account": "<name>"` — use that account.
-2. Else if `registry.active` is set — use the session default.
+2. Else if `SessionState.active_account` is set — use the session default.
 3. Else if exactly one account exists — auto-select it.
 4. Else — return `ERR_NO_ACCOUNT`.
 
@@ -211,7 +211,7 @@ On every tool call (except `use_account` and `list_accounts`):
 
 **`use_account`:**
 - Input: `{ "account": "work" }`
-- Sets `registry.active` to the named account.
+- Sets `SessionState.active_account` on the calling session to the named account.
 - Returns confirmation with the account name.
 - Bypasses posture checks, rate limiting, and circuit breaker — it is an
   infrastructure tool, not an IMAP operation.


### PR DESCRIPTION
## Summary

Closes #139. Two line edits in `docs/superpowers/specs/2026-04-13-sprint-3-design.md` renaming the stale field `registry.active` to its current name `SessionState.active_account`. Task 15 of the multi-client daemon work moved the session-default account slot off `AccountRegistry` onto per-session state; the sprint-3 design spec hadn't been updated.

This is polish release PR 9 (Wave A). Plan doc: `docs/superpowers/plans/2026-04-23-polish-pr09-doc-sweep.md` (on `plan/polish-release`).

## Test plan

- [x] `rg -n 'registry\.active|AccountRegistry\.active|AccountRegistry::active' docs/` returns only historical-context hits in the followups plan (and the polish-release spec on the planning branch) — no hits in the sprint-3 design spec.
- [x] Pre-commit hooks passed (typos, trim trailing whitespace, cargo-deny).