### PR TITLE
refactor(rimap-server): dedupe config-path resolution (#138)

### DIFF
--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -128,11 +128,7 @@ async fn daemon_main(config_override: Option<PathBuf>) -> anyhow::Result<()> {
     hardening::lock_down_process()
         .context("daemon startup hardening (rlimit_core / prctl_dumpable)")?;
 
-    let config_path = config_override
-        .or_else(|| resolve_config_path(None))
-        .ok_or_else(|| {
-            anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
-        })?;
+    let config_path = resolve_or_default(config_override)?;
     let multi = load_and_validate(&config_path)
         .with_context(|| format!("loading config {}", config_path.display()))?;
     let audit = audit_init::init_audit_writer_multi(&multi, &config_path)
@@ -212,15 +208,22 @@ async fn daemon_main(config_override: Option<PathBuf>) -> anyhow::Result<()> {
     mcp_result
 }
 
-/// Resolve the config file path from `--config` or the
-/// `RUSTY_IMAP_MCP_CONFIG` environment variable, erroring if neither is set.
-fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
-    cli.config
-        .clone()
+/// Resolve a config-file path from an explicit `--config` override, falling
+/// back to the `RUSTY_IMAP_MCP_CONFIG` environment variable via
+/// [`resolve_config_path`]. Errors with the same "no config path" message
+/// used by the previous inline implementations.
+fn resolve_or_default(override_: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    override_
         .or_else(|| resolve_config_path(None))
         .ok_or_else(|| {
             anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
         })
+}
+
+/// Resolve the config file path from `--config` or the
+/// `RUSTY_IMAP_MCP_CONFIG` environment variable, erroring if neither is set.
+fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
+    resolve_or_default(cli.config.clone())
 }
 
 /// Resolve the attachment download directory from a multi-account config.
@@ -331,5 +334,38 @@ mod resolve_download_dir_tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o700, "expected 0700, got {mode:o}");
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod resolve_or_default_tests {
+    use super::resolve_or_default;
+    use std::path::PathBuf;
+
+    #[test]
+    fn override_path_wins_over_env() {
+        let explicit = PathBuf::from("/tmp/custom.toml");
+        let got = resolve_or_default(Some(explicit.clone())).unwrap();
+        assert_eq!(got, explicit);
+    }
+
+    #[test]
+    fn no_override_no_env_error_message_is_actionable() {
+        // We cannot force resolve_config_path to return None on a host where
+        // ProjectDirs::from succeeds — on Linux it falls back to /etc/passwd
+        // via getpwuid when HOME is unset, so there's no env-var combo that
+        // disables it. When it *does* return None (headless / unusual passwd
+        // configs), the error surface must name the fix the user should take.
+        temp_env::with_var("RUSTY_IMAP_MCP_CONFIG", None::<&str>, || {
+            if let Err(e) = resolve_or_default(None) {
+                let msg = e.to_string();
+                assert!(msg.contains("--config"), "error lacks --config hint: {msg}");
+                assert!(
+                    msg.contains("RUSTY_IMAP_MCP_CONFIG"),
+                    "error lacks env-var hint: {msg}",
+                );
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary

Closes #138 (labeled `good first issue`). Extracts a private helper `resolve_or_default(override_: Option<PathBuf>) -> anyhow::Result<PathBuf>` in `crates/rimap-server/src/main.rs` that collapses the two inline `override.or_else(|| resolve_config_path(None)).ok_or_else(...)` patterns used by `daemon_main` and `resolve_cli_config_path`.

Behavior and error message unchanged. Polish release PR 10 (Wave A).

## Changes

- New helper `resolve_or_default` with the exact prior error wording preserved.
- `daemon_main` and `resolve_cli_config_path` now each call through the helper in one line.
- Two unit tests for the helper (override-wins + error-path with honest platform caveat in comments).

## Test plan

- [x] `cargo test -p rimap-server` — 276 tests pass across 15 test suites.
- [x] `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings` — clean.
- [x] `rg -n 'resolve_config_path' crates/rimap-server/src/main.rs` — three hits (import, docstring link, and the single call inside the helper). No other call sites.

## Notes on the test for the error path

The error path fires when `resolve_config_path(None)` returns `None`, which happens only when `ProjectDirs::from(...)` fails. On Linux, `ProjectDirs` falls back to `/etc/passwd` via `getpwuid` when `HOME` is unset, so clearing env vars does not force the `None` branch on a typical host. The test is therefore a no-op on hosts where the fallback succeeds and asserts on the actionability of the error message (names both `--config` and `RUSTY_IMAP_MCP_CONFIG`) on hosts where it does fire. This is intentional and documented inline.

## Plan doc

`docs/superpowers/plans/2026-04-23-polish-pr10-config-path-dry.md` (merged via #152).

The plan split this into two commits (add helper, then wire it up). The split ran into a lint-expectation issue (the intermediate `#[expect(dead_code)]` on the helper became an unfulfilled expectation in the test build, which `-D warnings` rejects). This PR ships as one squashed commit, which is also cleaner for `git bisect`. The plan was otherwise accurate.