### PR TITLE
phase2: initial fixes — macOS sandbox test + rustls-webpki advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,21 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
+  check-macos:
+    name: check (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: 1.94.0) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          key: macos
+      - run: cargo check --workspace --locked --all-targets
+
   test:
     name: test (stable)
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/rimap-server/src/tools/retrieval/sandbox.rs
+++ b/crates/rimap-server/src/tools/retrieval/sandbox.rs
@@ -162,12 +162,18 @@ mod tests {
     #[test]
     fn resolve_dest_dir_accepts_valid_path() {
         let tmp = tempfile::tempdir().unwrap();
-        let sub = tmp.path().join("sub");
+        // Canonicalize once so the assertion below sees the same prefix
+        // form `resolve_dest_dir` produces internally. On macOS,
+        // `tempfile::tempdir()` returns `/var/folders/.../T/...` which
+        // canonicalize()s to `/private/var/folders/.../T/...`; without
+        // this, `result.starts_with(allowed)` compares the two forms
+        // and fails despite the path being legitimately inside.
+        let allowed = tmp.path().canonicalize().unwrap();
+        let sub = allowed.join("sub");
         std::fs::create_dir_all(&sub).unwrap();
-        let allowed = tmp.path();
-        let fallback = tmp.path();
-        let result = resolve_dest_dir(Some(sub.to_str().unwrap()), allowed, fallback).unwrap();
-        assert!(result.starts_with(allowed));
+        let fallback = allowed.clone();
+        let result = resolve_dest_dir(Some(sub.to_str().unwrap()), &allowed, &fallback).unwrap();
+        assert!(result.starts_with(&allowed));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First Phase-2 extraction after the daemon rollback. Two small, targeted fixes that are required for the rolled-back `main` to pass CI.

- **`fix(rimap-server): canonicalize allowed_root in sandbox test for macOS`** — cherry-pick of `5078a79` (originally PR #189). The test `resolve_dest_dir_accepts_valid_path` was failing on macOS because `tempfile::tempdir()` returns `/var/folders/.../T/...` while `canonicalize()` resolves the `/var → /private/var` symlink. Test-only change; no production behavior modified.
- **`deps: bump rustls-webpki 0.103.12 -> 0.103.13 (RUSTSEC-2026-0104)`** — single-line lockfile bump to clear a `cargo-deny` advisory for a reachable panic in CRL `from_der` parsing. Project doesn't currently consume CRLs, so not exploitable in practice; bumped anyway to keep supply-chain checks green.

Both fixes are pre-existing on the rolled-back `main` (the macOS fix because we lost it in the rollback; the rustls advisory because it was published after the rollback baseline).

## Context

Phase-2 of the rollback documented in `docs/superpowers/specs/2026-05-02-multi-client-stdio-design.md` §12. The full pre-rollback history is preserved on `archive/daemon-experiment`.

## Test plan

- [ ] CI: `test (stable)` and `check (macOS)` pass
- [ ] CI: `cargo-deny` clears (no advisories)
- [ ] CI: `clippy`, `rustfmt`, `test (MSRV 1.88.0)`, `zizmor self-check`, `SonarQube` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)