### PR TITLE
ci(fuzz): grant actions: read so ClusterFuzzLite can fetch artifacts

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,11 @@ concurrency:
 
 permissions:
   contents: read
+  # ClusterFuzzLite's run_fuzzers action calls the actions REST API to fetch
+  # prior-run artifacts (corpus persistence + previous-build crash attribution).
+  # Without this scope every API call returns 401 and both features silently
+  # degrade. See issue #202.
+  actions: read
   # 'security-events: write' would be needed to upload SARIF; not used here
   # because crash artifacts are sufficient for B1's scope.
 


### PR DESCRIPTION
## Summary
- Adds `actions: read` to the `permissions:` block in `.github/workflows/fuzz.yml`.
- ClusterFuzzLite's `run_fuzzers` action calls `GET /repos/{owner}/{repo}/actions/artifacts` to fetch prior-run artifacts (corpus persistence + previous-build crash attribution). Without this scope, every call returns `401 Bad credentials` and both features silently degrade — every random crash gets reported as "newly introduced" even when the underlying bug pre-existed the PR.
- Inline comment explains the rationale and references issue #202.

Fixes #202.

## Test plan
- [ ] `pr-smoke` run on this PR completes with **no** `401 Bad credentials` lines in the log.
- [ ] Run log shows `Found previous build of target.` instead of `Could not run previous build of target ... Assuming crash was newly introduced.`
- [ ] On a follow-up push to this branch, the `INFO: seed corpus: files: N` count is higher than the first run (corpus persistence working).
- [ ] Nightly job inherits the same top-level `permissions:` block; verification deferred to the next 03:17 UTC run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)