### PR TITLE
fix(rimap-server): polish PR 1 — daemon/state.rs cleanup (#141, #143, #145)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,6 +2212,7 @@ name = "rimap-server"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert_cmd",
  "clap",
  "governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ secrecy = "0.10"
 governor = "0.10"
 utf7-imap = "0.3.2"
 nonzero_ext = "0.3"
+arc-swap = "1"
 parking_lot = "0.12"
 
 # Async runtime

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -52,6 +52,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 governor = { workspace = true }
 tempfile = { workspace = true }
+arc-swap = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1.1", default-features = false, features = ["process", "fs"] }

--- a/crates/rimap-server/src/daemon/audit_sink.rs
+++ b/crates/rimap-server/src/daemon/audit_sink.rs
@@ -70,23 +70,6 @@ impl SessionAuditSink {
         inputs.session_id = Some(self.session_id);
         self.writer.log_tool_end(inputs)
     }
-
-    /// The underlying writer, for emitting records that are explicitly
-    /// NOT session-scoped (e.g. `process_start` / `process_end`).
-    /// Call sites must justify their non-session status.
-    ///
-    /// Scoped to `pub(crate)` so session-scoped code outside this crate
-    /// cannot bypass the `session_id` injection — out-of-crate call sites
-    /// must go through `log_tool_start` / `log_tool_end`.
-    #[must_use]
-    #[expect(
-        dead_code,
-        reason = "in-crate escape hatch for non-session-scoped records (process_start/process_end); \
-                  kept available even when no current caller uses it, per MCP-AUD-03 design"
-    )]
-    pub(crate) fn raw_writer(&self) -> &AuditWriter {
-        &self.writer
-    }
 }
 
 #[cfg(test)]

--- a/crates/rimap-server/src/daemon/state.rs
+++ b/crates/rimap-server/src/daemon/state.rs
@@ -26,15 +26,25 @@ pub struct DaemonState {
     pub(crate) registry: Arc<AccountRegistry>,
     /// Audit writer; the single fs-locked backing file is shared.
     pub(crate) audit: AuditWriter,
-    /// Attachment download directory (read-only after boot).
-    #[expect(dead_code, reason = "will be read by download-attachment tool (#145)")]
+    /// Attachment download directory (read-only after boot). Stored on
+    /// `DaemonState` and propagated into `AccountRegistry::build`, which
+    /// copies it onto each `AccountState`; tool handlers read it from the
+    /// per-account copy. The daemon-level field is currently vestigial —
+    /// retained for symmetry with other daemon-shared paths and as a
+    /// holding spot for any future tool that needs the unscoped path.
+    #[expect(
+        dead_code,
+        reason = "vestigial daemon-level copy; per-account download_dir on AccountState is the live path"
+    )]
     pub(crate) download_dir: Arc<std::path::Path>,
     /// Cancellation channel sender for the audit drainer.
     pub(crate) cancellation_tx: CancelledToolEndSender,
-    /// Daemon start time (used to compute session durations).
+    /// Daemon start time. Captured for symmetry with `process_start`'s
+    /// timestamp; nothing reads it today (per-session durations come from
+    /// `SessionState.started_at`, not from this field).
     #[expect(
         dead_code,
-        reason = "will be read by session-duration reporting (#145)"
+        reason = "vestigial; eligible for removal in a future cleanup PR"
     )]
     pub(crate) started_at: Instant,
     /// Bound on concurrent shim sessions. An `OwnedSemaphorePermit` is

--- a/crates/rimap-server/src/daemon/state.rs
+++ b/crates/rimap-server/src/daemon/state.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Instant;
 
+use arc_swap::ArcSwapOption;
 use rimap_audit::redact::RedactionSalt;
 use rimap_audit::{AuditWriter, CancelledToolEndSender};
 use rimap_core::{SessionId, account::AccountId};
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::Semaphore;
 
 use crate::boot::registry::AccountRegistry;
 
@@ -107,9 +108,10 @@ pub struct SessionState {
     /// Generated on accept; carried through every audit record.
     pub id: SessionId,
     /// Session-scoped active account (overrides the config default).
-    /// `RwLock` because `use_account` is the only writer and reads
-    /// happen on every tool call.
-    pub active_account: RwLock<Option<AccountId>>,
+    /// `ArcSwapOption` because `use_account` is the only writer and
+    /// reads happen on every tool call; lock-free swap removes the
+    /// `.await` from the read path. See #143.
+    pub active_account: ArcSwapOption<AccountId>,
     /// When this session started — for `duration_ms` on `session_end`.
     pub started_at: Instant,
     /// Count of completed tool calls in this session, feeds
@@ -124,7 +126,7 @@ impl SessionState {
     pub fn new(id: SessionId) -> Self {
         Self {
             id,
-            active_account: RwLock::new(None),
+            active_account: ArcSwapOption::from(None),
             started_at: Instant::now(),
             tool_call_count: std::sync::atomic::AtomicU64::new(0),
         }
@@ -137,18 +139,31 @@ mod tests {
     use super::SessionState;
     use rimap_core::SessionId;
 
-    #[tokio::test]
-    async fn new_session_has_no_active_account() {
+    #[test]
+    fn new_session_has_no_active_account() {
         let s = SessionState::new(SessionId::new());
-        assert!(s.active_account.read().await.is_none());
+        assert!(s.active_account.load().is_none());
     }
 
-    #[tokio::test]
-    async fn active_account_write_then_read_reflects_update() {
+    #[test]
+    fn active_account_store_then_load_reflects_update() {
+        use std::sync::Arc;
         let s = SessionState::new(SessionId::new());
         let id = rimap_core::account::AccountId::new("work").unwrap();
-        *s.active_account.write().await = Some(id.clone());
-        assert_eq!(*s.active_account.read().await, Some(id));
+        s.active_account.store(Some(Arc::new(id.clone())));
+        let loaded = s.active_account.load_full();
+        assert_eq!(loaded.as_deref(), Some(&id));
+    }
+
+    #[test]
+    fn active_account_store_is_lock_free_no_await_required() {
+        // Compile-time proof: if `store` still needed `.await`, this
+        // non-async fn could not call it. The test exists so a future
+        // refactor back to RwLock breaks compilation.
+        use std::sync::Arc;
+        let s = SessionState::new(SessionId::new());
+        let id = rimap_core::account::AccountId::new("work").unwrap();
+        s.active_account.store(Some(Arc::new(id)));
     }
 
     #[test]

--- a/crates/rimap-server/src/daemon/state.rs
+++ b/crates/rimap-server/src/daemon/state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Instant;
 
+use rimap_audit::redact::RedactionSalt;
 use rimap_audit::{AuditWriter, CancelledToolEndSender};
 use rimap_core::{SessionId, account::AccountId};
 use tokio::sync::{RwLock, Semaphore};
@@ -12,31 +13,83 @@ use crate::boot::registry::AccountRegistry;
 
 /// Daemon-wide shared state. One `Arc<DaemonState>` is built at boot and
 /// cloned into every `PerSessionHandler`.
+///
+/// Fields are `pub(crate)` so in-crate code reads them directly; external
+/// consumers (the `main.rs` binary + integration tests) must construct via
+/// [`DaemonState::new`] and go through the in-crate APIs for reads. See
+/// issue #145 (Tighten `DaemonState` field visibility).
 pub struct DaemonState {
     /// Account registry (all accounts, all connections, all per-account
     /// governors and breakers). `Connection`s are already `Arc`-backed
     /// internally; sharing the registry via `Arc` gives every session
     /// cheap access.
-    pub registry: Arc<AccountRegistry>,
+    pub(crate) registry: Arc<AccountRegistry>,
     /// Audit writer; the single fs-locked backing file is shared.
-    pub audit: AuditWriter,
+    pub(crate) audit: AuditWriter,
     /// Attachment download directory (read-only after boot).
-    pub download_dir: Arc<std::path::Path>,
+    #[expect(dead_code, reason = "will be read by download-attachment tool (#145)")]
+    pub(crate) download_dir: Arc<std::path::Path>,
     /// Cancellation channel sender for the audit drainer.
-    pub cancellation_tx: CancelledToolEndSender,
+    pub(crate) cancellation_tx: CancelledToolEndSender,
     /// Daemon start time (used to compute session durations).
-    pub started_at: Instant,
+    #[expect(
+        dead_code,
+        reason = "will be read by session-duration reporting (#145)"
+    )]
+    pub(crate) started_at: Instant,
     /// Bound on concurrent shim sessions. An `OwnedSemaphorePermit` is
     /// acquired on each accept and held for the session's lifetime;
     /// dropping the permit (when the session future returns) releases
     /// the slot. Connections that arrive while the semaphore is
     /// exhausted are rejected with a paired
     /// `session_start` + `session_end(Rejected)` audit pair.
-    pub session_permits: Arc<Semaphore>,
+    pub(crate) session_permits: Arc<Semaphore>,
     /// Daemon-wide aggregate of completed tool calls across all sessions.
     /// Incremented in `emit_session_end` with each session's final count.
     /// Read in `daemon_main` to populate `process_end.total_tool_calls`.
-    pub total_tool_calls: AtomicU64,
+    pub(crate) total_tool_calls: AtomicU64,
+    /// Per-process salt used by [`rimap_audit::redact::Redactor`] to hash
+    /// tool arguments. One salt for the daemon lifetime; hashes are not
+    /// comparable across restarts (by design — fresh randomness per boot).
+    /// Cloned cheaply into every `ImapMcpServer`. See #141.
+    pub(crate) redaction_salt: Arc<RedactionSalt>,
+}
+
+impl DaemonState {
+    /// Build daemon-wide shared state. Called once in `daemon_main`;
+    /// integration tests also use this so a new field on `DaemonState`
+    /// does not require updating every test's struct literal.
+    ///
+    /// Generates one [`RedactionSalt`] from the OS RNG and wraps it in
+    /// `Arc` so `spawn_blocking` closures can cheaply capture it.
+    #[must_use]
+    pub fn new(
+        registry: Arc<AccountRegistry>,
+        audit: AuditWriter,
+        download_dir: Arc<std::path::Path>,
+        cancellation_tx: CancelledToolEndSender,
+        session_permits: Arc<Semaphore>,
+    ) -> Self {
+        Self {
+            registry,
+            audit,
+            download_dir,
+            cancellation_tx,
+            started_at: Instant::now(),
+            session_permits,
+            total_tool_calls: AtomicU64::new(0),
+            redaction_salt: Arc::new(RedactionSalt::new_random()),
+        }
+    }
+
+    /// Read the daemon-wide total tool-call counter. `main.rs` consumes
+    /// this at `process_end` emission; external callers have no other
+    /// reason to touch the `AtomicU64` directly.
+    #[must_use]
+    pub fn total_tool_calls(&self) -> u64 {
+        self.total_tool_calls
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
 }
 
 /// Per-client-connection state.
@@ -112,5 +165,59 @@ mod tests {
             daemon_total.fetch_add(per_session, Ordering::Relaxed);
         }
         assert_eq!(daemon_total.load(Ordering::Relaxed), 3 + 5 + 7 + 1);
+    }
+
+    #[tokio::test]
+    async fn daemon_state_new_builds_one_salt_per_daemon_lifetime() {
+        use std::collections::BTreeMap;
+        use std::sync::Arc;
+
+        use rimap_audit::{AuditOptions, AuditWriter, Seq};
+        use tempfile::tempdir;
+
+        use super::DaemonState;
+        use crate::boot::registry::AccountRegistry;
+
+        fn build_state(dir: &std::path::Path) -> Arc<DaemonState> {
+            let audit = AuditWriter::open(&AuditOptions {
+                path: dir.join("a.jsonl"),
+                rotate_bytes: 0,
+                rotate_keep: 0,
+                retention_seconds: None,
+                fail_open: false,
+                initial_seq: Seq::FIRST,
+            })
+            .unwrap();
+            let (cancellation_tx, _rx) = rimap_audit::cancellation_channel();
+            Arc::new(DaemonState::new(
+                Arc::new(AccountRegistry::new(BTreeMap::new())),
+                audit,
+                Arc::from(dir.to_path_buf().into_boxed_path()),
+                cancellation_tx,
+                Arc::new(tokio::sync::Semaphore::new(1)),
+            ))
+        }
+
+        let dir_a = tempdir().unwrap();
+        let dir_b = tempdir().unwrap();
+        let state_a = build_state(dir_a.path());
+        let state_b = build_state(dir_b.path());
+
+        // Different daemon constructions => different salt Arcs (each `new()`
+        // mints its own RedactionSalt). A weaker test that compared two clones
+        // of the same `state.redaction_salt` would be trivially true regardless
+        // of implementation; this catches a regression that re-allocates on
+        // every read.
+        assert!(
+            !Arc::ptr_eq(&state_a.redaction_salt, &state_b.redaction_salt),
+            "DaemonState::new must mint a fresh RedactionSalt per daemon",
+        );
+
+        // Within one daemon, cloning the field yields the same Arc.
+        let clone_a = Arc::clone(&state_a.redaction_salt);
+        assert!(
+            Arc::ptr_eq(&state_a.redaction_salt, &clone_a),
+            "Arc clones of the salt field must point to the same allocation",
+        );
     }
 }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -179,15 +179,13 @@ async fn daemon_main(config_override: Option<PathBuf>) -> anyhow::Result<()> {
         usize::try_from(multi.daemon.max_concurrent_sessions.get()).unwrap_or(usize::MAX);
     let session_permits = Arc::new(tokio::sync::Semaphore::new(max_sessions));
 
-    let state = Arc::new(DaemonState {
-        registry: Arc::new(registry),
-        audit: audit.clone(),
+    let state = Arc::new(DaemonState::new(
+        Arc::new(registry),
+        audit.clone(),
         download_dir,
         cancellation_tx,
-        started_at: std::time::Instant::now(),
         session_permits,
-        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-    });
+    ));
 
     let shutdown = install_shutdown_handler();
     let mcp_result = run(state.clone(), listener, shutdown).await;
@@ -199,9 +197,7 @@ async fn daemon_main(config_override: Option<PathBuf>) -> anyhow::Result<()> {
     if let Err(e) = drainer_handle.await {
         tracing::error!(error = %e, "cancellation drainer join error");
     }
-    let total_tool_calls = state
-        .total_tool_calls
-        .load(std::sync::atomic::Ordering::Relaxed);
+    let total_tool_calls = state.total_tool_calls();
     if let Err(e) = audit.log_process_end(rimap_audit::ProcessEnd {
         reason,
         total_tool_calls,

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -163,7 +163,7 @@ impl ImapMcpServer {
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> (serde_json::Value, String) {
         let args_value = serde_json::Value::Object(args.clone());
-        let redacted = Redactor::new(&tool.redaction_schema(), self.redaction_salt.as_ref())
+        let redacted = Redactor::new(&tool.redaction_schema(), self.state.redaction_salt.as_ref())
             .apply(&args_value);
         let hash = hash_arguments(&args_value);
         (redacted, hash)
@@ -454,15 +454,13 @@ mod tests {
         let (cancellation_tx, _cancellation_rx) = rimap_audit::cancellation_channel();
         let download_dir: Arc<std::path::Path> =
             Arc::from(std::path::Path::new("/tmp/test-downloads"));
-        let daemon_state = Arc::new(DaemonState {
-            registry: Arc::new(AccountRegistry::new(BTreeMap::new())),
+        let daemon_state = Arc::new(DaemonState::new(
+            Arc::new(AccountRegistry::new(BTreeMap::new())),
             audit,
             download_dir,
             cancellation_tx,
-            started_at: std::time::Instant::now(),
-            session_permits: Arc::new(tokio::sync::Semaphore::new(64)),
-            total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-        });
+            Arc::new(tokio::sync::Semaphore::new(64)),
+        ));
         let session_state = Arc::new(SessionState::new(rimap_core::SessionId::new()));
         let server = ImapMcpServer::new(daemon_state, session_state);
 

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -356,15 +356,13 @@ mod tests {
         let (cancellation_tx, _cancellation_rx) = rimap_audit::cancellation_channel();
         let download_dir: Arc<std::path::Path> =
             Arc::from(std::path::Path::new("/tmp/test-downloads"));
-        let daemon_state = Arc::new(DaemonState {
-            registry: Arc::new(registry),
-            audit: audit.clone(),
+        let daemon_state = Arc::new(DaemonState::new(
+            Arc::new(registry),
+            audit.clone(),
             download_dir,
             cancellation_tx,
-            started_at: std::time::Instant::now(),
-            session_permits: Arc::new(tokio::sync::Semaphore::new(64)),
-            total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-        });
+            Arc::new(tokio::sync::Semaphore::new(64)),
+        ));
         let session_state = Arc::new(SessionState::new(rimap_core::SessionId::new()));
         let server = ImapMcpServer::new(daemon_state, session_state);
 

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -431,9 +431,7 @@ impl ServerHandler for ImapMcpServer {
                 .await;
         }
 
-        let account = self
-            .resolve_account_for_call(namespaced_account.as_deref(), &mut args)
-            .await?;
+        let account = self.resolve_account_for_call(namespaced_account.as_deref(), &mut args)?;
 
         self.dispatch_account_scoped(
             account,
@@ -519,7 +517,7 @@ impl ImapMcpServer {
     /// Precedence: URI namespace, then `args["account"]`, then the session
     /// default, then auto-select. Consumes the `account` entry from `args`
     /// so the downstream handler does not observe it as a tool argument.
-    async fn resolve_account_for_call(
+    fn resolve_account_for_call(
         &self,
         namespaced_account: Option<&str>,
         args: &mut serde_json::Map<String, serde_json::Value>,
@@ -528,9 +526,9 @@ impl ImapMcpServer {
             args.remove("account")
                 .and_then(|v| v.as_str().map(String::from))
         });
-        let session_default = self.session.active_account.read().await.clone();
+        let session_default = self.session.active_account.load_full();
         self.registry()
-            .resolve_with_active(explicit_account.as_deref(), session_default.as_ref())
+            .resolve_with_active(explicit_account.as_deref(), session_default.as_deref())
             .map_err(|e| crate::mcp::error::to_mcp_error(&e))
     }
 }

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -9,7 +9,6 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use rimap_audit::redact::RedactionSalt;
 use rimap_core::account::AccountId;
 use rimap_core::tool::ToolName;
 use rmcp::RoleServer;
@@ -38,15 +37,13 @@ pub struct ImapMcpServer {
     pub(crate) session: Arc<SessionState>,
     /// Session-scoped audit sink — guarantees `session_id` injection.
     pub(crate) audit: SessionAuditSink,
-    /// Per-process salt used when applying `Redactor` to tool arguments.
-    /// Wrapped in `Arc` so `spawn_blocking` closures can cheaply capture it.
-    pub(crate) redaction_salt: Arc<RedactionSalt>,
 }
 
 impl ImapMcpServer {
-    /// Construct a per-session server. Builds the per-process redaction salt;
-    /// per-tool schemas are dispatched on demand via
-    /// [`rimap_audit::redact::ToolRedactionSchema::redaction_schema`].
+    /// Construct a per-session server. Per-tool schemas are dispatched on
+    /// demand via [`rimap_audit::redact::ToolRedactionSchema::redaction_schema`];
+    /// the per-process redaction salt lives on [`DaemonState`] and is shared
+    /// across every session.
     #[must_use]
     pub fn new(state: Arc<DaemonState>, session: Arc<SessionState>) -> Self {
         let audit = SessionAuditSink::new(state.audit.clone(), session.id);
@@ -54,7 +51,6 @@ impl ImapMcpServer {
             state,
             session,
             audit,
-            redaction_salt: Arc::new(RedactionSalt::new_random()),
         }
     }
 

--- a/crates/rimap-server/src/tools/admin/accounts.rs
+++ b/crates/rimap-server/src/tools/admin/accounts.rs
@@ -53,6 +53,10 @@ pub struct ListAccountsMeta {
 /// codepoints, or if it is not a valid account-name shape. Returns
 /// `RimapError::UnknownAccount { ... }` if the name does not match a
 /// configured account.
+#[expect(
+    clippy::unused_async,
+    reason = "handler shape uniform with async-handler siblings"
+)]
 pub async fn handle_use_account(
     session: &SessionState,
     registry: &AccountRegistry,
@@ -88,12 +92,15 @@ pub async fn handle_use_account(
         })?;
 
     let previous = {
-        let mut guard = session.active_account.write().await;
-        let prev = guard.as_ref().map(ToString::to_string);
-        if guard.as_ref() != Some(&new_id) {
-            *guard = Some(new_id);
+        use std::sync::Arc;
+        let prev_arc = session.active_account.load_full();
+        let prev_string = prev_arc.as_deref().map(ToString::to_string);
+        // Skip the store if the value is identical — avoids a pointless
+        // allocation of Arc<AccountId> on the no-op path.
+        if prev_arc.as_deref() != Some(&new_id) {
+            session.active_account.store(Some(Arc::new(new_id)));
         }
-        prev
+        prev_string
     };
 
     Ok(ToolResponse::meta_only(UseAccountMeta {

--- a/crates/rimap-server/tests/common/daemon_harness.rs
+++ b/crates/rimap-server/tests/common/daemon_harness.rs
@@ -96,15 +96,13 @@ pub fn test_daemon_state_with_limit(
     let (cancellation_tx, _cancellation_rx) = rimap_audit::cancellation_channel();
     let session_permits = Arc::new(tokio::sync::Semaphore::new(max_concurrent_sessions));
 
-    Arc::new(DaemonState {
+    Arc::new(DaemonState::new(
         registry,
         audit,
         download_dir,
         cancellation_tx,
-        started_at: std::time::Instant::now(),
         session_permits,
-        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-    })
+    ))
 }
 
 impl TestDaemon {

--- a/crates/rimap-server/tests/dispatch_ticket.rs
+++ b/crates/rimap-server/tests/dispatch_ticket.rs
@@ -44,15 +44,13 @@ fn build_test_server() -> TestFixture {
     let registry = AccountRegistry::new(BTreeMap::new());
     let (cancellation_tx, _cancellation_rx) = rimap_audit::cancellation_channel();
     let download_dir: Arc<std::path::Path> = Arc::from(std::path::Path::new("/tmp/test-downloads"));
-    let daemon_state = Arc::new(DaemonState {
-        registry: Arc::new(registry),
-        audit: audit.clone(),
+    let daemon_state = Arc::new(DaemonState::new(
+        Arc::new(registry),
+        audit.clone(),
         download_dir,
         cancellation_tx,
-        started_at: std::time::Instant::now(),
-        session_permits: Arc::new(tokio::sync::Semaphore::new(64)),
-        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-    });
+        Arc::new(tokio::sync::Semaphore::new(64)),
+    ));
     let session_state = Arc::new(SessionState::new(rimap_core::SessionId::new()));
     let server = ImapMcpServer::new(daemon_state, session_state);
 
@@ -214,15 +212,13 @@ async fn drop_during_body_enqueues_cancellation_tool_end() {
     let drainer = spawn_drainer(cancellation_rx, audit.clone());
     let download_dir_2: Arc<std::path::Path> =
         Arc::from(std::path::Path::new("/tmp/test-downloads"));
-    let daemon_state_2 = Arc::new(rimap_server::daemon::state::DaemonState {
-        registry: Arc::new(registry),
-        audit: audit.clone(),
-        download_dir: download_dir_2,
+    let daemon_state_2 = Arc::new(rimap_server::daemon::state::DaemonState::new(
+        Arc::new(registry),
+        audit.clone(),
+        download_dir_2,
         cancellation_tx,
-        started_at: std::time::Instant::now(),
-        session_permits: Arc::new(tokio::sync::Semaphore::new(64)),
-        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-    });
+        Arc::new(tokio::sync::Semaphore::new(64)),
+    ));
     let session_id = rimap_core::SessionId::new();
     let session_state_2 = Arc::new(rimap_server::daemon::state::SessionState::new(session_id));
     let server = Arc::new(rimap_server::mcp::server::ImapMcpServer::new(

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -283,15 +283,13 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
     let registry = rimap_server::boot::registry::AccountRegistry::new(accounts);
 
     let (cancellation_tx, _cancellation_rx) = rimap_audit::cancellation_channel();
-    let daemon_state = Arc::new(DaemonState {
-        registry: Arc::new(registry),
-        audit: audit.clone(),
-        download_dir: std::sync::Arc::from(download_dir.path().to_path_buf().into_boxed_path()),
+    let daemon_state = Arc::new(DaemonState::new(
+        Arc::new(registry),
+        audit.clone(),
+        std::sync::Arc::from(download_dir.path().to_path_buf().into_boxed_path()),
         cancellation_tx,
-        started_at: std::time::Instant::now(),
-        session_permits: Arc::new(tokio::sync::Semaphore::new(64)),
-        total_tool_calls: std::sync::atomic::AtomicU64::new(0),
-    });
+        Arc::new(tokio::sync::Semaphore::new(64)),
+    ));
     let session_state = Arc::new(SessionState::new(rimap_core::SessionId::new()));
     let server = ImapMcpServer::new(daemon_state, session_state);
 


### PR DESCRIPTION
## Summary

Wave B PR 1 of the polish release. Bundles three coupled changes on `crates/rimap-server/src/daemon/state.rs`:

- **#141** — Hoist `RedactionSalt` from per-session to `DaemonState`. One random salt at boot, cloned via `Arc` into every `ImapMcpServer`. Removes a pointless `RedactionSalt::new_random()` call per accept.
- **#143** — Replace `SessionState.active_account: RwLock<Option<AccountId>>` with `arc-swap::ArcSwapOption<AccountId>`. Removes the async-lock `.read().await.clone()` from the per-tool-call hot path; `resolve_account_for_call` becomes synchronous.
- **#145** — Tighten `DaemonState` fields from `pub` to `pub(crate)` behind a new `pub fn DaemonState::new(...)` constructor and a `pub fn total_tool_calls(&self) -> u64` accessor. Delete the unused `SessionAuditSink::raw_writer` accessor.

Plan: [`docs/superpowers/plans/2026-04-23-polish-pr01-daemon-state.md`](docs/superpowers/plans/2026-04-23-polish-pr01-daemon-state.md).

## Commits

1. `987540b` — `chore(deps): reintroduce arc-swap` (#143 prep)
2. `048286a` — `refactor(rimap-server): hoist RedactionSalt and tighten DaemonState visibility (#141, #145)`
3. `45f91fd` — `docs(rimap-server): rewrite #[expect(dead_code)] reasons on DaemonState` (review fix)
4. `927726a` — `perf(rimap-server): swap SessionState.active_account to ArcSwapOption (#143)`
5. `a91372c` — `refactor(rimap-server): delete unused SessionAuditSink::raw_writer (#145)`

## Notes

- `arc-swap` was previously a workspace dep (removed in `4596078` as dead code during the multi-client-daemon work); this PR puts it back.
- Two `DaemonState` fields (`download_dir`, `started_at`) are now visibly dead at the lib level. They were always dead but `pub` hid it from clippy. Annotated with `#[expect(dead_code)]` and accurate reasons; deletion is left for a follow-up cleanup PR rather than expanding scope here.
- `resolve_account_for_call` dropped its `async` modifier (no `.await` remains in the body); the call site lost its `.await`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes (modulo the pre-existing `socket_path`/`socket_setup` env-var test flake unrelated to this PR)
- [x] `cargo deny check advisories bans licenses` clean
- [x] `typos` clean
- [x] New tests cover: salt-per-daemon invariant, ArcSwapOption load/store/no-await

Closes #141, #143, #145.