### PR TITLE
feat: multi-client stdio (B1) — replaces daemon design

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ Binaries are published for five targets on each
 - [Audit log format](docs/audit-log.md)
 - [Full documentation index](docs/INDEX.md)
 
+## Troubleshooting
+
+- **`rusty-imap-mcp` exits at startup with `audit file ... is already locked`** —
+  another `rusty-imap-mcp` process holds the audit lock. Each MCP
+  client must use a distinct `[audit].path`; see
+  [Running multiple MCP clients](docs/audit-log.md#running-multiple-mcp-clients)
+  for the configuration pattern.
+
 ## License
 
 Dual-licensed under MIT OR Apache-2.0. See `LICENSE-MIT` and

--- a/crates/rimap-audit/src/record/error.rs
+++ b/crates/rimap-audit/src/record/error.rs
@@ -30,8 +30,9 @@ pub enum AuditError {
     },
     /// The audit file is already locked by another process.
     #[error(
-        "audit file `{path}` is already locked by another rusty-imap-mcp process; \
-         only one instance may run against a given audit path"
+        "audit file `{path}` is already locked by another rusty-imap-mcp process. \
+         Each MCP client must use a distinct `[audit].path`; \
+         see docs/audit-log.md#running-multiple-mcp-clients"
     )]
     Locked {
         /// Path that could not be locked.
@@ -154,8 +155,27 @@ mod tests {
             path: PathBuf::from("/tmp/a.jsonl"),
         };
         let msg = err.to_string();
-        assert!(msg.contains("/tmp/a.jsonl"));
-        assert!(msg.contains("another rusty-imap-mcp process"));
+        assert!(msg.contains("/tmp/a.jsonl"), "got: {msg}");
+        assert!(msg.contains("another rusty-imap-mcp process"), "got: {msg}");
+        assert!(
+            msg.contains("distinct `[audit].path`"),
+            "message must name the resolution; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn locked_message_includes_docs_anchor() {
+        // The error string is the canonical entry-point users see when the
+        // lock collides. It must point at the docs anchor so the cross-link
+        // does not silently rot when docs/audit-log.md is edited.
+        let err = AuditError::Locked {
+            path: PathBuf::from("/tmp/a.jsonl"),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("docs/audit-log.md#running-multiple-mcp-clients"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/rimap-audit/tests/docs_anchor.rs
+++ b/crates/rimap-audit/tests/docs_anchor.rs
@@ -1,0 +1,32 @@
+//! Pins the cross-link from `AuditError::Locked`'s Display string
+//! (`docs/audit-log.md#running-multiple-mcp-clients`) to the heading that
+//! defines that anchor. If `docs/audit-log.md` is reorganized and the
+//! heading is renamed without a coordinated update to the error message,
+//! this test fails.
+
+#![expect(clippy::expect_used, reason = "tests")]
+#![expect(clippy::panic, reason = "tests")]
+
+use std::path::PathBuf;
+
+#[test]
+fn audit_log_md_defines_running_multiple_mcp_clients_heading() {
+    // CARGO_MANIFEST_DIR points at crates/rimap-audit/. Walk up two levels
+    // to reach the workspace root, then read docs/audit-log.md.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root must exist two levels above crate dir")
+        .to_path_buf();
+    let docs_path = workspace_root.join("docs").join("audit-log.md");
+
+    let content = std::fs::read_to_string(&docs_path).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", docs_path.display());
+    });
+
+    assert!(
+        content.contains("\n## Running multiple MCP clients\n"),
+        "docs/audit-log.md must define the `## Running multiple MCP clients` \
+         heading referenced by AuditError::Locked. Did the heading get renamed?",
+    );
+}

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -123,6 +123,130 @@ Config-related event. Declared for future use.
   default. Set `audit.fail_open = true` to suppress write failures
   and continue (not recommended -- audit records will be lost).
 
+## Running multiple MCP clients
+
+`rusty-imap-mcp` holds an exclusive lock on its configured `[audit].path`
+for the lifetime of the process. A second process against the same path
+fails immediately with `ERR_CONFIG`. The lock guards append atomicity,
+the per-process `seq` allocator, the inode tamper chain, and the
+in-memory provenance ring — all forensic invariants that depend on a
+single writer.
+
+To run multiple MCP clients on the same machine — for example, two
+Claude Code windows on different projects, or Claude Code alongside
+Codex — give each MCP client its own `rusty-imap-mcp` config file with
+a distinct `[audit].path`.
+
+### Supported scenarios
+
+#### Single MCP client
+
+The default. Nothing to configure beyond the standard setup. One
+`[audit].path`, one `rusty-imap-mcp` PID, one audit file.
+
+#### Cross-application: Claude Code + Codex
+
+Each host application has its own MCP config; point each at a
+different `rusty-imap-mcp` config file with its own audit path.
+
+`~/.claude.json` (Claude Code, user-scope):
+
+```json
+{
+  "mcpServers": {
+    "rusty-imap": {
+      "command": "/usr/local/bin/rusty-imap-mcp",
+      "args": ["--config", "/home/dave/.config/rusty-imap-mcp/claude.toml"]
+    }
+  }
+}
+```
+
+`~/.codex/config.toml` (Codex):
+
+```toml
+[mcp_servers.rusty-imap]
+command = "/usr/local/bin/rusty-imap-mcp"
+args = ["--config", "/home/dave/.config/rusty-imap-mcp/codex.toml"]
+```
+
+`~/.config/rusty-imap-mcp/claude.toml`:
+
+```toml
+[audit]
+path = "~/.local/state/rusty-imap-mcp/audit-claude.jsonl"
+# ... rest of config identical between the two
+```
+
+`~/.config/rusty-imap-mcp/codex.toml`:
+
+```toml
+[audit]
+path = "~/.local/state/rusty-imap-mcp/audit-codex.jsonl"
+# ...
+```
+
+#### Cross-project: per-project `.mcp.json`
+
+For users whose MCP usage is tied to a specific repository, register
+`rusty-imap-mcp` at project scope rather than user scope. Each project
+gets its own `.mcp.json` and its own audit path.
+
+```bash
+cd /home/dave/src/work-project
+claude mcp add --scope project rusty-imap /usr/local/bin/rusty-imap-mcp \
+  -- --config /home/dave/.config/rusty-imap-mcp/work.toml
+```
+
+This writes `/home/dave/src/work-project/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rusty-imap": {
+      "command": "/usr/local/bin/rusty-imap-mcp",
+      "args": ["--config", "/home/dave/.config/rusty-imap-mcp/work.toml"]
+    }
+  }
+}
+```
+
+A second project gets the same treatment with its own paths. Each
+Claude Code window opened in a project loads that project's
+`.mcp.json` and spawns its own `rusty-imap-mcp` child against that
+project's audit file.
+
+### Unsupported: same MCP-client config across multiple windows
+
+If you have one `rusty-imap-mcp` entry in `~/.claude.json` (user
+scope) and open two Claude Code windows, both windows spawn their own
+child against the same audit path. The second child fails to acquire
+the lock and exits with `ERR_CONFIG`.
+
+Two options:
+
+1. Move the entry to project scope (`.mcp.json`) so each project gets
+   its own audit path, as in the cross-project example above.
+2. Accept that one window will lose its `rusty-imap-mcp` MCP server.
+   The other features of that Claude Code window are unaffected; only
+   the rusty-imap-mcp tools are unavailable in the losing window
+   until the holding window exits.
+
+A future database-backed audit store will remove this constraint by
+sharing the audit log across processes; until then, distinct
+`[audit].path` values per concurrent MCP client are the supported
+pattern.
+
+### Per-account rate limits and circuit breakers
+
+Each `rusty-imap-mcp` process maintains its own per-account
+`Governor` (rate limiter) and `CircuitBreaker`. With multiple
+concurrent MCP clients on the same IMAP account, each client's
+budget is independent. Operators who need a single per-account
+ceiling enforced across all local clients should track the future
+database-backed audit store, which will share this state by
+construction.
+
 ## Rotation
 
 When the active file exceeds `audit.rotate_bytes` (default 10 MiB),

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -47,6 +47,12 @@ username = "you@gmail.com"
 path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
 ```
 
+If you plan to run multiple MCP clients against this account (e.g.
+two Claude Code windows on different projects, or Claude Code
+alongside Codex), see
+[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
+for the per-client configuration pattern.
+
 Replace `you@gmail.com` with your Gmail address.
 
 ## Step 3: Store your credentials

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -84,6 +84,12 @@ posture = "draft-safe"
 path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
 ```
 
+If you plan to run multiple MCP clients against this account (e.g.
+two Claude Code windows on different projects, or Claude Code
+alongside Codex), see
+[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
+for the per-client configuration pattern.
+
 Replace `you@proton.me` with your Proton email address and
 `tls_fingerprint_sha256` with the output from Step 2.
 

--- a/docs/superpowers/plans/2026-05-02-multi-client-stdio.md
+++ b/docs/superpowers/plans/2026-05-02-multi-client-stdio.md
@@ -315,10 +315,59 @@ grep -n "^## Running multiple MCP clients" docs/audit-log.md
 
 Expected: matches one line.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Add the symmetric docs-anchor test in `rimap-audit`**
+
+Task 1's `locked_message_includes_docs_anchor` test pins one end of the cross-link (the error message). This step pins the other end (the heading in the docs file) so a future heading rename breaks the test rather than silently breaking the user-facing UX.
+
+Create `crates/rimap-audit/tests/docs_anchor.rs` with:
+
+```rust
+//! Pins the cross-link from `AuditError::Locked`'s Display string
+//! (`docs/audit-log.md#running-multiple-mcp-clients`) to the heading that
+//! defines that anchor. If `docs/audit-log.md` is reorganized and the
+//! heading is renamed without a coordinated update to the error message,
+//! this test fails.
+
+use std::path::PathBuf;
+
+#[test]
+fn audit_log_md_defines_running_multiple_mcp_clients_heading() {
+    // CARGO_MANIFEST_DIR points at crates/rimap-audit/. Walk up two levels
+    // to reach the workspace root, then read docs/audit-log.md.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root must exist two levels above crate dir")
+        .to_path_buf();
+    let docs_path = workspace_root.join("docs").join("audit-log.md");
+
+    let content = std::fs::read_to_string(&docs_path).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", docs_path.display());
+    });
+
+    assert!(
+        content.contains("\n## Running multiple MCP clients\n"),
+        "docs/audit-log.md must define the `## Running multiple MCP clients` \
+         heading referenced by AuditError::Locked. Did the heading get renamed?",
+    );
+}
+```
+
+- [ ] **Step 5: Run the new test to confirm it passes**
+
+Run:
 
 ```bash
-git add docs/audit-log.md
+cargo test -p rimap-audit --test docs_anchor
+```
+
+Expected: PASS (the heading was inserted in Step 2). If it fails with "missing heading", re-check Step 2 — the heading text must be exactly `## Running multiple MCP clients` on its own line, surrounded by blank lines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/audit-log.md crates/rimap-audit/tests/docs_anchor.rs \
+  docs/superpowers/plans/2026-05-02-multi-client-stdio.md
 git commit -m "$(cat <<'EOF'
 docs(audit-log): add "Running multiple MCP clients" section
 
@@ -328,6 +377,10 @@ Document the supported multi-client configuration patterns
 config snippets for Claude Code (~/.claude.json + project-scope
 .mcp.json) and Codex. Anchor target for the rewritten
 AuditError::Locked message.
+
+Adds a symmetric `crates/rimap-audit/tests/docs_anchor.rs`
+integration test that fails if the new heading is renamed without
+a coordinated update to AuditError::Locked. Plan updated in lockstep.
 EOF
 )"
 ```
@@ -529,20 +582,25 @@ Expected: clean.
 Confirm all cross-links resolve to a defined anchor:
 
 ```bash
-echo "--- references ---"
+echo "--- slugified references ---"
 grep -rn "running-multiple-mcp-clients" \
-  README.md docs/ crates/rimap-audit/src/record/error.rs
-echo "--- definition ---"
+  README.md docs/ crates/rimap-audit/
+echo "--- heading definition ---"
 grep -n "^## Running multiple MCP clients" docs/audit-log.md
+echo "--- symmetric test heading literal ---"
+grep -n "Running multiple MCP clients" crates/rimap-audit/tests/docs_anchor.rs
 ```
 
-Expected references (5 total, exactly):
+Expected slugified references (6 total, exactly):
 - `README.md` — 1 hit (Task 5 troubleshooting bullet)
 - `docs/quickstart-gmail.md` — 1 hit (Task 3)
 - `docs/quickstart-proton-bridge.md` — 1 hit (Task 4)
 - `crates/rimap-audit/src/record/error.rs` — 2 hits (the `#[error]` string literal in Task 1 Step 4, and the test assertion in Task 1 Step 2)
+- `crates/rimap-audit/tests/docs_anchor.rs` — 1 hit (the doc comment naming the cross-link)
 
-Expected definition: 1 hit on the heading line in `docs/audit-log.md` (Task 2).
+Expected heading definition: 1 hit on the heading line in `docs/audit-log.md` (Task 2).
+
+Expected symmetric test heading literal: at least 2 hits in `crates/rimap-audit/tests/docs_anchor.rs` (the assertion's expected substring and its failure message).
 
 If any reference appears without a matching definition (or vice versa), an anchor name has drifted — fix before proceeding.
 

--- a/docs/superpowers/plans/2026-05-02-multi-client-stdio.md
+++ b/docs/superpowers/plans/2026-05-02-multi-client-stdio.md
@@ -1,0 +1,570 @@
+# Multi-client stdio (B1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing audit-lock-collision failure actionable, and document the multi-client config pattern, so users running multiple MCP clients on the same machine can configure around the constraint.
+
+**Architecture:** Pure UX change. The `AuditError::Locked` message gets rewritten to name the resolution and point at a new docs anchor. Three documentation files (`docs/audit-log.md`, both quickstarts, README) get a "Running multiple MCP clients" section / cross-link. No code architecture changes; no new mechanisms; no new dependencies. See spec at `docs/superpowers/specs/2026-05-02-multi-client-stdio-design.md`.
+
+**Tech Stack:** Rust 2024 edition; `thiserror` for error display; existing `cargo nextest` / `cargo test` test runners; pre-commit hooks via `prek` already installed.
+
+**Open questions resolved here (from spec §11):**
+- **Error message format:** single-line. The error names path + resolution + docs anchor in one line. Long-form guidance lives in `docs/audit-log.md`. Reasons: predictable terminal rendering, simple `to_string()` test assertions, conventional `thiserror` style.
+- **README troubleshooting placement:** create a new minimal `## Troubleshooting` section between `## Documentation` (line 156) and `## License` (line 164). One bullet now; gives a place to add future entries.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility after change |
+|---|---|---|
+| `crates/rimap-audit/src/record/error.rs` | Modify `#[error]` on `Locked` variant; update tests | Defines the new actionable message; tests pin path + anchor presence |
+| `docs/audit-log.md` | Insert new section "Running multiple MCP clients" between "File handling" and "Rotation" | Authoritative reference for the multi-client config pattern; the docs anchor target |
+| `docs/quickstart-gmail.md` | Insert one paragraph after the `[audit]` config block | Cross-link from setup flow to the multi-client docs |
+| `docs/quickstart-proton-bridge.md` | Insert one paragraph after the `[audit]` config block | Same as Gmail quickstart |
+| `README.md` | New `## Troubleshooting` section before `## License` | One-line entry pointing at the docs anchor |
+
+Test files touched:
+- `crates/rimap-audit/src/record/error.rs` (the inline `mod tests { … }` block at line 120)
+
+No new files. No deletions.
+
+---
+
+## Task 1: Update the `AuditError::Locked` Display message
+
+**Files:**
+- Modify: `crates/rimap-audit/src/record/error.rs:31-39` (the `#[error]` attribute on the `Locked` variant)
+- Modify: `crates/rimap-audit/src/record/error.rs:151-159` (the `locked_message_names_the_path` test)
+- Modify: `crates/rimap-audit/src/record/error.rs` (add a new sibling test inside the same `mod tests` block)
+
+- [ ] **Step 1: Read the current code**
+
+```bash
+cat crates/rimap-audit/src/record/error.rs | sed -n '31,40p'
+cat crates/rimap-audit/src/record/error.rs | sed -n '151,160p'
+```
+
+Expected: see the current `Locked` variant with text `"audit file ... only one instance may run against a given audit path"`, and the existing test asserting on `/tmp/a.jsonl` and `another rusty-imap-mcp process`.
+
+- [ ] **Step 2: Update the existing test for new wording (failing test first)**
+
+In `crates/rimap-audit/src/record/error.rs`, replace the existing `locked_message_names_the_path` test (lines 151-159) with:
+
+```rust
+    #[test]
+    fn locked_message_names_the_path() {
+        let err = AuditError::Locked {
+            path: PathBuf::from("/tmp/a.jsonl"),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("/tmp/a.jsonl"), "got: {msg}");
+        assert!(
+            msg.contains("another rusty-imap-mcp process"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("distinct `[audit].path`"),
+            "message must name the resolution; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn locked_message_includes_docs_anchor() {
+        // The error string is the canonical entry-point users see when the
+        // lock collides. It must point at the docs anchor so the cross-link
+        // does not silently rot when docs/audit-log.md is edited.
+        let err = AuditError::Locked {
+            path: PathBuf::from("/tmp/a.jsonl"),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("docs/audit-log.md#running-multiple-mcp-clients"),
+            "got: {msg}"
+        );
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p rimap-audit --lib -- record::error::tests::locked_message
+```
+
+Expected: both tests FAIL — the existing message does not contain `distinct `[audit].path`` nor the docs anchor.
+
+- [ ] **Step 4: Update the `Locked` variant's `#[error]` attribute**
+
+In `crates/rimap-audit/src/record/error.rs`, replace lines 31-35 (the `#[error(...)]` line preceding `Locked`) with:
+
+```rust
+    /// The audit file is already locked by another process.
+    #[error(
+        "audit file `{path}` is already locked by another rusty-imap-mcp process. \
+         Each MCP client must use a distinct `[audit].path`; \
+         see docs/audit-log.md#running-multiple-mcp-clients"
+    )]
+    Locked {
+```
+
+The string is one logical line (single `\` line continuations only — no `\n`), so the rendered error is one line.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p rimap-audit --lib -- record::error::tests::locked_message
+```
+
+Expected: both `locked_message_names_the_path` and `locked_message_includes_docs_anchor` PASS.
+
+- [ ] **Step 6: Run the full audit crate test suite to confirm no regression**
+
+Run:
+
+```bash
+cargo test -p rimap-audit
+```
+
+Expected: all tests pass, including `crates/rimap-audit/tests/concurrent_lock.rs` (which asserts on the `AuditError::Locked` variant shape, not its message).
+
+- [ ] **Step 7: Run clippy on the audit crate**
+
+Run:
+
+```bash
+cargo clippy -p rimap-audit --all-targets --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-audit/src/record/error.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-audit): make AuditError::Locked actionable
+
+The lock-collision error now names the resolution (use a distinct
+`[audit].path` per MCP client) and points at the docs anchor that
+holds the worked configuration examples. Pin the docs cross-link in a
+test so docs/audit-log.md heading renames are caught.
+
+Variant shape unchanged; call sites and downstream conversions are
+not touched.
+EOF
+)"
+```
+
+---
+
+## Task 2: Add "Running multiple MCP clients" section to `docs/audit-log.md`
+
+**Files:**
+- Modify: `docs/audit-log.md` — insert a new section between "File handling" (lines 109-124) and "Rotation" (line 126)
+
+- [ ] **Step 1: Read the current section boundaries**
+
+```bash
+sed -n '108,128p' docs/audit-log.md
+```
+
+Expected: see the end of the "File handling" section (line ~124) and the start of "## Rotation" (line 126).
+
+- [ ] **Step 2: Insert the new section**
+
+In `docs/audit-log.md`, immediately after the existing "File handling" section (after line 124, before the blank line that precedes `## Rotation`), insert:
+
+```markdown
+
+## Running multiple MCP clients
+
+`rusty-imap-mcp` holds an exclusive lock on its configured `[audit].path`
+for the lifetime of the process. A second process against the same path
+fails immediately with `ERR_CONFIG`. The lock guards append atomicity,
+the per-process `seq` allocator, the inode tamper chain, and the
+in-memory provenance ring — all forensic invariants that depend on a
+single writer.
+
+To run multiple MCP clients on the same machine — for example, two
+Claude Code windows on different projects, or Claude Code alongside
+Codex — give each MCP client its own `rusty-imap-mcp` config file with
+a distinct `[audit].path`.
+
+### Supported scenarios
+
+#### Single MCP client
+
+The default. Nothing to configure beyond the standard setup. One
+`[audit].path`, one `rusty-imap-mcp` PID, one audit file.
+
+#### Cross-application: Claude Code + Codex
+
+Each host application has its own MCP config; point each at a
+different `rusty-imap-mcp` config file with its own audit path.
+
+`~/.claude.json` (Claude Code, user-scope):
+
+```json
+{
+  "mcpServers": {
+    "rusty-imap": {
+      "command": "/usr/local/bin/rusty-imap-mcp",
+      "args": ["--config", "/home/dave/.config/rusty-imap-mcp/claude.toml"]
+    }
+  }
+}
+```
+
+`~/.codex/config.toml` (Codex):
+
+```toml
+[mcp_servers.rusty-imap]
+command = "/usr/local/bin/rusty-imap-mcp"
+args = ["--config", "/home/dave/.config/rusty-imap-mcp/codex.toml"]
+```
+
+`~/.config/rusty-imap-mcp/claude.toml`:
+
+```toml
+[audit]
+path = "~/.local/state/rusty-imap-mcp/audit-claude.jsonl"
+# ... rest of config identical between the two
+```
+
+`~/.config/rusty-imap-mcp/codex.toml`:
+
+```toml
+[audit]
+path = "~/.local/state/rusty-imap-mcp/audit-codex.jsonl"
+# ...
+```
+
+#### Cross-project: per-project `.mcp.json`
+
+For users whose MCP usage is tied to a specific repository, register
+`rusty-imap-mcp` at project scope rather than user scope. Each project
+gets its own `.mcp.json` and its own audit path.
+
+```bash
+cd /home/dave/src/work-project
+claude mcp add --scope project rusty-imap /usr/local/bin/rusty-imap-mcp \
+  -- --config /home/dave/.config/rusty-imap-mcp/work.toml
+```
+
+This writes `/home/dave/src/work-project/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rusty-imap": {
+      "command": "/usr/local/bin/rusty-imap-mcp",
+      "args": ["--config", "/home/dave/.config/rusty-imap-mcp/work.toml"]
+    }
+  }
+}
+```
+
+A second project gets the same treatment with its own paths. Each
+Claude Code window opened in a project loads that project's
+`.mcp.json` and spawns its own `rusty-imap-mcp` child against that
+project's audit file.
+
+### Unsupported: same MCP-client config across multiple windows
+
+If you have one `rusty-imap-mcp` entry in `~/.claude.json` (user
+scope) and open two Claude Code windows, both windows spawn their own
+child against the same audit path. The second child fails to acquire
+the lock and exits with `ERR_CONFIG`.
+
+Two options:
+
+1. Move the entry to project scope (`.mcp.json`) so each project gets
+   its own audit path, as in the cross-project example above.
+2. Accept that one window will lose its `rusty-imap-mcp` MCP server.
+   The other features of that Claude Code window are unaffected; only
+   the rusty-imap-mcp tools are unavailable in the losing window
+   until the holding window exits.
+
+A future database-backed audit store will remove this constraint by
+sharing the audit log across processes; until then, distinct
+`[audit].path` values per concurrent MCP client are the supported
+pattern.
+
+### Per-account rate limits and circuit breakers
+
+Each `rusty-imap-mcp` process maintains its own per-account
+`Governor` (rate limiter) and `CircuitBreaker`. With multiple
+concurrent MCP clients on the same IMAP account, each client's
+budget is independent. Operators who need a single per-account
+ceiling enforced across all local clients should track the future
+database-backed audit store, which will share this state by
+construction.
+```
+
+- [ ] **Step 3: Verify the anchor renders correctly**
+
+The error message in Task 1 references `docs/audit-log.md#running-multiple-mcp-clients`. Markdown auto-anchors lowercase the heading and replace spaces with hyphens, so "Running multiple MCP clients" → `#running-multiple-mcp-clients`. Verify by inspection:
+
+```bash
+grep -n "^## Running multiple MCP clients" docs/audit-log.md
+```
+
+Expected: matches one line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/audit-log.md
+git commit -m "$(cat <<'EOF'
+docs(audit-log): add "Running multiple MCP clients" section
+
+Document the supported multi-client configuration patterns
+(cross-application, cross-project) and the unsupported case
+(multiple windows sharing one user-scope config). Includes worked
+config snippets for Claude Code (~/.claude.json + project-scope
+.mcp.json) and Codex. Anchor target for the rewritten
+AuditError::Locked message.
+EOF
+)"
+```
+
+---
+
+## Task 3: Cross-link from `docs/quickstart-gmail.md`
+
+**Files:**
+- Modify: `docs/quickstart-gmail.md` — add one paragraph immediately after the `[audit]` config block (the block ending at line 48)
+
+- [ ] **Step 1: Read the current audit block**
+
+```bash
+sed -n '44,52p' docs/quickstart-gmail.md
+```
+
+Expected: see the `[audit]` config snippet (lines 46-48) followed by the existing "Replace `you@gmail.com`..." paragraph.
+
+- [ ] **Step 2: Insert the cross-link paragraph**
+
+In `docs/quickstart-gmail.md`, between the closing ` ``` ` of the audit block (line 48) and the next paragraph "Replace `you@gmail.com` with your Gmail address." (line 50), insert:
+
+```markdown
+
+If you plan to run multiple MCP clients against this account (e.g.
+two Claude Code windows on different projects, or Claude Code
+alongside Codex), see
+[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
+for the per-client configuration pattern.
+```
+
+The relative link `audit-log.md#running-multiple-mcp-clients` is correct because both files live under `docs/`.
+
+- [ ] **Step 3: Verify the link resolves**
+
+```bash
+grep -n "running-multiple-mcp-clients" docs/quickstart-gmail.md docs/audit-log.md
+```
+
+Expected: `docs/quickstart-gmail.md` references the anchor; `docs/audit-log.md` defines it via `## Running multiple MCP clients`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/quickstart-gmail.md
+git commit -m "$(cat <<'EOF'
+docs(quickstart-gmail): cross-link to multi-client audit pattern
+
+Point users from the Gmail setup flow at the new
+docs/audit-log.md#running-multiple-mcp-clients section so the
+multi-client constraint is discoverable from first-time setup.
+EOF
+)"
+```
+
+---
+
+## Task 4: Cross-link from `docs/quickstart-proton-bridge.md`
+
+**Files:**
+- Modify: `docs/quickstart-proton-bridge.md` — add one paragraph immediately after the `[audit]` config block (line 84)
+
+- [ ] **Step 1: Read the current audit block**
+
+```bash
+sed -n '80,90p' docs/quickstart-proton-bridge.md
+```
+
+Expected: see the `[audit]` config snippet around lines 83-84 followed by the next paragraph.
+
+- [ ] **Step 2: Insert the cross-link paragraph**
+
+In `docs/quickstart-proton-bridge.md`, between the closing ` ``` ` of the audit block and the paragraph that follows it, insert:
+
+```markdown
+
+If you plan to run multiple MCP clients against this account (e.g.
+two Claude Code windows on different projects, or Claude Code
+alongside Codex), see
+[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
+for the per-client configuration pattern.
+```
+
+(Same wording as Task 3 — duplicated here so this task is self-contained.)
+
+- [ ] **Step 3: Verify the link resolves**
+
+```bash
+grep -n "running-multiple-mcp-clients" docs/quickstart-proton-bridge.md docs/audit-log.md
+```
+
+Expected: `docs/quickstart-proton-bridge.md` references the anchor; `docs/audit-log.md` defines it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/quickstart-proton-bridge.md
+git commit -m "$(cat <<'EOF'
+docs(quickstart-proton-bridge): cross-link to multi-client audit pattern
+
+Point users from the Proton Bridge setup flow at the new
+docs/audit-log.md#running-multiple-mcp-clients section so the
+multi-client constraint is discoverable from first-time setup.
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `## Troubleshooting` section to `README.md`
+
+**Files:**
+- Modify: `README.md` — insert a new `## Troubleshooting` section between `## Documentation` (line 156) and `## License` (line 164)
+
+- [ ] **Step 1: Read the surrounding sections**
+
+```bash
+sed -n '155,170p' README.md
+```
+
+Expected: see the end of `## Documentation` and the start of `## License`.
+
+- [ ] **Step 2: Insert the new section**
+
+In `README.md`, between the end of the `## Documentation` section and the `## License` heading (line 164), insert:
+
+```markdown
+
+## Troubleshooting
+
+- **`rusty-imap-mcp` exits at startup with `audit file ... is already locked`** —
+  another `rusty-imap-mcp` process holds the audit lock. Each MCP
+  client must use a distinct `[audit].path`; see
+  [Running multiple MCP clients](docs/audit-log.md#running-multiple-mcp-clients)
+  for the configuration pattern.
+```
+
+- [ ] **Step 3: Verify the link resolves**
+
+```bash
+grep -n "running-multiple-mcp-clients" README.md docs/audit-log.md
+```
+
+Expected: `README.md` references the anchor; `docs/audit-log.md` defines it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs(readme): add Troubleshooting section with multi-client lock entry
+
+One bullet pointing at docs/audit-log.md#running-multiple-mcp-clients
+for the audit-lock-collision case. Establishes a Troubleshooting
+section so future entries have a stable home.
+EOF
+)"
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run the full workspace test suite**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: all tests pass. The audit error tests from Task 1 confirm the new wording; nothing else changed.
+
+- [ ] **Step 2: Run clippy across the workspace**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Run cargo fmt check**
+
+Run:
+
+```bash
+cargo fmt --check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Cross-check every anchor reference**
+
+Confirm all cross-links resolve to a defined anchor:
+
+```bash
+echo "--- references ---"
+grep -rn "running-multiple-mcp-clients" \
+  README.md docs/ crates/rimap-audit/src/record/error.rs
+echo "--- definition ---"
+grep -n "^## Running multiple MCP clients" docs/audit-log.md
+```
+
+Expected references (5 total, exactly):
+- `README.md` — 1 hit (Task 5 troubleshooting bullet)
+- `docs/quickstart-gmail.md` — 1 hit (Task 3)
+- `docs/quickstart-proton-bridge.md` — 1 hit (Task 4)
+- `crates/rimap-audit/src/record/error.rs` — 2 hits (the `#[error]` string literal in Task 1 Step 4, and the test assertion in Task 1 Step 2)
+
+Expected definition: 1 hit on the heading line in `docs/audit-log.md` (Task 2).
+
+If any reference appears without a matching definition (or vice versa), an anchor name has drifted — fix before proceeding.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/multi-client-b1
+```
+
+Expected: branch pushed; PR can be opened on GitHub.
+
+---
+
+## What this plan does NOT do
+
+Out-of-scope (per spec §3 and §8):
+
+- No daemon, no service install scripts, no socket/named-pipe transport.
+- No `--instance` CLI flag, no audit path templates, no per-process auto-derivation.
+- No new `[audit]` config fields. No new audit record kinds.
+- No shared rate limiter / circuit breaker. No cross-process provenance ring.
+- No `audit merge --paths` glob. No database backend.
+- No re-extraction of non-daemon work from `archive/daemon-experiment` (Phase 2 of the rollback; tracked separately).
+
+If reviewers ask for any of these, redirect to the spec's §3 (non-goals) and §8 (deferred).

--- a/docs/superpowers/specs/2026-05-02-multi-client-stdio-design.md
+++ b/docs/superpowers/specs/2026-05-02-multi-client-stdio-design.md
@@ -1,0 +1,129 @@
+# Multi-client stdio — design
+
+Issue: (file on merge)
+Target crates: `rimap-audit` (error message), docs only elsewhere.
+Related:
+- Replaces: `docs/superpowers/specs/2026-04-22-multi-client-daemon-design.md` (preserved on `archive/daemon-experiment`).
+- Code references at HEAD `948a29f`: `crates/rimap-audit/src/record/error.rs:31-39` (`AuditError::Locked`), `crates/rimap-audit/src/writer/mod.rs:127` (lock acquisition), `docs/audit-log.md:109-124` (current file-handling docs).
+
+## 1. Problem
+
+`rusty-imap-mcp` enforces a hard "one process per audit path" invariant via `fs4::FileExt::try_lock_exclusive`. A user running two MCP clients on the same audit path fails to start the second server with `audit file already locked; only one instance may run against a given audit path`. The error names the path but does not tell the user what to do about it, and no project documentation describes the multi-client pattern.
+
+The lock itself is load-bearing — it guards append atomicity, monotonic per-process `seq`, the inode tamper chain, the in-memory provenance ring, and the in-memory rate-limit / circuit-breaker state. We are not relaxing it. We are signposting the existing mechanism so users can configure around the collision.
+
+The earlier multi-client daemon design (`2026-04-22-multi-client-daemon-design.md`, now archived) attempted to solve this by introducing a long-running daemon process plus a stdio shim, with platform-specific service integration (systemd, launchd, Windows SCM). That work was completed and merged but is being rolled back. The OS-specific service surface and the per-user operational burden of running a service exceeded the value delivered for an MCP server whose typical use is tied to a single Claude Code window or repository.
+
+## 2. Goals
+
+- Make the existing lock-collision failure actionable: the error tells the user *what* collided and *how* to configure around it.
+- Document the multi-client configuration pattern in user-facing docs (audit-log reference, both quickstarts, README troubleshooting).
+- Preserve every audit invariant from the v0 design literally — no schema changes, no new record kinds, no concurrency primitives added.
+- Leave the door open for a future database-backed audit store. Anything we add now should be small enough to delete cleanly when that lands.
+
+## 3. Non-goals
+
+- No daemon process. No long-running singleton. No socket or named-pipe transport.
+- No platform service integration (systemd, launchd, Windows SCM, Task Scheduler).
+- No new CLI subcommands (`daemon`, `shim`, `service install/uninstall/run`).
+- No `--instance <name>` CLI flag, no audit path templates, no per-process auto-derived audit paths (PID or ULID suffixes). The path stays exactly what the user wrote in `[audit].path`.
+- No new fields in `[audit]` config block. No new audit record kinds (`session_start`, `session_end`, `peer_identity`, `session_id`).
+- No shared rate limiter or circuit breaker across processes. Each process keeps its own per-account state, as in v0.
+- No cross-file `audit merge` query. One file at a time; users `cat` or shell-glob for cross-file analysis.
+- No new dependencies.
+
+## 4. Architecture
+
+Identical to pre-daemon v0 (current HEAD `948a29f`). One `rusty-imap-mcp` PID per MCP-client config entry. Each PID exclusively locks its configured `[audit].path` for its lifetime. Multi-client = multiple MCP-client configs pointing at distinct rusty-imap-mcp configs, each with a distinct audit path. No coordination between processes.
+
+```
+┌──────────────┐  stdio/MCP   ┌──────────────────────────────┐
+│ MCP client A │ ───────────► │ rusty-imap-mcp (PID 1234)    │
+│ (Claude work)│              │  --config work-config.toml   │
+└──────────────┘              │  audit-work.jsonl (locked)   │
+                              └──────────────────────────────┘
+
+┌──────────────┐  stdio/MCP   ┌──────────────────────────────┐
+│ MCP client B │ ───────────► │ rusty-imap-mcp (PID 5678)    │
+│ (Codex)      │              │  --config codex-config.toml  │
+└──────────────┘              │  audit-codex.jsonl (locked)  │
+                              └──────────────────────────────┘
+```
+
+The two processes never know about each other. They share the same IMAP account on the upstream server, but each opens its own connection, runs its own rate limiter, writes its own audit chain.
+
+## 5. Code change
+
+Single change in `crates/rimap-audit/src/record/error.rs`. The `AuditError::Locked` variant keeps its shape (`Locked { path: PathBuf }`), so call sites (`crates/rimap-audit/src/writer/mod.rs:127`, `crates/rimap-audit/src/reader/mod.rs:118`, the failure paths in `rotation.rs` and `concurrent_lock.rs` tests) are not touched. Only the `#[error]` Display string changes.
+
+Current text:
+> `audit file `{path}` is already locked by another rusty-imap-mcp process; only one instance may run against a given audit path`
+
+New text (multi-line via `\n`):
+> `audit file `{path}` is already locked by another rusty-imap-mcp process.\n\nEach MCP client must use a distinct `[audit].path`. To run multiple MCP clients (e.g. two Claude Code windows on different projects, or Claude Code + Codex), point each at a different config file with its own audit path.\n\nSee docs/audit-log.md#running-multiple-mcp-clients for the configuration pattern.`
+
+The exact wording is finalized in the implementation plan; the spec commits to the *shape* (names path, names the resolution, points at the docs anchor).
+
+## 6. Documentation changes
+
+### 6.1 `docs/audit-log.md`
+
+New section after "File handling" (before "Rotation"):
+
+**Running multiple MCP clients**
+
+A worked example showing the pattern:
+1. The constraint (one PID per audit path) and why it exists (forensic invariants).
+2. The supported scenarios:
+   - Single MCP client (default — no change needed).
+   - Cross-application: Claude Code + Codex with distinct host configs.
+   - Cross-project: per-project `.mcp.json` (project-scope) configs.
+3. The unsupported scenario: two Claude Code windows sharing one user-scope MCP config entry. State plainly that this collides and how to either avoid it (use project scope) or accept that one window will fail to start the MCP server.
+4. Concrete config snippets for each supported scenario, showing a Claude Code `~/.claude.json` entry, a Codex `~/.codex/config.toml` entry, and the two distinct rusty-imap-mcp config files differing only in `[audit].path`.
+
+### 6.2 `docs/quickstart-gmail.md` and `docs/quickstart-proton-bridge.md`
+
+In each quickstart, add a one-paragraph cross-reference under the audit-config block: "If you plan to run multiple MCP clients against this account, see `docs/audit-log.md#running-multiple-mcp-clients` for the per-client config pattern." No worked examples in the quickstarts; they stay focused on first-time setup.
+
+### 6.3 `README.md`
+
+Add one bullet to the existing troubleshooting section (or create a minimal one if none exists at HEAD): "If `rusty-imap-mcp` exits at startup with `audit file ... is already locked`, see `docs/audit-log.md#running-multiple-mcp-clients`."
+
+## 7. Accepted regressions vs the archived daemon design
+
+These are functionality the daemon design provided that we are *not* providing here. They are accepted, with the explicit understanding that they return when the database-backed audit store lands.
+
+- **Per-account rate limiter is per-process, not per-account-globally.** Two MCP clients against the same IMAP account each get their own `Governor` budget. An attacker controlling the host can in principle multiply the per-account ceiling by spawning N MCP clients. This was the v0 behavior. The daemon's multiplexing fixed it; B1 reintroduces it.
+- **Per-account circuit breaker is per-process.** Same shape: a flap visible to one client does not trip the breaker for another client.
+- **Provenance ring buffer is per-process.** The ring of recently-read message-IDs that gets attached to `tool_end.provenance.message_ids_recently_read` is scoped to one PID. Sub-agents within the same MCP-client process share the parent's ring; sibling clients do not.
+- **Cross-client audit queries.** `audit merge` reads one file. To query across two clients' logs the user runs it twice or pipes through `cat`/`jq`.
+
+## 8. Explicitly deferred
+
+- **Database-backed audit storage** (the user-stated future direction). Replaces the per-file model entirely. Naturally re-enables shared rate limits, cross-client provenance, and cross-client queries.
+- **Any IPC alternative** to address the rate-limit regression in the meantime — only if the regression turns out to bite a real user.
+- **`audit merge --paths a,b,c`** cross-file glob. Trivial to add later if the deferred database doesn't land first.
+- **Re-extracting non-daemon work from `archive/daemon-experiment`.** Tracked as Phase 2 of the rollback (separate work; not in this spec). Includes TLS fingerprint dry-run (#151), mail-parser panic isolation (#201/#212), grapheme-safe truncation (#194), mutation-cleanup waves (#192/#193), ClusterFuzzLite (#202), test-strategy work, deps bumps, etc.
+
+## 9. Testing
+
+- **Unit:** `crates/rimap-audit/src/record/error.rs` already has `locked_message_names_the_path` (line 152). Update its assertion for the new wording. Add a sibling test asserting the message contains the docs anchor token (`docs/audit-log.md#running-multiple-mcp-clients`) so future edits do not silently break the cross-link.
+- **Integration:** `crates/rimap-audit/tests/concurrent_lock.rs` asserts on the variant shape (`AuditError::Locked { path: p }`). Should keep passing without change. Verify in implementation.
+- No new integration tests required; the runtime behavior is unchanged. The change is text-only.
+
+## 10. Migration / back-compat
+
+No breaking changes. No config schema changes. No CLI changes. No audit record schema changes. Existing single-client deployments are not affected — the lock acquisition path runs identical code; only the error string differs on the failure branch.
+
+Users currently running multiple MCP clients against the same audit path are already failing today; the new error message tells them how to fix their config. No data migration is required.
+
+## 11. Risk and open questions
+
+- **Risk: docs anchor drift.** The error message hard-codes `docs/audit-log.md#running-multiple-mcp-clients`. If the doc heading is renamed, the link in the error rots. Mitigation: the new sibling test asserts the anchor token is present in the error message. A separate (out-of-scope here) docs link-check would catch the doc side; tracked as a future hygiene item.
+- **Risk: rate-limit regression bites a real user.** If a user reports per-account ceilings being multiplied by client count, the response is to prioritize the database work, not to revisit the daemon design. Document this stance in the rejected-alternatives section of the database spec when it is written.
+- **Open question: README troubleshooting placement.** At HEAD `948a29f` there is no dedicated troubleshooting section in `README.md`. The implementation plan decides whether to create a new section or place the cross-link inline in an existing section.
+- **Open question: error message length.** A multi-line error message embedded via `thiserror`'s `#[error(...)]` attribute is unusual. The implementation plan decides whether to keep the multi-line form or compress to a single line with the long-form guidance only in `docs/audit-log.md`. Both options preserve the spec invariant: the error names the path, names the resolution, and points at the docs anchor.
+
+## 12. Lineage
+
+This design replaces the multi-client daemon design at `docs/superpowers/specs/2026-04-22-multi-client-daemon-design.md`, which was implemented (the `multi-client-daemon` PR series #150 through the `polish-pr*` follow-ups #152–#173, the macOS daemon test fix #199, and the Windows Service work #216) and then rolled back. The implemented daemon code is preserved on branch `archive/daemon-experiment` (tip `8895c5a`, pushed to `origin/archive/daemon-experiment`); see `git log 948a29f..archive/daemon-experiment` for the full commit set. Local `main` is at `948a29f` (the pre-daemon STARTTLS merge `Merge pull request #123 from randomparity/feat/imap-starttls`); `origin/main` is left at `8895c5a` pending a separate Phase 2 extraction of non-daemon improvements (TLS fingerprint dry-run #200, mail-parser panic isolation #204/#212, grapheme-safe truncation #197, mutation-cleanup #195/#196/#198, ClusterFuzzLite #202/#203, test-strategy #190/#191, deps bumps, code-health and CI work).


### PR DESCRIPTION
## Summary

Adopt **B1 (per-client audit paths via config)** as the simpler alternative to the multi-client daemon. Pure UX change — no daemon, no service install, no socket transport, no new mechanisms.

- Rewrite `AuditError::Locked` Display message to be actionable (names path + resolution + docs anchor).
- Add `## Running multiple MCP clients` section to `docs/audit-log.md` with worked Claude Code / Codex / project-scope config snippets.
- Cross-link from both quickstarts and a new `## Troubleshooting` section in `README.md`.
- Symmetric integration test pinning the docs heading so the cross-link can't silently rot.

## Context

The multi-client daemon design (PR #150 + polish series + Windows Service #216) is being rolled back — the OS-specific service surface and per-user operational burden exceeded the value for a stdio MCP server typically tied to one Claude Code window or repository. Daemon code preserved on `archive/daemon-experiment`.

Spec: `docs/superpowers/specs/2026-05-02-multi-client-stdio-design.md`
Plan: `docs/superpowers/plans/2026-05-02-multi-client-stdio.md`

## Accepted regressions vs daemon

- Per-account rate limit and circuit breaker stay per-process. Recoverable when the deferred database-backed audit store lands.
- Cross-client audit queries: `audit merge` reads one file at a time.

## Stacking note

Branch is rebased on top of `phase2/initial-fixes` (PR #220). Merge #220 first; this PR will then show only the multi-client commits.

## Test plan

- [ ] CI: `test (stable)`, `clippy`, `rustfmt`, `cargo-deny`, `test (MSRV 1.88.0)`, `check (macOS)`, `zizmor self-check`, `SonarQube`
- [ ] Manual: trigger `AuditError::Locked` (run two `rusty-imap-mcp` processes against the same audit path); confirm new message reads cleanly and the docs link resolves
- [ ] Docs: render `docs/audit-log.md` and confirm the new section's config snippets are well-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)