### PR TITLE
fix(rimap-core,rimap-audit): polish PR 4 — shared ulid_newtype! macro (#146)

### DIFF
--- a/crates/rimap-audit/src/record/ids.rs
+++ b/crates/rimap-audit/src/record/ids.rs
@@ -7,7 +7,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
-use ulid::Ulid;
 
 /// Per-process monotonic sequence number. Starts at 1 on `process_start`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -37,24 +36,11 @@ impl fmt::Display for Seq {
     }
 }
 
-/// Stable identifier for a single process lifetime. Backed by a ULID so logs
-/// from different processes interleave in a meaningful order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ProcessId(pub Ulid);
-
-impl ProcessId {
-    /// Generate a fresh process ID from the current system time + randomness.
-    #[must_use]
-    pub fn new_now() -> Self {
-        Self(Ulid::new())
-    }
-}
-
-impl fmt::Display for ProcessId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+rimap_core::ulid_newtype! {
+    /// Stable identifier for a single process lifetime. Backed by a ULID so
+    /// logs from different processes interleave in a meaningful order.
+    pub struct ProcessId;
+    ctor: new_now;
 }
 
 /// Millisecond-precision UTC timestamp, serialized as RFC 3339.
@@ -142,6 +128,30 @@ mod tests {
     #[test]
     fn seq_display_uses_integer() {
         assert_eq!(Seq(42).to_string(), "42");
+    }
+
+    #[test]
+    fn process_id_serde_json_is_a_bare_string_not_a_struct() {
+        // On-disk schema pin for ProcessId: serializes as a bare JSON
+        // string, NOT as `{"0":"..."}`. Every audit record on disk
+        // carries one of these; any drift breaks the reader.
+        let id = ProcessId::new_now();
+        let json = serde_json::to_string(&id).unwrap();
+        assert!(json.starts_with('"') && json.ends_with('"'), "{json}");
+        let inner = &json[1..json.len() - 1];
+        assert_eq!(
+            inner.len(),
+            26,
+            "serialized form must be a raw ULID: {json}"
+        );
+    }
+
+    #[test]
+    fn process_id_round_trips_through_serde_json() {
+        let id = ProcessId::new_now();
+        let json = serde_json::to_string(&id).unwrap();
+        let back: ProcessId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
     }
 
     #[test]

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod session;
 pub mod tls;
 pub mod tool;
 pub mod uid_selector;
+pub mod ulid_newtype;
 pub mod warning;
 
 pub use crate::auth_event::{AuthEvent, AuthResult};

--- a/crates/rimap-core/src/session.rs
+++ b/crates/rimap-core/src/session.rs
@@ -4,48 +4,10 @@
 //! sorted by `session_id` land in roughly creation order — a forensic
 //! aid when reading the audit log.
 
-use core::fmt;
-use core::str::FromStr;
-
-use serde::{Deserialize, Serialize};
-
-/// Per-client-connection identifier. Generated on accept.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct SessionId(ulid::Ulid);
-
-impl SessionId {
-    /// Generate a fresh `SessionId` from the system clock + randomness.
-    #[must_use]
-    pub fn new() -> Self {
-        Self(ulid::Ulid::new())
-    }
-
-    /// Underlying ULID (escape hatch for interop).
-    #[must_use]
-    pub fn as_ulid(self) -> ulid::Ulid {
-        self.0
-    }
-}
-
-impl Default for SessionId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl fmt::Display for SessionId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-/// Parse a 26-char ULID into a `SessionId`.
-impl FromStr for SessionId {
-    type Err = ulid::DecodeError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ulid::Ulid::from_str(s).map(Self)
-    }
+crate::ulid_newtype! {
+    /// Per-client-connection identifier. Generated on accept.
+    pub struct SessionId;
+    ctor: new;
 }
 
 #[cfg(test)]
@@ -87,6 +49,23 @@ mod tests {
         assert!(
             second.to_string() > first.to_string(),
             "expected later ULID's string form to be >= earlier; got {first} then {second}"
+        );
+    }
+
+    #[test]
+    fn serde_json_is_a_bare_string_not_a_struct() {
+        // On-disk schema pin: SessionId serializes as a bare JSON string,
+        // NOT as `{"0":"..."}`. Any future refactor that drops serde
+        // transparent would break every recorded audit log. This test is
+        // deliberately conservative.
+        let id = SessionId::new();
+        let json = serde_json::to_string(&id).unwrap();
+        assert!(json.starts_with('"') && json.ends_with('"'), "{json}");
+        let inner = &json[1..json.len() - 1];
+        assert_eq!(
+            inner.len(),
+            26,
+            "serialized form must be a raw ULID: {json}"
         );
     }
 }

--- a/crates/rimap-core/src/ulid_newtype.rs
+++ b/crates/rimap-core/src/ulid_newtype.rs
@@ -1,0 +1,136 @@
+//! Declarative macro that generates ULID newtypes sharing the same
+//! serde/Display/FromStr/Default boilerplate. Each newtype picks its
+//! own constructor name so the macro can replace both
+//! [`crate::SessionId`] (with `new`) and `rimap_audit::ProcessId`
+//! (with `new_now`) without breaking the hundreds of existing call
+//! sites.
+
+/// Define a ULID-backed newtype with `serde_transparent`, `Display`,
+/// `FromStr` (via `ulid::DecodeError`), `Default`, and a caller-chosen
+/// constructor.
+///
+/// # Usage
+///
+/// ```ignore
+/// rimap_core::ulid_newtype! {
+///     /// Per-connection identifier generated on accept.
+///     pub struct SessionId;
+///     ctor: new;
+/// }
+/// ```
+///
+/// The constructor `$ctor` is a `pub fn $ctor() -> Self` that seeds a
+/// fresh [`ulid::Ulid`] from the system clock + RNG. `Default::default`
+/// forwards to it.
+#[macro_export]
+macro_rules! ulid_newtype {
+    ($(#[$outer:meta])* $vis:vis struct $name:ident; ctor: $ctor:ident $(;)?) => {
+        $(#[$outer])*
+        #[derive(
+            ::core::fmt::Debug,
+            ::core::clone::Clone,
+            ::core::marker::Copy,
+            ::core::cmp::PartialEq,
+            ::core::cmp::Eq,
+            ::core::hash::Hash,
+            ::serde::Serialize,
+            ::serde::Deserialize,
+        )]
+        #[serde(transparent)]
+        $vis struct $name(::ulid::Ulid);
+
+        impl $name {
+            /// Generate a fresh value from the system clock + randomness.
+            #[must_use]
+            pub fn $ctor() -> Self {
+                Self(::ulid::Ulid::new())
+            }
+
+            /// Underlying ULID (escape hatch for interop).
+            #[must_use]
+            pub fn as_ulid(self) -> ::ulid::Ulid {
+                self.0
+            }
+        }
+
+        impl ::core::default::Default for $name {
+            fn default() -> Self {
+                Self::$ctor()
+            }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl ::core::str::FromStr for $name {
+            type Err = ::ulid::DecodeError;
+            fn from_str(s: &str) -> ::core::result::Result<Self, Self::Err> {
+                ::core::str::FromStr::from_str(s).map(Self)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    // Macro invocation lives inside the test module so the macro's generated
+    // type is confined to tests — no production code touches this newtype.
+    crate::ulid_newtype! {
+        /// Test-only newtype exercising every trait the macro generates.
+        pub(super) struct MacroProbe;
+        ctor: new_now;
+    }
+
+    use core::str::FromStr;
+
+    #[test]
+    fn display_round_trips_via_from_str() {
+        let id = MacroProbe::new_now();
+        let s = id.to_string();
+        assert_eq!(s.len(), 26, "ULID canonical form is 26 chars: {s}");
+        let back = MacroProbe::from_str(&s).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn default_is_fresh_value() {
+        let a = MacroProbe::default();
+        let b = MacroProbe::default();
+        assert_ne!(a, b, "default() must mint a fresh ULID each call");
+    }
+
+    #[test]
+    fn serde_transparent_serializes_as_bare_string() {
+        let id = MacroProbe::new_now();
+        let json = serde_json::to_string(&id).unwrap();
+        // The outer braces of a struct would be `{"0":"..."}` — transparent
+        // drops them, leaving a bare JSON string. Any drift from bare-string
+        // form is an on-disk schema break.
+        assert!(json.starts_with('"') && json.ends_with('"'), "{json}");
+        let inner = &json[1..json.len() - 1];
+        assert_eq!(
+            inner.len(),
+            26,
+            "serialized form must be a raw ULID: {json}"
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_value() {
+        let id = MacroProbe::new_now();
+        let json = serde_json::to_string(&id).unwrap();
+        let back: MacroProbe = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn as_ulid_returns_inner_value() {
+        let id = MacroProbe::new_now();
+        let inner = id.as_ulid();
+        assert_eq!(inner.to_string(), id.to_string());
+    }
+}


### PR DESCRIPTION
## Summary

Wave B PR 4 of the polish release. Closes #146.

Adds a single declarative macro `rimap_core::ulid_newtype!` that generates a serde-transparent ULID newtype with `Display`, `FromStr` (via `ulid::DecodeError`), `Default`, and a caller-chosen constructor. Migrates both existing ULID newtypes to invocations of it:

- `rimap_core::SessionId` (constructor: `new`)
- `rimap_audit::record::ids::ProcessId` (constructor: `new_now`)

Public API on both types unchanged — every existing call site (`SessionId::new()`, `ProcessId::new_now()`, `Display`, `FromStr`, `Default`, `serde(transparent)`) continues to resolve. The migration is a pure structural refactor with no behaviour change at the serialization level.

Plan: [`docs/superpowers/plans/2026-04-23-polish-pr04-ulid-newtype.md`](docs/superpowers/plans/2026-04-23-polish-pr04-ulid-newtype.md).

## Commits

1. `bd7b746` — `feat(rimap-core): add ulid_newtype! macro for shared ULID newtypes` (macro + 5 self-tests)
2. `9559806` — `refactor(rimap-core): migrate SessionId to ulid_newtype! macro`
3. `af90c22` — `refactor(rimap-audit): migrate ProcessId to rimap-core's ulid_newtype!`

## Notes

- Both newtypes get a new byte-stable serde test (`serde_json_is_a_bare_string_not_a_struct` / `process_id_serde_json_is_a_bare_string_not_a_struct`) that pins the on-disk JSON shape — this is a regression guard; flipping `serde(transparent)` off in the future would break audit logs on disk and these tests catch it.
- `ProcessId`'s inner field tightens from `pub Ulid` to private `Ulid`. Verified before swap: no caller anywhere in the workspace accesses `.0` on a `ProcessId`.
- Plan errors caught during implementation: `$crate::ulid_newtype!` only works inside macro bodies (changed to `crate::ulid_newtype!`), and `pub mod` ordering in `rimap-core/src/lib.rs` is `uid_selector` before `ulid_newtype` (alphabetical: `d < l`).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes (all suites green)
- [x] `cargo deny check advisories bans licenses` clean
- [x] `typos` clean

Closes #146.