### PR TITLE
fix(rimap-audit,rimap-server): polish PR 6 — &Map audit APIs (#149)

### DIFF
--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::record::{
 };
 pub use crate::redact::{
     FieldPolicy, RedactionSalt, RedactionSchema, Redactor, ToolRedactionSchema, hash_arguments,
-    schemas,
+    hash_arguments_map, schemas,
 };
 pub use crate::writer::provenance::ProvenanceBuffer;
 pub use crate::writer::self_check::{TrailingState, current_inode, read_trailing_state};

--- a/crates/rimap-audit/src/redact/mod.rs
+++ b/crates/rimap-audit/src/redact/mod.rs
@@ -110,19 +110,32 @@ impl<'a> Redactor<'a> {
     ///
     /// Non-object inputs are turned into a one-field object
     /// `{"_non_object": "<redacted:?>"}` so the audit layer always writes a
-    /// homogeneous shape.
+    /// homogeneous shape. Callers that already hold an owned
+    /// `Map<String, Value>` should call [`Redactor::apply_map`] directly;
+    /// this method exists to preserve the `&Value` public surface.
     #[must_use]
     pub fn apply(&self, args: &Value) -> Value {
-        let Value::Object(map) = args else {
+        if let Value::Object(map) = args {
+            self.apply_map(map)
+        } else {
             let mut out = Map::new();
             out.insert(
                 "_non_object".to_string(),
                 Value::String("<redacted:?>".to_string()),
             );
-            return Value::Object(out);
-        };
+            Value::Object(out)
+        }
+    }
+
+    /// Apply the schema to an argument map directly, skipping the
+    /// `Value::Object(...)` wrap that [`Redactor::apply`] requires. Output
+    /// is byte-identical to `apply(&Value::Object(map.clone()))`; used by
+    /// `rimap-server::mcp::audit_envelope::compute_tool_args_artifacts` to
+    /// avoid a per-tool-call deep-clone of the argument map (#149).
+    #[must_use]
+    pub fn apply_map(&self, args: &Map<String, Value>) -> Value {
         let mut out = Map::new();
-        for (name, value) in map {
+        for (name, value) in args {
             let policy = self
                 .schema
                 .policies
@@ -191,6 +204,26 @@ impl<'a> Redactor<'a> {
 )]
 pub fn hash_arguments(args: &Value) -> String {
     let bytes = serde_json::to_vec(args).expect("serde_json::to_vec of Value is infallible");
+    let digest = Sha256::digest(&bytes);
+    hex::encode(digest)
+}
+
+/// Computes `sha256(serde_json::to_vec(args))` on the *unredacted* arguments
+/// for the `arguments_hash_sha256` audit field. Accepts `&Map<String, Value>`
+/// directly so callers with an already-owned map skip the
+/// `Value::Object(...)` wrap+clone.
+///
+/// Output is byte-identical to `hash_arguments(&Value::Object(map.clone()))`
+/// because `Value::serialize` delegates to `Map::serialize` for the Object
+/// variant — no outer framing is emitted.
+#[must_use]
+#[expect(
+    clippy::expect_used,
+    clippy::missing_panics_doc,
+    reason = "serde_json::to_vec(Map<String, Value>) is infallible"
+)]
+pub fn hash_arguments_map(args: &Map<String, Value>) -> String {
+    let bytes = serde_json::to_vec(args).expect("serde_json::to_vec of Map is infallible");
     let digest = Sha256::digest(&bytes);
     hex::encode(digest)
 }
@@ -526,7 +559,9 @@ mod tests {
 
     use rimap_core::tool::ToolName;
 
-    use crate::redact::{FieldPolicy, RedactionSalt, RedactionSchema, Redactor, hash_arguments};
+    use crate::redact::{
+        FieldPolicy, RedactionSalt, RedactionSchema, Redactor, hash_arguments, hash_arguments_map,
+    };
 
     fn schema() -> RedactionSchema {
         RedactionSchema::new(
@@ -816,5 +851,64 @@ mod tests {
             schema.policies.get("message_count").copied(),
             Some(FieldPolicy::Verbatim),
         );
+    }
+
+    #[test]
+    fn apply_and_apply_map_produce_identical_output_for_object_input() {
+        // The new apply_map exists so callers with a Map in hand skip the
+        // Value::Object wrap+clone. Output MUST be byte-identical to what
+        // apply(&Value::Object(map)) returns, otherwise callers migrating
+        // from one to the other would break on-disk audit record stability.
+        let s = schema();
+        let salt = salt();
+        let r = Redactor::new(&s, &salt);
+        let map: serde_json::Map<String, serde_json::Value> = json!({
+            "subject": "hi",
+            "body_text": "long body",
+            "in_reply_to_uid": 42,
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let via_value = r.apply(&serde_json::Value::Object(map.clone()));
+        let via_map = r.apply_map(&map);
+        assert_eq!(via_value, via_map);
+    }
+
+    #[test]
+    fn hash_arguments_and_hash_arguments_map_are_byte_identical_for_object_input() {
+        // Same invariant for the hash function: if callers switch from
+        // hash_arguments(Value) to hash_arguments_map(Map), the audit
+        // record's arguments_hash_sha256 field must not change.
+        let map: serde_json::Map<String, serde_json::Value> = json!({
+            "folder": "INBOX",
+            "uid": 17,
+            "subject": "hi",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let via_value = hash_arguments(&serde_json::Value::Object(map.clone()));
+        let via_map = hash_arguments_map(&map);
+        assert_eq!(via_value, via_map);
+    }
+
+    #[test]
+    fn hash_arguments_map_is_deterministic() {
+        // Parallel guard to the pre-existing `hash_arguments_is_stable_and_hex_encoded`
+        // test, but for the Map variant — ensures the Map path does not
+        // accidentally serialize with a different field-ordering policy.
+        let map: serde_json::Map<String, serde_json::Value> = json!({
+            "uid": 1,
+            "folder": "INBOX",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let a = hash_arguments_map(&map);
+        let b = hash_arguments_map(&map);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -28,7 +28,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rimap_audit::record::{Provenance, ResultSummary, ToolStatus};
-use rimap_audit::redact::{Redactor, ToolRedactionSchema, hash_arguments};
+use rimap_audit::redact::{Redactor, ToolRedactionSchema, hash_arguments_map};
 use rimap_audit::{CancelledToolEndSender, ToolEndInputs, ToolStartInputs};
 use rimap_core::tool::ToolName;
 use rmcp::model::{CallToolResult, ErrorData};
@@ -162,10 +162,9 @@ impl ImapMcpServer {
         tool: ToolName,
         args: &serde_json::Map<String, serde_json::Value>,
     ) -> (serde_json::Value, String) {
-        let args_value = serde_json::Value::Object(args.clone());
         let redacted = Redactor::new(&tool.redaction_schema(), self.state.redaction_salt.as_ref())
-            .apply(&args_value);
-        let hash = hash_arguments(&args_value);
+            .apply_map(args);
+        let hash = hash_arguments_map(args);
         (redacted, hash)
     }
 
@@ -431,6 +430,75 @@ mod tests {
             !contents.contains(r#""status":"cancelled""#),
             "disarmed guard must not write a cancellation record: {contents}",
         );
+    }
+
+    /// Regression test for #149: `compute_tool_args_artifacts` MUST produce
+    /// the same `arguments_hash_sha256` after the refactor to
+    /// `hash_arguments_map`. If someone swaps the underlying serialization
+    /// path (e.g. sorts Map keys, changes the JSON writer), existing
+    /// audit-log consumers break. This test compares the output against an
+    /// explicit `hash_arguments(&Value::Object(map))` expected value — the
+    /// pre-refactor code path — so the identity is pinned regardless of
+    /// which implementation `compute_tool_args_artifacts` chooses internally.
+    #[tokio::test]
+    async fn compute_artifacts_hash_matches_legacy_value_object_path() {
+        use std::collections::BTreeMap;
+        use std::sync::Arc;
+
+        use rimap_audit::{
+            AuditOptions, AuditWriter, Seq,
+            redact::{hash_arguments, hash_arguments_map},
+        };
+
+        use crate::boot::registry::AccountRegistry;
+        use crate::daemon::state::{DaemonState, SessionState};
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // Force 0700 on the audit-parent tempdir per #147 — `AuditWriter::open`
+        // refuses looser modes since the ensure_tight_dir migration.
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let audit = AuditWriter::open(&AuditOptions {
+            path: dir.path().join("audit.jsonl"),
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap();
+        let (cancellation_tx, _rx) = rimap_audit::cancellation_channel();
+        let download_dir: Arc<std::path::Path> =
+            Arc::from(std::path::Path::new("/tmp/test-downloads"));
+        let daemon_state = Arc::new(DaemonState::new(
+            Arc::new(AccountRegistry::new(BTreeMap::new())),
+            audit,
+            download_dir,
+            cancellation_tx,
+            Arc::new(tokio::sync::Semaphore::new(64)),
+        ));
+        let session_state = Arc::new(SessionState::new(rimap_core::SessionId::new()));
+        let server = ImapMcpServer::new(daemon_state, session_state);
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "folder".to_string(),
+            serde_json::Value::String("INBOX".to_string()),
+        );
+        args.insert(
+            "uid".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(17)),
+        );
+
+        let (_redacted, computed) = server.compute_tool_args_artifacts(ToolName::Search, &args);
+
+        let legacy = hash_arguments(&serde_json::Value::Object(args.clone()));
+        let via_map = hash_arguments_map(&args);
+        assert_eq!(computed, legacy, "hash diverged from Value::Object path");
+        assert_eq!(computed, via_map, "hash diverged from Map path");
     }
 
     /// `compute_tool_args_artifacts` must hash the FULL args map as


### PR DESCRIPTION
## Summary

Wave B PR 6 of the polish release — and the final Wave B PR. Closes #149.

Adds additive `&Map<String, Value>`-taking variants to `rimap-audit`:

- `Redactor::apply_map(&self, args: &Map<String, Value>) -> Value`
- `hash_arguments_map(args: &Map<String, Value>) -> String`

Existing `apply(&Value)` and `hash_arguments(&Value)` remain as thin wrappers — no external caller churns. `compute_tool_args_artifacts` in `rimap-server` switches to the `_map` variants, dropping the `Value::Object(args.clone())` deep-clone that existed only to satisfy the `&Value` signatures.

Plan: [`docs/superpowers/plans/2026-04-23-polish-pr06-map-audit-apis.md`](docs/superpowers/plans/2026-04-23-polish-pr06-map-audit-apis.md).

## Commits

1. `97f26ac` — `feat(rimap-audit): add Redactor::apply_map and hash_arguments_map` (additive APIs + 3 byte-identity tests)
2. `7a60fa8` — `perf(rimap-server): drop per-tool-call args Map clone in audit envelope`

## Notes

- Hash output is byte-identical to the previous path. `Value::Object(m).serialize()` forwards directly to `Map::serialize` with no outer framing — three regression tests pin this invariant on both sides of the crate boundary.
- `apply` was rewritten to delegate to `apply_map` for the `Value::Object` case, with a single `if let Some` branch (clippy preferred this over `match` for the small fallback).
- Smallest of the four Wave B PRs by line count.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes (modulo the pre-existing `socket_path`/`socket_setup` `TMPDIR` env-race flake unrelated to this PR — same flake observed on PR #161)
- [x] `cargo deny check advisories bans licenses` clean
- [x] `typos` clean

Closes #149.