### PR TITLE
fix(rimap-server): polish PR 2 — session-end reliability (#137, #142)

### DIFF
--- a/crates/rimap-server/src/daemon/run.rs
+++ b/crates/rimap-server/src/daemon/run.rs
@@ -1,15 +1,67 @@
 //! Daemon entry point: accept loop, per-session spawn, graceful shutdown.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use rimap_audit::record::PeerIdentity;
 use rimap_core::SessionId;
-use tokio::sync::{Notify, OwnedSemaphorePermit};
+use tokio::sync::{Mutex, Notify, OwnedSemaphorePermit};
 use tokio::task::JoinSet;
 
 use crate::daemon::state::{DaemonState, SessionState};
 use crate::daemon::transport::{AcceptedConnection, PlatformListener};
 use crate::mcp::server::ImapMcpServer;
+
+/// Side table of in-flight sessions, keyed by `SessionId`. Used by the
+/// graceful-shutdown drain to synthesize `session_end(DaemonShutdown)`
+/// records for sessions that `JoinSet::shutdown` aborts before they
+/// could emit their own end records (see #137).
+///
+/// The map lives behind a Tokio `Mutex` rather than a `parking_lot`
+/// mutex because the contention pattern is async-task spawn/join, not
+/// CPU-bound — and the lock is held only across two `HashMap` ops
+/// (insert/remove or drain), well under the `await_holding_lock` clippy
+/// threshold.
+pub(crate) struct LiveSessions {
+    inner: Mutex<HashMap<SessionId, Arc<SessionState>>>,
+}
+
+impl LiveSessions {
+    /// Construct an empty live-session table.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record that `session` is now in flight. Called from the accept
+    /// loop immediately before `sessions.spawn(...)`.
+    pub(crate) async fn insert(&self, sid: SessionId, session: Arc<SessionState>) {
+        self.inner.lock().await.insert(sid, session);
+    }
+
+    /// Remove `sid` from the table. Called from `build_session_future`
+    /// on every normal exit path — both Ok and Err cases — so an
+    /// aborted future is the only one that leaves an entry behind.
+    pub(crate) async fn remove(&self, sid: SessionId) {
+        self.inner.lock().await.remove(&sid);
+    }
+
+    /// Test-only convenience for membership checks.
+    #[cfg(test)]
+    pub(crate) async fn contains(&self, sid: SessionId) -> bool {
+        self.inner.lock().await.contains_key(&sid)
+    }
+
+    /// Drain every remaining entry. Called from `drain_sessions` AFTER
+    /// `JoinSet::shutdown().await`, so any session still here was
+    /// aborted mid-flight and needs a synthesized `session_end`.
+    pub(crate) async fn drain(&self) -> Vec<(SessionId, Arc<SessionState>)> {
+        let mut guard = self.inner.lock().await;
+        std::mem::take(&mut *guard).into_iter().collect()
+    }
+}
 
 /// Run the daemon until a shutdown signal fires.
 ///
@@ -32,6 +84,7 @@ where
     let socket_path = resolve_socket_path();
     let peer_gate = make_peer_gate();
     let mut sessions: JoinSet<()> = JoinSet::new();
+    let live = Arc::new(LiveSessions::new());
 
     loop {
         tokio::select! {
@@ -67,11 +120,16 @@ where
                     drop(stream);
                     continue;
                 }
+                // Insert BEFORE spawn so `drain_sessions` can find the
+                // session even if the accept loop exits between insert
+                // and spawn.
+                live.insert(sid, Arc::clone(&session)).await;
                 sessions.spawn(build_session_future(
                     Arc::clone(&state),
                     stream,
                     session,
                     permit,
+                    Arc::clone(&live),
                 ));
             }
             Some(_) = sessions.join_next() => {
@@ -81,13 +139,38 @@ where
     }
 
     listener.shutdown();
-    drain_sessions(sessions).await;
+    drain_sessions(sessions, &state, Arc::clone(&live)).await;
     Ok(())
 }
 
-/// Wait up to 5 seconds for in-flight sessions to finish, then abort the rest.
-async fn drain_sessions(mut sessions: JoinSet<()>) {
+/// Wait up to 5 seconds for in-flight sessions to finish, then abort the rest
+/// AND synthesize a `session_end(DaemonShutdown)` audit record for every
+/// session that was aborted. The synthesized record carries the per-session
+/// duration and tool-call count harvested from `SessionState`, byte-
+/// equivalent to what the live future would have emitted.
+///
+/// See #137: prior to this fix, `JoinSet::shutdown().await` aborted the
+/// in-flight session futures before they could emit their own end records,
+/// leaving the audit log silently incomplete.
+async fn drain_sessions(
+    mut sessions: JoinSet<()>,
+    state: &Arc<DaemonState>,
+    live: Arc<LiveSessions>,
+) {
     if sessions.is_empty() {
+        // No tasks ever spawned; the live table should be empty too, but
+        // belt-and-braces drain it in case an entry slipped in between
+        // `live.insert` and `sessions.spawn` and the accept loop then
+        // exited.
+        for (_, session) in live.drain().await {
+            emit_session_end(
+                state,
+                &session,
+                rimap_audit::record::SessionEndReason::DaemonShutdown,
+                None,
+            )
+            .await;
+        }
         return;
     }
     tracing::info!(
@@ -106,13 +189,36 @@ async fn drain_sessions(mut sessions: JoinSet<()>) {
             Ok(None) | Err(_) => break, // drained or deadline elapsed
         }
     }
-    let aborted = sessions.len();
+    let still_running = sessions.len();
     let shutdown = tokio::time::timeout(std::time::Duration::from_secs(2), sessions.shutdown());
-    if shutdown.await.is_ok() {
-        tracing::info!(aborted_count = aborted, "session drain complete");
+    let shutdown_clean = shutdown.await.is_ok();
+
+    // After `JoinSet::shutdown`, any remaining entry in `live` is a session
+    // that was aborted mid-flight. Synthesize its `session_end` record
+    // now — same content the live future would have emitted, with reason
+    // = DaemonShutdown.
+    let aborted = live.drain().await;
+    let synthesized = aborted.len();
+    for (_, session) in aborted {
+        emit_session_end(
+            state,
+            &session,
+            rimap_audit::record::SessionEndReason::DaemonShutdown,
+            None,
+        )
+        .await;
+    }
+
+    if shutdown_clean {
+        tracing::info!(
+            join_set_aborted = still_running,
+            session_end_synthesized = synthesized,
+            "session drain complete",
+        );
     } else {
         tracing::warn!(
-            aborted_count = aborted,
+            join_set_aborted = still_running,
+            session_end_synthesized = synthesized,
             "session shutdown deadline exceeded; exiting with stuck tasks",
         );
     }
@@ -267,12 +373,14 @@ async fn build_session_future<S>(
     stream: S,
     session: Arc<SessionState>,
     permit: OwnedSemaphorePermit,
+    live: Arc<LiveSessions>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     // Hold the permit for the session's lifetime; drops when this future
     // returns, releasing a slot back to the semaphore.
     let _permit = permit;
+    let sid = session.id;
     let mcp = ImapMcpServer::new(Arc::clone(&state), Arc::clone(&session));
     let serve_result = Box::pin(rmcp::serve_server(mcp, stream)).await;
     let running = match serve_result {
@@ -286,12 +394,16 @@ async fn build_session_future<S>(
                 Some(format!("serve_server init: {e}")),
             )
             .await;
+            // Remove only AFTER emission so a panic in emit_session_end
+            // leaves the entry visible for the drain path's safety net.
+            live.remove(sid).await;
             return;
         }
     };
     let quit = running.waiting().await;
     let (reason, last_err) = session_end_from_quit(quit);
     emit_session_end(&state, &session, reason, last_err).await;
+    live.remove(sid).await;
 }
 
 /// Map `waiting()`'s `QuitReason` outcome to an audit `(SessionEndReason,
@@ -329,9 +441,6 @@ async fn emit_session_end(
     let total = session
         .tool_call_count
         .load(std::sync::atomic::Ordering::Relaxed);
-    // Sessions aborted by `drain_sessions` after the 5s grace window don't
-    // reach this point — their in-flight tool_call_count does not contribute
-    // to the daemon-level aggregator. Tracked as #137.
     state
         .total_tool_calls
         .fetch_add(total, std::sync::atomic::Ordering::Relaxed);
@@ -343,4 +452,63 @@ async fn emit_session_end(
         last_error,
     };
     log_session_end_blocking(state, end).await;
+}
+
+#[cfg(test)]
+mod live_sessions_tests {
+    use super::LiveSessions;
+    use crate::daemon::state::SessionState;
+    use rimap_core::SessionId;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn insert_then_remove_drops_entry() {
+        let live = LiveSessions::new();
+        let sid = SessionId::new();
+        let session = Arc::new(SessionState::new(sid));
+        live.insert(sid, Arc::clone(&session)).await;
+        assert!(live.contains(sid).await);
+        live.remove(sid).await;
+        assert!(!live.contains(sid).await);
+    }
+
+    #[tokio::test]
+    async fn drain_returns_all_remaining_entries_in_one_pass() {
+        let live = LiveSessions::new();
+        let sid_a = SessionId::new();
+        let sid_b = SessionId::new();
+        live.insert(sid_a, Arc::new(SessionState::new(sid_a))).await;
+        live.insert(sid_b, Arc::new(SessionState::new(sid_b))).await;
+        let drained = live.drain().await;
+        assert_eq!(drained.len(), 2);
+        // After draining the table is empty so subsequent drain returns nothing.
+        let again = live.drain().await;
+        assert!(again.is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_preserves_session_state_arc_for_duration_and_count_reads() {
+        // The drain path uses `started_at` and `tool_call_count` from the
+        // returned SessionState — pin that the Arcs come back live, not
+        // lost copies. Bumping the counter inside the drained Arc must be
+        // visible to the holder of the original Arc.
+        let live = LiveSessions::new();
+        let sid = SessionId::new();
+        let session = Arc::new(SessionState::new(sid));
+        live.insert(sid, Arc::clone(&session)).await;
+        let drained = live.drain().await;
+        assert_eq!(drained.len(), 1);
+        let (drained_sid, drained_session) = &drained[0];
+        assert_eq!(*drained_sid, sid);
+        drained_session
+            .tool_call_count
+            .fetch_add(7, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            session
+                .tool_call_count
+                .load(std::sync::atomic::Ordering::Relaxed),
+            7,
+            "drained Arc must point to the same SessionState as the inserted Arc",
+        );
+    }
 }

--- a/crates/rimap-server/src/daemon/run.rs
+++ b/crates/rimap-server/src/daemon/run.rs
@@ -315,6 +315,51 @@ async fn log_session_end_blocking(state: &Arc<DaemonState>, end: rimap_audit::re
     }
 }
 
+/// Emit a paired `session_start` + `session_end(reason)` for a connection
+/// that we refused at the gate. Both records hit the audit writer inside a
+/// single `spawn_blocking` so the accept loop only pays one task-spawn
+/// round trip per rejection, not two.
+///
+/// Errors are logged but not propagated; at this point the connection is
+/// already being dropped and the caller has nothing to do with the result.
+async fn log_session_rejected_pair(
+    state: &Arc<DaemonState>,
+    sid: SessionId,
+    identity: PeerIdentity,
+    socket_path: &str,
+    reason: rimap_audit::record::SessionEndReason,
+    last_error: Option<String>,
+) {
+    let audit = state.audit.clone();
+    let socket_path = socket_path.to_owned();
+    let join = tokio::task::spawn_blocking(move || {
+        let start = rimap_audit::record::SessionStart {
+            session_id: sid,
+            peer_identity: identity,
+            socket_path,
+        };
+        if let Err(e) = audit.log_session_start(start) {
+            tracing::error!(error = %e, "rejected-pair session_start write failed");
+            return;
+        }
+        let end = rimap_audit::record::SessionEnd {
+            session_id: sid,
+            reason,
+            duration_ms: 0,
+            total_tool_calls: 0,
+            last_error,
+        };
+        if let Err(e) = audit.log_session_end(end) {
+            tracing::warn!(error = %e, "rejected-pair session_end write failed");
+        }
+    })
+    .await;
+    if let Err(join_err) = join {
+        let rimap_err = crate::mcp::spawn_blocking_panic_error(join_err);
+        tracing::error!(error = %rimap_err, "rejected-pair spawn_blocking join error");
+    }
+}
+
 /// Emit paired `session_start` + `session_end(PeerUidRejected)` for a
 /// connection whose peer identity does not match ours, then close it.
 async fn handle_rejected_peer(
@@ -323,15 +368,15 @@ async fn handle_rejected_peer(
     socket_path: &str,
 ) {
     let sid = SessionId::new();
-    let _ = log_session_start_blocking(state, sid, identity.clone(), socket_path).await;
-    let end = rimap_audit::record::SessionEnd {
-        session_id: sid,
-        reason: rimap_audit::record::SessionEndReason::PeerUidRejected,
-        duration_ms: 0,
-        total_tool_calls: 0,
-        last_error: None,
-    };
-    log_session_end_blocking(state, end).await;
+    log_session_rejected_pair(
+        state,
+        sid,
+        identity.clone(),
+        socket_path,
+        rimap_audit::record::SessionEndReason::PeerUidRejected,
+        None,
+    )
+    .await;
     tracing::warn!(?identity, "rejected peer with mismatching identity");
 }
 
@@ -344,15 +389,15 @@ async fn handle_rejected_over_capacity(
     socket_path: &str,
 ) {
     let sid = SessionId::new();
-    let _ = log_session_start_blocking(state, sid, identity.clone(), socket_path).await;
-    let end = rimap_audit::record::SessionEnd {
-        session_id: sid,
-        reason: rimap_audit::record::SessionEndReason::Rejected,
-        duration_ms: 0,
-        total_tool_calls: 0,
-        last_error: Some("max_concurrent_sessions reached".to_owned()),
-    };
-    log_session_end_blocking(state, end).await;
+    log_session_rejected_pair(
+        state,
+        sid,
+        identity.clone(),
+        socket_path,
+        rimap_audit::record::SessionEndReason::Rejected,
+        Some("max_concurrent_sessions reached".to_owned()),
+    )
+    .await;
     tracing::warn!(
         ?identity,
         "rejected session: max_concurrent_sessions reached",

--- a/crates/rimap-server/tests/daemon_graceful_shutdown.rs
+++ b/crates/rimap-server/tests/daemon_graceful_shutdown.rs
@@ -83,10 +83,81 @@ async fn shutdown_drains_active_sessions_within_deadline() {
         "expected at least 2 session_start records (one per client); got {session_starts}:\n{audit}"
     );
 
-    // session_end is only emitted if the session task runs to completion.
-    // When the drain deadline expires, `JoinSet::shutdown().await` aborts
-    // remaining tasks — those futures are dropped mid-flight without reaching
-    // `emit_session_end`. So session_end count may be 0, 1, or 2 depending on
-    // timing; we do not assert a minimum here. The timing assertion above
-    // (elapsed < 6 s) is the meaningful correctness check for the abort path.
+    // After the fix (#137), drain_sessions synthesizes session_end records for
+    // aborted sessions. Every start must now have a matching end.
+    let session_ends = audit
+        .lines()
+        .filter(|l| l.contains(r#""kind":"session_end""#))
+        .count();
+    assert_eq!(
+        session_starts, session_ends,
+        "every session_start must have a matching session_end after #137 fix; \
+         starts={session_starts} ends={session_ends}\naudit log:\n{audit}"
+    );
+}
+
+/// Regression test for #137: every active session emits a
+/// `session_end(reason="daemon_shutdown")` record when the daemon
+/// shuts down, including those aborted mid-flight by the `JoinSet`
+/// drain. Before the fix, aborted futures never reached
+/// `emit_session_end` and the audit log was missing those records.
+#[tokio::test]
+async fn shutdown_synthesizes_session_end_for_aborted_sessions() {
+    let tempdir = tight_tempdir();
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let socket_path = tempdir.path().join("daemon.sock");
+    let state = test_daemon_state(tempdir.path(), &audit_path);
+    let daemon =
+        TestDaemon::spawn_bare(tempdir, audit_path.clone(), socket_path.clone(), state).await;
+
+    // Open two sessions and write nothing through them. The shim-layer
+    // serve_server.waiting() is parked on a stalled stdin read; we don't
+    // need to send any MCP frames — what matters is that the session is
+    // ALIVE in the daemon's JoinSet at shutdown time.
+    let s1 = UnixStream::connect(&daemon.socket_path)
+        .await
+        .expect("connect 1");
+    let s2 = UnixStream::connect(&daemon.socket_path)
+        .await
+        .expect("connect 2");
+
+    // Give the accept loop a beat to spawn the per-session futures and
+    // call `live.insert` for each. 50ms is generous on every CI we run
+    // and far faster than the 5s drain window.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Trigger shutdown. The drain has 5s to clean-close, then JoinSet
+    // aborts. Sessions that never completed handshake will be aborted —
+    // exactly the path #137 fixes.
+    let audit_log = daemon.shutdown().await;
+    drop(s1);
+    drop(s2);
+
+    // Count `session_end(reason="daemon_shutdown")` records.
+    let shutdown_ends = audit_log
+        .lines()
+        .filter(|line| line.contains(r#""kind":"session_end""#))
+        .filter(|line| line.contains(r#""reason":"daemon_shutdown""#))
+        .count();
+    assert_eq!(
+        shutdown_ends, 2,
+        "expected 2 session_end(daemon_shutdown) records, got {shutdown_ends}; \
+         audit log was:\n{audit_log}",
+    );
+
+    // Total session_end count must equal session_start count — no orphan
+    // start records and no over-count.
+    let starts = audit_log
+        .lines()
+        .filter(|line| line.contains(r#""kind":"session_start""#))
+        .count();
+    let ends = audit_log
+        .lines()
+        .filter(|line| line.contains(r#""kind":"session_end""#))
+        .count();
+    assert_eq!(
+        starts, ends,
+        "session_start ({starts}) must pair with session_end ({ends}); \
+         audit log was:\n{audit_log}",
+    );
 }


### PR DESCRIPTION
## Summary

Wave C PR 2 of the polish release. Closes #137; refs #142.

Fixes the audit-log gap where `JoinSet::shutdown` aborts in-flight session futures before they reach `emit_session_end`. The audit log was missing `session_end(reason="daemon_shutdown")` records for any session that didn't clean-close inside the 5s drain window — a violation of the design spec's "each session emits session_end on shutdown" contract.

The fix tracks active sessions in a `LiveSessions` side table keyed by `SessionId` (`Arc<Mutex<HashMap<...>>>`). Each session removes itself on every normal exit path; whatever's left after `JoinSet::shutdown().await` is by definition an aborted session. The drain synthesizes a `session_end(DaemonShutdown)` record using the SAME `emit_session_end` helper as the live path, inheriting the `total_tool_calls.fetch_add` aggregator hop.

#142's primary spawn_blocking migration was already shipped in main; this PR closes the optional second-half by coalescing the paired `session_start` + `session_end(reason)` writes for rejected-peer / over-capacity into a single `spawn_blocking` round trip (one task-spawn cost per rejection instead of two; on-disk record shape unchanged).

Plan: [`docs/superpowers/plans/2026-04-23-polish-pr02-session-end-reliability.md`](docs/superpowers/plans/2026-04-23-polish-pr02-session-end-reliability.md).

## Commits

1. `de53fd0` — `fix(rimap-server): synthesize session_end for shutdown-aborted sessions` — the substantive fix bundles `LiveSessions` + accept-loop wiring + drain synthesis + behavioural test.
2. `dfe42db` — `perf(rimap-server): coalesce rejected-peer paired audit writes` — single spawn_blocking per rejection.

## Notes

- Plan deviation: `LiveSessions` uses `HashMap<SessionId, Arc<SessionState>>`, not the plan's `BTreeMap`, because `SessionId` is `Hash + Eq` but not `Ord`. No functional difference for our use (no ordered iteration).
- Existing `shutdown_drains_active_sessions_within_deadline` test was strengthened with a `session_starts == session_ends` invariant — catches the prior bug independently of the new test.
- Three new `LiveSessions` unit tests pin insert/remove/drain semantics + Arc-equality (a drained Arc must point at the same SessionState as the inserted one).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes (all suites green)
- [x] `cargo deny check advisories bans licenses` clean
- [x] `typos` clean
- [x] New behavioural test (`shutdown_synthesizes_session_end_for_aborted_sessions`) proves the bug fix
- [x] Pre-existing graceful-shutdown / max-sessions tests pass without modification (clean-close path still works)

Closes #137. Refs #142.