### PR TITLE
fix(rimap-core,rimap-audit): polish PR 5 — shared ensure_tight_dir helper (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **audit (security, minor-breaking):** `AuditWriter::open` now rejects a
+  symlinked, wrong-owned, or non-`0700` audit parent directory. Operators
+  whose deployment scripts symlink the audit dir or relied on the previous
+  best-effort chmod must migrate to a real `0700` directory owned by the
+  running user before upgrade. The strict TOCTOU-safe check is the same
+  primitive the daemon already enforces on its socket directory (#147).
 - **Breaking (keyring):** Credential keyring entries are now namespaced by
   account id (`<account-id>/<username>@<host>`) to prevent collisions in
   multi-account deployments (#77). Existing entries under the legacy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "rimap-core",
+ "rustix",
  "serde",
  "serde_json",
  "sha2",
@@ -2173,6 +2174,7 @@ version = "1.0.0"
 dependencies = [
  "hex",
  "proptest",
+ "rustix",
  "schemars",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -283,9 +283,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -370,9 +370,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -550,13 +550,13 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1344,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.204"
+version = "2.1.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e3200a2474f99d0ea576a7c76aabda7cdcc795cc27f2d93f30ab79867820d"
+checksum = "194b4aac978e4e46f782a95ecdb06bc69919c935e783984e5f5b817545881beb"
 dependencies = [
  "psl-types",
 ]
@@ -2182,6 +2182,7 @@ dependencies = [
  "sha2",
  "strum",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "ulid",
 ]
@@ -2358,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",
@@ -2373,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 # Audit log
 fs4 = { version = "0.13", default-features = false, features = ["sync"] }
 libc = "0.2"
+rustix = { version = "1.1", default-features = false, features = ["process", "fs"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde", "serde-well-known"] }
 ulid = { version = "1.2", features = ["serde"] }

--- a/crates/rimap-audit/Cargo.toml
+++ b/crates/rimap-audit/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+rustix = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rimap-audit/src/cancellation.rs
+++ b/crates/rimap-audit/src/cancellation.rs
@@ -94,7 +94,17 @@ mod tests {
     use crate::{AuditWriter, Seq, ToolEndInputs, ToolStartInputs};
     use rimap_core::ErrorCode;
     use rimap_core::tool::ToolName;
-    use tempfile::tempdir;
+    use tempfile::TempDir;
+
+    fn tight_tempdir() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        dir
+    }
 
     fn dummy_inputs(account: &str) -> ToolEndInputs {
         ToolEndInputs {
@@ -133,7 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn drainer_writes_records_to_audit_writer() {
-        let dir = tempdir().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),

--- a/crates/rimap-audit/src/writer/log.rs
+++ b/crates/rimap-audit/src/writer/log.rs
@@ -291,9 +291,20 @@ mod session_writer_tests {
     use rimap_core::SessionId;
     use tempfile::TempDir;
 
+    fn tight_tempdir() -> TempDir {
+        let dir = TempDir::new().expect("tmpdir");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("chmod 0700");
+        }
+        dir
+    }
+
     #[test]
     fn log_session_start_writes_a_session_start_record() {
-        let dir = TempDir::new().expect("tmpdir");
+        let dir = tight_tempdir();
         let path = dir.path().join("a.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -326,7 +337,7 @@ mod session_writer_tests {
 
     #[test]
     fn log_session_end_writes_a_session_end_record() {
-        let dir = TempDir::new().expect("tmpdir");
+        let dir = tight_tempdir();
         let path = dir.path().join("a.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),

--- a/crates/rimap-audit/src/writer/mod.rs
+++ b/crates/rimap-audit/src/writer/mod.rs
@@ -105,13 +105,31 @@ impl AuditWriter {
     pub fn open(opts: &AuditOptions) -> Result<Self, AuditError> {
         if let Some(parent) = opts.path.parent()
             && !parent.as_os_str().is_empty()
-            && !parent.exists()
         {
-            std::fs::create_dir_all(parent).map_err(|source| AuditError::ParentDir {
-                path: opts.path.clone(),
-                source,
-            })?;
-            set_parent_mode_0700(parent);
+            #[cfg(unix)]
+            {
+                let our_uid = rustix::process::geteuid().as_raw();
+                // Drop the OwnedFd immediately — the subsequent
+                // writer_open_options().open(&opts.path) re-walks the path,
+                // so holding the fd would be only a momentary defense. The
+                // verified-state-at-this-instant is the security property we
+                // want; a concurrent attacker with write access to the
+                // parent directory would already have bigger problems.
+                let _verified_parent =
+                    rimap_core::fs::ensure_tight_dir(parent, our_uid).map_err(|source| {
+                        AuditError::ParentDir {
+                            path: opts.path.clone(),
+                            source,
+                        }
+                    })?;
+            }
+            #[cfg(not(unix))]
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).map_err(|source| AuditError::ParentDir {
+                    path: opts.path.clone(),
+                    source,
+                })?;
+            }
         }
         let file = crate::fs::writer_open_options()
             .open(&opts.path)
@@ -256,21 +274,6 @@ pub(crate) fn set_file_mode_0600(file: &File) {
 #[cfg(not(unix))]
 pub(crate) fn set_file_mode_0600(_file: &File) {}
 
-#[cfg(unix)]
-fn set_parent_mode_0700(parent: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-    if let Ok(meta) = std::fs::metadata(parent) {
-        let mut perms = meta.permissions();
-        perms.set_mode(0o700);
-        if let Err(err) = std::fs::set_permissions(parent, perms) {
-            tracing::warn!(error = %err, "failed to set audit parent dir mode 0700");
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn set_parent_mode_0700(_parent: &Path) {}
-
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::panic, reason = "tests")]
 mod tests {
@@ -279,9 +282,22 @@ mod tests {
     use crate::AuditError;
     use crate::writer::{AuditOptions, AuditWriter};
 
+    /// Create a temporary directory with mode 0700 so that `ensure_tight_dir`
+    /// accepts it as an audit parent on Unix. On non-Unix the default mode is
+    /// fine.
+    fn tight_tempdir() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        dir
+    }
+
     #[test]
     fn open_creates_file_and_acquires_lock() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -298,7 +314,7 @@ mod tests {
 
     #[test]
     fn second_open_against_same_path_fails_with_locked() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let _first = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -326,7 +342,7 @@ mod tests {
 
     #[test]
     fn drop_releases_the_lock() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         {
             let _first = AuditWriter::open(&AuditOptions {
@@ -373,7 +389,7 @@ mod tests {
         use crate::record::ids::{ProcessId, Seq, Timestamp};
         use crate::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -410,7 +426,7 @@ mod tests {
         use crate::record::ids::{ProcessId, Seq, Timestamp};
         use crate::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -445,7 +461,7 @@ mod tests {
         use crate::record::ids::{ProcessId, Seq, Timestamp};
         use crate::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -515,7 +531,7 @@ mod tests {
         use crate::record::ids::{ProcessId, Seq, Timestamp};
         use crate::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -557,7 +573,7 @@ mod tests {
 
     #[test]
     fn writer_holds_a_stable_process_id() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path,
@@ -575,7 +591,7 @@ mod tests {
 
     #[test]
     fn writer_allocates_sequential_seqs() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path,
@@ -596,7 +612,7 @@ mod tests {
 
     #[test]
     fn writer_resumes_seq_from_initial_seq_option() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path,
@@ -615,7 +631,7 @@ mod tests {
     fn log_auth_writes_one_record_with_allocated_seq() {
         use crate::record::{Auth, AuthResult};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -659,7 +675,7 @@ mod tests {
     fn log_auth_uses_writer_process_id_for_every_record() {
         use crate::record::{Auth, AuthResult};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -705,7 +721,7 @@ mod tests {
         use crate::writer::ProcessStartInputs;
         use crate::writer::self_check::TrailingState;
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -749,7 +765,7 @@ mod tests {
     fn log_process_end_writes_valid_record() {
         use crate::record::{ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -781,7 +797,7 @@ mod tests {
     fn log_process_end_uses_writer_process_id() {
         use crate::record::{ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),
@@ -808,12 +824,52 @@ mod tests {
         assert_eq!(v["reason"], "signal_term");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn open_rejects_audit_parent_that_is_a_symlink() {
+        // Security invariant from #147: AuditWriter::open must refuse a
+        // symlinked parent directory. Before #147, set_parent_mode_0700
+        // silently chmodded through the symlink; after #147 we fail loud.
+        use crate::record::ids::Seq;
+        use std::os::unix::fs::PermissionsExt as _;
+        use tempfile::TempDir;
+
+        let base = TempDir::new().unwrap();
+        let real_parent = base.path().join("real");
+        std::fs::create_dir_all(&real_parent).unwrap();
+        std::fs::set_permissions(&real_parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let link_parent = base.path().join("link");
+        std::os::unix::fs::symlink(&real_parent, &link_parent).unwrap();
+
+        let audit_path = link_parent.join("audit.jsonl");
+        let err = AuditWriter::open(&AuditOptions {
+            path: audit_path,
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap_err();
+
+        match err {
+            AuditError::ParentDir { source, .. } => {
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+                assert!(
+                    source.to_string().contains("symlink"),
+                    "expected symlink-specific error, got: {source}",
+                );
+            }
+            other => panic!("expected ParentDir, got {other:?}"),
+        }
+    }
+
     #[test]
     fn log_process_start_marks_inode_unchanged_when_matching() {
         use crate::writer::ProcessStartInputs;
         use crate::writer::self_check::TrailingState;
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),

--- a/crates/rimap-audit/tests/concurrent_lock.rs
+++ b/crates/rimap-audit/tests/concurrent_lock.rs
@@ -5,11 +5,23 @@
 #![expect(clippy::panic, reason = "tests")]
 
 use rimap_audit::{AuditError, AuditOptions, AuditWriter};
+use std::os::unix::fs::PermissionsExt as _;
 use tempfile::TempDir;
+
+/// Tempdir whose mode is forced to 0700. Required because `AuditWriter::open`
+/// (post-#147) refuses parent directories with looser permissions, and
+/// `tempfile::TempDir::new()` may create with 0755 depending on the system
+/// `umask`. Each integration test that uses `dir.path()` directly as the
+/// audit parent must build the tempdir through this helper.
+fn tight_tempdir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
 
 #[test]
 fn concurrent_open_fails_fast_with_locked() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let _first = AuditWriter::open(&AuditOptions {
         path: path.clone(),
@@ -38,7 +50,7 @@ fn concurrent_open_fails_fast_with_locked() {
 
 #[test]
 fn lock_released_after_drop_allows_reopen() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     {
         let _first = AuditWriter::open(&AuditOptions {

--- a/crates/rimap-audit/tests/fail_open.rs
+++ b/crates/rimap-audit/tests/fail_open.rs
@@ -10,6 +10,15 @@ use rimap_audit::record::{AuditRecord, Payload, ProcessEnd, ProcessEndReason};
 use rimap_audit::{AuditOptions, AuditWriter};
 use tempfile::TempDir;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
+
 fn make_record(seq: u64) -> AuditRecord {
     AuditRecord {
         seq: Seq(seq),
@@ -36,7 +45,7 @@ fn unlock_parent(parent: &std::path::Path) {
 
 #[test]
 fn fail_open_false_propagates_rotation_failure() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let writer = AuditWriter::open(&AuditOptions {
         path: path.clone(),
@@ -64,7 +73,7 @@ fn fail_open_false_propagates_rotation_failure() {
 
 #[test]
 fn fail_open_true_suppresses_rotation_failure_and_counts_it() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let writer = AuditWriter::open(&AuditOptions {
         path: path.clone(),

--- a/crates/rimap-audit/tests/rotation.rs
+++ b/crates/rimap-audit/tests/rotation.rs
@@ -6,12 +6,22 @@
 #![expect(clippy::panic, reason = "tests")]
 
 use std::collections::BTreeSet;
+use std::os::unix::fs::PermissionsExt as _;
 
 use rimap_audit::{
     AuditError, AuditOptions, AuditRecord, AuditWriter, Payload, ProcessEnd, ProcessEndReason,
     ProcessId, Seq, Timestamp,
 };
 use tempfile::TempDir;
+
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
 
 fn record(seq: u64) -> AuditRecord {
     AuditRecord {
@@ -29,7 +39,7 @@ const N: u64 = 25;
 
 #[test]
 fn writes_survive_multiple_rotations() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let writer = AuditWriter::open(&AuditOptions {
         path: path.clone(),
@@ -69,7 +79,7 @@ fn writes_survive_multiple_rotations() {
 
 #[test]
 fn lock_persists_across_rotations() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let writer = AuditWriter::open(&AuditOptions {
         path: path.clone(),

--- a/crates/rimap-core/Cargo.toml
+++ b/crates/rimap-core/Cargo.toml
@@ -28,3 +28,4 @@ rustix = { workspace = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 proptest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/rimap-core/Cargo.toml
+++ b/crates/rimap-core/Cargo.toml
@@ -22,6 +22,9 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 strum = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true }
 proptest = { workspace = true }

--- a/crates/rimap-core/src/fs.rs
+++ b/crates/rimap-core/src/fs.rs
@@ -1,0 +1,261 @@
+//! Filesystem primitives shared across `rimap-*` crates.
+//!
+//! Currently hosts [`ensure_tight_dir`], the TOCTOU-safe "create or verify
+//! that this directory is mode 0700 and owned by us, refusing symlinks" op
+//! used by the daemon socket-directory bootstrap and the audit writer's
+//! parent-directory tightening.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::io;
+use std::os::fd::OwnedFd;
+use std::path::Path;
+
+use rustix::fs::{AtFlags, FileType, Mode, OFlags, fstat, mkdirat, open, openat, statat};
+use rustix::io::Errno;
+
+/// Flags used for every directory handle this module holds.
+///
+/// `O_NOFOLLOW` refuses a symlinked leaf, `O_DIRECTORY` refuses a non-directory,
+/// `O_CLOEXEC` stops the fd leaking across `exec`, `O_PATH` means we only need
+/// the fd as an anchor for subsequent `*at` syscalls — we never read or write
+/// it directly.
+const DIR_OFLAGS: OFlags = OFlags::PATH
+    .union(OFlags::DIRECTORY)
+    .union(OFlags::NOFOLLOW)
+    .union(OFlags::CLOEXEC);
+
+/// Ensure `dir` exists, is owned by `our_uid`, is mode 0700, and is not a
+/// symlink. Creates the directory (mode 0700) if missing.
+///
+/// The leaf is opened with `openat(parent_fd, name, O_NOFOLLOW | O_DIRECTORY
+/// | O_CLOEXEC | O_PATH)` so that a hostile swap of an ancestor between
+/// syscalls cannot smuggle the caller onto a different directory. The returned
+/// [`OwnedFd`] pins the verified directory — callers that perform follow-up
+/// syscalls inside `dir` should keep the fd alive and use `*at` syscalls
+/// against it rather than re-walking the path. Callers that need only the
+/// invariant can drop the fd immediately.
+///
+/// Refuses to operate on a symlinked directory, a wrong-owner directory, or a
+/// too-permissive directory — these signal a hostile or compromised filesystem
+/// state and should fail loudly rather than be "fixed" silently.
+///
+/// # Errors
+/// Returns `PermissionDenied` if the directory (or its leaf component) is a
+/// symlink, is owned by a different UID, or has mode other than 0700. A
+/// directory with any of setuid, setgid, or sticky bits set is rejected for
+/// the same reason — remove those bits (e.g. `chmod 0700`) to proceed.
+/// Returns `NotADirectory` if the path exists but is not a directory. Returns
+/// the underlying I/O error from `create_dir_all` / `mkdirat` on bootstrap.
+pub fn ensure_tight_dir(dir: &Path, our_uid: u32) -> io::Result<OwnedFd> {
+    let (parent, name) = split_parent_and_name(dir)?;
+
+    let parent_fd = open_parent(parent)?;
+
+    match openat(&parent_fd, name, DIR_OFLAGS, Mode::empty()) {
+        Ok(fd) => verify_dir(&fd, dir, our_uid).map(|()| fd),
+        // `O_NOFOLLOW | O_DIRECTORY` on a symlink-to-directory returns either
+        // `ELOOP` or `ENOTDIR` depending on kernel path-walk order; treat both
+        // as "leaf is a symlink" and refuse.
+        Err(Errno::LOOP | Errno::NOTDIR) if leaf_is_symlink(&parent_fd, name) => {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("directory {} is a symlink", dir.display()),
+            ))
+        }
+        Err(Errno::NOTDIR) => Err(io::Error::new(
+            io::ErrorKind::NotADirectory,
+            format!("parent of {} is not a directory", dir.display()),
+        )),
+        Err(Errno::NOENT) => {
+            if let Err(e) = mkdirat(&parent_fd, name, Mode::from_raw_mode(0o700))
+                && e != Errno::EXIST
+            {
+                return Err(io::Error::from_raw_os_error(e.raw_os_error()));
+            }
+            let fd = openat(&parent_fd, name, DIR_OFLAGS, Mode::empty())
+                .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
+            verify_dir(&fd, dir, our_uid).map(|()| fd)
+        }
+        Err(e) => Err(io::Error::from_raw_os_error(e.raw_os_error())),
+    }
+}
+
+fn leaf_is_symlink(parent_fd: &OwnedFd, name: &OsStr) -> bool {
+    statat(parent_fd, name, AtFlags::SYMLINK_NOFOLLOW)
+        .map(|s| FileType::from_raw_mode(s.st_mode) == FileType::Symlink)
+        .unwrap_or(false)
+}
+
+fn split_parent_and_name(dir: &Path) -> io::Result<(&Path, &OsStr)> {
+    let parent = dir.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("directory {} has no parent", dir.display()),
+        )
+    })?;
+    let name = dir.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("directory {} has no file name", dir.display()),
+        )
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    Ok((parent, name))
+}
+
+fn open_parent(parent: &Path) -> io::Result<OwnedFd> {
+    match open(parent, DIR_OFLAGS, Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::LOOP | Errno::NOTDIR) if path_is_symlink(parent) => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("parent {} is a symlink", parent.display()),
+        )),
+        Err(Errno::NOTDIR) => Err(io::Error::new(
+            io::ErrorKind::NotADirectory,
+            format!("parent {} is not a directory", parent.display()),
+        )),
+        Err(Errno::NOENT) => {
+            std::fs::create_dir_all(parent)?;
+            open(parent, DIR_OFLAGS, Mode::empty())
+                .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
+        }
+        Err(e) => Err(io::Error::from_raw_os_error(e.raw_os_error())),
+    }
+}
+
+fn path_is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+fn verify_dir(fd: &OwnedFd, dir: &Path, our_uid: u32) -> io::Result<()> {
+    let stat = fstat(fd).map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
+    let stat_uid = uid_to_u32(stat.st_uid);
+    if stat_uid != our_uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "directory {} is owned by uid {}, not {}",
+                dir.display(),
+                stat_uid,
+                our_uid
+            ),
+        ));
+    }
+    let perm_bits = Mode::from_raw_mode(stat.st_mode)
+        & (Mode::RWXU | Mode::RWXG | Mode::RWXO | Mode::SUID | Mode::SGID | Mode::SVTX);
+    if perm_bits != Mode::RWXU {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "directory {} has mode {:o}, require 0700",
+                dir.display(),
+                perm_bits.as_raw_mode()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn uid_to_u32<T: TryInto<u32>>(uid: T) -> u32 {
+    uid.try_into().unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::ensure_tight_dir;
+    use std::io;
+    use std::os::unix::fs::PermissionsExt as _;
+    use tempfile::TempDir;
+
+    fn our_uid() -> u32 {
+        rustix::process::geteuid().as_raw()
+    }
+
+    #[test]
+    fn creates_dir_when_absent() {
+        let base = TempDir::new().unwrap();
+        let target = base.path().join("r/sock-dir");
+        ensure_tight_dir(&target, our_uid()).unwrap();
+        assert!(target.is_dir());
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn accepts_existing_dir_that_is_already_0700_and_ours() {
+        let base = TempDir::new().unwrap();
+        let target = base.path().join("ok");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
+        ensure_tight_dir(&target, our_uid()).unwrap();
+    }
+
+    #[test]
+    fn rejects_too_permissive_dir() {
+        let base = TempDir::new().unwrap();
+        let target = base.path().join("slack");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let err = ensure_tight_dir(&target, our_uid()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("0700"));
+    }
+
+    #[test]
+    fn rejects_symlinked_dir() {
+        let base = TempDir::new().unwrap();
+        let real = base.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let err = ensure_tight_dir(&link, our_uid()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("symlink"));
+    }
+
+    #[test]
+    fn rejects_symlinked_ancestor() {
+        let base = TempDir::new().unwrap();
+        let real_parent = base.path().join("real");
+        std::fs::create_dir_all(real_parent.join("ok")).unwrap();
+        std::fs::set_permissions(&real_parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(
+            real_parent.join("ok"),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real_parent, &link).unwrap();
+        let err = ensure_tight_dir(&link.join("ok"), our_uid()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn rejects_wrong_owner_reports_uid_in_message() {
+        // Cannot actually chown to a different UID without root, so we
+        // assert the rejection message contains the uid we asked for by
+        // passing our_uid + 1 (the dir is ours). This forces the wrong-uid
+        // branch deterministically.
+        let base = TempDir::new().unwrap();
+        let target = base.path().join("mine");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let bogus_uid = our_uid().wrapping_add(1);
+        let err = ensure_tight_dir(&target, bogus_uid).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            err.to_string().contains(&bogus_uid.to_string()),
+            "expected uid {bogus_uid} in error message: {err}",
+        );
+    }
+}

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod credential;
 pub use credential::{CredentialResolver, CredentialResolverError, CredentialSource};
 pub mod error;
 pub mod folder_name;
+#[cfg(unix)]
+pub mod fs;
 pub mod posture;
 pub mod posture_matrix;
 pub mod session;

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -60,7 +60,9 @@ fn require_proton() -> Option<ProtonConfig> {
 }
 
 fn build_connection(cfg: &ProtonConfig) -> Connection {
-    let dir = tempfile::tempdir().unwrap();
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
     let audit = AuditWriter::open(&AuditOptions {
         path: dir.path().join("audit.jsonl"),
         rotate_bytes: 0,

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -556,6 +556,14 @@ impl ConnectedHarness {
     ) -> Result<Self, HarnessError> {
         let harness = DovecotHarness::try_start()?;
         let audit_dir = TempDir::new().expect("tempdir");
+        // `AuditWriter::open` (post-#147) refuses parents with looser modes;
+        // `tempfile::TempDir::new()` may inherit 0755 from the system umask.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(audit_dir.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("chmod 0700 on audit tempdir");
+        }
         let audit_path = audit_dir.path().join("audit.jsonl");
         let audit = AuditWriter::open(&AuditOptions {
             path: audit_path,

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -55,7 +55,7 @@ tempfile = { workspace = true }
 arc-swap = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "1.1", default-features = false, features = ["process", "fs"] }
+rustix = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/rimap-server/src/boot/audit_init.rs
+++ b/crates/rimap-server/src/boot/audit_init.rs
@@ -102,6 +102,16 @@ mod tests {
 
     use super::init_audit_writer_multi;
 
+    /// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+    /// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+    /// `umask` (often 0755).
+    fn tight_tempdir() -> TempDir {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        dir
+    }
+
     fn write_config(dir: &TempDir) -> std::path::PathBuf {
         let audit = dir.path().join("audit.jsonl");
         let config_path = dir.path().join("config.toml");
@@ -130,7 +140,7 @@ allowed_base_dir = "{}"
     fn process_start_emitted_as_first_record() {
         use sha2::{Digest, Sha256};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let config_path = write_config(&dir);
 
         let raw = rimap_config::loader::load_from_path(&config_path).unwrap();
@@ -167,7 +177,7 @@ allowed_base_dir = "{}"
     fn process_end_writes_after_start() {
         use rimap_audit::{ProcessEnd, ProcessEndReason};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let config_path = write_config(&dir);
         let raw = rimap_config::loader::load_from_path(&config_path).unwrap();
         let validated = rimap_config::validate::validate_legacy_as_multi(raw).unwrap();
@@ -202,7 +212,7 @@ allowed_base_dir = "{}"
             ProcessId, Seq, Timestamp,
         };
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let config_path = write_config(&dir);
         let raw = rimap_config::loader::load_from_path(&config_path).unwrap();
         let validated = rimap_config::validate::validate_legacy_as_multi(raw).unwrap();

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -110,6 +110,16 @@ mod tests {
 
     use crate::cli::dry_run::run;
 
+    /// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+    /// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+    /// `umask` (often 0755).
+    fn tight_tempdir() -> TempDir {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        dir
+    }
+
     fn write_minimal_config(dir: &TempDir) -> PathBuf {
         let audit = dir.path().join("audit.jsonl");
         let config_path = dir.path().join("config.toml");
@@ -133,7 +143,7 @@ allowed_base_dir = "{}"
 
     #[tokio::test]
     async fn dry_run_prints_matrix_with_default_posture() {
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = write_minimal_config(&dir);
         let mut out = Vec::new();
         run(&path, &mut out).await.unwrap();
@@ -150,7 +160,7 @@ allowed_base_dir = "{}"
     async fn second_dry_run_against_same_audit_fails_with_config_error() {
         use rimap_audit::{AuditOptions, AuditWriter};
 
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = write_minimal_config(&dir);
 
         // First dry-run acquires the lock for the duration of the call.
@@ -188,7 +198,7 @@ allowed_base_dir = "{}"
         // matrix at runtime, so printing them as `[deny]` alongside content
         // tools misleads users into thinking the tools are unavailable. They
         // should appear in their own "always available" section instead.
-        let dir = TempDir::new().unwrap();
+        let dir = tight_tempdir();
         let path = write_minimal_config(&dir);
         let mut out = Vec::new();
         run(&path, &mut out).await.unwrap();

--- a/crates/rimap-server/src/daemon/audit_sink.rs
+++ b/crates/rimap-server/src/daemon/audit_sink.rs
@@ -85,8 +85,15 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
-    fn fresh_writer() -> (TempDir, AuditWriter, PathBuf) {
+    fn tight_tempdir() -> TempDir {
+        use std::os::unix::fs::PermissionsExt as _;
         let dir = TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        dir
+    }
+
+    fn fresh_writer() -> (TempDir, AuditWriter, PathBuf) {
+        let dir = tight_tempdir();
         let path = dir.path().join("a.jsonl");
         let writer = AuditWriter::open(&AuditOptions {
             path: path.clone(),

--- a/crates/rimap-server/src/daemon/socket_setup.rs
+++ b/crates/rimap-server/src/daemon/socket_setup.rs
@@ -1,201 +1,36 @@
-//! Prepare the daemon's socket parent directory with tight permissions.
+//! Daemon socket-directory preparation — thin wrapper over
+//! [`rimap_core::fs::ensure_tight_dir`].
+//!
+//! The production primitive lives in `rimap-core::fs` so the audit writer
+//! can share it. This module retains its crate-local name for the one
+//! daemon caller (`main.rs`) and continues to host the socket-flavoured
+//! integration tests that exercise the full code path through rustix.
 
 #![cfg(unix)]
 
-use std::ffi::OsStr;
 use std::io;
 use std::os::fd::OwnedFd;
 use std::path::Path;
 
-use rustix::fs::{Mode, OFlags, fstat, mkdirat, open, openat};
-use rustix::io::Errno;
-
-/// Open flags used for every directory handle we hold. `O_NOFOLLOW` refuses a
-/// symlinked leaf, `O_DIRECTORY` refuses a non-directory, `O_CLOEXEC` stops the
-/// fd leaking across exec, `O_PATH` means we only need the fd as an anchor for
-/// subsequent `*at` syscalls — we never read or write it directly.
-const DIR_OFLAGS: OFlags = OFlags::PATH
-    .union(OFlags::DIRECTORY)
-    .union(OFlags::NOFOLLOW)
-    .union(OFlags::CLOEXEC);
-
-/// Ensure `dir` exists, is owned by `our_uid`, is mode 0700, and is not a
-/// symlink. Creates the directory (mode 0700) if missing.
-///
-/// The leaf is opened with `openat(parent_fd, name, O_NOFOLLOW | O_DIRECTORY
-/// | O_CLOEXEC | O_PATH)` so that a hostile swap of an ancestor between
-/// syscalls cannot smuggle us onto a different directory. The returned
-/// `OwnedFd` pins the verified directory — callers should keep it alive and
-/// use `*at` syscalls against it rather than re-walking the path.
-///
-/// Refuses to operate on a symlinked directory, a wrong-owner directory, or a
-/// too-permissive directory — these signal a hostile or compromised filesystem
-/// state and should fail loudly rather than be "fixed" silently.
+/// Ensure the daemon socket's parent directory exists, is owned by the
+/// running user, and is mode 0700 — delegating to the shared helper.
 ///
 /// # Errors
-/// Returns `PermissionDenied` if the directory (or its leaf component) is a
-/// symlink, is owned by a different UID, or has mode other than 0700. A
-/// directory with any of setuid, setgid, or sticky bits set is rejected for
-/// the same reason — remove those bits (e.g. `chmod 0700`) to proceed.
-/// Returns `NotADirectory` if the path exists but is not a directory. Returns
-/// the underlying I/O error from `create_dir_all` / `mkdirat` on bootstrap.
+/// Propagates every error from [`rimap_core::fs::ensure_tight_dir`].
 pub fn prepare_socket_dir(dir: &Path, our_uid: u32) -> io::Result<OwnedFd> {
-    let (parent, name) = split_parent_and_name(dir)?;
-
-    let parent_fd = open_parent(parent)?;
-
-    match openat(&parent_fd, name, DIR_OFLAGS, Mode::empty()) {
-        Ok(fd) => verify_dir(&fd, dir, our_uid).map(|()| fd),
-        // `O_NOFOLLOW | O_DIRECTORY` on a symlink-to-directory returns either
-        // `ELOOP` or `ENOTDIR` depending on kernel path-walk order; treat both
-        // as "leaf is a symlink" and refuse.
-        Err(Errno::LOOP | Errno::NOTDIR) if leaf_is_symlink(&parent_fd, name) => {
-            Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("socket directory {} is a symlink", dir.display()),
-            ))
-        }
-        Err(Errno::NOTDIR) => Err(io::Error::new(
-            io::ErrorKind::NotADirectory,
-            format!("socket parent {} is not a directory", dir.display()),
-        )),
-        Err(Errno::NOENT) => {
-            // `EEXIST` means a concurrent starter won the mkdir; the directory
-            // now exists, so fall through to the re-openat below. The
-            // subsequent fstat + uid/mode check will verify the winning
-            // creator set the mode correctly — if they didn't, we fail closed.
-            if let Err(e) = mkdirat(&parent_fd, name, Mode::from_raw_mode(0o700))
-                && e != Errno::EXIST
-            {
-                return Err(io::Error::from_raw_os_error(e.raw_os_error()));
-            }
-            let fd = openat(&parent_fd, name, DIR_OFLAGS, Mode::empty())
-                .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
-            verify_dir(&fd, dir, our_uid).map(|()| fd)
-        }
-        Err(e) => Err(io::Error::from_raw_os_error(e.raw_os_error())),
-    }
-}
-
-/// Distinguish "leaf is a symlink" from other `ENOTDIR` causes so we can give
-/// the caller an accurate error kind. We use `fstatat` with
-/// `AT_SYMLINK_NOFOLLOW` to inspect the leaf without traversing it.
-fn leaf_is_symlink(parent_fd: &OwnedFd, name: &OsStr) -> bool {
-    use rustix::fs::{AtFlags, FileType, statat};
-    statat(parent_fd, name, AtFlags::SYMLINK_NOFOLLOW)
-        .map(|s| FileType::from_raw_mode(s.st_mode) == FileType::Symlink)
-        .unwrap_or(false)
-}
-
-/// Split `dir` into a (parent, leaf) pair. Rejects paths that have no parent
-/// (e.g. "/" or a bare filename with no directory component) because those
-/// cannot be opened via the parent-fd-pinned flow.
-fn split_parent_and_name(dir: &Path) -> io::Result<(&Path, &OsStr)> {
-    let parent = dir.parent().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("socket directory {} has no parent", dir.display()),
-        )
-    })?;
-    let name = dir.file_name().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("socket directory {} has no file name", dir.display()),
-        )
-    })?;
-    // `dir.parent()` returns "" for a bare filename like "foo"; coerce to "."
-    // so `open(parent)` actually resolves CWD.
-    let parent = if parent.as_os_str().is_empty() {
-        Path::new(".")
-    } else {
-        parent
-    };
-    Ok((parent, name))
-}
-
-/// Open `parent` as a directory fd. `O_NOFOLLOW` refuses a symlinked last
-/// component of the parent path, catching the "ancestor swap" attack where a
-/// symlink is spliced in above the target dir. Falls back to `create_dir_all`
-/// if the parent chain is missing — the ancestors are expected to be
-/// system-managed (e.g. `XDG_RUNTIME_DIR`) so bootstrapping them is
-/// acceptable; the symlink-safety guarantee applies to the leaf we return.
-///
-/// Note: `O_NOFOLLOW` only protects the final component. Earlier components
-/// of `parent` are resolved by the kernel and may still traverse symlinks —
-/// that is acceptable here because the ancestors are trusted system paths.
-fn open_parent(parent: &Path) -> io::Result<OwnedFd> {
-    match open(parent, DIR_OFLAGS, Mode::empty()) {
-        Ok(fd) => Ok(fd),
-        Err(Errno::LOOP | Errno::NOTDIR) if path_is_symlink(parent) => Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("socket parent {} is a symlink", parent.display()),
-        )),
-        Err(Errno::NOTDIR) => Err(io::Error::new(
-            io::ErrorKind::NotADirectory,
-            format!("socket parent {} is not a directory", parent.display()),
-        )),
-        Err(Errno::NOENT) => {
-            std::fs::create_dir_all(parent)?;
-            open(parent, DIR_OFLAGS, Mode::empty())
-                .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
-        }
-        Err(e) => Err(io::Error::from_raw_os_error(e.raw_os_error())),
-    }
-}
-
-/// Check whether `path` is itself a symlink (via `lstat`). Used only to pick
-/// the right error kind — the open has already failed, so this is not a
-/// TOCTOU window.
-fn path_is_symlink(path: &Path) -> bool {
-    std::fs::symlink_metadata(path)
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false)
-}
-
-/// Enforce ownership + mode invariants against a directory fd. Using `fstat`
-/// on the already-opened fd removes any TOCTOU gap against the path walk.
-fn verify_dir(fd: &OwnedFd, dir: &Path, our_uid: u32) -> io::Result<()> {
-    let stat = fstat(fd).map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
-    // `st_uid` is `u32` on Linux but `uid_t` on other Unixes; the rustix
-    // `as_raw_mode` / bitflag round-trip is the platform-agnostic path.
-    let stat_uid = uid_to_u32(stat.st_uid);
-    if stat_uid != our_uid {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "socket directory {} is owned by uid {}, not {}",
-                dir.display(),
-                stat_uid,
-                our_uid
-            ),
-        ));
-    }
-    let perm_bits = Mode::from_raw_mode(stat.st_mode)
-        & (Mode::RWXU | Mode::RWXG | Mode::RWXO | Mode::SUID | Mode::SGID | Mode::SVTX);
-    if perm_bits != Mode::RWXU {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "socket directory {} has mode {:o}, require 0700",
-                dir.display(),
-                perm_bits.as_raw_mode()
-            ),
-        ));
-    }
-    Ok(())
-}
-
-/// Normalize a `stat.st_uid` value (`uid_t` on some targets, `u32` on Linux)
-/// to `u32` without triggering `useless_conversion`. `uid_t` is unsigned on
-/// every Unix target rustix supports, so truncation cannot happen in practice.
-fn uid_to_u32<T: TryInto<u32>>(uid: T) -> u32 {
-    uid.try_into().unwrap_or(u32::MAX)
+    rimap_core::fs::ensure_tight_dir(dir, our_uid)
 }
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::*;
+    //! The integration tests here exercise the same code paths as the
+    //! `rimap_core::fs::tests` unit tests; both are kept because the
+    //! socket-setup caller is a security-sensitive code path and bisecting
+    //! a future regression is easier when both test suites are green.
+
+    use super::prepare_socket_dir;
+    use std::io;
     use std::os::unix::fs::PermissionsExt as _;
     use tempfile::TempDir;
 
@@ -214,26 +49,6 @@ mod tests {
     }
 
     #[test]
-    fn accepts_existing_dir_that_is_already_0700_and_ours() {
-        let base = TempDir::new().unwrap();
-        let target = base.path().join("ok");
-        std::fs::create_dir_all(&target).unwrap();
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
-        prepare_socket_dir(&target, our_uid()).unwrap();
-    }
-
-    #[test]
-    fn rejects_too_permissive_dir() {
-        let base = TempDir::new().unwrap();
-        let target = base.path().join("slack");
-        std::fs::create_dir_all(&target).unwrap();
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let err = prepare_socket_dir(&target, our_uid()).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
-        assert!(err.to_string().contains("0700"));
-    }
-
-    #[test]
     fn rejects_symlinked_dir() {
         let base = TempDir::new().unwrap();
         let real = base.path().join("real");
@@ -247,20 +62,13 @@ mod tests {
     }
 
     #[test]
-    fn rejects_symlinked_ancestor() {
+    fn rejects_too_permissive_dir() {
         let base = TempDir::new().unwrap();
-        let real_parent = base.path().join("real");
-        std::fs::create_dir_all(real_parent.join("ok")).unwrap();
-        std::fs::set_permissions(&real_parent, std::fs::Permissions::from_mode(0o700)).unwrap();
-        std::fs::set_permissions(
-            real_parent.join("ok"),
-            std::fs::Permissions::from_mode(0o700),
-        )
-        .unwrap();
-        let link = base.path().join("link");
-        std::os::unix::fs::symlink(&real_parent, &link).unwrap();
-        // Asking us to "prepare" link/ok must refuse because an ancestor is a symlink.
-        let err = prepare_socket_dir(&link.join("ok"), our_uid()).unwrap_err();
+        let target = base.path().join("slack");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let err = prepare_socket_dir(&target, our_uid()).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("0700"));
     }
 }

--- a/crates/rimap-server/src/daemon/state.rs
+++ b/crates/rimap-server/src/daemon/state.rs
@@ -198,10 +198,17 @@ mod tests {
         use std::sync::Arc;
 
         use rimap_audit::{AuditOptions, AuditWriter, Seq};
-        use tempfile::tempdir;
+        use tempfile::TempDir;
 
         use super::DaemonState;
         use crate::boot::registry::AccountRegistry;
+
+        fn tight_tempdir() -> TempDir {
+            use std::os::unix::fs::PermissionsExt as _;
+            let dir = TempDir::new().unwrap();
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+            dir
+        }
 
         fn build_state(dir: &std::path::Path) -> Arc<DaemonState> {
             let audit = AuditWriter::open(&AuditOptions {
@@ -223,8 +230,8 @@ mod tests {
             ))
         }
 
-        let dir_a = tempdir().unwrap();
-        let dir_b = tempdir().unwrap();
+        let dir_a = tight_tempdir();
+        let dir_b = tight_tempdir();
         let state_a = build_state(dir_a.path());
         let state_b = build_state(dir_b.path());
 

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -304,9 +304,18 @@ mod tests {
     use rimap_audit::{AuditWriter, Seq, ToolStartInputs, cancellation_channel, spawn_drainer};
     use rimap_core::SessionId;
     use rimap_core::tool::ToolName;
-    use tempfile::tempdir;
 
     use super::AuditEnvelopeGuard;
+
+    /// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+    /// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+    /// `umask` (often 0755).
+    fn tight_tempdir() -> tempfile::TempDir {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        dir
+    }
 
     fn test_writer(path: std::path::PathBuf) -> AuditWriter {
         AuditWriter::open(&AuditOptions {
@@ -327,7 +336,7 @@ mod tests {
     /// This is the core invariant for #71, #99, and the `session_id` fix.
     #[tokio::test]
     async fn dropped_guard_enqueues_cancellation_record() {
-        let dir = tempdir().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = test_writer(path.clone());
 
@@ -394,7 +403,7 @@ mod tests {
     /// A disarmed guard's drop is a no-op: no cancellation record is written.
     #[tokio::test]
     async fn disarmed_guard_does_not_enqueue() {
-        let dir = tempdir().unwrap();
+        let dir = tight_tempdir();
         let path = dir.path().join("audit.jsonl");
         let writer = test_writer(path.clone());
 
@@ -440,7 +449,7 @@ mod tests {
         use crate::daemon::state::{DaemonState, SessionState};
         use crate::mcp::server::ImapMcpServer;
 
-        let dir = tempdir().unwrap();
+        let dir = tight_tempdir();
         let audit_path = dir.path().join("audit.jsonl");
         let audit = AuditWriter::open(&AuditOptions {
             path: audit_path,

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -340,7 +340,15 @@ mod tests {
         use crate::daemon::state::{DaemonState, SessionState};
         use crate::mcp::server::ImapMcpServer;
 
-        let tmp = TempDir::new().expect("tempdir");
+        fn tight_tempdir() -> TempDir {
+            use std::os::unix::fs::PermissionsExt as _;
+            let dir = TempDir::new().expect("tempdir");
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("chmod 0700 on audit tempdir");
+            dir
+        }
+
+        let tmp = tight_tempdir();
         let audit_path = tmp.path().join("audit.jsonl");
         let audit = AuditWriter::open(&AuditOptions {
             path: audit_path.clone(),

--- a/crates/rimap-server/tests/audit_fail_open.rs
+++ b/crates/rimap-server/tests/audit_fail_open.rs
@@ -9,11 +9,20 @@
 
 use rimap_audit::{AuditOptions, AuditWriter, Seq, ToolStartInputs};
 use rimap_core::tool::ToolName;
-use tempfile::tempdir;
+
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> tempfile::TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
 
 #[test]
 fn fail_open_suppresses_write_failure_and_increments_counter() {
-    let dir = tempdir().unwrap();
+    let dir = tight_tempdir();
     let writer = AuditWriter::open(&AuditOptions {
         path: dir.path().join("audit.jsonl"),
         rotate_bytes: 10 * 1024 * 1024,
@@ -55,7 +64,7 @@ fn fail_open_false_propagates_write_failure() {
     // AuditError::Write. Not strictly required by #72 but pins the
     // complementary contract so a regression in either direction trips a
     // test.
-    let dir = tempdir().unwrap();
+    let dir = tight_tempdir();
     let writer = AuditWriter::open(&AuditOptions {
         path: dir.path().join("audit.jsonl"),
         rotate_bytes: 10 * 1024 * 1024,

--- a/crates/rimap-server/tests/audit_merge.rs
+++ b/crates/rimap-server/tests/audit_merge.rs
@@ -13,6 +13,16 @@ use rimap_audit::{
 };
 use tempfile::TempDir;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
+
 fn record(seq: u64, pid: ProcessId) -> AuditRecord {
     AuditRecord {
         seq: Seq(seq),
@@ -27,7 +37,7 @@ fn record(seq: u64, pid: ProcessId) -> AuditRecord {
 
 #[test]
 fn audit_merge_round_trips_synthetic_log() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
     let config_path = dir.path().join("config.toml");
     std::fs::write(&config_path, b"# synthetic config for test").unwrap();
@@ -91,7 +101,7 @@ fn audit_merge_round_trips_synthetic_log() {
 
 #[test]
 fn audit_merge_filters_by_kind() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let path = dir.path().join("audit.jsonl");
 
     {

--- a/crates/rimap-server/tests/daemon_graceful_shutdown.rs
+++ b/crates/rimap-server/tests/daemon_graceful_shutdown.rs
@@ -9,6 +9,17 @@ use tempfile::TempDir;
 use tokio::io::AsyncWriteExt as _;
 use tokio::net::UnixStream;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700 on tempdir");
+    dir
+}
+
 /// Verifies that SIGTERM (simulated via `shutdown.notify_one`) stops the accept
 /// loop and drains in-flight sessions within the 5s deadline configured in
 /// `run::drain_sessions`.
@@ -18,7 +29,7 @@ use tokio::net::UnixStream;
 /// within the drain window.
 #[tokio::test]
 async fn shutdown_drains_active_sessions_within_deadline() {
-    let tempdir = TempDir::new().expect("tempdir");
+    let tempdir = tight_tempdir();
     let audit_path = tempdir.path().join("audit.jsonl");
     let socket_path = tempdir.path().join("daemon.sock");
     let state = test_daemon_state(tempdir.path(), &audit_path);

--- a/crates/rimap-server/tests/daemon_happy_path.rs
+++ b/crates/rimap-server/tests/daemon_happy_path.rs
@@ -7,9 +7,20 @@ mod common;
 use common::daemon_harness::{TestDaemon, test_daemon_state};
 use tempfile::TempDir;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700 on tempdir");
+    dir
+}
+
 #[tokio::test]
 async fn daemon_spawns_and_shuts_down_cleanly() {
-    let tempdir = TempDir::new().expect("tempdir");
+    let tempdir = tight_tempdir();
     let audit_path = tempdir.path().join("audit.jsonl");
     let socket_path = tempdir.path().join("daemon.sock");
     let state = test_daemon_state(tempdir.path(), &audit_path);
@@ -29,7 +40,7 @@ async fn client_connects_and_sees_clean_session_lifecycle() {
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::UnixStream;
 
-    let tempdir = TempDir::new().expect("tempdir");
+    let tempdir = tight_tempdir();
     let audit_path = tempdir.path().join("audit.jsonl");
     let socket_path = tempdir.path().join("daemon.sock");
     let state = test_daemon_state(tempdir.path(), &audit_path);

--- a/crates/rimap-server/tests/daemon_max_sessions.rs
+++ b/crates/rimap-server/tests/daemon_max_sessions.rs
@@ -14,9 +14,20 @@ use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::UnixStream;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700 on tempdir");
+    dir
+}
+
 #[tokio::test]
 async fn daemon_rejects_session_past_limit() {
-    let tempdir = TempDir::new().expect("tempdir");
+    let tempdir = tight_tempdir();
     let audit_path = tempdir.path().join("audit.jsonl");
     let socket_path = tempdir.path().join("daemon.sock");
     // Bound at 1: the first connection holds the only permit; the
@@ -105,7 +116,7 @@ async fn daemon_releases_permit_on_session_end() {
     // Limit = 1. First connection holds the permit, then closes. A
     // second connection afterwards must succeed (no rejection) because
     // the permit dropped with the first session future.
-    let tempdir = TempDir::new().expect("tempdir");
+    let tempdir = tight_tempdir();
     let audit_path = tempdir.path().join("audit.jsonl");
     let socket_path = tempdir.path().join("daemon.sock");
     let state = test_daemon_state_with_limit(tempdir.path(), &audit_path, 1);

--- a/crates/rimap-server/tests/dispatch_ticket.rs
+++ b/crates/rimap-server/tests/dispatch_ticket.rs
@@ -22,6 +22,17 @@ use rimap_server::mcp::server::ImapMcpServer;
 use serde_json::json;
 use tempfile::TempDir;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700 on audit tempdir");
+    dir
+}
+
 struct TestFixture {
     server: ImapMcpServer,
     audit_path: std::path::PathBuf,
@@ -29,7 +40,7 @@ struct TestFixture {
 }
 
 fn build_test_server() -> TestFixture {
-    let audit_dir = TempDir::new().expect("audit tempdir");
+    let audit_dir = tight_tempdir();
     let audit_path = audit_dir.path().join("audit.jsonl");
     let audit = AuditWriter::open(&AuditOptions {
         path: audit_path.clone(),
@@ -194,7 +205,7 @@ async fn drop_during_body_enqueues_cancellation_tool_end() {
     use std::sync::Arc;
     use tokio::time::Duration;
 
-    let audit_dir = tempfile::TempDir::new().expect("audit tempdir");
+    let audit_dir = tight_tempdir();
     let audit_path = audit_dir.path().join("audit.jsonl");
     let audit = rimap_audit::AuditWriter::open(&rimap_audit::AuditOptions {
         path: audit_path.clone(),

--- a/crates/rimap-server/tests/dry_run_cli.rs
+++ b/crates/rimap-server/tests/dry_run_cli.rs
@@ -7,6 +7,16 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
+
 fn write_config(dir: &TempDir) -> std::path::PathBuf {
     let audit = dir.path().join("audit.jsonl");
     let path = dir.path().join("config.toml");
@@ -33,7 +43,7 @@ allowed_base_dir = "{}"
 
 #[test]
 fn dry_run_exits_zero_and_prints_matrix() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let config = write_config(&dir);
     Command::cargo_bin("rusty-imap-mcp")
         .unwrap()
@@ -64,7 +74,7 @@ fn missing_config_exits_non_zero_with_error_log() {
 
 #[test]
 fn unknown_tool_override_exits_non_zero() {
-    let dir = TempDir::new().unwrap();
+    let dir = tight_tempdir();
     let audit = dir.path().join("audit.jsonl");
     let config = dir.path().join("config.toml");
     let body = format!(

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -47,6 +47,16 @@ use tempfile::TempDir;
 use rimap_server::daemon::state::{DaemonState, SessionState};
 use rimap_server::mcp::server::ImapMcpServer;
 
+/// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
+/// modes after #147 and `tempfile::TempDir::new()` may inherit the system
+/// `umask` (often 0755).
+fn tight_tempdir() -> TempDir {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    dir
+}
+
 // ── Container harness (adapted from rimap-imap) ─────────────────────
 
 fn runtime() -> &'static str {
@@ -248,7 +258,7 @@ struct TestEnv {
 }
 
 fn build_test_env(harness: DovecotHarness) -> TestEnv {
-    let audit_dir = TempDir::new().expect("audit tempdir");
+    let audit_dir = tight_tempdir();
     let download_dir = TempDir::new().expect("download tempdir");
 
     let audit = AuditWriter::open(&AuditOptions {


### PR DESCRIPTION
## Summary

Wave B PR 5 of the polish release. Closes #147.

Extracts the TOCTOU-safe directory-tightening primitive from `rimap-server::daemon::socket_setup::prepare_socket_dir` into a shared `rimap_core::fs::ensure_tight_dir`. `prepare_socket_dir` becomes a one-line delegator. `rimap-audit::writer::AuditWriter::open` swaps from the best-effort `set_parent_mode_0700` chmod to the strict `ensure_tight_dir` check.

**Security tightening, not a regression.** A symlinked, wrong-owned, or non-`0700` audit parent directory now fails `AuditWriter::open` loudly (`AuditError::ParentDir`) instead of silently chmodding through the symlink. CHANGELOG entry flags this as minor-breaking for operators whose deployment scripts symlinked the audit dir.

Plan: [`docs/superpowers/plans/2026-04-23-polish-pr05-ensure-tight-dir.md`](docs/superpowers/plans/2026-04-23-polish-pr05-ensure-tight-dir.md).

## Commits

1. `b1a6c46` — `chore(deps): hoist rustix to workspace and add to rimap-core, rimap-audit`
2. `ca144e0` — `feat(rimap-core): add fs::ensure_tight_dir TOCTOU-safe dir primitive`
3. `c30a1c6` — `refactor(rimap-server): delegate prepare_socket_dir to rimap_core::fs`
4. `144bf92` — `refactor(rimap-audit): use rimap_core::fs::ensure_tight_dir for audit parent`
5. `d487b90` — `test(audit,server,imap): tighten test tempdirs to mode 0700`

## Notes

- Helper signature: `ensure_tight_dir(&Path, u32) -> io::Result<OwnedFd>`. Returns `OwnedFd` (not `()` as the issue body proposed) so `main.rs` retains its ancestor-symlink-swap defense-in-depth across `UnixListener::bind`. Audit-writer callers drop the fd.
- `socket_setup.rs` shrunk from 267 lines to 75 (one-line delegator + 3 retained integration tests).
- Test cascade: 20 test/test-support files needed `tight_tempdir()` (or inline `chmod 0700`) because `tempfile::TempDir::new()` inherits 0755 from a typical umask, which the new strict check rejects. Comprehensive batch fix in commit 5.
- `rustix` dep migrated from rimap-server's direct version pin to workspace inheritance; both `rimap-core` and `rimap-audit` now depend on it (Unix-only).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes (Dovecot integration tests included after the cascade fix)
- [x] `cargo deny check advisories bans licenses` clean
- [x] `typos` clean
- [x] New behavioural test (`open_rejects_audit_parent_that_is_a_symlink`) proves the security tightening
- [x] CHANGELOG entry under `[Unreleased] / Changed`

Closes #147.