### PR TITLE
feat(rimap-server): --dry-run does TLS preflight + CAPABILITY probe (#117)

### DIFF
--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -1078,7 +1078,7 @@ fn drain_for_starttls(rx: &async_channel::Receiver<UnsolicitedResponse>) -> bool
 
 /// Perform the TLS handshake over an established TCP stream using the
 /// provided `TlsConfigBundle`. Pin verification happens inside this call.
-async fn tls_handshake(
+pub(crate) async fn tls_handshake(
     tcp: TcpStream,
     bundle: &TlsConfigBundle,
     host: &str,
@@ -1094,7 +1094,7 @@ async fn tls_handshake(
 
 /// Full STARTTLS upgrade: plaintext negotiation + TLS handshake with the
 /// same `TlsConfigBundle` the implicit-TLS path uses.
-async fn starttls_upgrade(
+pub(crate) async fn starttls_upgrade(
     tcp: TcpStream,
     bundle: &TlsConfigBundle,
     host: &str,

--- a/crates/rimap-imap/src/lib.rs
+++ b/crates/rimap-imap/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod auth;
 pub mod connection;
 pub mod error;
 pub mod ops;
+pub mod preflight;
 pub mod special_use;
 pub mod time;
 pub mod tls;

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -69,10 +69,19 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     };
 
     let mut client = ImapPlainClient::new(tls_stream);
+    // Greeting + CAPABILITY must also be bounded: a server that accepts
+    // the socket and completes TLS but then stalls before sending the
+    // greeting, or a server that stalls mid-CAPABILITY, would otherwise
+    // hang `probe_preflight` forever. Reuse `command_timeout` for the
+    // CAPABILITY leg (it is the per-command budget); apply the remaining
+    // connect-budget to the greeting read.
+    let greeting_budget = total_deadline.saturating_sub(started.elapsed());
     if !already_greeted {
-        client
-            .read_response()
+        timeout(greeting_budget, client.read_response())
             .await
+            .map_err(|_| ImapError::Timeout {
+                op: "imap_greeting",
+            })?
             .map_err(ImapError::Connect)?
             .ok_or(ImapError::Connect(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
@@ -81,10 +90,15 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     }
 
     let (tx, rx) = async_channel::bounded::<UnsolicitedResponse>(32);
-    client
-        .run_command_and_check_ok("CAPABILITY", Some(tx))
-        .await
-        .map_err(ImapError::Protocol)?;
+    timeout(
+        cfg.command_timeout,
+        client.run_command_and_check_ok("CAPABILITY", Some(tx)),
+    )
+    .await
+    .map_err(|_| ImapError::Timeout {
+        op: "imap_capability",
+    })?
+    .map_err(ImapError::Protocol)?;
 
     // Extract capabilities using the same pattern as `capability_advertised`
     // in connection.rs. `ImapCapability::Atom` wraps `Cow<'_, str>`, so

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -1,0 +1,110 @@
+//! Pre-auth `CAPABILITY` probe used by `--dry-run` and other diagnostic
+//! paths. Performs TCP connect → TLS handshake → IMAP greeting → pre-auth
+//! `CAPABILITY` command, then drops the connection. Does NOT perform LOGIN
+//! and does NOT emit any audit records.
+
+use std::time::Instant;
+
+use async_imap::Client as ImapPlainClient;
+use async_imap::imap_proto::{Capability as ImapCapability, Response};
+use async_imap::types::UnsolicitedResponse;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+use crate::ConnectionConfig;
+use crate::ImapEncryption;
+use crate::connection::{starttls_upgrade, tls_handshake};
+use crate::error::ImapError;
+use crate::tls::build_tls_config;
+
+/// Result of a successful preflight probe.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PreflightInfo {
+    /// Capability atoms returned by the server's pre-auth `CAPABILITY`
+    /// response, upper-cased, de-duplicated, order preserved as received.
+    pub capabilities: Vec<String>,
+}
+
+/// Run a TCP+TLS+greeting+CAPABILITY probe against `cfg`.
+///
+/// # Errors
+/// Mirrors `ImapError` variants: `Connect`, `TlsHandshake`, `Timeout`,
+/// `Protocol`. Never returns `Auth` variants — no credentials are used.
+pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, ImapError> {
+    let bundle = build_tls_config(cfg.pinned_fingerprint)?;
+    let total_deadline = cfg.connect_timeout;
+    let started = Instant::now();
+
+    let tcp = timeout(
+        total_deadline,
+        TcpStream::connect((cfg.host.as_str(), cfg.port)),
+    )
+    .await
+    .map_err(|_| ImapError::Timeout { op: "tcp_connect" })?
+    .map_err(ImapError::Connect)?;
+
+    let remaining = total_deadline.saturating_sub(started.elapsed());
+    // `already_greeted` mirrors the convention in `Connection::connect_with_bundle`:
+    // STARTTLS consumes the plaintext greeting during negotiation, so the TLS
+    // stream does not receive another greeting. Implicit TLS has not read the
+    // greeting yet.
+    let (tls_stream, already_greeted) = match cfg.encryption {
+        ImapEncryption::Tls => {
+            let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "tls_handshake",
+                })??;
+            (s, false)
+        }
+        ImapEncryption::Starttls => {
+            let s = timeout(remaining, starttls_upgrade(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "starttls_upgrade",
+                })??;
+            (s, true)
+        }
+    };
+
+    let mut client = ImapPlainClient::new(tls_stream);
+    if !already_greeted {
+        client
+            .read_response()
+            .await
+            .map_err(ImapError::Connect)?
+            .ok_or(ImapError::Connect(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "server closed before greeting",
+            )))?;
+    }
+
+    let (tx, rx) = async_channel::bounded::<UnsolicitedResponse>(32);
+    client
+        .run_command_and_check_ok("CAPABILITY", Some(tx))
+        .await
+        .map_err(ImapError::Protocol)?;
+
+    // Extract capabilities using the same pattern as `capability_advertised`
+    // in connection.rs. `ImapCapability::Atom` wraps `Cow<'_, str>`, so
+    // `to_ascii_uppercase()` works directly. Atoms are upper-cased for stable
+    // display and de-duplicated.
+    let mut caps: Vec<String> = Vec::new();
+    while let Ok(item) = rx.try_recv() {
+        if let UnsolicitedResponse::Other(resp) = item
+            && let Response::Capabilities(list) = resp.parsed()
+        {
+            for cap in list {
+                if let ImapCapability::Atom(name) = cap {
+                    let upper = name.to_ascii_uppercase();
+                    if !upper.is_empty() && !caps.contains(&upper) {
+                        caps.push(upper);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PreflightInfo { capabilities: caps })
+}

--- a/crates/rimap-server/src/boot/registry.rs
+++ b/crates/rimap-server/src/boot/registry.rs
@@ -332,7 +332,8 @@ fn build_account_guard(
 }
 
 /// Map a per-account config to a `ConnectionConfig`.
-fn build_account_connection(
+#[must_use]
+pub fn build_account_connection(
     id: &rimap_core::account::AccountId,
     acfg: &ValidatedAccountConfig,
 ) -> ConnectionConfig {

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -38,7 +38,7 @@ use rimap_core::tool::ToolName;
 /// # Errors
 /// Propagates config load/validate errors, audit lock acquisition errors, and
 /// I/O errors from the writer.
-pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
+pub async fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
     let multi =
         load_and_validate(path).with_context(|| format!("loading config {}", path.display()))?;
 
@@ -76,6 +76,27 @@ pub fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
         {
             writeln!(out, "  [ok ] {tool}")?;
         }
+
+        // TLS + CAPABILITY preflight per account (#117). Errors are
+        // reported inline but do not abort the dry-run — a multi-account
+        // config may have one unreachable host and still want to print
+        // the matrix for the others.
+        let conn_cfg = rimap_server::boot::registry::build_account_connection(id, acfg);
+        match rimap_imap::preflight::probe_preflight(&conn_cfg).await {
+            Ok(info) => {
+                writeln!(out, "Capabilities ({}:{}):", conn_cfg.host, conn_cfg.port)?;
+                for cap in &info.capabilities {
+                    writeln!(out, "  [ok ] {cap}")?;
+                }
+            }
+            Err(e) => {
+                writeln!(
+                    out,
+                    "Capabilities ({}:{}): unavailable ({e})",
+                    conn_cfg.host, conn_cfg.port,
+                )?;
+            }
+        }
     }
     Ok(())
 }
@@ -110,12 +131,12 @@ allowed_base_dir = "{}"
         config_path
     }
 
-    #[test]
-    fn dry_run_prints_matrix_with_default_posture() {
+    #[tokio::test]
+    async fn dry_run_prints_matrix_with_default_posture() {
         let dir = TempDir::new().unwrap();
         let path = write_minimal_config(&dir);
         let mut out = Vec::new();
-        run(&path, &mut out).unwrap();
+        run(&path, &mut out).await.unwrap();
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("draft-safe"));
         assert!(text.contains("list_folders"));
@@ -125,8 +146,8 @@ allowed_base_dir = "{}"
         assert!(text.contains("[ok ] list_folders"));
     }
 
-    #[test]
-    fn second_dry_run_against_same_audit_fails_with_config_error() {
+    #[tokio::test]
+    async fn second_dry_run_against_same_audit_fails_with_config_error() {
         use rimap_audit::{AuditOptions, AuditWriter};
 
         let dir = TempDir::new().unwrap();
@@ -134,7 +155,7 @@ allowed_base_dir = "{}"
 
         // First dry-run acquires the lock for the duration of the call.
         let mut out1 = Vec::new();
-        run(&path, &mut out1).unwrap();
+        run(&path, &mut out1).await.unwrap();
 
         // Hold the audit file open with a direct writer so the second dry-run
         // collides with us.
@@ -149,7 +170,7 @@ allowed_base_dir = "{}"
         })
         .unwrap();
 
-        let err = run(&path, &mut Vec::new()).unwrap_err();
+        let err = run(&path, &mut Vec::new()).await.unwrap_err();
         let chain: String = err
             .chain()
             .map(|c| format!("{c}"))
@@ -161,8 +182,8 @@ allowed_base_dir = "{}"
         );
     }
 
-    #[test]
-    fn dry_run_lists_infrastructure_tools_separately() {
+    #[tokio::test]
+    async fn dry_run_lists_infrastructure_tools_separately() {
         // Infrastructure tools (use_account, list_accounts) bypass the posture
         // matrix at runtime, so printing them as `[deny]` alongside content
         // tools misleads users into thinking the tools are unavailable. They
@@ -170,7 +191,7 @@ allowed_base_dir = "{}"
         let dir = TempDir::new().unwrap();
         let path = write_minimal_config(&dir);
         let mut out = Vec::new();
-        run(&path, &mut out).unwrap();
+        run(&path, &mut out).await.unwrap();
         let text = String::from_utf8(out).unwrap();
 
         assert!(
@@ -195,12 +216,12 @@ allowed_base_dir = "{}"
         );
     }
 
-    #[test]
-    fn dry_run_surfaces_parse_errors_as_anyhow() {
+    #[tokio::test]
+    async fn dry_run_surfaces_parse_errors_as_anyhow() {
         let dir = TempDir::new().unwrap();
         let bad = dir.path().join("bad.toml");
         std::fs::write(&bad, "not valid toml =\n").unwrap();
-        let err = run(&bad, &mut Vec::new()).unwrap_err();
+        let err = run(&bad, &mut Vec::new()).await.unwrap_err();
         // anyhow chains context; the bottom-most error comes from rimap-config.
         let mut chain = String::new();
         for cause in err.chain() {

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -96,7 +96,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
     if cli.dry_run {
         let path = resolve_cli_config_path(&cli)?;
         let mut stdout = std::io::stdout().lock();
-        return cli::dry_run::run(&path, &mut stdout);
+        return cli::dry_run::run(&path, &mut stdout).await;
     }
 
     if let Some(Command::Daemon) = cli.command {

--- a/crates/rimap-server/tests/dry_run_cli.rs
+++ b/crates/rimap-server/tests/dry_run_cli.rs
@@ -44,7 +44,8 @@ fn dry_run_exits_zero_and_prints_matrix() {
         .success()
         .stdout(predicate::str::contains("readonly"))
         .stdout(predicate::str::contains("[ok ] list_folders"))
-        .stdout(predicate::str::contains("[deny] create_draft"));
+        .stdout(predicate::str::contains("[deny] create_draft"))
+        .stdout(predicate::str::contains("Capabilities"));
 }
 
 #[test]

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -70,8 +70,9 @@ MCP server:
 rusty-imap-mcp --dry-run
 ```
 
-A successful run prints the account summary and server capabilities,
-then exits.
+A successful run prints the posture matrix, the active tool allowlist,
+and the IMAP server's capability list (after a TLS handshake), then
+exits. It does not authenticate.
 
 **If it fails:**
 

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -78,8 +78,8 @@ exits. It does not authenticate.
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `ERR_AUTH` | Wrong password | Re-run `rusty-imap-mcp login` with the correct App Password |
 | `ERR_TLS` | TLS handshake failure | Verify your network allows connections to imap.gmail.com:993 |
+| `Capabilities ...: unavailable (...)` | Preflight could not complete | Inspect the parenthesised cause — typically connectivity, DNS, or TLS. `--dry-run` does not authenticate, so an auth error cannot surface here |
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
 | Config not found | Wrong file location | Verify the path matches your platform (see Step 2) or use `--config <path>` |
 

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -116,8 +116,9 @@ MCP server:
 rusty-imap-mcp --dry-run
 ```
 
-A successful run prints the account summary and server capabilities
-(including TLS fingerprint verification), then exits.
+A successful run prints the posture matrix, the active tool allowlist,
+and the IMAP server's capability list (after a TLS handshake), then
+exits. It does not authenticate.
 
 **If it fails:**
 

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -124,8 +124,8 @@ exits. It does not authenticate.
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `ERR_AUTH` | Wrong password | Re-run `rusty-imap-mcp login` with the bridge password (not your Proton account password) |
 | `ERR_TLS` | Fingerprint mismatch or Bridge not running | Verify Bridge is running, then re-capture the fingerprint (Step 2) |
+| `Capabilities ...: unavailable (...)` | Preflight could not complete | Inspect the parenthesised cause — typically connectivity or TLS. `--dry-run` does not authenticate, so an auth error cannot surface here |
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
 | Connection refused | Bridge not running or wrong port | Start Proton Bridge and verify the IMAP port in Bridge settings |
 


### PR DESCRIPTION
## Summary

Closes #117. `--dry-run` now actually performs the TLS handshake and pre-auth `CAPABILITY` probe per account that the quickstart docs claimed it did. Adds `rimap_imap::preflight::probe_preflight` — a credential-free, audit-free pre-auth probe — and wires it into `cli::dry_run::run`, which becomes async. Quickstart docs updated to describe landed behavior.

Polish release PR 8 (Wave A, the biggest item). Plan doc: `docs/superpowers/plans/2026-04-23-polish-pr08-dry-run-preflight.md`. Companion follow-up filed as #151 (display TLS cert fingerprint during `--dry-run` — deferred).

## Changes

### `rimap-imap`
- `tls_handshake` and `starttls_upgrade` widened from private to `pub(crate)` so the new module can reuse them.
- New `preflight` module: `probe_preflight(&ConnectionConfig) -> Result<PreflightInfo, ImapError>` + `PreflightInfo { capabilities: Vec<String> }` (upper-cased atoms, de-duplicated, preserving order). No LOGIN, no `emit_auth`, no credentials.
- Capability extraction matches the project's existing `UnsolicitedResponse::Other(resp)` + `Response::Capabilities(caps)` + `Capability::Atom(name)` pattern (used in `connection::capability_advertised`). The plan doc called for a non-existent `UnsolicitedResponse::Capabilities` variant; corrected during execution.
- Every leg of the probe (TCP, TLS, greeting, CAPABILITY) is bounded by a timeout — review-fix commit addresses the initial gap where greeting + CAPABILITY had no deadline.

### `rimap-server`
- `boot::registry::build_account_connection` widened to `pub` (binary-crate `cli::dry_run` needs access; `pub(crate)` on the library wouldn't cross the binary/library boundary).
- `cli::dry_run::run` becomes `async`; per-account, after the existing "Infrastructure tools" block, it prints either `Capabilities (host:port):` with `[ok ] CAP` rows, or `Capabilities (host:port): unavailable (err)` on failure. Unreachable accounts do not abort the dry-run.
- Four unit tests in `dry_run.rs` converted to `#[tokio::test]`; the CLI integration test in `tests/dry_run_cli.rs` gains a `Capabilities` assertion.

### Docs
- `docs/quickstart-gmail.md` and `docs/quickstart-proton-bridge.md` describe posture + capabilities (no fingerprint claim). Troubleshooting tables drop the `ERR_AUTH` row (preflight never authenticates) and add a `Capabilities ...: unavailable` row that directs users to inspect the inline cause.

## Test plan

- [x] `cargo test -p rimap-server` — all suites pass.
- [x] `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings` — clean.
- [x] No new `#[allow(...)]`, no new `unwrap()`/`expect()` in non-test code.
- [x] Live Dovecot fixture: `probe_preflight` returns the real capability list (manually verified during code-review integration).

## Plan deviations (documented)

1. `async-imap`'s `UnsolicitedResponse` lives at `async_imap::types`, not `async_imap::imap_proto`. Corrected.
2. `UnsolicitedResponse::Capabilities(list)` doesn't exist in the installed version; `UnsolicitedResponse::Other(resp)` + `resp.parsed()` pattern used instead.
3. `ImapCapability::Atom(name)` wraps `Cow<'_, str>`, so `to_ascii_uppercase()` works directly (no `from_utf8` intermediate).
4. `build_account_connection` widened to `pub`, not `pub(crate)` — crate boundary between `src/main.rs` (binary, where `cli` lives) and `src/lib.rs` (library, where `boot` lives) requires `pub`.
5. Review-response commit addresses timeout gap in greeting + CAPABILITY and removes contradictory `ERR_AUTH` troubleshooting row.