### PR TITLE
fix: address issues #174, #179, #180

### DIFF
--- a/crates/rimap-core/Cargo.toml
+++ b/crates/rimap-core/Cargo.toml
@@ -23,7 +23,13 @@ hex = { workspace = true }
 strum = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true }
+# `std` is required so `rustix::fd::AsFd` resolves to the `std::os::fd` re-export
+# rather than the no_std polyfill trait — otherwise `std::os::fd::OwnedFd` does
+# not satisfy the `AsFd` bound on `openat` / `fstat` and standalone builds of
+# this crate (`cargo check -p rimap-core`) fail. The workspace's `fs4`
+# dependency happens to enable it transitively, but isolated checks must not
+# rely on that unification.
+rustix = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rimap-core/src/fs.rs
+++ b/crates/rimap-core/src/fs.rs
@@ -18,11 +18,34 @@ use rustix::io::Errno;
 /// Flags used for every directory handle this module holds.
 ///
 /// `O_NOFOLLOW` refuses a symlinked leaf, `O_DIRECTORY` refuses a non-directory,
-/// `O_CLOEXEC` stops the fd leaking across `exec`, `O_PATH` means we only need
-/// the fd as an anchor for subsequent `*at` syscalls — we never read or write
-/// it directly.
+/// `O_CLOEXEC` stops the fd leaking across `exec`. On platforms that support it
+/// we additionally pass `O_PATH` to signal that we only need the fd as an anchor
+/// for subsequent `*at` syscalls — we never read or write it directly. On
+/// platforms without `O_PATH` (notably macOS and the BSDs other than FreeBSD)
+/// the fd is opened for read instead; the security invariants enforced by
+/// [`verify_dir`] are unchanged.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "redox",
+))]
 const DIR_OFLAGS: OFlags = OFlags::PATH
     .union(OFlags::DIRECTORY)
+    .union(OFlags::NOFOLLOW)
+    .union(OFlags::CLOEXEC);
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "redox",
+)))]
+const DIR_OFLAGS: OFlags = OFlags::DIRECTORY
     .union(OFlags::NOFOLLOW)
     .union(OFlags::CLOEXEC);
 
@@ -30,8 +53,9 @@ const DIR_OFLAGS: OFlags = OFlags::PATH
 /// symlink. Creates the directory (mode 0700) if missing.
 ///
 /// The leaf is opened with `openat(parent_fd, name, O_NOFOLLOW | O_DIRECTORY
-/// | O_CLOEXEC | O_PATH)` so that a hostile swap of an ancestor between
-/// syscalls cannot smuggle the caller onto a different directory. The returned
+/// | O_CLOEXEC)` (plus `O_PATH` on platforms that support it) so that a hostile
+/// swap of an ancestor between syscalls cannot smuggle the caller onto a
+/// different directory. The returned
 /// [`OwnedFd`] pins the verified directory — callers that perform follow-up
 /// syscalls inside `dir` should keep the fd alive and use `*at` syscalls
 /// against it rather than re-walking the path. Callers that need only the

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -382,63 +382,16 @@ impl Connection {
     > {
         let mut client = async_imap::Client::new(tls_stream);
 
-        // Read the server greeting — skipped for STARTTLS, which already
-        // consumed the greeting during plaintext negotiation. An absent greeting
-        // (EOF) or BYE status means the server immediately rejected us.
-        // Pre-resolve; carry `None`.
-        if !already_greeted {
-            let greeting = client
-                .read_response()
-                .await
-                .map_err(|e| (ImapError::Connect(e), None))?
-                .ok_or((
-                    ImapError::Auth {
-                        reason: AuthFailure::ServerRejected,
-                    },
-                    None,
-                ))?;
-
-            if let Response::Data {
-                status: Status::Bye,
-                ..
-            } = greeting.parsed()
-            {
-                return Err((
-                    ImapError::Auth {
-                        reason: AuthFailure::ServerRejected,
-                    },
-                    None,
-                ));
-            }
-        }
-
-        // Issue CAPABILITY and scan responses for LOGINDISABLED.
-        // We create a bounded channel so intermediate untagged responses
-        // (including `* CAPABILITY ...`) are routed through it rather than
-        // being silently discarded. Pre-resolve; carry `None`.
-        let (tx, rx) = async_channel::bounded::<UnsolicitedResponse>(32);
-        client
-            .run_command_and_check_ok("CAPABILITY", Some(tx))
+        read_greeting(&mut client, already_greeted)
             .await
-            .map_err(|e| (ImapError::Protocol(e), None))?;
+            .map_err(|e| (e, None))?;
+        assert_login_enabled(&mut client)
+            .await
+            .map_err(|e| (e, None))?;
 
-        // Drain whatever arrived on the channel (non-blocking; the command
-        // has already completed). A `Response::Capabilities` list containing
-        // LOGINDISABLED means LOGIN is prohibited. Pre-resolve; carry `None`.
-        let logindisabled = drain_for_logindisabled(&rx);
-        if logindisabled {
-            return Err((
-                ImapError::Auth {
-                    reason: AuthFailure::CapabilityMissing { needed: "LOGIN" },
-                },
-                None,
-            ));
-        }
-
-        // Resolve the password from the injected resolver. A missing
-        // credential is an authentication failure, not a network
-        // failure — map it to ERR_AUTH so retry logic and operator
-        // messages stay accurate. Pre-resolve; carry `None`.
+        // A missing credential is an authentication failure, not a network
+        // failure — map it to ERR_AUTH so retry logic and operator messages
+        // stay accurate.
         let cfg = &self.inner.cfg;
         let (password, credential_source) = self
             .inner
@@ -474,8 +427,16 @@ impl Connection {
             }
         };
 
-        // Post-login: probe CAPABILITY for MOVE (RFC 6851),
-        // UIDPLUS (RFC 4315), and LIST-STATUS (RFC 5819).
+        self.probe_post_login_capabilities(&mut session).await;
+
+        Ok((session, credential_source))
+    }
+
+    /// Post-login CAPABILITY probe: caches MOVE / UIDPLUS / LIST-STATUS
+    /// support on `self.inner` for later operations to gate on. A failed
+    /// probe is logged and treated as "no extensions" — callers must not
+    /// fail the login over this.
+    async fn probe_post_login_capabilities(&self, session: &mut ImapSession) {
         let (has_move, has_uidplus, has_list_status) = match session.capabilities().await {
             Ok(caps) => (
                 caps.has_str("MOVE"),
@@ -496,8 +457,6 @@ impl Connection {
         self.inner
             .has_list_status
             .store(has_list_status, Ordering::Relaxed);
-
-        Ok((session, credential_source))
     }
 
     /// Emit an [`AuthEvent`] through the injected sink. Runs the
@@ -983,6 +942,58 @@ fn capability_advertised(rx: &async_channel::Receiver<UnsolicitedResponse>, atom
 /// `Response::Capabilities` item contains the `LOGINDISABLED` atom.
 fn drain_for_logindisabled(rx: &async_channel::Receiver<UnsolicitedResponse>) -> bool {
     capability_advertised(rx, "LOGINDISABLED")
+}
+
+/// Read the post-TLS-handshake server greeting, unless `already_greeted`
+/// is `true` (STARTTLS, where the plaintext negotiation already consumed
+/// the greeting). An EOF or `BYE` greeting means the server immediately
+/// rejected us — surfaced as `AuthFailure::ServerRejected`.
+async fn read_greeting(
+    client: &mut async_imap::Client<TlsStream<TcpStream>>,
+    already_greeted: bool,
+) -> Result<(), ImapError> {
+    if already_greeted {
+        return Ok(());
+    }
+    let greeting = client
+        .read_response()
+        .await
+        .map_err(ImapError::Connect)?
+        .ok_or(ImapError::Auth {
+            reason: AuthFailure::ServerRejected,
+        })?;
+
+    if let Response::Data {
+        status: Status::Bye,
+        ..
+    } = greeting.parsed()
+    {
+        return Err(ImapError::Auth {
+            reason: AuthFailure::ServerRejected,
+        });
+    }
+    Ok(())
+}
+
+/// Issue `CAPABILITY` and assert that LOGIN is permitted. The bounded
+/// channel ensures the unsolicited `* CAPABILITY ...` response is
+/// captured rather than discarded; any `LOGINDISABLED` atom in that
+/// response is mapped to `AuthFailure::CapabilityMissing { needed: "LOGIN" }`.
+async fn assert_login_enabled(
+    client: &mut async_imap::Client<TlsStream<TcpStream>>,
+) -> Result<(), ImapError> {
+    let (tx, rx) = async_channel::bounded::<UnsolicitedResponse>(32);
+    client
+        .run_command_and_check_ok("CAPABILITY", Some(tx))
+        .await
+        .map_err(ImapError::Protocol)?;
+
+    if drain_for_logindisabled(&rx) {
+        return Err(ImapError::Auth {
+            reason: AuthFailure::CapabilityMissing { needed: "LOGIN" },
+        });
+    }
+    Ok(())
 }
 
 /// Plaintext STARTTLS negotiation: greeting → CAPABILITY → STARTTLS.

--- a/crates/rimap-server/tests/common/shim_jsonrpc.rs
+++ b/crates/rimap-server/tests/common/shim_jsonrpc.rs
@@ -9,12 +9,15 @@
     reason = "test helpers panic with diagnostic context on failure"
 )]
 
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::time::Duration;
 
 use serde_json::Value;
-use tokio::io::{AsyncWriteExt as _, BufReader, Lines};
-use tokio::process::{ChildStdin, ChildStdout};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
 /// Per-read timeout for the shim's stdout. 15s gives debug-build cold
 /// starts headroom on slow CI runners; the local-dev common case takes
@@ -56,4 +59,72 @@ pub async fn recv_frame(reader: &mut Lines<BufReader<ChildStdout>>, what: &str) 
         .unwrap_or_else(|| panic!("{what} EOF before response"));
     serde_json::from_str(&line)
         .unwrap_or_else(|e| panic!("{what} response is not valid JSON: {e}; line: {line}"))
+}
+
+/// Allocate a tempdir to use as `XDG_RUNTIME_DIR`, chmod it 0700, and
+/// pre-create the `<runtime_dir>/rusty-imap-mcp/` parent so the daemon
+/// socket can bind there. Returns the tempdir; callers pass `.path()`
+/// into both [`DovecotDaemon::try_spawn_at`] and the shim's
+/// `XDG_RUNTIME_DIR` env var.
+#[must_use]
+pub fn make_runtime_dir() -> TempDir {
+    let runtime_dir = TempDir::new().unwrap_or_else(|e| panic!("runtime dir: {e}"));
+    std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700))
+        .unwrap_or_else(|e| panic!("chmod 0700 on runtime dir: {e}"));
+    let socket_path = resolved_socket_path(runtime_dir.path());
+    let Some(socket_parent) = socket_path.parent() else {
+        panic!("resolved socket path has no parent");
+    };
+    std::fs::create_dir_all(socket_parent).unwrap_or_else(|e| panic!("create socket parent: {e}"));
+    std::fs::set_permissions(socket_parent, std::fs::Permissions::from_mode(0o700))
+        .unwrap_or_else(|e| panic!("chmod 0700 on socket parent: {e}"));
+    runtime_dir
+}
+
+/// Spawn `rusty-imap-mcp shim` against `runtime_dir`, complete the MCP
+/// `initialize` + `notifications/initialized` handshake, and return the
+/// live child + pipe handles for the test to drive further requests.
+///
+/// `client_name` distinguishes the shim's `clientInfo.name` for log
+/// triage when a test fails — pick something descriptive of the
+/// scenario.
+pub async fn spawn_shim_and_initialize(
+    runtime_dir: &Path,
+    client_name: &str,
+) -> (Child, ChildStdin, Lines<BufReader<ChildStdout>>) {
+    let shim_bin = assert_cmd::cargo::cargo_bin("rusty-imap-mcp");
+    let mut shim = Command::new(&shim_bin)
+        .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env_remove("TMPDIR")
+        .arg("shim")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn shim: {e}"));
+    let mut stdin = shim.stdin.take().unwrap_or_else(|| panic!("shim stdin"));
+    let stdout = shim.stdout.take().unwrap_or_else(|| panic!("shim stdout"));
+    let mut reader = BufReader::new(stdout).lines();
+
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": "0.0.1"}
+        }
+    });
+    send_frame(&mut stdin, &init, "initialize").await;
+    let _ = recv_frame(&mut reader, "initialize").await;
+
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    send_frame(&mut stdin, &initialized, "notifications/initialized").await;
+
+    (shim, stdin, reader)
 }

--- a/crates/rimap-server/tests/daemon_dovecot_audit.rs
+++ b/crates/rimap-server/tests/daemon_dovecot_audit.rs
@@ -1,0 +1,102 @@
+//! Asserts that a tool failure inside `run_with_audit_envelope`'s body
+//! still emits a paired `tool_start` + `tool_end(status=error,
+//! error_code=Some(_))`. Drives `fetch_message` against a non-existent
+//! folder so EXAMINE returns NO and the handler maps it to
+//! `ErrorCode::ImapProtocol` after `tool_start` has fired.
+
+#![cfg(unix)]
+#![expect(clippy::expect_used, reason = "tests")]
+
+mod common;
+
+use serde_json::Value;
+
+use common::dovecot_daemon_harness::DovecotDaemon;
+use common::shim_jsonrpc::{
+    READ_TIMEOUT, make_runtime_dir, recv_frame, resolved_socket_path, send_frame,
+    spawn_shim_and_initialize,
+};
+
+#[tokio::test]
+async fn tool_failure_inside_envelope_emits_paired_start_end_error() {
+    let runtime_dir = make_runtime_dir();
+    let socket_path = resolved_socket_path(runtime_dir.path());
+
+    let Some(daemon) = DovecotDaemon::try_spawn_at(64, socket_path).await else {
+        return;
+    };
+
+    let (mut shim, mut stdin, mut reader) =
+        spawn_shim_and_initialize(runtime_dir.path(), "rimap-tool-failure-audit-test").await;
+
+    let call = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "fetch_message",
+            "arguments": {
+                "folder": "DefinitelyNotAFolder-rimap174",
+                "uid": 1
+            }
+        }
+    });
+    send_frame(&mut stdin, &call, "tools/call").await;
+    // Drain so the shim settles before EOF; the audit log is the contract.
+    let _ = recv_frame(&mut reader, "tools/call").await;
+
+    drop(stdin);
+    let _ = tokio::time::timeout(READ_TIMEOUT, shim.wait()).await;
+
+    let result = daemon.shutdown().await;
+
+    let mut start: Option<Value> = None;
+    let mut end: Option<Value> = None;
+    let mut start_count = 0usize;
+    let mut end_count = 0usize;
+    for line in result.log.lines() {
+        let Ok(v) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if v["tool"] != "fetch_message" {
+            continue;
+        }
+        match v["kind"].as_str() {
+            Some("tool_start") => {
+                start_count += 1;
+                start.get_or_insert(v);
+            }
+            Some("tool_end") => {
+                end_count += 1;
+                end.get_or_insert(v);
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        start_count, 1,
+        "expected exactly one tool_start for fetch_message; got {start_count}\nlog:\n{}",
+        result.log,
+    );
+    assert_eq!(
+        end_count, 1,
+        "expected exactly one tool_end for fetch_message; got {end_count}\nlog:\n{}",
+        result.log,
+    );
+
+    let start = start.expect("tool_start present");
+    let end = end.expect("tool_end present");
+    assert_eq!(
+        end["start_seq"], start["seq"],
+        "tool_end.start_seq must reference the paired tool_start.seq;\nstart={start}\nend={end}",
+    );
+    assert_eq!(
+        end["status"], "error",
+        "tool_end must record status=error for an in-envelope failure; got {end}",
+    );
+    assert!(
+        end["error_code"].is_string(),
+        "tool_end must carry a non-null error_code string; got {end}",
+    );
+}

--- a/crates/rimap-server/tests/daemon_dovecot_shim_reconnect.rs
+++ b/crates/rimap-server/tests/daemon_dovecot_shim_reconnect.rs
@@ -9,55 +9,19 @@
 
 mod common;
 
-use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
-use std::process::Stdio;
-
-use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt as _, BufReader};
-use tokio::process::Command;
 
 use common::dovecot_daemon_harness::DovecotDaemon;
-use common::shim_jsonrpc::{READ_TIMEOUT, recv_frame, resolved_socket_path, send_frame};
+use common::shim_jsonrpc::{
+    READ_TIMEOUT, make_runtime_dir, recv_frame, resolved_socket_path, send_frame,
+    spawn_shim_and_initialize,
+};
 
 /// Drive one shim subprocess against `runtime_dir`'s XDG path:
-/// `initialize` + `notifications/initialized` + `tools/list`, then EOF
-/// stdin so the shim exits. Returns once the shim has exited or the wait
-/// timed out.
+/// initialize handshake + `tools/list`, then EOF stdin so the shim exits.
 async fn run_shim_session(runtime_dir: &Path) {
-    let shim_bin = assert_cmd::cargo::cargo_bin("rusty-imap-mcp");
-    let mut shim = Command::new(&shim_bin)
-        .env("XDG_RUNTIME_DIR", runtime_dir)
-        .env_remove("TMPDIR")
-        .arg("shim")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .kill_on_drop(true)
-        .spawn()
-        .expect("spawn shim");
-    let mut stdin = shim.stdin.take().expect("shim stdin");
-    let stdout = shim.stdout.take().expect("shim stdout");
-    let mut reader = BufReader::new(stdout).lines();
-
-    let init = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": "2025-06-18",
-            "capabilities": {},
-            "clientInfo": {"name": "rimap-shim-reconnect-test", "version": "0.0.1"}
-        }
-    });
-    send_frame(&mut stdin, &init, "initialize").await;
-    let _ = recv_frame(&mut reader, "initialize").await;
-
-    let initialized = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/initialized"
-    });
-    send_frame(&mut stdin, &initialized, "notifications/initialized").await;
+    let (mut shim, mut stdin, mut reader) =
+        spawn_shim_and_initialize(runtime_dir, "rimap-shim-reconnect-test").await;
 
     let list = serde_json::json!({
         "jsonrpc": "2.0",
@@ -85,18 +49,8 @@ fn first_process_id(log: &str) -> Option<String> {
 
 #[tokio::test]
 async fn shim_reconnects_to_new_daemon_after_restart() {
-    // Outer runtime dir hosts the resolver path. The shim's XDG resolver
-    // lands at `<runtime_dir>/rusty-imap-mcp/daemon.sock`; both daemons
-    // bind there in turn.
-    let runtime_dir = TempDir::new().expect("runtime dir");
-    std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700))
-        .expect("chmod 0700 on runtime dir");
-
+    let runtime_dir = make_runtime_dir();
     let socket_path = resolved_socket_path(runtime_dir.path());
-    let socket_parent = socket_path.parent().expect("socket has parent");
-    std::fs::create_dir_all(socket_parent).expect("create socket parent");
-    std::fs::set_permissions(socket_parent, std::fs::Permissions::from_mode(0o700))
-        .expect("chmod 0700 on socket parent");
 
     // Daemon 1.
     let Some(daemon1) = DovecotDaemon::try_spawn_at(64, socket_path.clone()).await else {


### PR DESCRIPTION
## Summary

Three independent fixes bundled per request, one commit each.

- **#180 — `rimap-core` macOS / standalone build** (`97b9381`). Splits `DIR_OFLAGS` into a Linux-family branch that keeps `O_PATH` and a fallback that drops it, matching rustix's own gating for `OFlags::PATH`. Also enables rustix's `std` feature directly on `rimap-core` so `cargo check -p rimap-core --locked` works in isolation — previously it relied on `fs4` to pull `std` in transitively, which surfaced as the `std::os::fd::OwnedFd: rustix::fd::AsFd` cascade in the issue.
- **#179 — extract `imap_login` helpers** (`5c9885c`). Splits the 127-line function into `read_greeting`, `assert_login_enabled` (free fns), and `probe_post_login_capabilities` (method). `imap_login` is now 60 lines. No behavior change.
- **#174 — daemon-Dovecot tool-failure audit scenario** (`786b958`). Adds the deferred 5th scenario from PR #173: drives `fetch_message` against a non-existent folder through the shim subprocess and asserts a paired `tool_start` + `tool_end(status=error, error_code=Some(_))` referenced by `start_seq`. Lifts the runtime-dir setup and shim-initialize handshake into shared helpers so both this test and the existing `daemon_dovecot_shim_reconnect` test stop hand-rolling the same 30 lines.

Closes #174, #179, #180.

## Test plan

- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p rimap-core --locked`
- [x] `cargo test -p rimap-imap --locked --lib` (116 tests pass)
- [x] `RIMAP_REQUIRE_LIVE_IMAP=1 cargo test -p rimap-server --test daemon_dovecot_audit --locked`
- [x] `RIMAP_REQUIRE_LIVE_IMAP=1 cargo test -p rimap-server --test daemon_dovecot_shim_reconnect --locked`
- [ ] CI matrix on macOS — out of scope for this PR; #180 mentions extending the CI matrix as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)