### PR TITLE
deps: bump mail-parser to 0.11.3, verify #201 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "mail-parser"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
+checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
 dependencies = [
  "hashify",
 ]

--- a/crates/rimap-content/tests/upstream_201_direct.rs
+++ b/crates/rimap-content/tests/upstream_201_direct.rs
@@ -1,0 +1,13 @@
+//! Direct verification that mail-parser 0.11.3 no longer panics on the
+//! issue #201 crash input. Unlike `parser_panic_safety.rs`, this test
+//! deliberately bypasses our `safe_parse` `catch_unwind` shim and calls
+//! the upstream API directly. If the upstream bug returns, this test
+//! aborts the test runner with a panic — exactly what we want as a
+//! regression signal.
+
+const CRASH_INPUT: &[u8] = include_bytes!("data/mail_parser_panic_201.eml");
+
+#[test]
+fn upstream_mail_parser_does_not_panic_on_issue_201_input() {
+    let _ = mail_parser::MessageParser::default().parse(CRASH_INPUT);
+}


### PR DESCRIPTION
## Summary

- Bump `mail-parser` 0.11.2 → 0.11.3 in `Cargo.lock` (workspace constraint `"0.11"` already permitted it).
- Add `crates/rimap-content/tests/upstream_201_direct.rs` — calls `mail_parser::MessageParser::default().parse` on the recovered crash bytes **without** our `catch_unwind` shim, so any future upstream regression is caught immediately.

## Why

Upstream commit [`2bff6e8d`](https://github.com/stalwartlabs/mail-parser/commit/2bff6e8d) (in 0.11.3, released 2026-05-02) — "Fix panic with messages containing corrupted attachments" — closes [stalwartlabs/mail-parser#145](https://github.com/stalwartlabs/mail-parser/issues/145), which has the same panic signature as our #201 (`parsers/message.rs:449:67`, "range start index 9 out of range for slice of length 4").

The `safe_parse` `catch_unwind` shim from #204 stays in place as defense in depth.

## Verification (this branch)

| Check | Result |
| --- | --- |
| Direct `mail_parser` call on crash bytes (0.11.2 — negative control) | **panics** at `mail-parser-0.11.2/src/parsers/message.rs:449:67` with the exact #201 signature |
| Direct `mail_parser` call on crash bytes (0.11.3) | passes |
| `cargo test -p rimap-content` (228 unit + 4 #201 entry-point regression + 1 new direct) | green |
| `cargo test --workspace --all-features` | green |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `prek run` (commit hooks: fmt, clippy, deny, nextest, typos, etc.) | clean |

Closes #201.

## Test plan

- [x] Negative control: same test panics on 0.11.2 with the exact #201 signature
- [x] On 0.11.3: passes
- [x] Existing `parser_panic_safety.rs` regression suite still green
- [x] Full workspace tests + clippy + cargo deny green
- [ ] CI green on this PR