### PR TITLE
docs(agents): sync required-checks enumeration with branch protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,12 +163,12 @@ are the ones that trip people up or aren't obvious from the lint set.
 - **`prek` hooks run on every commit and push.** If a hook fails, fix the
   underlying issue — do not `--no-verify`. Do not `--amend` commits that have
   been pushed.
-- **PR workflow:** feature branch -> push -> PR against `main`. CI runs all six
-  status checks (`rustfmt`, `clippy`, `test (stable)`, `test (MSRV 1.88.0)`,
-  `cargo-deny`, `zizmor self-check`), plus `SonarQube` for code quality. `main`
-  has branch protection requiring the status checks strict (branch must be up
-  to date). A separate release workflow triggers on `v*` tags and builds
-  binaries for five platform targets.
+- **PR workflow:** feature branch -> push -> PR against `main`. CI runs all seven
+  status checks (`rustfmt`, `clippy`, `check (macOS)`, `test (stable)`,
+  `test (MSRV 1.88.0)`, `cargo-deny`, `zizmor self-check`), plus `SonarQube` for
+  code quality. `main` has branch protection requiring the status checks strict
+  (branch must be up to date). A separate release workflow triggers on `v*` tags
+  and builds binaries for five platform targets.
 - **Never force-push to `main`.** Never amend commits that have been pushed.
   Never skip hooks.
 


### PR DESCRIPTION
## Summary

Following PR #185 / issue #184, the branch protection rule on `main` now
requires `check (macOS)` alongside the previous six gating checks. Update
the `AGENTS.md` PR-workflow paragraph to match — "all six status checks"
becomes "all seven", and `check (macOS)` is added to the enumerated list.

No code change. The plan at `docs/superpowers/plans/2026-04-29-ci-macos-matrix.md`
explicitly deferred this doc-sync to its own PR.

## Test plan

- [ ] CI passes (no functional changes; markdown-only edit)