### PR TITLE
test: B1 Phase 2 — mutation baseline + ClusterFuzzLite workflow

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,11 @@
+# ClusterFuzzLite Rust integration for rusty-imap-mcp.
+#
+# The base-builder-rust image ships nightly Rust + cargo-fuzz pre-installed.
+# We copy the whole repo so build.sh can reach both `fuzz/` (the cargo-fuzz
+# crate) and `crates/rimap-content` (its path dependency).
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+COPY . $SRC/rusty-imap-mcp
+COPY .clusterfuzzlite/build.sh $SRC/
+WORKDIR $SRC/rusty-imap-mcp

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+#
+# ClusterFuzzLite build entry point. Compiles each fuzz target in
+# `fuzz/fuzz_targets/` and copies the resulting binary plus its seed
+# corpus to $OUT, where ClusterFuzzLite expects them.
+#
+# `cargo +nightly fuzz build -O` matches the local `just fuzz` invocation
+# pattern; the `-O` flag is load-bearing because mail-parser 0.11.2 trips
+# internal `debug_assert!` guards on malformed multipart input in debug
+# builds.
+
+cd "$SRC/rusty-imap-mcp/fuzz"
+
+cargo +nightly fuzz build -O
+
+FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"
+
+for f in fuzz_targets/*.rs; do
+    name="$(basename "${f%.*}")"
+    cp "$FUZZ_TARGET_OUTPUT_DIR/$name" "$OUT/"
+    if [ -d "corpus/$name" ]; then
+        zip -j -r "$OUT/${name}_seed_corpus.zip" "corpus/$name"
+    fi
+done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,23 +1,22 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 #
-# ClusterFuzzLite build entry point. Compiles each fuzz target in
-# `fuzz/fuzz_targets/` and copies the resulting binary plus its seed
-# corpus to $OUT, where ClusterFuzzLite expects them.
+# ClusterFuzzLite build entry point. Builds every fuzz target in
+# `fuzz/fuzz_targets/` and copies binary + seed corpus to $OUT.
 #
-# `cargo +nightly fuzz build -O` matches the local `just fuzz` invocation
-# pattern; the `-O` flag is load-bearing because mail-parser 0.11.2 trips
-# internal `debug_assert!` guards on malformed multipart input in debug
-# builds.
+# Release mode (-O) is required: debug builds trip upstream
+# `debug_assert!` guards on malformed input.
+set -euo pipefail
 
 cd "$SRC/rusty-imap-mcp/fuzz"
 
 cargo +nightly fuzz build -O
 
-FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"
+host_triple="$(cargo +nightly -vV | awk '/^host:/ {print $2}')"
+fuzz_out_dir="target/${host_triple}/release"
 
 for f in fuzz_targets/*.rs; do
     name="$(basename "${f%.*}")"
-    cp "$FUZZ_TARGET_OUTPUT_DIR/$name" "$OUT/"
+    cp "$fuzz_out_dir/$name" "$OUT/"
     if [ -d "corpus/$name" ]; then
         zip -j -r "$OUT/${name}_seed_corpus.zip" "corpus/$name"
     fi

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep the ClusterFuzzLite Docker context lean. Without this file, every
+# `docker build` against `.clusterfuzzlite/Dockerfile` ships gigabytes of
+# local build artifacts to the daemon. CI runners are clean checkouts so
+# this only protects local invocations.
+
+.git/
+.worktrees/
+target/
+fuzz/target/
+fuzz/artifacts/
+fuzz/coverage/
+mutants.out/
+mutants.out.old/
+*.log

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -67,6 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with fuzz/fuzz_targets/*.rs.
         target: [content_mime, content_html, content_rfc2047, content_charset]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,85 @@
+name: Fuzz
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/rimap-content/**'
+      - 'crates/rimap-audit/**'
+      - 'crates/rimap-server/**'
+      - 'fuzz/**'
+      - '.github/workflows/fuzz.yml'
+  schedule:
+    # Nightly at 03:17 UTC. The odd minute spreads load on shared GHA
+    # cron schedulers (top-of-the-hour cron jobs queue heavily).
+    - cron: '17 3 * * *'
+
+concurrency:
+  # PR-smoke runs share a per-PR group so a force-push cancels the prior run.
+  # Nightly runs share a single global group so two nightly cycles cannot
+  # overlap if one runs long.
+  group: fuzz-${{ github.event_name == 'schedule' && 'nightly' || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  # 'security-events: write' would be needed to upload SARIF; not used here
+  # because crash artifacts are sufficient for B1's scope.
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  pr-smoke:
+    name: pr-smoke (${{ matrix.target }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [content_mime, content_html]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          sanitizer: address
+      - name: Run fuzzer (${{ matrix.target }})
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: address
+          # Restrict to a single target per matrix slot so a crash in one
+          # does not mask a regression in the other.
+          parallel-fuzzing: false
+
+  nightly:
+    name: nightly (${{ matrix.target }})
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [content_mime, content_html, content_rfc2047, content_charset]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          sanitizer: address
+      - name: Run fuzzer (${{ matrix.target }})
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          fuzz-seconds: 1800  # 30 minutes per target
+          mode: batch
+          sanitizer: address
+          parallel-fuzzing: false

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,8 @@ on:
       - 'crates/rimap-audit/**'
       - 'crates/rimap-server/**'
       - 'fuzz/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/fuzz.yml'
   schedule:
     # Nightly at 03:17 UTC. The odd minute spreads load on shared GHA

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -1,0 +1,80 @@
+# Mutation-baseline — Targeted-trust-boundary survivor inventory
+
+**Updated:** 2026-04-30
+**Tool:** `cargo-mutants` (run via `just mutants-crate <name>`)
+**Scope:** Five trust-boundary crates — `rimap-content`, `rimap-authz`,
+`rimap-audit`, `rimap-server`, `rimap-imap`. Other workspace crates are
+out of scope per spec
+[`2026-04-30-test-strategy-improvements-design.md`](../2026-04-30-test-strategy-improvements-design.md).
+
+A survivor is recorded here when it is *not* a true bug in the test suite —
+either because the mutation is mathematically equivalent to the original
+code, or because it falls in a code path the spec explicitly classifies as
+"plumbing, best-effort." Survivors that *are* test-suite gaps are killed by
+adding a test, not annotated.
+
+---
+
+## `rimap-content`
+
+**Last refresh:** 2026-04-30.
+**Surviving mutants in non-`bin/` code:** 80.
+
+> **Cap exceeded.** B1's mutation cleanup is scoped to "manageable inline
+> cleanup," with a 30-survivor cap defined in the plan. The refreshed run
+> recorded 80 survivors outside `src/bin/`, well above that threshold, so
+> Tasks 8 and 9 are deferred to a follow-up plan. The full survivor list
+> for this run is preserved at `/tmp/rimap-content-survivors.txt` on the
+> author's machine and in `mutants.out/missed.txt` for this commit; per-file
+> breakdown is summarised in the table below. Fuzz harnesses (Task 6,
+> already shipped in PR #190) and ClusterFuzzLite wiring (Task 10) still
+> ship in this sprint.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+| _populated by Task 8/9_ |  |  |  |
+
+Per-file survivor counts at 2026-04-30 refresh (for sizing the follow-up
+plan):
+
+| File | Survivors |
+|---|---:|
+| `src/lookalike.rs` | 14 |
+| `src/parse/filename.rs` | 10 |
+| `src/parse/bodies.rs` | 9 |
+| `src/html/style_parse.rs` | 8 |
+| `src/parse/headers.rs` | 7 |
+| `src/html/mismatch.rs` | 7 |
+| `src/parse/mime_scrub.rs` | 6 |
+| `src/threading.rs` | 4 |
+| `src/raw_parts.rs` | 3 |
+| `src/lib.rs` | 3 |
+| `src/html/mod.rs` | 3 |
+| `src/parse/mod.rs` | 2 |
+| `src/unicode.rs` | 1 |
+| `src/parse/meta.rs` | 1 |
+| `src/parse/attachments.rs` | 1 |
+| `src/html/extract.rs` | 1 |
+| **Total** | **80** |
+
+Run summary (646 mutants total): 479 caught, 96 missed (80 outside
+`src/bin/`, 16 inside), 8 timeout, 63 unviable.
+
+The `bin/epvme_runner.rs` survivors are out of scope for B1 — that crate is
+diagnostic tooling, not production. Re-evaluate post-B4.
+
+## `rimap-authz`
+
+_Populated in Sprint B2._
+
+## `rimap-audit`
+
+_Populated in Sprint B2._
+
+## `rimap-server`
+
+_Populated in Sprint B3._
+
+## `rimap-imap`
+
+_Populated in Sprint B3._

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -29,12 +29,10 @@ adding a test, not annotated.
 > harnesses (Task 6, already shipped in PR #190) and ClusterFuzzLite
 > wiring (Task 10) still ship in this sprint.
 
-| File:line | Mutation | Reason kept | Annotation site |
-|---|---|---|---|
-| _deferred to follow-up plan (B1 Tasks 8/9 over-cap)_ |  |  |  |
+No survivors are annotated yet — the per-survivor table lands in the
+B1-followup PR.
 
-Per-file survivor counts at 2026-04-30 refresh (for sizing the follow-up
-plan):
+Per-file survivor counts at the 2026-04-30 refresh:
 
 | File | Survivors |
 |---|---:|
@@ -62,18 +60,6 @@ Run summary (646 mutants total): 479 caught, 96 missed (80 outside
 The `bin/epvme_runner.rs` survivors are out of scope for B1 — that crate is
 diagnostic tooling, not production. Re-evaluate post-B4.
 
-## `rimap-authz`
-
-_Populated in Sprint B2._
-
-## `rimap-audit`
-
-_Populated in Sprint B2._
-
-## `rimap-server`
-
-_Populated in Sprint B3._
-
-## `rimap-imap`
-
-_Populated in Sprint B3._
+The other four trust-boundary crates (`rimap-authz`, `rimap-audit`,
+`rimap-server`, `rimap-imap`) get their own sections here when Sprints
+B2–B3 land.

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -23,16 +23,15 @@ adding a test, not annotated.
 > **Cap exceeded.** B1's mutation cleanup is scoped to "manageable inline
 > cleanup," with a 30-survivor cap defined in the plan. The refreshed run
 > recorded 80 survivors outside `src/bin/`, well above that threshold, so
-> Tasks 8 and 9 are deferred to a follow-up plan. The full survivor list
-> for this run is preserved at `/tmp/rimap-content-survivors.txt` on the
-> author's machine and in `mutants.out/missed.txt` for this commit; per-file
-> breakdown is summarised in the table below. Fuzz harnesses (Task 6,
-> already shipped in PR #190) and ClusterFuzzLite wiring (Task 10) still
-> ship in this sprint.
+> Tasks 8 and 9 are deferred to a follow-up plan. The per-file breakdown
+> below sizes that follow-up; the full line-by-line survivor list is not
+> committed (regenerate by re-running the plan's Task 7 Step 1). Fuzz
+> harnesses (Task 6, already shipped in PR #190) and ClusterFuzzLite
+> wiring (Task 10) still ship in this sprint.
 
 | File:line | Mutation | Reason kept | Annotation site |
 |---|---|---|---|
-| _populated by Task 8/9_ |  |  |  |
+| _deferred to follow-up plan (B1 Tasks 8/9 over-cap)_ |  |  |  |
 
 Per-file survivor counts at 2026-04-30 refresh (for sizing the follow-up
 plan):


### PR DESCRIPTION
## Summary

Sprint B1 Phase 2 of the test-strategy-improvements plan. Phase 1 (the four `cargo-fuzz` harnesses + their seed corpora + two security fixes the harnesses surfaced) shipped via #190.

Phase 2 lands two artifacts:

- **Refreshed `cargo-mutants` baseline for `rimap-content`** — recorded in [`docs/superpowers/specs/test-strategy/mutation-baseline.md`](docs/superpowers/specs/test-strategy/mutation-baseline.md). The 2026-04-30 refresh found **80 surviving mutants outside `src/bin/`**, exceeding the plan's 30-survivor cap for "manageable inline cleanup." Per the plan, **Tasks 8 and 9 (the per-module mutation cleanup) are deferred to a follow-up plan.** Per-file breakdown is captured in the baseline doc to size that follow-up.
- **ClusterFuzzLite CI workflow** — `.github/workflows/fuzz.yml`. PR-smoke runs `content_mime` + `content_html` for 5 min each on every PR that touches the fuzzed crates, the workspace `Cargo.toml`/`Cargo.lock`, or the workflow itself. Nightly cron at 03:17 UTC runs all four B1 targets at 30 min each. ClusterFuzzLite pinned to tag `v1` (`884713a6c30a92e5e8544c39945cd7cb630abcd1`).

This PR is small because the cap-exceeded outcome cuts most of the originally-planned scope.

## Test plan

- [x] `actionlint .github/workflows/fuzz.yml` — clean.
- [x] `zizmor .github/workflows/fuzz.yml` — clean (no findings, no suppressions).
- [x] All pre-commit hooks pass on every commit (typos, end-of-files, mixed-line-ending, branch-name, etc.).
- [x] `mutation-baseline.md` documents the 2026-04-30 state for `rimap-content` (80 survivors, cap exceeded, follow-up scoped).
- [ ] All seven existing `just ci` checks pass on this branch (rustfmt, clippy, check (macOS), test (stable), test (MSRV 1.88.0), cargo-deny, zizmor self-check).
- [ ] The new `fuzz / pr-smoke (content_mime)` and `fuzz / pr-smoke (content_html)` jobs appear in this PR's status checks and run to completion green.

## Out of scope (deferred)

- Per-module `cargo-mutants` cleanup of `rimap-content` (Tasks 8–9 in the plan). Cap exceeded, will land in its own plan.
- Mutation work on `rimap-authz`, `rimap-audit`, `rimap-server`, `rimap-imap`. Those are Sprints B2–B3.

## Follow-up issues to open after merge

1. `test(rimap-content): finish mutation cleanup deferred from Sprint B1 Phase 2` — 80 survivors documented in `mutation-baseline.md`.
2. `test(epvme_runner): triage cargo-mutants survivors in diagnostic binary` — pre-existing, ~44 survivors as of 2026-04-08 baseline.
3. `refactor(workspace): replace remaining UTF-8 boundary-walk copies with truncate_graphemes` — three sites identified during Phase 1 /simplify review (`lookalike.rs:183`, `audit/writer/provenance.rs:74`, `server/tools/retrieval/fetch_message.rs:151`).

Refs: [`docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md`](docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md), [`docs/superpowers/plans/2026-04-30-test-strategy-b1-rimap-content.md`](docs/superpowers/plans/2026-04-30-test-strategy-b1-rimap-content.md).