### PR TITLE
ci: skip SonarQube on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,11 @@ jobs:
 
   sonarqube:
     name: SonarQube
-    # Skip on PRs from forks (they can't access the SONAR_TOKEN secret).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Skip on PRs from forks and from Dependabot (neither can access the
+    # SONAR_TOKEN secret). Skipped required checks satisfy branch protection.
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-24.04
     # SONAR_TOKEN lives in the `sonarcloud` environment for future hardening
     # (branch restrictions, required reviewers) without changing the workflow.


### PR DESCRIPTION
## Summary
- Extend the existing `if:` guard on the `sonarqube` job in `.github/workflows/ci.yml` to also skip when `github.actor == 'dependabot[bot]'`.
- Dependabot-triggered runs cannot read repo secrets, so the job currently fails with an empty `SONAR_TOKEN` (e.g., #120).
- Branch protection on `main` does not need to change: `SonarQube` stays a required check, and GitHub treats job-level `if:`-skipped jobs as passing for required checks (same mechanism the existing fork-skip relies on).

## Test plan
- [ ] CI on this PR runs and is green (this PR is not from Dependabot, so SonarQube still runs here).
- [ ] After merge, rebase PR #120 onto `main` and confirm `SonarQube` reports as skipped and the PR becomes mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)