### PR TITLE
feat: surface TLS cert fingerprint during --dry-run (#151)

### DIFF
--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -1240,6 +1240,88 @@ mod tests {
         }
     }
 
+    // Helper: build a TlsConfigBundle with `observed` pre-set in last_observed.
+    fn bundle_with_observed(observed: TlsFingerprint) -> crate::tls::TlsConfigBundle {
+        let b = crate::tls::build_tls_config(None).expect("build_tls_config");
+        b.last_observed.get_or_init(|| observed);
+        b
+    }
+
+    #[test]
+    fn enrich_tls_handshake_mismatch_rewrites_to_typed_tls_error() {
+        // When the observed fingerprint differs from the configured pin, the
+        // raw TlsHandshake error must be rewritten to Tls { observed, expected }
+        // so callers can surface the exact fingerprints.
+        let expected = TlsFingerprint::from_cert_der(b"expected-pin");
+        let observed = TlsFingerprint::from_cert_der(b"observed-cert");
+        assert_ne!(expected, observed);
+        let bundle = bundle_with_observed(observed);
+        let err = ImapError::TlsHandshake(tokio_rustls::rustls::Error::General(
+            "handshake failed".into(),
+        ));
+        let enriched = super::enrich_tls_handshake_error(err, &bundle, Some(expected));
+        match enriched {
+            ImapError::Tls {
+                observed: obs,
+                expected: exp,
+            } => {
+                assert_eq!(obs, observed, "observed fingerprint must be propagated");
+                assert_eq!(exp, expected, "expected fingerprint must be propagated");
+            }
+            other => panic!("expected Tls variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enrich_tls_handshake_matching_pin_passes_through_unchanged() {
+        // When observed == expected (matching pin), the error must pass through as
+        // TlsHandshake — a non-mismatch handshake failure should not masquerade as
+        // a pin mismatch.
+        let fp = TlsFingerprint::from_cert_der(b"same-cert");
+        let bundle = bundle_with_observed(fp);
+        let err =
+            ImapError::TlsHandshake(tokio_rustls::rustls::Error::General("other error".into()));
+        let enriched = super::enrich_tls_handshake_error(err, &bundle, Some(fp));
+        match enriched {
+            ImapError::TlsHandshake(e) => {
+                assert!(e.to_string().contains("other error"));
+            }
+            other => panic!("expected TlsHandshake variant (no rewrite), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enrich_tls_handshake_no_pin_passes_through_unchanged() {
+        // When no pin is configured, TlsHandshake must pass through regardless
+        // of the observed fingerprint.
+        let observed = TlsFingerprint::from_cert_der(b"some-cert");
+        let bundle = bundle_with_observed(observed);
+        let err =
+            ImapError::TlsHandshake(tokio_rustls::rustls::Error::General("generic tls".into()));
+        let enriched = super::enrich_tls_handshake_error(err, &bundle, None);
+        match enriched {
+            ImapError::TlsHandshake(_) => {}
+            other => panic!("expected TlsHandshake passthrough, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enrich_tls_handshake_non_handshake_error_passes_through() {
+        // Only TlsHandshake variants are rewritten; other ImapError variants must
+        // pass through unmodified.
+        let bundle = bundle_with_observed(TlsFingerprint::from_cert_der(b"any"));
+        let err = ImapError::Timeout { op: "tcp_connect" };
+        let enriched = super::enrich_tls_handshake_error(
+            err,
+            &bundle,
+            Some(TlsFingerprint::from_cert_der(b"pin")),
+        );
+        match enriched {
+            ImapError::Timeout { op: "tcp_connect" } => {}
+            other => panic!("expected Timeout passthrough, got {other:?}"),
+        }
+    }
+
     /// Regression test for the cancellation contract on
     /// [`Connection::emit_auth`]: the sink still observes the event even
     /// when the awaiting future is dropped before `spawn_blocking`

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -139,7 +139,7 @@ impl std::fmt::Debug for Connection {
 /// mismatch error surfaces on every TLS-failing path.
 pub(crate) fn enrich_tls_handshake_error(
     err: ImapError,
-    bundle: &crate::tls::TlsConfigBundle,
+    bundle: &TlsConfigBundle,
     pinned: Option<TlsFingerprint>,
 ) -> ImapError {
     match err {
@@ -147,7 +147,7 @@ pub(crate) fn enrich_tls_handshake_error(
             (Some(expected), Some(observed)) if expected != observed => {
                 ImapError::Tls { observed, expected }
             }
-            _ => ImapError::TlsHandshake(inner),
+            (Some(_) | None, _) => ImapError::TlsHandshake(inner),
         },
         other => other,
     }

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -132,6 +132,27 @@ impl std::fmt::Debug for Connection {
     }
 }
 
+/// If `err` is `ImapError::TlsHandshake` and the bundle observed a fingerprint
+/// that disagrees with `pinned`, rewrite into `ImapError::Tls { observed,
+/// expected }`. Other error variants and matching observations pass through
+/// unchanged. Used by both `connect_inner` and `probe_preflight` so the typed
+/// mismatch error surfaces on every TLS-failing path.
+pub(crate) fn enrich_tls_handshake_error(
+    err: ImapError,
+    bundle: &crate::tls::TlsConfigBundle,
+    pinned: Option<TlsFingerprint>,
+) -> ImapError {
+    match err {
+        ImapError::TlsHandshake(inner) => match (pinned, bundle.last_observed.get().copied()) {
+            (Some(expected), Some(observed)) if expected != observed => {
+                ImapError::Tls { observed, expected }
+            }
+            _ => ImapError::TlsHandshake(inner),
+        },
+        other => other,
+    }
+}
+
 impl Connection {
     /// Build a connection handle. Does NOT open a socket.
     ///
@@ -229,16 +250,14 @@ impl Connection {
         let raw_outcome = self.connect_with_bundle(&bundle).await;
         let (outcome, credential_source) = match raw_outcome {
             Ok((session, src)) => (Ok(session), Some(src)),
-            Err((ImapError::TlsHandshake(inner), src)) => {
-                let enriched = match (cfg.pinned_fingerprint, bundle.last_observed.get().copied()) {
-                    (Some(expected), Some(observed)) if expected != observed => {
-                        ImapError::Tls { observed, expected }
-                    }
-                    (Some(_) | None, _) => ImapError::TlsHandshake(inner),
-                };
-                (Err(enriched), src)
-            }
-            Err((other, src)) => (Err(other), src),
+            Err((err, src)) => (
+                Err(enrich_tls_handshake_error(
+                    err,
+                    &bundle,
+                    cfg.pinned_fingerprint,
+                )),
+                src,
+            ),
         };
 
         let observed = bundle.last_observed.get().copied();

--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -135,8 +135,9 @@ impl std::fmt::Debug for Connection {
 /// If `err` is `ImapError::TlsHandshake` and the bundle observed a fingerprint
 /// that disagrees with `pinned`, rewrite into `ImapError::Tls { observed,
 /// expected }`. Other error variants and matching observations pass through
-/// unchanged. Used by both `connect_inner` and `probe_preflight` so the typed
-/// mismatch error surfaces on every TLS-failing path.
+/// unchanged. Centralizes the rewrite so every TLS-failing code path produces
+/// a typed `ImapError::Tls { observed, expected }` when both fingerprints are
+/// known, rather than the generic `TlsHandshake` variant.
 pub(crate) fn enrich_tls_handshake_error(
     err: ImapError,
     bundle: &TlsConfigBundle,
@@ -1240,7 +1241,6 @@ mod tests {
         }
     }
 
-    // Helper: build a TlsConfigBundle with `observed` pre-set in last_observed.
     fn bundle_with_observed(observed: TlsFingerprint) -> crate::tls::TlsConfigBundle {
         let b = crate::tls::build_tls_config(None).expect("build_tls_config");
         b.last_observed.get_or_init(|| observed);

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -112,6 +112,13 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     // CAPABILITY leg (it is the per-command budget); apply the remaining
     // connect-budget to the greeting read.
     let greeting_budget = total_deadline.saturating_sub(started.elapsed());
+    // cargo-mutants: escapes unit tests — `delete !` inverts TLS/STARTTLS
+    // greeting-read logic: for TLS (already_greeted=false) the mutant skips
+    // reading the server greeting, so CAPABILITY would be sent before the
+    // client has consumed the greeting bytes, causing a protocol error.
+    // Covered by case_21 (TLS) and the starttls suite (STARTTLS) in the
+    // Dovecot integration harness; not testable at unit level without a live
+    // TLS IMAP server.
     if !already_greeted {
         timeout(greeting_budget, client.read_response())
             .await
@@ -148,6 +155,11 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
             for cap in list {
                 if let ImapCapability::Atom(name) = cap {
                     let upper = name.to_ascii_uppercase();
+                    // cargo-mutants: escapes unit tests — mutations on
+                    // `!is_empty()`, `!contains()`, and `&&` vs `||` only
+                    // manifest with real capability atoms from a live server.
+                    // All three are caught by case_21 (asserts non-empty
+                    // capabilities vec) in the Dovecot integration suite.
                     if !upper.is_empty() && !caps.contains(&upper) {
                         caps.push(upper);
                     }

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -27,9 +27,10 @@ pub struct PreflightInfo {
     /// response, upper-cased, de-duplicated, order preserved as received.
     pub capabilities: Vec<String>,
     /// Leaf-cert SHA-256 fingerprint observed during the TLS handshake.
-    /// The TLS verifier writes the value into the `last_observed` slot
-    /// during `verify_server_cert`; `probe_preflight` reads the slot
-    /// after the CAPABILITY round-trip succeeds and surfaces it here.
+    /// Captured from the verifier's `last_observed` slot. Always populated
+    /// on a successful `probe_preflight` (the verifier runs before TLS
+    /// completes); a `None` would indicate a programming bug, surfaced as
+    /// `ImapError::TlsHandshake` rather than a panic.
     pub tls_fingerprint: rimap_core::TlsFingerprint,
 }
 
@@ -71,6 +72,8 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     // STARTTLS consumes the plaintext greeting during negotiation, so the TLS
     // stream does not receive another greeting. Implicit TLS has not read the
     // greeting yet.
+    let enrich =
+        |e| crate::connection::enrich_tls_handshake_error(e, &bundle, cfg.pinned_fingerprint);
     let (tls_stream, already_greeted) = match cfg.encryption {
         ImapEncryption::Tls => {
             let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
@@ -78,13 +81,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
                 .map_err(|_| ImapError::Timeout {
                     op: "tls_handshake",
                 })?
-                .map_err(|e| {
-                    crate::connection::enrich_tls_handshake_error(
-                        e,
-                        &bundle,
-                        cfg.pinned_fingerprint,
-                    )
-                })?;
+                .map_err(enrich)?;
             (s, false)
         }
         ImapEncryption::Starttls => {
@@ -93,13 +90,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
                 .map_err(|_| ImapError::Timeout {
                     op: "starttls_upgrade",
                 })?
-                .map_err(|e| {
-                    crate::connection::enrich_tls_handshake_error(
-                        e,
-                        &bundle,
-                        cfg.pinned_fingerprint,
-                    )
-                })?;
+                .map_err(enrich)?;
             (s, true)
         }
     };
@@ -112,13 +103,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     // CAPABILITY leg (it is the per-command budget); apply the remaining
     // connect-budget to the greeting read.
     let greeting_budget = total_deadline.saturating_sub(started.elapsed());
-    // cargo-mutants: escapes unit tests — `delete !` inverts TLS/STARTTLS
-    // greeting-read logic: for TLS (already_greeted=false) the mutant skips
-    // reading the server greeting, so CAPABILITY would be sent before the
-    // client has consumed the greeting bytes, causing a protocol error.
-    // Covered by case_21 (TLS) and the starttls suite (STARTTLS) in the
-    // Dovecot integration harness; not testable at unit level without a live
-    // TLS IMAP server.
+    // cargo-mutants: only exercised by Dovecot integration (case_21 / starttls suite); no live IMAP server at unit level.
     if !already_greeted {
         timeout(greeting_budget, client.read_response())
             .await
@@ -155,11 +140,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
             for cap in list {
                 if let ImapCapability::Atom(name) = cap {
                     let upper = name.to_ascii_uppercase();
-                    // cargo-mutants: escapes unit tests — mutations on
-                    // `!is_empty()`, `!contains()`, and `&&` vs `||` only
-                    // manifest with real capability atoms from a live server.
-                    // All three are caught by case_21 (asserts non-empty
-                    // capabilities vec) in the Dovecot integration suite.
+                    // cargo-mutants: filter mutations only manifest with real CAPABILITY atoms; covered by case_21's `!info.capabilities.is_empty()` assertion.
                     if !upper.is_empty() && !caps.contains(&upper) {
                         caps.push(upper);
                     }

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -31,8 +31,12 @@ pub struct PreflightInfo {
     pub tls_fingerprint: rimap_core::TlsFingerprint,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl PreflightInfo {
-    /// Create a new `PreflightInfo` for testing and diagnostic purposes.
+    /// Construct a `PreflightInfo` for tests. Bypasses `#[non_exhaustive]`
+    /// so test crates can synthesize fixtures without going through
+    /// `probe_preflight`. Gated behind `test-support` to keep the constructor
+    /// out of the production public API surface.
     #[must_use]
     pub fn new(capabilities: Vec<String>, tls_fingerprint: rimap_core::TlsFingerprint) -> Self {
         Self {

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -1,7 +1,9 @@
 //! Pre-auth `CAPABILITY` probe used by `--dry-run` and other diagnostic
 //! paths. Performs TCP connect → TLS handshake → IMAP greeting → pre-auth
-//! `CAPABILITY` command, then drops the connection. Does NOT perform LOGIN
-//! and does NOT emit any audit records.
+//! `CAPABILITY` command, then drops the connection. Captures the leaf-cert
+//! SHA-256 fingerprint observed during the handshake (returned via
+//! `PreflightInfo.tls_fingerprint`). Does NOT perform LOGIN and does NOT
+//! emit any audit records.
 
 use std::time::Instant;
 

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -31,6 +31,17 @@ pub struct PreflightInfo {
     pub tls_fingerprint: rimap_core::TlsFingerprint,
 }
 
+impl PreflightInfo {
+    /// Create a new `PreflightInfo` for testing and diagnostic purposes.
+    #[must_use]
+    pub fn new(capabilities: Vec<String>, tls_fingerprint: rimap_core::TlsFingerprint) -> Self {
+        Self {
+            capabilities,
+            tls_fingerprint,
+        }
+    }
+}
+
 /// Run a TCP+TLS+greeting+CAPABILITY probe against `cfg`.
 ///
 /// # Errors

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -25,8 +25,9 @@ pub struct PreflightInfo {
     /// response, upper-cased, de-duplicated, order preserved as received.
     pub capabilities: Vec<String>,
     /// Leaf-cert SHA-256 fingerprint observed during the TLS handshake.
-    /// Captured from the verifier's `last_observed` slot before any IMAP
-    /// traffic flows.
+    /// The TLS verifier writes the value into the `last_observed` slot
+    /// during `verify_server_cert`; `probe_preflight` reads the slot
+    /// after the CAPABILITY round-trip succeeds and surfaces it here.
     pub tls_fingerprint: rimap_core::TlsFingerprint,
 }
 

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -24,6 +24,10 @@ pub struct PreflightInfo {
     /// Capability atoms returned by the server's pre-auth `CAPABILITY`
     /// response, upper-cased, de-duplicated, order preserved as received.
     pub capabilities: Vec<String>,
+    /// Leaf-cert SHA-256 fingerprint observed during the TLS handshake.
+    /// Captured from the verifier's `last_observed` slot before any IMAP
+    /// traffic flows.
+    pub tls_fingerprint: rimap_core::TlsFingerprint,
 }
 
 /// Run a TCP+TLS+greeting+CAPABILITY probe against `cfg`.
@@ -120,5 +124,13 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
         }
     }
 
-    Ok(PreflightInfo { capabilities: caps })
+    let tls_fingerprint = bundle.last_observed.get().copied().ok_or_else(|| {
+        ImapError::TlsHandshake(tokio_rustls::rustls::Error::General(
+            "verifier did not capture fingerprint".into(),
+        ))
+    })?;
+    Ok(PreflightInfo {
+        capabilities: caps,
+        tls_fingerprint,
+    })
 }

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -55,7 +55,15 @@ impl PreflightInfo {
 /// Mirrors `ImapError` variants: `Connect`, `TlsHandshake`, `Timeout`,
 /// `Protocol`. Never returns `Auth` variants — no credentials are used.
 pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, ImapError> {
-    let bundle = build_tls_config(cfg.pinned_fingerprint)?;
+    // Pinned mode: enforce the configured fingerprint via PinningVerifier.
+    // Unpinned mode: use the capture-only verifier so a self-signed cert
+    // (e.g., Proton Bridge) does not abort the probe before we can surface
+    // the fingerprint to the operator. Trust-on-first-use applies — same
+    // posture as the openssl recipe in the quickstart.
+    let bundle = match cfg.pinned_fingerprint {
+        Some(_) => build_tls_config(cfg.pinned_fingerprint)?,
+        None => crate::tls::build_tls_config_capture_only()?,
+    };
     let total_deadline = cfg.connect_timeout;
     let started = Instant::now();
 

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -60,7 +60,14 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
                 .await
                 .map_err(|_| ImapError::Timeout {
                     op: "tls_handshake",
-                })??;
+                })?
+                .map_err(|e| {
+                    crate::connection::enrich_tls_handshake_error(
+                        e,
+                        &bundle,
+                        cfg.pinned_fingerprint,
+                    )
+                })?;
             (s, false)
         }
         ImapEncryption::Starttls => {
@@ -68,7 +75,14 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
                 .await
                 .map_err(|_| ImapError::Timeout {
                     op: "starttls_upgrade",
-                })??;
+                })?
+                .map_err(|e| {
+                    crate::connection::enrich_tls_handshake_error(
+                        e,
+                        &bundle,
+                        cfg.pinned_fingerprint,
+                    )
+                })?;
             (s, true)
         }
     };

--- a/crates/rimap-imap/src/tls.rs
+++ b/crates/rimap-imap/src/tls.rs
@@ -160,6 +160,70 @@ pub struct TlsConfigBundle {
     pub last_observed: Arc<OnceLock<TlsFingerprint>>,
 }
 
+/// Diagnostic-only verifier: captures the leaf-cert fingerprint and ALWAYS
+/// accepts the cert. Used by `probe_preflight` in unpinned mode so an
+/// operator can observe what the server presents during onboarding even
+/// against a self-signed cert that the system trust store would reject.
+///
+/// **Never use this verifier on the auth path.** It accepts any cert,
+/// including a network attacker's. The trust commitment for `--dry-run`
+/// is identical to running `openssl s_client` over the same network: the
+/// operator must trust the network at fingerprint-extraction time.
+#[derive(Debug)]
+pub(crate) struct CaptureOnlyVerifier {
+    last_observed: Arc<OnceLock<TlsFingerprint>>,
+    provider: Arc<tokio_rustls::rustls::crypto::CryptoProvider>,
+}
+
+impl ServerCertVerifier for CaptureOnlyVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, tokio_rustls::rustls::Error> {
+        let observed = TlsFingerprint::from_cert_der(end_entity.as_ref());
+        let _ = self.last_observed.set(observed);
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        tokio_rustls::rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        tokio_rustls::rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
 /// Build a `TlsConfigBundle`. If `pinned.is_some()`, uses `PinningVerifier`
 /// (skips chain validation). Otherwise uses webpki-roots with
 /// `CapturingVerifier`.
@@ -222,6 +286,41 @@ pub fn build_tls_config(
             .with_custom_certificate_verifier(capturing)
             .with_no_client_auth()
     };
+
+    Ok(TlsConfigBundle {
+        config: Arc::new(config),
+        last_observed,
+    })
+}
+
+/// Build a `TlsConfigBundle` whose verifier captures the leaf-cert
+/// fingerprint and accepts any cert (no chain validation). Diagnostic-only
+/// — `probe_preflight` uses this in unpinned mode so operators can see
+/// what the server presents during onboarding, including for self-signed
+/// certs that webpki-roots would reject.
+///
+/// **Trust on first use.** A network attacker's cert will be captured
+/// and reported as if it were the server's. Document this in any
+/// caller-facing UX.
+///
+/// # Errors
+/// Same conditions as `build_tls_config`: would only fire if rustls
+/// cannot construct a `ClientConfig` with the workspace's safe default
+/// protocol versions.
+pub fn build_tls_config_capture_only() -> Result<TlsConfigBundle, crate::error::ImapError> {
+    let last_observed = Arc::new(OnceLock::new());
+    let provider = Arc::new(tokio_rustls::rustls::crypto::ring::default_provider());
+
+    let verifier = Arc::new(CaptureOnlyVerifier {
+        last_observed: Arc::clone(&last_observed),
+        provider: Arc::clone(&provider),
+    });
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(crate::error::ImapError::TlsHandshake)?
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
 
     Ok(TlsConfigBundle {
         config: Arc::new(config),

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -886,3 +886,28 @@ mod starttls {
         );
     }
 }
+
+#[tokio::test]
+async fn case_21_probe_preflight_returns_observed_fingerprint() {
+    let Some(h) = boot(PinChoice::None) else {
+        return;
+    };
+    let cfg = ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: DovecotHarness::host().to_string(),
+        port: h.harness.port(),
+        encryption: rimap_imap::ImapEncryption::Tls,
+        username: DovecotHarness::username().to_string(),
+        pinned_fingerprint: None,
+        connect_timeout: Duration::from_secs(10),
+        command_timeout: Duration::from_secs(10),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    let info = rimap_imap::preflight::probe_preflight(&cfg)
+        .await
+        .expect("preflight should succeed against the live harness");
+    assert_eq!(info.tls_fingerprint, h.harness.pinned_fingerprint());
+    assert!(!info.capabilities.is_empty());
+}

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -911,3 +911,35 @@ async fn case_21_probe_preflight_returns_observed_fingerprint() {
     assert_eq!(info.tls_fingerprint, h.harness.pinned_fingerprint());
     assert!(!info.capabilities.is_empty());
 }
+
+#[tokio::test]
+async fn case_22_probe_preflight_mismatch_returns_typed_tls_error() {
+    let Some(h) = boot(PinChoice::None) else {
+        return;
+    };
+    let wrong = rimap_core::TlsFingerprint::from_cert_der(b"deliberately-wrong");
+    let cfg = ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: DovecotHarness::host().to_string(),
+        port: h.harness.port(),
+        encryption: rimap_imap::ImapEncryption::Tls,
+        username: DovecotHarness::username().to_string(),
+        pinned_fingerprint: Some(wrong),
+        connect_timeout: Duration::from_secs(10),
+        command_timeout: Duration::from_secs(10),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    let err = rimap_imap::preflight::probe_preflight(&cfg)
+        .await
+        .expect_err("mismatched pin must produce an error");
+    match err {
+        ImapError::Tls { observed, expected } => {
+            assert_eq!(observed, h.harness.pinned_fingerprint());
+            assert_eq!(expected, wrong);
+        }
+        #[expect(clippy::panic, reason = "test failure path")]
+        other => panic!("expected ImapError::Tls, got {other:?}"),
+    }
+}

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -20,6 +20,12 @@
 //! Infrastructure tools (always available):
 //!   [ok ] use_account
 //!   [ok ] list_accounts
+//! Capabilities (imap.example.com:993):
+//!   [ok ] IMAP4REV1
+//!   [ok ] IDLE
+//! TLS fingerprint (sha256):
+//!   ab:cd:...:ef
+//!   (add `tls_fingerprint_sha256 = "ab:cd:...:ef"` under [imap] in config.toml to pin)
 //! ```
 
 use std::io::Write;
@@ -47,9 +53,7 @@ use rimap_core::tool::ToolName;
 /// fingerprint to surface when the verifier never ran or the value is not
 /// meaningfully informative.
 ///
-/// Used by unit tests below; will be called from `run()` in task 5.
-#[allow(clippy::allow_attributes, dead_code)]
-// ^ Justification: Used by tests; wiring into run() is task 5.
+/// Used by unit tests below and called from `run()`.
 fn write_fingerprint_section<W: Write>(
     out: &mut W,
     result: &Result<rimap_imap::preflight::PreflightInfo, rimap_imap::error::ImapError>,
@@ -144,7 +148,8 @@ pub async fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
         // config may have one unreachable host and still want to print
         // the matrix for the others.
         let conn_cfg = rimap_server::boot::registry::build_account_connection(id, acfg);
-        match rimap_imap::preflight::probe_preflight(&conn_cfg).await {
+        let preflight_result = rimap_imap::preflight::probe_preflight(&conn_cfg).await;
+        match &preflight_result {
             Ok(info) => {
                 writeln!(out, "Capabilities ({}:{}):", conn_cfg.host, conn_cfg.port)?;
                 for cap in &info.capabilities {
@@ -159,6 +164,7 @@ pub async fn run<W: Write>(path: &Path, out: &mut W) -> anyhow::Result<()> {
                 )?;
             }
         }
+        write_fingerprint_section(out, &preflight_result, conn_cfg.pinned_fingerprint)?;
     }
     Ok(())
 }

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -429,4 +429,70 @@ allowed_base_dir = "{}"
             "mismatch diagnostic must not appear:\n{text}"
         );
     }
+
+    fn write_multi_account_config(dir: &TempDir) -> PathBuf {
+        let audit = dir.path().join("audit.jsonl");
+        let config_path = dir.path().join("config.toml");
+        let body = format!(
+            r#"
+[[accounts]]
+name = "work"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "alice@work.test"
+
+[[accounts]]
+name = "personal"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = 1143
+username = "alice@personal.test"
+
+[audit]
+path = "{audit}"
+allowed_base_dir = "{base}"
+"#,
+            audit = audit.display(),
+            base = dir.path().display(),
+        );
+        std::fs::write(&config_path, body).unwrap();
+        config_path
+    }
+
+    #[tokio::test]
+    async fn dry_run_single_account_omits_account_header() {
+        // With exactly one account the "Account: <name>" header should be
+        // absent — it is only useful when multiple accounts share the output.
+        let dir = tight_tempdir();
+        let path = write_minimal_config(&dir);
+        let mut out = Vec::new();
+        run(&path, &mut out).await.unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            !text.contains("Account:"),
+            "single-account output must not contain 'Account:' header:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_multi_account_prints_account_headers() {
+        // With two accounts each section must be prefixed with
+        // "Account: <name>" so users can tell the sections apart.
+        let dir = tight_tempdir();
+        let path = write_multi_account_config(&dir);
+        let mut out = Vec::new();
+        run(&path, &mut out).await.unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("Account: work"),
+            "multi-account output must contain 'Account: work':\n{text}"
+        );
+        assert!(
+            text.contains("Account: personal"),
+            "multi-account output must contain 'Account: personal':\n{text}"
+        );
+    }
 }

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -73,7 +73,7 @@ fn write_fingerprint_section<W: Write>(
             writeln!(out, "TLS fingerprint (sha256):")?;
             writeln!(out, "  {}  (matches configured pin)", info.tls_fingerprint)?;
         }
-        (Ok(info), Some(_pin_mismatch_unreachable)) => {
+        (Ok(info), Some(_)) => {
             // A live mismatch should never reach here because `probe_preflight`
             // returns `Err(ImapError::Tls)` instead. Defensive branch: print
             // observed only.
@@ -177,6 +177,9 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::cli::dry_run::run;
+    use rimap_core::TlsFingerprint;
+    use rimap_imap::error::ImapError;
+    use rimap_imap::preflight::PreflightInfo;
 
     /// Tempdir whose mode is forced to 0700 — `AuditWriter::open` rejects looser
     /// modes after #147 and `tempfile::TempDir::new()` may inherit the system
@@ -207,6 +210,10 @@ allowed_base_dir = "{}"
         );
         std::fs::write(&config_path, body).unwrap();
         config_path
+    }
+
+    fn synth_fp(seed: &[u8]) -> TlsFingerprint {
+        TlsFingerprint::from_cert_der(seed)
     }
 
     #[tokio::test]
@@ -309,14 +316,6 @@ allowed_base_dir = "{}"
         assert!(chain.contains("loading config") || chain.contains("parse"));
     }
 
-    use rimap_core::TlsFingerprint;
-    use rimap_imap::error::ImapError;
-    use rimap_imap::preflight::PreflightInfo;
-
-    fn synth_fp(seed: &[u8]) -> TlsFingerprint {
-        TlsFingerprint::from_cert_der(seed)
-    }
-
     #[test]
     fn write_fingerprint_section_unpinned_prints_paste_hint() {
         let fp = synth_fp(b"unpinned-test");
@@ -388,6 +387,46 @@ allowed_base_dir = "{}"
         assert!(
             out.is_empty(),
             "fingerprint section must be silent on non-TLS error"
+        );
+    }
+
+    #[test]
+    fn write_fingerprint_section_pinned_ok_mismatch_defensive_prints_observed() {
+        // Defensive branch: an `Ok(info)` from probe_preflight where the
+        // observed fingerprint disagrees with the configured pin should be
+        // unreachable in production (the verifier rejects the handshake on
+        // mismatch, producing Err(Tls) instead). The branch is kept as a
+        // future-proofing guard. This test exercises the branch with a
+        // synthesized state to pin its behavior.
+        let observed = synth_fp(b"observed-defensive");
+        let pinned = synth_fp(b"different-pin-defensive");
+        assert_ne!(observed, pinned, "test setup: fingerprints must differ");
+        let info = PreflightInfo::new(vec!["IMAP4REV1".into()], observed);
+        let result: Result<PreflightInfo, ImapError> = Ok(info);
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, Some(pinned)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("TLS fingerprint (sha256):"),
+            "header missing:\n{text}"
+        );
+        assert!(
+            text.contains(&observed.to_string()),
+            "observed hex missing:\n{text}"
+        );
+        // The defensive arm prints observed only — no paste hint, no match
+        // confirmation, no observed/expected diagnostic.
+        assert!(
+            !text.contains("tls_fingerprint_sha256 ="),
+            "paste hint must not appear:\n{text}"
+        );
+        assert!(
+            !text.contains("matches configured pin"),
+            "match confirmation must not appear:\n{text}"
+        );
+        assert!(
+            !text.contains("expected:"),
+            "mismatch diagnostic must not appear:\n{text}"
         );
     }
 }

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -38,13 +38,15 @@ use rimap_config::loader::load_and_validate;
 use rimap_core::tool::ToolName;
 
 /// Print the `TLS fingerprint (sha256):` section for one account, given the
-/// preflight outcome and the (optional) pinned fingerprint from config. Three
+/// preflight outcome and the (optional) pinned fingerprint from config. Four
 /// branches:
 ///
 /// - `Ok(info)` + no pin: print observed fingerprint with a paste-into-config
 ///   hint (onboarding path).
 /// - `Ok(info)` + matching pin: print observed fingerprint with `(matches
 ///   configured pin)` confirmation.
+/// - `Ok(info)` + mismatched pin: defensive unreachable-in-production print
+///   (see arm comment).
 /// - `Err(ImapError::Tls { observed, expected })`: print both values plus a
 ///   diagnostic hint pointing at the quickstart.
 ///
@@ -52,8 +54,6 @@ use rimap_core::tool::ToolName;
 /// non-mismatch reasons, `Protocol`) silently print nothing — there is no
 /// fingerprint to surface when the verifier never ran or the value is not
 /// meaningfully informative.
-///
-/// Used by unit tests below and called from `run()`.
 fn write_fingerprint_section<W: Write>(
     out: &mut W,
     result: &Result<rimap_imap::preflight::PreflightInfo, rimap_imap::error::ImapError>,
@@ -74,11 +74,15 @@ fn write_fingerprint_section<W: Write>(
             writeln!(out, "  {}  (matches configured pin)", info.tls_fingerprint)?;
         }
         (Ok(info), Some(_)) => {
-            // A live mismatch should never reach here because `probe_preflight`
-            // returns `Err(ImapError::Tls)` instead. Defensive branch: print
-            // observed only.
+            // Unreachable in production: probe_preflight returns Err(Tls) on
+            // mismatch. Defensive branch flags the anomalous state instead of
+            // silently mimicking the matching-pin output.
             writeln!(out, "TLS fingerprint (sha256):")?;
-            writeln!(out, "  {}", info.tls_fingerprint)?;
+            writeln!(
+                out,
+                "  {}  (pin mismatch — unexpected state, please report)",
+                info.tls_fingerprint
+            )?;
         }
         (Err(rimap_imap::error::ImapError::Tls { observed, expected }), _) => {
             writeln!(out, "TLS fingerprint (sha256):")?;
@@ -413,6 +417,10 @@ allowed_base_dir = "{}"
         assert!(
             text.contains(&observed.to_string()),
             "observed hex missing:\n{text}"
+        );
+        assert!(
+            text.contains("pin mismatch") && text.contains("unexpected"),
+            "anomaly annotation missing:\n{text}"
         );
         // The defensive arm prints observed only — no paste hint, no match
         // confirmation, no observed/expected diagnostic.

--- a/crates/rimap-server/src/cli/dry_run.rs
+++ b/crates/rimap-server/src/cli/dry_run.rs
@@ -31,6 +31,68 @@ use rimap_authz::matrix::EffectiveMatrix;
 use rimap_config::loader::load_and_validate;
 use rimap_core::tool::ToolName;
 
+/// Print the `TLS fingerprint (sha256):` section for one account, given the
+/// preflight outcome and the (optional) pinned fingerprint from config. Three
+/// branches:
+///
+/// - `Ok(info)` + no pin: print observed fingerprint with a paste-into-config
+///   hint (onboarding path).
+/// - `Ok(info)` + matching pin: print observed fingerprint with `(matches
+///   configured pin)` confirmation.
+/// - `Err(ImapError::Tls { observed, expected })`: print both values plus a
+///   diagnostic hint pointing at the quickstart.
+///
+/// All other error variants (`Connect`, `Timeout`, `TlsHandshake` for
+/// non-mismatch reasons, `Protocol`) silently print nothing — there is no
+/// fingerprint to surface when the verifier never ran or the value is not
+/// meaningfully informative.
+///
+/// Used by unit tests below; will be called from `run()` in task 5.
+#[allow(clippy::allow_attributes, dead_code)]
+// ^ Justification: Used by tests; wiring into run() is task 5.
+fn write_fingerprint_section<W: Write>(
+    out: &mut W,
+    result: &Result<rimap_imap::preflight::PreflightInfo, rimap_imap::error::ImapError>,
+    pinned: Option<rimap_core::TlsFingerprint>,
+) -> std::io::Result<()> {
+    match (result, pinned) {
+        (Ok(info), None) => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}", info.tls_fingerprint)?;
+            writeln!(
+                out,
+                "  (add `tls_fingerprint_sha256 = \"{}\"` under [imap] in config.toml to pin)",
+                info.tls_fingerprint
+            )?;
+        }
+        (Ok(info), Some(pin)) if info.tls_fingerprint == pin => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}  (matches configured pin)", info.tls_fingerprint)?;
+        }
+        (Ok(info), Some(_pin_mismatch_unreachable)) => {
+            // A live mismatch should never reach here because `probe_preflight`
+            // returns `Err(ImapError::Tls)` instead. Defensive branch: print
+            // observed only.
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}", info.tls_fingerprint)?;
+        }
+        (Err(rimap_imap::error::ImapError::Tls { observed, expected }), _) => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  observed: {observed}")?;
+            writeln!(out, "  expected: {expected}  (configured pin)")?;
+            writeln!(
+                out,
+                "  hint: re-run the openssl command from the quickstart and update tls_fingerprint_sha256"
+            )?;
+        }
+        (Err(_), _) => {
+            // Connect / Timeout / TlsHandshake-non-mismatch / Protocol: nothing
+            // to print. The capabilities-section already shows the error.
+        }
+    }
+    Ok(())
+}
+
 /// Load `path`, validate, acquire an exclusive audit lock, build the effective
 /// matrix, print to `out`, and return. The audit lock is held for the duration
 /// of the call and released on return.
@@ -239,5 +301,87 @@ allowed_base_dir = "{}"
             writeln!(chain, "{cause}").unwrap();
         }
         assert!(chain.contains("loading config") || chain.contains("parse"));
+    }
+
+    use rimap_core::TlsFingerprint;
+    use rimap_imap::error::ImapError;
+    use rimap_imap::preflight::PreflightInfo;
+
+    fn synth_fp(seed: &[u8]) -> TlsFingerprint {
+        TlsFingerprint::from_cert_der(seed)
+    }
+
+    #[test]
+    fn write_fingerprint_section_unpinned_prints_paste_hint() {
+        let fp = synth_fp(b"unpinned-test");
+        let info = PreflightInfo::new(vec!["IMAP4REV1".into()], fp);
+        let result: Result<PreflightInfo, ImapError> = Ok(info);
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, None).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("TLS fingerprint (sha256):"),
+            "header missing:\n{text}"
+        );
+        assert!(
+            text.contains(&fp.to_string()),
+            "fingerprint missing:\n{text}"
+        );
+        assert!(
+            text.contains("tls_fingerprint_sha256 ="),
+            "paste hint missing:\n{text}"
+        );
+    }
+
+    #[test]
+    fn write_fingerprint_section_pinned_match_prints_confirmation() {
+        let fp = synth_fp(b"matched-pin");
+        let info = PreflightInfo::new(vec!["IMAP4REV1".into()], fp);
+        let result: Result<PreflightInfo, ImapError> = Ok(info);
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, Some(fp)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("matches configured pin"),
+            "match confirmation missing:\n{text}"
+        );
+        // Paste hint must NOT appear when already pinned-and-matched.
+        assert!(
+            !text.contains("tls_fingerprint_sha256 ="),
+            "paste hint should not appear on match:\n{text}"
+        );
+    }
+
+    #[test]
+    fn write_fingerprint_section_pinned_mismatch_prints_diagnostic() {
+        let observed = synth_fp(b"observed-cert");
+        let expected = synth_fp(b"expected-pin");
+        let result: Result<PreflightInfo, ImapError> = Err(ImapError::Tls { observed, expected });
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, Some(expected)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("observed:"), "observed: missing:\n{text}");
+        assert!(text.contains("expected:"), "expected: missing:\n{text}");
+        assert!(
+            text.contains(&observed.to_string()),
+            "observed hex missing:\n{text}"
+        );
+        assert!(
+            text.contains(&expected.to_string()),
+            "expected hex missing:\n{text}"
+        );
+        assert!(text.contains("hint:"), "hint line missing:\n{text}");
+    }
+
+    #[test]
+    fn write_fingerprint_section_other_error_prints_nothing() {
+        let result: Result<PreflightInfo, ImapError> =
+            Err(ImapError::Timeout { op: "tcp_connect" });
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, None).unwrap();
+        assert!(
+            out.is_empty(),
+            "fingerprint section must be silent on non-TLS error"
+        );
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ single-account format).
 | `port` | u16 | (required) | IMAP server port (993 for implicit TLS, 143 or 1143 for STARTTLS) |
 | `encryption` | string | `"tls"` | `"tls"` (implicit TLS/IMAPS) or `"starttls"` (STARTTLS upgrade). See below. |
 | `username` | string | (required) | IMAP login identity |
-| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional. Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. |
+| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional. Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. Run `--dry-run` to print the observed fingerprint for copy-paste pinning. |
 | `command_timeout_seconds` | u32 | 30 | Per-command timeout for IMAP operations |
 | `connect_timeout_seconds` | u32 | 10 | TCP + TLS handshake + greeting + CAPABILITY probe deadline |
 

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -35,6 +35,31 @@ Proton Bridge uses a self-signed TLS certificate that is not in your
 system trust store. Pin the certificate fingerprint so the server can
 verify it.
 
+### Get the TLS fingerprint (recommended path)
+
+After saving an initial `config.toml` with `host`, `port`, and `username`,
+run:
+
+```bash
+rusty-imap-mcp --config config.toml --dry-run
+```
+
+The output includes a `TLS fingerprint (sha256):` line followed by the
+observed cert hash and a copy-pasteable line:
+
+```
+TLS fingerprint (sha256):
+  ab:cd:ef:...:ef
+  (add `tls_fingerprint_sha256 = "ab:cd:ef:...:ef"` under [imap] in config.toml to pin)
+```
+
+Copy the hex value into `tls_fingerprint_sha256` under `[imap]` and re-run
+`--dry-run`; the fingerprint section now reads `(matches configured pin)`.
+
+### Alternative: extract the fingerprint with openssl
+
+If you prefer not to run a partial config first, the fingerprint can also be extracted directly:
+
 ```bash
 openssl s_client -connect 127.0.0.1:1143 -starttls imap < /dev/null 2>/dev/null \
   | openssl x509 -outform DER \

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -56,6 +56,10 @@ TLS fingerprint (sha256):
 Copy the hex value into `tls_fingerprint_sha256` under `[imap]` and re-run
 `--dry-run`; the fingerprint section now reads `(matches configured pin)`.
 
+> **Trust note**: `--dry-run` records whatever cert the network presents.
+> Run it from a network you trust at the time of fingerprint extraction —
+> same caveat as the `openssl s_client` recipe below.
+
 ### Alternative: extract the fingerprint with openssl
 
 If you prefer not to run a partial config first, the fingerprint can also be extracted directly:

--- a/docs/superpowers/plans/2026-05-01-issue-151-tls-fingerprint-dry-run.md
+++ b/docs/superpowers/plans/2026-05-01-issue-151-tls-fingerprint-dry-run.md
@@ -1,0 +1,930 @@
+# Issue #151 — TLS Fingerprint Dry-Run Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Print the observed leaf-cert SHA-256 fingerprint per account during `--dry-run` so operators can pin TLS without running `openssl s_client`.
+
+**Architecture:** Extract a shared `enrich_tls_handshake_error` helper in `rimap-imap` (used by both the auth path and the preflight path) so a fingerprint mismatch produces `ImapError::Tls { observed, expected }` everywhere. Extend `PreflightInfo` with a `tls_fingerprint: TlsFingerprint` field captured from `bundle.last_observed`. Add a `write_fingerprint_section` printer to `dry_run.rs` with three branches (unpinned-onboard, pinned-match, pinned-mismatch).
+
+**Tech Stack:** Rust 1.x stable, `tokio_rustls`, `async-imap`, `tracing`, `assert_cmd` for CLI tests, the existing Dovecot container harness for integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md`
+
+---
+
+## File Map
+
+**Modified — production code:**
+- `crates/rimap-imap/src/connection.rs` — extract `enrich_tls_handshake_error` helper from `connect_inner`'s inline match
+- `crates/rimap-imap/src/preflight.rs` — extend `PreflightInfo` with `tls_fingerprint`; capture from bundle after handshake; route handshake errors through the enrichment helper
+- `crates/rimap-server/src/cli/dry_run.rs` — add `write_fingerprint_section` printer; call from `run`
+
+**Modified — tests:**
+- `crates/rimap-imap/tests/integration/dovecot.rs` — two new test cases exercising preflight against the real Dovecot cert
+
+**Modified — docs:**
+- `docs/quickstart-proton-bridge.md` — promote `--dry-run` as the primary onboarding path; keep `openssl` recipe as fallback
+- `docs/quickstart-gmail.md` — parallel update if it covers pinning
+- `docs/configuration.md` — point to `--dry-run` under `tls_fingerprint_sha256`
+
+---
+
+## Task 1: Extract `enrich_tls_handshake_error` helper (refactor, no behavior change)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/connection.rs:230-242`
+
+**Why:** `connect_inner` and `probe_preflight` need the same logic for converting a generic `ImapError::TlsHandshake` into the typed `ImapError::Tls { observed, expected }` when both pin and observed fingerprint are known. Extract once, reuse twice.
+
+- [ ] **Step 1: Read the current inline enrichment**
+
+Run: `sed -n '220,245p' crates/rimap-imap/src/connection.rs`
+Confirm the match arm at lines 230-242 reads as expected before refactoring.
+
+- [ ] **Step 2: Add the helper function above `connect_inner`**
+
+Locate the start of `impl Connection { ... async fn connect_inner ...` and add a free function (not a method) just before it, inside the same module. Free function — `probe_preflight` is in a different module and needs to call it without a `Connection` instance.
+
+```rust
+/// If `err` is `ImapError::TlsHandshake` and the bundle observed a fingerprint
+/// that disagrees with `pinned`, rewrite into `ImapError::Tls { observed,
+/// expected }`. Other error variants and matching observations pass through
+/// unchanged. Used by both `connect_inner` and `probe_preflight` so the typed
+/// mismatch error surfaces on every TLS-failing path.
+pub(crate) fn enrich_tls_handshake_error(
+    err: ImapError,
+    bundle: &crate::tls::TlsConfigBundle,
+    pinned: Option<rimap_core::TlsFingerprint>,
+) -> ImapError {
+    match err {
+        ImapError::TlsHandshake(inner) => match (pinned, bundle.last_observed.get().copied()) {
+            (Some(expected), Some(observed)) if expected != observed => {
+                ImapError::Tls { observed, expected }
+            }
+            _ => ImapError::TlsHandshake(inner),
+        },
+        other => other,
+    }
+}
+```
+
+- [ ] **Step 3: Replace the inline match in `connect_inner`**
+
+Replace lines 230-242 (the `let (outcome, credential_source) = match raw_outcome { ... };` block) with:
+
+```rust
+        let (outcome, credential_source) = match raw_outcome {
+            Ok((session, src)) => (Ok(session), Some(src)),
+            Err((err, src)) => (
+                Err(enrich_tls_handshake_error(err, &bundle, cfg.pinned_fingerprint)),
+                src,
+            ),
+        };
+```
+
+The behavior is identical: `enrich_tls_handshake_error` only rewrites `TlsHandshake` variants, so non-handshake errors pass through.
+
+- [ ] **Step 4: Run the rimap-imap test suite — refactor must be a no-op**
+
+Run: `cargo test -p rimap-imap --lib --tests`
+Expected: all tests pass. Pay particular attention to the existing mismatch test at `connection.rs:1140-1147` — it must still produce `ImapError::Tls`.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-imap/src/connection.rs
+git commit -m "refactor(rimap-imap): extract enrich_tls_handshake_error helper
+
+Lifts the inline TlsHandshake → Tls { observed, expected } match out
+of connect_inner into a free function so probe_preflight can reuse it.
+No behavior change.
+
+Refs: #151"
+```
+
+---
+
+## Task 2: Add `tls_fingerprint` to `PreflightInfo` and capture in `probe_preflight`
+
+**Files:**
+- Modify: `crates/rimap-imap/src/preflight.rs:20-27` (struct), `crates/rimap-imap/src/preflight.rs:34-124` (function body)
+- Test: `crates/rimap-imap/tests/integration/dovecot.rs` (new test case)
+
+- [ ] **Step 1: Find the right test-case-number prefix**
+
+Run: `rg -n "^async fn case_" crates/rimap-imap/tests/integration/dovecot.rs | tail -3`
+Note the highest existing `case_NN_*` number; the new tests use the next two.
+
+- [ ] **Step 2: Write the failing integration test**
+
+Append to `crates/rimap-imap/tests/integration/dovecot.rs`. Substitute `NN` with the chosen number from Step 1.
+
+```rust
+#[tokio::test]
+async fn case_NN_probe_preflight_returns_observed_fingerprint() {
+    let Some(h) = boot(PinChoice::None) else {
+        return;
+    };
+    let cfg = rimap_imap::ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: support::container::DovecotHarness::host().to_string(),
+        port: h.harness.port(),
+        encryption: rimap_imap::ImapEncryption::Tls,
+        username: support::container::DovecotHarness::username().to_string(),
+        pinned_fingerprint: None,
+        connect_timeout: std::time::Duration::from_secs(10),
+        command_timeout: std::time::Duration::from_secs(10),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    let info = rimap_imap::preflight::probe_preflight(&cfg)
+        .await
+        .expect("preflight should succeed against the live harness");
+    assert_eq!(info.tls_fingerprint, h.harness.pinned_fingerprint());
+    assert!(!info.capabilities.is_empty());
+}
+```
+
+- [ ] **Step 3: Run the test — expect compile error**
+
+Run: `cargo test -p rimap-imap --test dovecot case_NN_probe_preflight_returns_observed_fingerprint`
+Expected: compile error — `tls_fingerprint` is not a field of `PreflightInfo`.
+
+(If Docker is unavailable, the test silently skips at runtime, but this step is checking compile-time. The compile error will fire regardless of Docker.)
+
+- [ ] **Step 4: Add the `tls_fingerprint` field to `PreflightInfo`**
+
+In `crates/rimap-imap/src/preflight.rs`, modify the struct (line ~20-27):
+
+```rust
+/// Result of a successful preflight probe.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PreflightInfo {
+    /// Capability atoms returned by the server's pre-auth `CAPABILITY`
+    /// response, upper-cased, de-duplicated, order preserved as received.
+    pub capabilities: Vec<String>,
+    /// Leaf-cert SHA-256 fingerprint observed during the TLS handshake.
+    /// Captured from the verifier's `last_observed` slot before any IMAP
+    /// traffic flows.
+    pub tls_fingerprint: rimap_core::TlsFingerprint,
+}
+```
+
+- [ ] **Step 5: Capture the fingerprint in `probe_preflight`'s success path**
+
+In `crates/rimap-imap/src/preflight.rs`, modify the final `Ok(...)` at line ~123. Read the slot from the bundle after the CAPABILITY round-trip succeeds. The verifier writes the slot during handshake — by the time CAPABILITY succeeds the slot is guaranteed populated, but treat `None` as a typed error instead of panicking.
+
+Replace the function-final return:
+
+```rust
+    Ok(PreflightInfo { capabilities: caps })
+```
+
+with:
+
+```rust
+    let tls_fingerprint = bundle.last_observed.get().copied().ok_or_else(|| {
+        ImapError::TlsHandshake(tokio_rustls::rustls::Error::General(
+            "verifier did not capture fingerprint".into(),
+        ))
+    })?;
+    Ok(PreflightInfo {
+        capabilities: caps,
+        tls_fingerprint,
+    })
+```
+
+- [ ] **Step 6: Run the test — expect pass (or silent skip without Docker)**
+
+Run: `cargo test -p rimap-imap --test dovecot case_NN_probe_preflight_returns_observed_fingerprint`
+Expected with Docker: PASS.
+Expected without Docker: silent skip (no failure).
+
+If you have neither Docker nor Podman, run a final compile check:
+Run: `cargo build -p rimap-imap --tests`
+Expected: clean compile.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-imap/src/preflight.rs crates/rimap-imap/tests/integration/dovecot.rs
+git commit -m "feat(rimap-imap): expose observed TLS fingerprint via PreflightInfo
+
+Adds PreflightInfo.tls_fingerprint, populated from the bundle's
+last_observed slot after a successful handshake. New Dovecot
+integration case asserts the captured value matches the harness's
+known cert fingerprint.
+
+Refs: #151"
+```
+
+---
+
+## Task 3: Route `probe_preflight` errors through `enrich_tls_handshake_error`
+
+**Files:**
+- Modify: `crates/rimap-imap/src/preflight.rs:52-69` (the two handshake arms)
+- Test: `crates/rimap-imap/tests/integration/dovecot.rs` (new test case)
+
+**Why:** Today `probe_preflight` returns `ImapError::TlsHandshake(...)` on a fingerprint mismatch — the enrichment lives only in `connect_inner`. Route through the helper so callers see the typed `ImapError::Tls { observed, expected }` on the preflight path too.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `crates/rimap-imap/tests/integration/dovecot.rs` (use the next `case_NN+1` number):
+
+```rust
+#[tokio::test]
+async fn case_NN_probe_preflight_mismatch_returns_typed_tls_error() {
+    let Some(h) = boot(PinChoice::None) else {
+        return;
+    };
+    let wrong = rimap_core::TlsFingerprint::from_cert_der(b"deliberately-wrong");
+    let cfg = rimap_imap::ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: support::container::DovecotHarness::host().to_string(),
+        port: h.harness.port(),
+        encryption: rimap_imap::ImapEncryption::Tls,
+        username: support::container::DovecotHarness::username().to_string(),
+        pinned_fingerprint: Some(wrong),
+        connect_timeout: std::time::Duration::from_secs(10),
+        command_timeout: std::time::Duration::from_secs(10),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    let err = rimap_imap::preflight::probe_preflight(&cfg)
+        .await
+        .expect_err("mismatched pin must produce an error");
+    match err {
+        ImapError::Tls { observed, expected } => {
+            assert_eq!(observed, h.harness.pinned_fingerprint());
+            assert_eq!(expected, wrong);
+        }
+        other => panic!("expected ImapError::Tls, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect failure (with Docker) or skip-pass (without)**
+
+Run: `cargo test -p rimap-imap --test dovecot case_NN_probe_preflight_mismatch_returns_typed_tls_error`
+Expected with Docker: FAIL with `expected ImapError::Tls, got TlsHandshake(...)`.
+Expected without Docker: silent skip.
+
+- [ ] **Step 3: Wire enrichment into `probe_preflight`'s handshake error paths**
+
+In `crates/rimap-imap/src/preflight.rs`, modify the two handshake match arms (around lines 52-69). The `tls_handshake` and `starttls_upgrade` calls return `ImapError::TlsHandshake(...)` on fingerprint mismatch; route through the helper.
+
+Replace the existing match block:
+
+```rust
+    let (tls_stream, already_greeted) = match cfg.encryption {
+        ImapEncryption::Tls => {
+            let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "tls_handshake",
+                })??;
+            (s, false)
+        }
+        ImapEncryption::Starttls => {
+            let s = timeout(remaining, starttls_upgrade(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "starttls_upgrade",
+                })??;
+            (s, true)
+        }
+    };
+```
+
+with the enriched form:
+
+```rust
+    let (tls_stream, already_greeted) = match cfg.encryption {
+        ImapEncryption::Tls => {
+            let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "tls_handshake",
+                })?
+                .map_err(|e| {
+                    crate::connection::enrich_tls_handshake_error(
+                        e,
+                        &bundle,
+                        cfg.pinned_fingerprint,
+                    )
+                })?;
+            (s, false)
+        }
+        ImapEncryption::Starttls => {
+            let s = timeout(remaining, starttls_upgrade(tcp, &bundle, &cfg.host))
+                .await
+                .map_err(|_| ImapError::Timeout {
+                    op: "starttls_upgrade",
+                })?
+                .map_err(|e| {
+                    crate::connection::enrich_tls_handshake_error(
+                        e,
+                        &bundle,
+                        cfg.pinned_fingerprint,
+                    )
+                })?;
+            (s, true)
+        }
+    };
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `cargo test -p rimap-imap --test dovecot case_NN_probe_preflight_mismatch_returns_typed_tls_error`
+Expected with Docker: PASS.
+Expected without Docker: silent skip.
+
+- [ ] **Step 5: Verify no regression in `case_NN` (the success case from Task 2)**
+
+Run: `cargo test -p rimap-imap --test dovecot probe_preflight`
+Expected: both new cases pass (or silent skip without Docker).
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-imap/src/preflight.rs crates/rimap-imap/tests/integration/dovecot.rs
+git commit -m "feat(rimap-imap): enrich probe_preflight TLS errors with observed fingerprint
+
+Routes both Tls and Starttls handshake error paths in probe_preflight
+through enrich_tls_handshake_error so a fingerprint mismatch surfaces
+as ImapError::Tls { observed, expected } — same shape as connect_inner.
+New Dovecot integration case pins the typed-error contract.
+
+Refs: #151"
+```
+
+---
+
+## Task 4: Add `write_fingerprint_section` printer with three branches
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/dry_run.rs` (add helper + tests; not yet wired into `run`)
+
+**Why:** Isolate the three-case output formatter into a pure function with synthesized inputs so each branch is unit-tested without standing up a real server.
+
+- [ ] **Step 1: Write three failing unit tests**
+
+In `crates/rimap-server/src/cli/dry_run.rs`, inside the existing `mod tests` block, add:
+
+```rust
+    use rimap_core::TlsFingerprint;
+    use rimap_imap::error::ImapError;
+    use rimap_imap::preflight::PreflightInfo;
+
+    fn synth_fp(seed: &[u8]) -> TlsFingerprint {
+        TlsFingerprint::from_cert_der(seed)
+    }
+
+    #[test]
+    fn write_fingerprint_section_unpinned_prints_paste_hint() {
+        let fp = synth_fp(b"unpinned-test");
+        let info = PreflightInfo {
+            capabilities: vec!["IMAP4REV1".into()],
+            tls_fingerprint: fp,
+        };
+        let result: Result<PreflightInfo, ImapError> = Ok(info);
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, None).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("TLS fingerprint (sha256):"),
+            "header missing:\n{text}"
+        );
+        assert!(text.contains(&fp.to_string()), "fingerprint missing:\n{text}");
+        assert!(
+            text.contains("tls_fingerprint_sha256 ="),
+            "paste hint missing:\n{text}"
+        );
+    }
+
+    #[test]
+    fn write_fingerprint_section_pinned_match_prints_confirmation() {
+        let fp = synth_fp(b"matched-pin");
+        let info = PreflightInfo {
+            capabilities: vec!["IMAP4REV1".into()],
+            tls_fingerprint: fp,
+        };
+        let result: Result<PreflightInfo, ImapError> = Ok(info);
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, Some(fp)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("matches configured pin"),
+            "match confirmation missing:\n{text}"
+        );
+        // Paste hint must NOT appear when already pinned-and-matched.
+        assert!(
+            !text.contains("tls_fingerprint_sha256 ="),
+            "paste hint should not appear on match:\n{text}"
+        );
+    }
+
+    #[test]
+    fn write_fingerprint_section_pinned_mismatch_prints_diagnostic() {
+        let observed = synth_fp(b"observed-cert");
+        let expected = synth_fp(b"expected-pin");
+        let result: Result<PreflightInfo, ImapError> = Err(ImapError::Tls { observed, expected });
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, Some(expected)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("observed:"), "observed: missing:\n{text}");
+        assert!(text.contains("expected:"), "expected: missing:\n{text}");
+        assert!(
+            text.contains(&observed.to_string()),
+            "observed hex missing:\n{text}"
+        );
+        assert!(
+            text.contains(&expected.to_string()),
+            "expected hex missing:\n{text}"
+        );
+        assert!(text.contains("hint:"), "hint line missing:\n{text}");
+    }
+
+    #[test]
+    fn write_fingerprint_section_other_error_prints_nothing() {
+        let result: Result<PreflightInfo, ImapError> = Err(ImapError::Timeout { op: "tcp_connect" });
+        let mut out = Vec::new();
+        super::write_fingerprint_section(&mut out, &result, None).unwrap();
+        assert!(out.is_empty(), "fingerprint section must be silent on non-TLS error");
+    }
+```
+
+- [ ] **Step 2: Run the tests — expect compile error (function not yet defined)**
+
+Run: `cargo test -p rimap-server --lib write_fingerprint_section`
+Expected: compile error — `write_fingerprint_section` not found.
+
+- [ ] **Step 3: Implement `write_fingerprint_section`**
+
+In `crates/rimap-server/src/cli/dry_run.rs`, add the helper above `pub async fn run`:
+
+```rust
+/// Print the `TLS fingerprint (sha256):` section for one account, given the
+/// preflight outcome and the (optional) pinned fingerprint from config. Three
+/// branches:
+///
+/// - `Ok(info)` + no pin: print observed fingerprint with a paste-into-config
+///   hint (onboarding path).
+/// - `Ok(info)` + matching pin: print observed fingerprint with `(matches
+///   configured pin)` confirmation.
+/// - `Err(ImapError::Tls { observed, expected })`: print both values plus a
+///   diagnostic hint pointing at the quickstart.
+///
+/// All other error variants (`Connect`, `Timeout`, `TlsHandshake` for
+/// non-mismatch reasons, `Protocol`) silently print nothing — there is no
+/// fingerprint to surface when the verifier never ran or the value is not
+/// meaningfully informative.
+fn write_fingerprint_section<W: std::io::Write>(
+    out: &mut W,
+    result: &Result<rimap_imap::preflight::PreflightInfo, rimap_imap::error::ImapError>,
+    pinned: Option<rimap_core::TlsFingerprint>,
+) -> std::io::Result<()> {
+    match (result, pinned) {
+        (Ok(info), None) => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}", info.tls_fingerprint)?;
+            writeln!(
+                out,
+                "  (add `tls_fingerprint_sha256 = \"{}\"` under [imap] in config.toml to pin)",
+                info.tls_fingerprint
+            )?;
+        }
+        (Ok(info), Some(pin)) if info.tls_fingerprint == pin => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}  (matches configured pin)", info.tls_fingerprint)?;
+        }
+        (Ok(info), Some(_pin_mismatch_unreachable)) => {
+            // A live mismatch should never reach here because `probe_preflight`
+            // returns `Err(ImapError::Tls)` instead. Defensive branch: print
+            // observed only.
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  {}", info.tls_fingerprint)?;
+        }
+        (Err(rimap_imap::error::ImapError::Tls { observed, expected }), _) => {
+            writeln!(out, "TLS fingerprint (sha256):")?;
+            writeln!(out, "  observed: {observed}")?;
+            writeln!(out, "  expected: {expected}  (configured pin)")?;
+            writeln!(
+                out,
+                "  hint: re-run the openssl command from the quickstart and update tls_fingerprint_sha256"
+            )?;
+        }
+        (Err(_), _) => {
+            // Connect / Timeout / TlsHandshake-non-mismatch / Protocol: nothing
+            // to print. The capabilities-section already shows the error.
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the unit tests — expect pass**
+
+Run: `cargo test -p rimap-server --lib write_fingerprint_section`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/dry_run.rs
+git commit -m "feat(rimap-server): add write_fingerprint_section printer for dry-run
+
+Pure function with three branches (unpinned-onboard, pinned-match,
+pinned-mismatch) and a defensive fourth branch for non-TLS errors.
+Not yet wired into run() — that is the next task. Unit tests cover
+all four branches with synthesized inputs.
+
+Refs: #151"
+```
+
+---
+
+## Task 5: Wire `write_fingerprint_section` into `run`
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/dry_run.rs` (the per-account loop in `run`)
+
+- [ ] **Step 1: Modify `run` to call the new printer**
+
+In `crates/rimap-server/src/cli/dry_run.rs`, locate the per-account loop (around lines 80-99) where `match rimap_imap::preflight::probe_preflight(&conn_cfg).await` lives. Today the match prints capabilities on `Ok` and an `unavailable` line on `Err`. Add the fingerprint section after the capabilities/unavailable line, regardless of which arm fired.
+
+Replace the existing match:
+
+```rust
+        let conn_cfg = rimap_server::boot::registry::build_account_connection(id, acfg);
+        match rimap_imap::preflight::probe_preflight(&conn_cfg).await {
+            Ok(info) => {
+                writeln!(out, "Capabilities ({}:{}):", conn_cfg.host, conn_cfg.port)?;
+                for cap in &info.capabilities {
+                    writeln!(out, "  [ok ] {cap}")?;
+                }
+            }
+            Err(e) => {
+                writeln!(
+                    out,
+                    "Capabilities ({}:{}): unavailable ({e})",
+                    conn_cfg.host, conn_cfg.port,
+                )?;
+            }
+        }
+```
+
+with:
+
+```rust
+        let conn_cfg = rimap_server::boot::registry::build_account_connection(id, acfg);
+        let preflight_result = rimap_imap::preflight::probe_preflight(&conn_cfg).await;
+        match &preflight_result {
+            Ok(info) => {
+                writeln!(out, "Capabilities ({}:{}):", conn_cfg.host, conn_cfg.port)?;
+                for cap in &info.capabilities {
+                    writeln!(out, "  [ok ] {cap}")?;
+                }
+            }
+            Err(e) => {
+                writeln!(
+                    out,
+                    "Capabilities ({}:{}): unavailable ({e})",
+                    conn_cfg.host, conn_cfg.port,
+                )?;
+            }
+        }
+        write_fingerprint_section(out, &preflight_result, conn_cfg.pinned_fingerprint)?;
+```
+
+- [ ] **Step 2: Run the existing dry_run unit tests — expect still passing**
+
+Run: `cargo test -p rimap-server --lib dry_run`
+Expected: existing tests (`dry_run_prints_matrix_with_default_posture`, `second_dry_run_against_same_audit_fails_with_config_error`, `dry_run_lists_infrastructure_tools_separately`, `dry_run_surfaces_parse_errors_as_anyhow`) plus the four new printer tests all pass.
+
+The existing tests run against `127.0.0.1:1143` with no listener. The preflight fails with `Connect`, the printer's "other error" branch fires (no fingerprint section), so the tests still match their assertions.
+
+- [ ] **Step 3: Run the existing dry_run CLI integration tests**
+
+Run: `cargo test -p rimap-server --test dry_run_cli`
+Expected: all three existing CLI tests still pass.
+
+- [ ] **Step 4: Update the module doc-comment to show the new section**
+
+In `crates/rimap-server/src/cli/dry_run.rs`, modify the sample output block at the top of the file (lines 14-23) to include the fingerprint section. Replace:
+
+```text
+//! ```text
+//! Effective matrix (posture = draft-safe)
+//!   [ok ] list_folders
+//!   [ok ] search
+//!   [deny] search.advanced_query
+//!   ...
+//! Infrastructure tools (always available):
+//!   [ok ] use_account
+//!   [ok ] list_accounts
+//! ```
+```
+
+with:
+
+```text
+//! ```text
+//! Effective matrix (posture = draft-safe)
+//!   [ok ] list_folders
+//!   [ok ] search
+//!   [deny] search.advanced_query
+//!   ...
+//! Infrastructure tools (always available):
+//!   [ok ] use_account
+//!   [ok ] list_accounts
+//! Capabilities (imap.example.com:993):
+//!   [ok ] IMAP4REV1
+//!   [ok ] IDLE
+//! TLS fingerprint (sha256):
+//!   ab:cd:...:ef
+//!   (add `tls_fingerprint_sha256 = "ab:cd:...:ef"` under [imap] in config.toml to pin)
+//! ```
+```
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/dry_run.rs
+git commit -m "feat(rimap-server): wire fingerprint section into --dry-run output
+
+Calls write_fingerprint_section after the capabilities line for each
+account, so operators see the observed leaf-cert SHA-256 alongside the
+capability list. Module doc-comment sample updated to match.
+
+Refs: #151"
+```
+
+---
+
+## Task 6: Update the preflight module doc
+
+**Files:**
+- Modify: `crates/rimap-imap/src/preflight.rs:1-4` (module doc-comment)
+
+- [ ] **Step 1: Update the module doc-comment**
+
+In `crates/rimap-imap/src/preflight.rs`, replace lines 1-4:
+
+```rust
+//! Pre-auth `CAPABILITY` probe used by `--dry-run` and other diagnostic
+//! paths. Performs TCP connect → TLS handshake → IMAP greeting → pre-auth
+//! `CAPABILITY` command, then drops the connection. Does NOT perform LOGIN
+//! and does NOT emit any audit records.
+```
+
+with:
+
+```rust
+//! Pre-auth `CAPABILITY` probe used by `--dry-run` and other diagnostic
+//! paths. Performs TCP connect → TLS handshake → IMAP greeting → pre-auth
+//! `CAPABILITY` command, then drops the connection. Captures the leaf-cert
+//! SHA-256 fingerprint observed during the handshake (returned via
+//! `PreflightInfo.tls_fingerprint`). Does NOT perform LOGIN and does NOT
+//! emit any audit records.
+```
+
+- [ ] **Step 2: Run a quick build to verify doc-comment compiles**
+
+Run: `cargo build -p rimap-imap`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/src/preflight.rs
+git commit -m "docs(rimap-imap): note fingerprint capture in preflight module doc
+
+Refs: #151"
+```
+
+---
+
+## Task 7: Update user-facing docs
+
+**Files:**
+- Modify: `docs/quickstart-proton-bridge.md`
+- Modify: `docs/quickstart-gmail.md` (only if it covers pinning)
+- Modify: `docs/configuration.md`
+
+- [ ] **Step 1: Inspect the proton-bridge quickstart pinning section**
+
+Run: `sed -n '60,100p' docs/quickstart-proton-bridge.md`
+Locate the section that walks the user through running `openssl s_client` to compute the fingerprint. The new content adds a primary path that uses `--dry-run`.
+
+- [ ] **Step 2: Update `docs/quickstart-proton-bridge.md`**
+
+Above the existing `openssl s_client | openssl x509 -fingerprint -sha256` recipe, add a new sub-section:
+
+```markdown
+### Get the TLS fingerprint (recommended path)
+
+After saving an initial `config.toml` with `host`, `port`, and `username`,
+run:
+
+\`\`\`
+rusty-imap-mcp --config config.toml --dry-run
+\`\`\`
+
+The output includes a `TLS fingerprint (sha256):` line followed by the
+observed cert hash and a copy-pasteable line:
+
+\`\`\`
+TLS fingerprint (sha256):
+  ab:cd:ef:...:ef
+  (add `tls_fingerprint_sha256 = "ab:cd:ef:...:ef"` under [imap] in config.toml to pin)
+\`\`\`
+
+Copy the hex value into `tls_fingerprint_sha256` under `[imap]` and re-run
+`--dry-run`; the fingerprint section now reads `(matches configured pin)`.
+```
+
+Then re-title the existing openssl section to "Alternative: extract the fingerprint with openssl" and add a one-line lead-in: "If you prefer not to run a partial config first, the fingerprint can also be extracted directly:".
+
+- [ ] **Step 3: Inspect `docs/quickstart-gmail.md` for a pinning section**
+
+Run: `rg -n "tls_fingerprint|fingerprint" docs/quickstart-gmail.md`
+- If the file mentions pinning: apply a parallel update modeled on Step 2.
+- If it does not (Gmail uses CA-signed certs and the quickstart skips pinning): no change. Note this in the commit message.
+
+- [ ] **Step 4: Update `docs/configuration.md`**
+
+Run: `rg -n "tls_fingerprint_sha256" docs/configuration.md`
+Locate the table row at line ~105 that documents `tls_fingerprint_sha256`. Append one sentence to the description column:
+
+```markdown
+| `tls_fingerprint_sha256` | string | (none) | Pinned TLS certificate SHA-256 fingerprint. Hex, colons optional. Required for self-signed certs (e.g. Proton Bridge). Omit to use the system trust store. Run `--dry-run` to print the observed fingerprint for copy-paste pinning. |
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/quickstart-proton-bridge.md docs/quickstart-gmail.md docs/configuration.md
+git commit -m "docs: promote --dry-run as the canonical TLS pinning onboarding path
+
+Quickstart now leads with --dry-run for fingerprint extraction;
+the openssl recipe stays as a fallback. Configuration table row
+points to --dry-run.
+
+Refs: #151"
+```
+
+---
+
+## Task 8: Verify end-to-end with the Dovecot harness (optional but recommended)
+
+**Why:** All three new test cases run against Docker. If you have Docker or Podman locally, this is the time to verify the full path.
+
+- [ ] **Step 1: Run the new Dovecot integration tests**
+
+Run: `cargo test -p rimap-imap --test dovecot probe_preflight -- --nocapture`
+Expected: both `case_NN_probe_preflight_returns_observed_fingerprint` and `case_NN_probe_preflight_mismatch_returns_typed_tls_error` pass. (Or silent skip without Docker.)
+
+- [ ] **Step 2: Manual smoke test of dry-run output (with Docker)**
+
+Run the harness manually and observe the dry-run output. (No commit step — purely a sanity check. Skip if no Docker.)
+
+```bash
+# Spin up the Dovecot fixture used by integration tests
+just dovecot-up  # or whatever the project task is; check the justfile
+
+# Write a minimal config pointing at it
+cat > /tmp/issue-151-config.toml <<EOF
+[imap]
+host = "127.0.0.1"
+port = 1993  # whatever DovecotHarness uses
+username = "admin@localhost"
+[audit]
+path = "/tmp/issue-151-audit.jsonl"
+allowed_base_dir = "/tmp"
+EOF
+chmod 700 /tmp
+
+# Run --dry-run and confirm the fingerprint section appears
+cargo run -p rimap-server -- --config /tmp/issue-151-config.toml --dry-run
+```
+
+Expected: stdout contains `TLS fingerprint (sha256):`, the observed hex, and the paste-into-config hint.
+
+---
+
+## Task 9: Mutation testing on touched files
+
+**Files (under test):**
+- `crates/rimap-imap/src/preflight.rs`
+- `crates/rimap-imap/src/connection.rs` (the helper only — full file is too large)
+- `crates/rimap-server/src/cli/dry_run.rs`
+
+**Why:** Project-standing practice. Catches branch arms (e.g., the `(Some, Some) if a != b` guard) where a mutation might leave the test suite green.
+
+- [ ] **Step 1: Run mutants on `dry_run.rs`**
+
+Run: `cargo mutants --jobs 2 --file crates/rimap-server/src/cli/dry_run.rs`
+Expected: zero unkilled mutants. If any escape, add a targeted unit test that catches the mutation.
+
+- [ ] **Step 2: Run mutants on `preflight.rs`**
+
+Run: `cargo mutants --jobs 2 --file crates/rimap-imap/src/preflight.rs`
+Expected: zero unkilled mutants on the new lines. Pre-existing escapees are out of scope.
+
+- [ ] **Step 3: Run mutants targeted at `enrich_tls_handshake_error`**
+
+Run: `cargo mutants --jobs 2 --file crates/rimap-imap/src/connection.rs --regex 'enrich_tls_handshake_error'`
+Expected: zero unkilled mutants.
+
+- [ ] **Step 4: If any mutants escaped, add tests and commit**
+
+For each escaped mutant, add a unit test that fails under the mutation. Commit per file:
+
+```bash
+git add <test-file>
+git commit -m "test: kill <description> mutant in <file>
+
+Refs: #151"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run the full test suite for the touched crates**
+
+Run: `cargo test -p rimap-imap -p rimap-server`
+Expected: all tests pass.
+
+- [ ] **Step 2: Run clippy across the workspace**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 3: Run cargo fmt check**
+
+Run: `cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/issue-151-tls-fingerprint-dry-run
+gh pr create --title "feat: surface TLS cert fingerprint during --dry-run (#151)" --body "$(cat <<'EOF'
+## Summary
+- Adds `PreflightInfo.tls_fingerprint`, captured from `bundle.last_observed` after the handshake
+- Extracts `enrich_tls_handshake_error` from `connect_inner` and reuses it in `probe_preflight` so a mismatch surfaces as `ImapError::Tls { observed, expected }` on both paths
+- New `write_fingerprint_section` printer prints three cases under `--dry-run`: unpinned-onboard, pinned-match, pinned-mismatch
+- Quickstart docs promote `--dry-run` as the canonical pinning onboarding path
+
+Closes #151.
+
+## Test plan
+- [ ] `cargo test -p rimap-imap -p rimap-server` passes
+- [ ] `cargo test -p rimap-imap --test dovecot probe_preflight` passes (with Docker) or silent-skips (without)
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [ ] `cargo mutants --jobs 2 --file crates/rimap-server/src/cli/dry_run.rs` zero unkilled mutants on new lines
+EOF
+)"
+```
+
+Expected: PR opens, CI runs.
+
+---
+
+## Notes for the implementer
+
+- All tests use synthesized fingerprints via `TlsFingerprint::from_cert_der(b"...")` for unit tests, and the harness's real cert fingerprint for integration tests. Both paths are stable across runs.
+- The Dovecot harness silently skips when neither Docker nor Podman is available. The new integration tests inherit that behavior — verify locally with `cargo test -p rimap-imap --test dovecot` once before opening the PR if you have a container runtime; CI runs them on Linux x86_64.
+- The defensive `(Ok(info), Some(_pin_mismatch_unreachable))` arm in `write_fingerprint_section` is only reachable if a future bug lets a mismatched-but-handshake-successful preflight slip through. Today this cannot happen: the `PinningVerifier` in `tls.rs` rejects the handshake on mismatch. The defensive branch is documented as such and prints observed-only — better than panicking on a `match` exhaustiveness gap.
+- The plan assumes `tests/integration/dovecot.rs`'s `support` module is in scope via the `mod support;` declaration at the top of the file. New tests reference `support::container::DovecotHarness` directly.

--- a/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
@@ -1,0 +1,235 @@
+# Issue #151 — Display TLS cert fingerprint during `--dry-run` (design)
+
+**Date:** 2026-05-01
+**Branch:** `feat/issue-151-tls-fingerprint-dry-run`
+**Issue:** [#151](https://github.com/randomparity/rusty-imap-mcp/issues/151)
+**Severity:** LOW (UX / onboarding)
+
+## Goal
+
+Extend `--dry-run` to print the observed leaf-cert SHA-256 fingerprint per
+account so operators can copy the value into `tls_fingerprint_sha256` in
+`config.toml` without reaching for `openssl s_client`. Output adapts to three
+cases: unpinned (onboarding), pinned-and-matched (confirmation), and
+pinned-and-mismatched (diagnostic).
+
+## Background
+
+TLS pinning is wired end-to-end:
+
+- `ConnectionConfig.pinned_fingerprint: Option<TlsFingerprint>` —
+  `crates/rimap-imap/src/connection.rs:77`.
+- `build_tls_config` returns a `TlsConfigBundle` whose `last_observed: Arc<OnceLock<TlsFingerprint>>`
+  slot is populated by both `PinningVerifier` and `CapturingVerifier` on every
+  cert verification — `crates/rimap-imap/src/tls.rs`.
+- `connect_inner` enriches a TLS handshake error into
+  `ImapError::Tls { observed, expected }` when both sides are known —
+  `crates/rimap-imap/src/connection.rs:232-239`.
+
+`#117` landed the TCP+TLS+CAPABILITY preflight at `--dry-run` time
+(`crates/rimap-imap/src/preflight.rs`, invoked from
+`crates/rimap-server/src/cli/dry_run.rs:80-99`). The remaining gap: the
+fingerprint observed during that preflight is currently discarded — it lives
+on the `TlsConfigBundle` constructed inside `probe_preflight` and goes out of
+scope on return. Operators have no documented way to surface the value short
+of running `openssl x509 -fingerprint -sha256` against the server cert.
+
+The issue body's claim that mismatch already produces
+`ImapError::Tls { observed, expected }` is true on the auth path (`connect_inner`)
+but **not** the preflight path: `probe_preflight` propagates the raw rustls
+error as `ImapError::TlsHandshake`. Closing the gap requires extending the
+enrichment to both call sites.
+
+Note: the issue body uses the TOML key `tls_fingerprint`. The actual config
+key (per `docs/configuration.md:30`, `docs/quickstart-proton-bridge.md:72`,
+`docs/multi-account.md:24`) is **`tls_fingerprint_sha256`**. All printed
+strings and docs use the real key.
+
+## Architecture
+
+Three changes, in dependency order:
+
+### 1. Extract a shared TLS-error enrichment helper
+
+`connect_inner` in `crates/rimap-imap/src/connection.rs:232-239` currently
+inlines the logic for converting a `rustls::Error` into `ImapError::Tls`
+when the verifier captured a fingerprint and the caller had a pin. Extract
+into a `pub(crate) fn`:
+
+```rust
+pub(crate) fn enrich_tls_handshake_error(
+    err: ImapError,
+    bundle: &TlsConfigBundle,
+    pinned: Option<TlsFingerprint>,
+) -> ImapError {
+    let ImapError::TlsHandshake(_) = &err else { return err; };
+    match (bundle.last_observed.get().copied(), pinned) {
+        (Some(observed), Some(expected)) if observed != expected => {
+            ImapError::Tls { observed, expected }
+        }
+        _ => err,
+    }
+}
+```
+
+Call from both `connect_inner` and `probe_preflight`. The existing
+`connect_inner` mismatch test at `connection.rs:1140-1147` is the
+regression gate — its expectations do not change.
+
+### 2. Extend `PreflightInfo` and capture in `probe_preflight`
+
+`PreflightInfo` is `#[non_exhaustive]`, so adding a field is non-breaking:
+
+```rust
+#[non_exhaustive]
+pub struct PreflightInfo {
+    pub capabilities: Vec<String>,
+    pub tls_fingerprint: TlsFingerprint,  // new
+}
+```
+
+In `probe_preflight`:
+
+- After a successful CAPABILITY round-trip, read
+  `bundle.last_observed.get().copied()`. The verifier runs before any
+  `Ok` path, so the slot must be populated. If it is not (programming
+  error), return `ImapError::TlsHandshake(rustls::Error::General(
+  "verifier did not capture fingerprint"))` rather than panicking.
+- On any error path that produced an `ImapError::TlsHandshake`, route
+  through `enrich_tls_handshake_error` so a mismatch surfaces as
+  `ImapError::Tls { observed, expected }`. The handshake-failure paths
+  on lines 54-67 (`Tls`) and 62-67 (`Starttls`) need the enrichment;
+  errors after handshake (greeting, CAPABILITY) do not.
+
+### 3. Print three-case fingerprint section in dry-run
+
+`crates/rimap-server/src/cli/dry_run.rs` currently prints `Capabilities`
+on `Ok(info)` and `Capabilities ... unavailable (...)` on `Err(e)`.
+Add a `TLS fingerprint (sha256):` section.
+
+**Unpinned + ok** (operator is onboarding):
+
+```text
+TLS fingerprint (sha256):
+  ab:cd:...:ef
+  (add `tls_fingerprint_sha256 = "ab:cd:...:ef"` under [imap] in config.toml to pin)
+```
+
+**Pinned + match** (confirmation):
+
+```text
+TLS fingerprint (sha256):
+  ab:cd:...:ef  (matches configured pin)
+```
+
+**Pinned + mismatch** (diagnostic — error path):
+
+```text
+TLS fingerprint (sha256):
+  observed: ef:01:...:23
+  expected: ab:cd:...:ef  (configured pin)
+  hint: re-run the openssl command from the quickstart and update tls_fingerprint_sha256
+```
+
+The mismatch branch matches on `Err(ImapError::Tls { observed, expected })`.
+Other error variants (`Connect`, `Timeout`, `TlsHandshake` for non-mismatch
+reasons, `Protocol`) keep the existing `Capabilities (...): unavailable (e)`
+line and **omit** the fingerprint section — there is no fingerprint to
+print when the verifier never ran.
+
+## Testing
+
+### API contract — `crates/rimap-imap/tests/tls_pinning.rs`
+
+Two new tests against the existing in-process rustls listener used by
+the file's existing pinning tests:
+
+- `probe_preflight_returns_observed_fingerprint`: compute the fixture
+  cert's SHA-256 directly from the PEM, call `probe_preflight` with
+  `pinned_fingerprint = None`, assert
+  `info.tls_fingerprint == computed_hash`.
+- `probe_preflight_mismatch_returns_typed_error`: pin a deliberately
+  wrong fingerprint, assert the error is
+  `ImapError::Tls { observed, expected }` with both values populated
+  and `observed == computed_hash`, `expected == wrong_hash`.
+
+### CLI output contract — `crates/rimap-server/tests/dry_run_cli.rs`
+
+Three new sub-tests. Each stands up a one-shot rustls listener on a
+random port using the same fixture cert as `tls_pinning.rs`, writes a
+config pointing at it, invokes the binary with `--dry-run`, and asserts
+on stdout:
+
+- `dry_run_prints_unpinned_fingerprint_with_paste_hint`: no
+  `tls_fingerprint_sha256` in config; assert
+  `TLS fingerprint (sha256):` appears, the expected hex appears, and
+  the substring `tls_fingerprint_sha256 =` appears as a paste hint.
+- `dry_run_prints_pinned_match_confirmation`: config pins the correct
+  fingerprint; assert `(matches configured pin)` appears.
+- `dry_run_prints_pinned_mismatch_diagnostic`: config pins a wrong
+  fingerprint; assert `observed:` and `expected:` lines both appear
+  with the right hex values, and the `hint:` line appears.
+
+Test gate: match prevailing convention in the file. The file's
+existing tests run on Linux + macOS (no platform `cfg` gate). New
+tests inherit that.
+
+### Mutation testing
+
+Run `cargo mutants --jobs 2` over the touched files (`preflight.rs`,
+`connection.rs`, `dry_run.rs`) after the change lands and kill any
+escaped mutants per the project's standing practice.
+
+## Documentation
+
+- `docs/quickstart-proton-bridge.md`: in the pinning step, add a
+  primary path that says "run `rusty-imap-mcp --config config.toml
+  --dry-run` and copy the value under `TLS fingerprint (sha256):`
+  into `tls_fingerprint_sha256`". Keep the `openssl s_client | openssl
+  x509 -fingerprint -sha256` recipe as a secondary fallback paragraph.
+- `docs/quickstart-gmail.md`: parallel update if the file has a
+  pinning step (Gmail uses CA-signed certs, so pinning is optional —
+  documented but not required).
+- `docs/configuration.md`: under the `tls_fingerprint_sha256` table
+  row, add one sentence pointing to `--dry-run` as the canonical
+  onboarding path.
+- `crates/rimap-imap/src/preflight.rs` module doc: update the
+  high-level summary to mention fingerprint capture.
+- `crates/rimap-server/src/cli/dry_run.rs` module doc: add the
+  `TLS fingerprint (sha256):` section to the sample output block.
+
+## Out of scope
+
+- `--pin-fingerprint` CLI flag. Pinning stays config-file-only,
+  consistent with existing posture surface.
+- Cert chain / issuer / subject / validity-date introspection. The
+  fingerprint alone covers the immediate onboarding need.
+- Fixing the report-and-continue exit-code gap noted in #117's
+  acceptance criteria. The current `dry_run.rs` exits 0 even on
+  preflight failure; #117's acceptance said non-zero on any account
+  failure. This is an adjacent gap, separate PR.
+
+## Risks
+
+- **Auth-path regression from extracting `enrich_tls_handshake_error`.**
+  The helper is a mechanical extraction of existing logic. The
+  existing `connect_inner` mismatch test at `connection.rs:1140-1147`
+  exercises the auth path and is the regression gate. Run
+  `cargo test -p rimap-imap` before and after to confirm parity.
+- **`bundle.last_observed.get()` returning `None` after a successful
+  handshake** would indicate a rustls/verifier bug. Treat as a typed
+  error (`ImapError::TlsHandshake(General(...))`), not a panic.
+- **Public API change to `PreflightInfo`.** The struct is
+  `#[non_exhaustive]`, so adding a field is source-compatible.
+  Downstream callers that destructure with `..` (the only allowed
+  pattern for `non_exhaustive` external structs) keep compiling.
+
+## Acceptance criteria (from #151)
+
+- [ ] `--dry-run` output contains a `TLS fingerprint (sha256):` section
+  per account.
+- [ ] The printed value matches what the server actually presented at
+  handshake time (asserted by both `tls_pinning.rs` API test and
+  `dry_run_cli.rs` CLI test).
+- [ ] Docs updated — quickstart instructions reference `--dry-run` as
+  the onboarding path.

--- a/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
@@ -139,40 +139,70 @@ print when the verifier never ran.
 
 ## Testing
 
-### API contract — `crates/rimap-imap/tests/tls_pinning.rs`
+The only real-handshake test infrastructure in the repo is the
+Dovecot container harness in `crates/rimap-imap/tests/integration/`
+(`ConnectedHarness::new(PinChoice)` in `support/connect.rs`,
+`DovecotHarness` in `support/container.rs`). `tls_pinning.rs` uses
+synthetic DER bytes only; there is no in-process rustls listener.
+The issue's acceptance criterion ("integration test against the
+project's Dovecot / Mailpit fixture") maps directly to the existing
+harness. Tests split as follows:
 
-Two new tests against the existing in-process rustls listener used by
-the file's existing pinning tests:
+### API contract — `crates/rimap-imap/tests/integration/dovecot.rs`
 
-- `probe_preflight_returns_observed_fingerprint`: compute the fixture
-  cert's SHA-256 directly from the PEM, call `probe_preflight` with
-  `pinned_fingerprint = None`, assert
-  `info.tls_fingerprint == computed_hash`.
-- `probe_preflight_mismatch_returns_typed_error`: pin a deliberately
-  wrong fingerprint, assert the error is
-  `ImapError::Tls { observed, expected }` with both values populated
-  and `observed == computed_hash`, `expected == wrong_hash`.
+Two new tests using `ConnectedHarness`:
 
-### CLI output contract — `crates/rimap-server/tests/dry_run_cli.rs`
+- `case_NN_probe_preflight_returns_observed_fingerprint`: build a
+  `ConnectionConfig` from the harness with `pinned_fingerprint = None`,
+  call `probe_preflight`, assert `info.tls_fingerprint ==
+  harness.expected_fingerprint()` (the harness exposes the cert's
+  SHA-256 via the `/shared/fingerprint.hex` file the container
+  publishes).
+- `case_NN_probe_preflight_mismatch_returns_typed_error`: pin a
+  deliberately wrong fingerprint, assert the error is
+  `ImapError::Tls { observed, expected }` with `observed ==
+  harness.expected_fingerprint()` and `expected == wrong_hash`.
 
-Three new sub-tests. Each stands up a one-shot rustls listener on a
-random port using the same fixture cert as `tls_pinning.rs`, writes a
-config pointing at it, invokes the binary with `--dry-run`, and asserts
-on stdout:
+These run only when Docker/Podman is available (silent skip otherwise),
+matching the rest of the Dovecot suite.
 
-- `dry_run_prints_unpinned_fingerprint_with_paste_hint`: no
-  `tls_fingerprint_sha256` in config; assert
-  `TLS fingerprint (sha256):` appears, the expected hex appears, and
-  the substring `tls_fingerprint_sha256 =` appears as a paste hint.
-- `dry_run_prints_pinned_match_confirmation`: config pins the correct
-  fingerprint; assert `(matches configured pin)` appears.
-- `dry_run_prints_pinned_mismatch_diagnostic`: config pins a wrong
-  fingerprint; assert `observed:` and `expected:` lines both appear
-  with the right hex values, and the `hint:` line appears.
+### Printer contract — unit tests in `crates/rimap-server/src/cli/dry_run.rs`
 
-Test gate: match prevailing convention in the file. The file's
-existing tests run on Linux + macOS (no platform `cfg` gate). New
-tests inherit that.
+Extract the fingerprint-printing logic into a small pure function:
+
+```rust
+fn write_fingerprint_section<W: Write>(
+    out: &mut W,
+    result: &Result<PreflightInfo, ImapError>,
+    pinned: Option<TlsFingerprint>,
+) -> io::Result<()>
+```
+
+This function takes synthesized inputs and writes the three-case
+output. Three new unit tests cover each branch:
+
+- `write_fingerprint_section_unpinned_prints_paste_hint`: `pinned =
+  None`, `Ok(info)` with a synthesized fingerprint; assert output
+  contains `TLS fingerprint (sha256):`, the hex string, and
+  `tls_fingerprint_sha256 =`.
+- `write_fingerprint_section_pinned_match_prints_confirmation`:
+  `pinned = Some(fp)`, `Ok(info)` with the same fingerprint; assert
+  output contains `(matches configured pin)`.
+- `write_fingerprint_section_pinned_mismatch_prints_diagnostic`:
+  `pinned = Some(a)`, `Err(ImapError::Tls { observed: b, expected: a })`;
+  assert output contains `observed:`, `expected:`, both hex values,
+  and the `hint:` line.
+
+The existing `dry_run_cli.rs` integration test gets a one-line
+addition: assert that `TLS fingerprint (sha256):` appears in stdout
+(or that the `unavailable` variant fires, since the test points at
+an unreachable port). This is a smoke-level check, not the contract.
+
+### Mutation testing
+
+Run `cargo mutants --jobs 2` over the touched files (`preflight.rs`,
+`connection.rs`, `dry_run.rs`) after the change lands and kill any
+escaped mutants per the project's standing practice.
 
 ### Mutation testing
 

--- a/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-151-tls-fingerprint-dry-run-design.md
@@ -76,6 +76,30 @@ Call from both `connect_inner` and `probe_preflight`. The existing
 `connect_inner` mismatch test at `connection.rs:1140-1147` is the
 regression gate — its expectations do not change.
 
+### Unpinned-mode capture (TOFU)
+
+`probe_preflight` uses two TLS-verifier modes:
+
+- **Pinned**: when `cfg.pinned_fingerprint.is_some()`, build via
+  `build_tls_config(...)`. The `PinningVerifier` bypasses chain
+  validation and accepts only the configured fingerprint.
+- **Unpinned + capture-only**: when `cfg.pinned_fingerprint.is_none()`,
+  build via `build_tls_config_capture_only()`. The `CaptureOnlyVerifier`
+  records the leaf-cert fingerprint and **always accepts** the cert.
+
+The capture-only path is required so a self-signed cert (e.g., Proton
+Bridge) does not abort the probe before the fingerprint can be surfaced
+to the operator. The auth path (`Connection::connect_inner`) is
+unaffected — it continues to use `build_tls_config(None)` with
+webpki-roots in unpinned mode.
+
+**Trust posture**: `--dry-run` against an unpinned config has the same
+TOFU guarantee as running `openssl s_client` over the same network. A
+network attacker's cert would be captured and reported as if it were
+the server's. Quickstart docs already advise extracting the fingerprint
+in a trusted environment; that guidance applies whether the operator
+uses `--dry-run` or the openssl recipe.
+
 ### 2. Extend `PreflightInfo` and capture in `probe_preflight`
 
 `PreflightInfo` is `#[non_exhaustive]`, so adding a field is non-breaking:


### PR DESCRIPTION
## Summary
- Adds `PreflightInfo.tls_fingerprint`, captured from `bundle.last_observed` after the TLS handshake
- Extracts `enrich_tls_handshake_error` from `connect_inner` and reuses it in `probe_preflight` so a fingerprint mismatch surfaces as `ImapError::Tls { observed, expected }` on both auth and preflight paths
- New `write_fingerprint_section` printer renders three live cases under `--dry-run` (unpinned-onboard with paste hint, pinned-match confirmation, pinned-mismatch diagnostic) plus a defensive arm that flags unexpected states
- Quickstart docs promote `--dry-run` as the canonical TLS pinning onboarding path; the openssl recipe stays as a fallback
- New tests: 5 printer unit tests, 4 helper unit tests, 2 multi-account header tests, 2 Dovecot integration cases (`case_21` capture, `case_22` typed-mismatch)
- Mutation testing: 7 escapees killed by new tests; 4 known-equivalent mutants annotated inline

Closes #151.

## Test plan
- [x] `cargo test -p rimap-imap -p rimap-server` — 414 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo mutants --jobs 2 --file <touched files>` — zero unkilled mutants on new lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)