### PR TITLE
Phase-2: Re-extract rimap-content mutation-cleanup waves (#225)

### DIFF
--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -182,6 +182,9 @@ fn parse_args() -> RunnerResult<Args> {
     })
 }
 
+// cargo-mutants: known-equivalent — usage() output is consumed only as stderr text in
+// RunnerError::UsageMessage / RunnerError::Argument; no test or production caller asserts on its
+// content. Mutating it to "" or "xyzzy" leaves all exit codes and JSON schema unchanged.
 fn usage() -> String {
     "usage: epvme_runner <dataset-root> [--limit N] [--json-out PATH]".to_string()
 }

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -607,4 +607,27 @@ mod tests {
         );
         assert!(is_success(&summary));
     }
+
+    #[test]
+    fn run_dataset_records_read_failures() {
+        // Kills the read_failure_count += 1 mutants in run_dataset (line 276:44):
+        // both += -> -= (would underflow usize) and += -> *= (would keep 0).
+        let tempdir = TempDir::new().unwrap();
+        let root = tempdir.path();
+        let missing = root.join("does-not-exist.eml");
+        let files = vec![missing.clone()];
+
+        let summary = run_dataset(root, &files, None, parse_message);
+
+        assert_eq!(summary.processed_files, 1);
+        assert_eq!(summary.read_failure_count, 1);
+        assert_eq!(summary.ok_count, 0);
+        assert_eq!(summary.recorded_failures.len(), 1);
+        assert_eq!(summary.recorded_failures[0].kind, "read_error");
+        assert_eq!(
+            summary.recorded_failures[0].path,
+            missing.display().to_string()
+        );
+        assert!(!is_success(&summary));
+    }
 }

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -374,6 +374,10 @@ fn print_summary(summary: &RunSummary) -> io::Result<()> {
     writeln!(stdout, "Read failures: {}", summary.read_failure_count)?;
     writeln!(stdout, "Panics: {}", summary.panic_count)?;
 
+    // cargo-mutants: known-equivalent — guard inversion would print the section header
+    // "Parse error kinds:" with zero rows; stdout phrasing is human-facing only and no
+    // test or production caller asserts on print_summary output. JSON schema
+    // (RunSummary fields) and the success verdict are unaffected.
     if !summary.parse_error_counts.is_empty() {
         writeln!(stdout, "Parse error kinds:")?;
         for (kind, count) in &summary.parse_error_counts {
@@ -381,6 +385,10 @@ fn print_summary(summary: &RunSummary) -> io::Result<()> {
         }
     }
 
+    // cargo-mutants: known-equivalent — guard inversion would print the section header
+    // "Warning counts:" with zero rows; stdout phrasing is human-facing only and no
+    // test or production caller asserts on print_summary output. JSON schema
+    // (RunSummary fields) and the success verdict are unaffected.
     if !summary.warning_counts.is_empty() {
         writeln!(stdout, "Warning counts:")?;
         for (warning, count) in &summary.warning_counts {
@@ -388,6 +396,10 @@ fn print_summary(summary: &RunSummary) -> io::Result<()> {
         }
     }
 
+    // cargo-mutants: known-equivalent — guard inversion would print the section header
+    // "Recorded failures (showing up to 50):" with zero rows; stdout phrasing is
+    // human-facing only and no test or production caller asserts on print_summary
+    // output. JSON schema (RunSummary fields) and the success verdict are unaffected.
     if !summary.recorded_failures.is_empty() {
         writeln!(
             stdout,

--- a/crates/rimap-content/src/bin/epvme_runner.rs
+++ b/crates/rimap-content/src/bin/epvme_runner.rs
@@ -521,6 +521,47 @@ mod tests {
             panic_path.display().to_string()
         );
         assert_eq!(summary.recorded_failures[0].kind, "panic");
+        // Kills panic_message return-value mutants (327:5): detail must be the
+        // actual panic message, not "" or "xyzzy".
+        assert_eq!(summary.recorded_failures[0].detail, "boom");
+    }
+
+    #[test]
+    fn panic_message_captures_string_payload() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("static str message".to_string());
+        assert_eq!(panic_message(payload), "static str message");
+    }
+
+    #[test]
+    fn panic_message_captures_static_str_payload() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("static literal");
+        assert_eq!(panic_message(payload), "static literal");
+    }
+
+    #[test]
+    fn panic_message_fallback_for_unknown_payload() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42u64);
+        assert_eq!(panic_message(payload), "panic payload was not a string");
+    }
+
+    #[test]
+    fn unknown_warning_code_label_informational() {
+        // ParseBodyTruncated has Informational severity (see rimap-core/src/warning.rs).
+        // Kills mutants 342:5 (return "" or "xyzzy") and 343:9 (delete Informational arm).
+        assert_eq!(
+            unknown_warning_code_label(WarningCode::ParseBodyTruncated),
+            "unknown_informational_warning",
+        );
+    }
+
+    #[test]
+    fn unknown_warning_code_label_adversarial() {
+        // UnicodeZeroWidthStripped has Adversarial severity (see rimap-core/src/warning.rs).
+        // Kills mutants 342:5 (return "" or "xyzzy") and 344:9 (delete Adversarial arm).
+        assert_eq!(
+            unknown_warning_code_label(WarningCode::UnicodeZeroWidthStripped),
+            "unknown_adversarial_warning",
+        );
     }
 
     #[test]

--- a/crates/rimap-content/src/html/extract.rs
+++ b/crates/rimap-content/src/html/extract.rs
@@ -177,3 +177,30 @@ pub(super) fn collect_anchor_hrefs(sanitized_html: &str) -> Vec<String> {
         .filter_map(|a| a.value().attr("href").map(str::to_string))
         .collect()
 }
+
+#[cfg(test)]
+mod extract_tests {
+    use super::push_text;
+
+    #[test]
+    fn push_text_does_not_prepend_space_at_start() {
+        // Kills `&& with ||` on the space-insertion guard. Under `||`,
+        // an empty `out` (`!out.is_empty() = false`) combined with a
+        // non-whitespace tail (`!out.ends_with(ws) = true`) still
+        // triggers the push, producing " hello" instead of "hello".
+        let mut out = String::new();
+        push_text(&mut out, "hello");
+        assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn push_text_does_not_double_space_after_existing_whitespace() {
+        // Companion to the above. Under `||`, a non-empty `out` ending
+        // in space (`!is_empty=true || ends_with_ws=true` short-circuits
+        // to true regardless of the second clause) still pushes another
+        // space, producing "abc  def" instead of "abc def".
+        let mut out = String::from("abc ");
+        push_text(&mut out, "def");
+        assert_eq!(out, "abc def");
+    }
+}

--- a/crates/rimap-content/src/html/mismatch.rs
+++ b/crates/rimap-content/src/html/mismatch.rs
@@ -40,6 +40,14 @@ pub(super) fn extract_registrable_domain(url_or_host: &str) -> Option<String> {
         .unwrap_or("")
         .trim_start_matches("www.");
     let host = host.split(':').next().unwrap_or(host);
+    // cargo-mutants: known-equivalent — `||` vs `&&` here is observably
+    // identical given that `host.is_empty()` implies `!host.contains('.')`.
+    // The only case the operators differ on is `is_empty=false &&
+    // !contains('.')=true` (a non-empty single-label host); both `||`
+    // and `&&` then send control through the idna+addr lookup, which
+    // returns `None` for any single-label host (no registrable domain
+    // exists above a TLD). `is_empty=true && !contains('.')=false` is
+    // unreachable: an empty string contains no `.`.
     if host.is_empty() || !host.contains('.') {
         return None;
     }
@@ -127,4 +135,85 @@ pub(super) fn detect_mismatches(
         }
     }
     (hits, overflow, unparsable_hrefs)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod mismatch_tests {
+    use scraper::Html;
+
+    use super::{detect_mismatches, extract_registrable_domain};
+    use crate::html::MAX_MISMATCH_HITS;
+
+    #[test]
+    fn extract_registrable_domain_rejects_mailto_scheme() {
+        // Kills `|| with &&` mutation at line 42 (the `||` joining the
+        // mailto: check to the rest of the chain). Under `&&`, only an
+        // input that satisfies all four `starts_with` checks
+        // simultaneously would early-return — no real input matches
+        // every scheme — so a `mailto://example.com` payload falls
+        // through and resolves to a registrable domain.
+        assert_eq!(
+            extract_registrable_domain("mailto://example.com"),
+            None,
+            "mailto:// must short-circuit even when the URL form has //",
+        );
+    }
+
+    #[test]
+    fn extract_registrable_domain_rejects_tel_scheme() {
+        // Kills `|| with &&` mutation at line 43.
+        assert_eq!(extract_registrable_domain("tel://example.com"), None);
+    }
+
+    #[test]
+    fn extract_registrable_domain_rejects_javascript_scheme() {
+        // Kills `|| with &&` mutation at line 44.
+        assert_eq!(extract_registrable_domain("javascript://example.com"), None,);
+    }
+
+    #[test]
+    fn extract_registrable_domain_rejects_data_scheme() {
+        // The `data:` line itself does not have a `||` mutation, but
+        // this anchor pins the scheme list and prevents future drift.
+        assert_eq!(extract_registrable_domain("data://example.com"), None);
+    }
+
+    /// Build an HTML document with `count` distinct mismatched anchors:
+    /// each anchor's href and text resolve to different registrable
+    /// domains so each one becomes an entry in `detect_mismatches`'s
+    /// hits list.
+    fn build_n_mismatched_anchors(count: usize) -> Html {
+        let mut body = String::new();
+        for i in 0..count {
+            // text says `evil-{i}.example`; href points at `actual.com`.
+            use std::fmt::Write as _;
+            write!(
+                body,
+                "<a href=\"https://actual.com\">https://evil-{i}.example</a>",
+            )
+            .unwrap();
+        }
+        Html::parse_document(&format!("<html><body>{body}</body></html>"))
+    }
+
+    #[test]
+    fn detect_mismatches_caps_hits_at_max_and_counts_overflow() {
+        // Construct MAX+2 distinct mismatches.
+        // Original: hits.len()=MAX, overflow=2.
+        // Kills `< with <=` (line 128): under `<=`, hits.len()=MAX+1
+        //   and overflow=1.
+        // Kills `+= with -=` (line 134): underflow on `overflow`
+        //   panics in debug; the test fails before assert.
+        // Kills `+= with *=` (line 134): overflow stays 0.
+        let document = build_n_mismatched_anchors(MAX_MISMATCH_HITS + 2);
+        let (hits, overflow, _) = detect_mismatches(&document);
+        assert_eq!(
+            hits.len(),
+            MAX_MISMATCH_HITS,
+            "hits cap should fire at MAX_MISMATCH_HITS, got {}",
+            hits.len(),
+        );
+        assert_eq!(overflow, 2, "overflow must count the post-cap mismatches");
+    }
 }

--- a/crates/rimap-content/src/html/mod.rs
+++ b/crates/rimap-content/src/html/mod.rs
@@ -203,6 +203,84 @@ mod tests {
     }
 
     #[test]
+    fn process_accepts_input_at_max_html_bytes() {
+        // Kills `> with >=` on `raw.len() > MAX_HTML_BYTES`. With `>=`,
+        // a 1 MiB body errors immediately with html_body kind; the
+        // original passes the check and proceeds (may emit body
+        // truncation warnings later, but kind != html_body).
+        let body = vec![b'a'; MAX_HTML_BYTES];
+        let result = process(&body, None);
+        match result {
+            Ok(_) => (),
+            Err(ContentError::LimitExceeded { kind, .. }) => {
+                assert_ne!(
+                    kind, HTML_BODY_LIMIT_KIND,
+                    "must not error with html_body kind at exactly MAX_HTML_BYTES",
+                );
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_emits_mismatch_summary_warning_when_overflow_positive() {
+        // Kills `> with <` on `if mismatch_overflow > 0`. With `<`,
+        // mismatch_overflow (a usize) can never satisfy `< 0`, so the
+        // summary warning is never emitted regardless of overflow.
+        // Construct MAX_MISMATCH_HITS + 3 distinct mismatched anchors;
+        // expect a warning whose detail mentions the overflow count.
+        use std::fmt::Write as _;
+        let mut body = String::new();
+        for i in 0..(MAX_MISMATCH_HITS + 3) {
+            write!(
+                body,
+                "<a href=\"https://actual.com\">https://evil-{i}.example</a>",
+            )
+            .expect("write! into String never fails");
+        }
+        let html = format!("<html><body>{body}</body></html>");
+        let result = process(html.as_bytes(), None).expect("sanitize must succeed");
+        let summary_count = result
+            .warnings
+            .iter()
+            .filter(|w| {
+                w.code == crate::output::WarningCode::HtmlLinkTextHrefMismatch
+                    && w.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("additional_hits="))
+            })
+            .count();
+        assert_eq!(
+            summary_count, 1,
+            "expected exactly one mismatch summary warning, got {summary_count}",
+        );
+    }
+
+    #[test]
+    fn process_scans_anchor_text_up_to_max_anchor_text_scan() {
+        // Kills `* with +` on `MAX_ANCHOR_TEXT_SCAN = 4 * 1024`. The
+        // mutant flips the constant to 4 + 1024 = 1028, well below 4 KiB.
+        // An anchor whose mismatched URL sits at byte offset ~2000
+        // (within 4 KiB but past 1 KiB) round-trips a mismatch warning
+        // under the original cap and silently drops it under the mutant.
+        let padding = "x".repeat(2000);
+        let html = format!(
+            "<html><body><a href=\"https://actual.com\">{padding} https://evil.example</a></body></html>",
+        );
+        let result = process(html.as_bytes(), None).expect("sanitize must succeed");
+        let mismatch_seen = result.warnings.iter().any(|w| {
+            w.code == crate::output::WarningCode::HtmlLinkTextHrefMismatch
+                && w.detail
+                    .as_deref()
+                    .is_some_and(|d| d.contains("text_domain=evil.example"))
+        });
+        assert!(
+            mismatch_seen,
+            "expected a mismatch warning for the URL at byte ~2000 within MAX_ANCHOR_TEXT_SCAN=4096",
+        );
+    }
+
+    #[test]
     fn process_empty_input_returns_empty_result() {
         let result = process(b"", None).expect("empty input is valid");
         assert!(result.body_text.is_empty());

--- a/crates/rimap-content/src/html/style_parse.rs
+++ b/crates/rimap-content/src/html/style_parse.rs
@@ -65,6 +65,12 @@ fn parse_translate_px(val: &str) -> Option<f64> {
         let trimmed = part.trim();
         if let Some(px_val) = parse_px(trimmed) {
             match min {
+                // cargo-mutants: known-equivalent — `<=` here is observably
+                // identical to `<`. The two predicates differ only when
+                // `px_val == current`, in which case both arms set
+                // `min = Some(px_val)` to a value already equal to the
+                // current minimum. The `Some(_)` arm below covers both
+                // "not new minimum" cases identically.
                 Some(current) if px_val < current => min = Some(px_val),
                 None => min = Some(px_val),
                 Some(_) => {}
@@ -153,4 +159,83 @@ pub(super) fn classify_inline_style(style: &str) -> Option<HiddenMethod> {
         return Some(HiddenMethod::ColorMatch);
     }
     None
+}
+
+#[cfg(test)]
+mod style_parse_tests {
+    use super::{HiddenMethod, classify_inline_style, parse_translate_px};
+
+    #[test]
+    fn parse_inline_style_drops_empty_values() {
+        // Kills `|| with &&` on the prop/val empty-skip guard. Under `&&`,
+        // declarations with an empty value would survive into the pairs
+        // vector, and `record` would store them in StyleHints. Pairing
+        // empty `color:` and `background-color:` would then trip
+        // `is_color_match` (Some("") == Some("")) and the classifier
+        // would falsely return ColorMatch.
+        assert_eq!(
+            classify_inline_style("color:; background-color:"),
+            None,
+            "empty-value declarations must not feed StyleHints",
+        );
+    }
+
+    #[test]
+    fn parse_translate_px_picks_most_negative_offset() {
+        // Kills both `< with false` and `< with ==` mutations on the
+        // match guard `px_val < current`. With `false`, the guard
+        // never fires after the first Some-match — first-wins instead
+        // of min-wins. With `==`, the guard only fires on equal values,
+        // which is the same first-wins outcome for distinct values.
+        let out = parse_translate_px("(-50px, -200px)");
+        assert_eq!(
+            out,
+            Some(-200.0),
+            "expected the more-negative offset to win, got {out:?}",
+        );
+    }
+
+    /// Build an inline style of `position: absolute; <prop>: <val>` and
+    /// return the classifier's result.
+    fn classify_with_positioned(prop: &str, val: &str) -> Option<HiddenMethod> {
+        let style = format!("position: absolute; {prop}: {val}");
+        classify_inline_style(&style)
+    }
+
+    #[test]
+    fn is_offscreen_left_does_not_fire_at_minus_100px() {
+        // Kills `< with <=` at line 110:55 (left_px boundary). With `<=`,
+        // left = -100px is treated as off-screen (returns OffScreen);
+        // the original `<` keeps it on-screen.
+        let result = classify_with_positioned("left", "-100px");
+        assert_ne!(result, Some(HiddenMethod::OffScreen));
+    }
+
+    #[test]
+    fn is_offscreen_top_does_not_fire_at_minus_100px() {
+        // Kills `< with <=` at line 111:53 (top_px boundary).
+        let result = classify_with_positioned("top", "-100px");
+        assert_ne!(result, Some(HiddenMethod::OffScreen));
+    }
+
+    #[test]
+    fn is_offscreen_top_threshold_is_negative_one_hundred_px() {
+        // Kills `delete -` at line 111:55 (the threshold's negative sign
+        // on `-100.0`). With the `-` deleted, the threshold becomes
+        // +100, and any negative top — including a clearly-on-screen
+        // -50 — is reported as OffScreen.
+        let result = classify_with_positioned("top", "-50px");
+        assert_ne!(
+            result,
+            Some(HiddenMethod::OffScreen),
+            "top: -50px must not classify as off-screen under the -100 threshold",
+        );
+    }
+
+    #[test]
+    fn is_offscreen_transform_does_not_fire_at_minus_100px() {
+        // Kills `< with <=` at line 112:72 (transform_offset_px boundary).
+        let result = classify_with_positioned("transform", "translate(-100px)");
+        assert_ne!(result, Some(HiddenMethod::OffScreen));
+    }
 }

--- a/crates/rimap-content/src/lib.rs
+++ b/crates/rimap-content/src/lib.rs
@@ -80,3 +80,26 @@ mod confusables_tests {
         );
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod extract_message_id_tests {
+    use super::extract_message_id;
+
+    #[test]
+    fn extract_returns_message_id_when_header_present() {
+        // Kills all three wholesale stubs at extract_message_id (None,
+        // Some(""), Some("xyzzy")). A constructed message with a
+        // distinctive Message-ID round-trips through mail_parser to
+        // a non-empty Some that contains the id substring.
+        let raw = b"From: a@example\r\n\
+                    Message-ID: <abc-123@example.com>\r\n\
+                    \r\n\
+                    body";
+        let id = extract_message_id(raw).expect("Message-ID must be extracted");
+        assert!(
+            id.contains("abc-123@example.com"),
+            "expected id to contain abc-123@example.com, got {id:?}",
+        );
+    }
+}

--- a/crates/rimap-content/src/lookalike.rs
+++ b/crates/rimap-content/src/lookalike.rs
@@ -100,6 +100,13 @@ fn labels_mix_scripts(domain: &str) -> bool {
 fn label_mixes_scripts(label: &str) -> bool {
     let mut scripts: HashSet<Script> = HashSet::new();
     for c in label.chars() {
+        // cargo-mutants: known-equivalent — `||` vs `&&` on either of the
+        // two `||` operators produces the same observable behaviour.
+        // Each char that the original `continue`s past — ASCII digits,
+        // `-`, `_` — has `Script::Common`, which the match below treats
+        // as a no-op (Common/Inherited/Unknown are not inserted into the
+        // `scripts` set). Whether the loop short-circuits or runs
+        // through, the set membership is unchanged.
         if c.is_ascii_digit() || c == '-' || c == '_' {
             continue;
         }
@@ -204,9 +211,20 @@ fn scan_body_urls(body_text: &str, out: &mut Vec<SecurityWarning>) {
 )]
 fn extract_domain_from_address(addr: &str) -> Option<String> {
     let trimmed = addr.trim();
+    // cargo-mutants: known-equivalent — `< with <=` on `lt < gt` is
+    // observably identical: `lt == gt` is unreachable when both `rfind`
+    // results are `Some`, since `<` and `>` are different characters
+    // and a single byte cannot be both. Distinct positions exercise
+    // the same arm under either operator.
     let inner = if let (Some(lt), Some(gt)) = (trimmed.rfind('<'), trimmed.rfind('>'))
         && lt < gt
     {
+        // cargo-mutants: known-equivalent — `+ with *` on `lt + 1` is
+        // observably identical for any reachable `lt`. `lt * 1 == lt`
+        // shifts the slice start by one byte to include the `<`
+        // delimiter; `rsplit_once('@')` then yields the same `(local,
+        // domain)` split because the leading `<` lands in the discarded
+        // local part, not the domain on the right of `@`.
         &trimmed[lt + 1..gt]
     } else {
         trimmed
@@ -239,6 +257,14 @@ fn extract_domain_from_url(url: &str) -> Option<String> {
     };
     let host = host.split(':').next().unwrap_or(host);
     let host = host.strip_prefix("www.").unwrap_or(host);
+    // cargo-mutants: known-equivalent — `||` vs `&&` here is observably
+    // identical: `host.is_empty()` implies `!host.contains('.')`, so
+    // the only case the operators differ on is `is_empty=false &&
+    // !contains('.')=true` (a non-empty single-label host). Both
+    // branches hand control to `Some(host.to_string())` for `||` or
+    // skip the early return for `&&`; either way, single-label hosts
+    // are filtered downstream by `classify_domain` (which requires a
+    // registrable PSL match).
     if host.is_empty() || !host.contains('.') {
         return None;
     }
@@ -552,5 +578,44 @@ mod tests {
             warnings.is_empty(),
             "no URLs in this body, got {warnings:?}"
         );
+    }
+
+    #[test]
+    fn audit_scans_url_at_byte_offset_2000() {
+        // Kills `* with +` on `MAX_LINKIFY_SCAN_BYTES = 64 * 1024`. The
+        // mutant flips the constant to 64 + 1024 = 1088, well below
+        // 64 KiB. A mixed-script URL placed at byte offset ~2000
+        // round-trips a warning under the original cap and is silently
+        // dropped under the mutant.
+        let prefix = "x".repeat(2000);
+        let body = format!("{prefix}https://p\u{0430}ypal.com/account");
+        let warnings = run_audit(&empty_meta(), &body, &[]);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == WarningCode::LookalikeMixedScript),
+            "expected a mixed-script warning for URL at byte ~2000, got {warnings:?}",
+        );
+    }
+
+    #[test]
+    fn extract_domain_from_address_strips_angle_brackets_at_position_zero() {
+        // Kills `+ with -` on `&trimmed[lt + 1..gt]` in
+        // extract_domain_from_address. With `-`, an input whose `<`
+        // sits at position 0 (e.g. "<a@b.com>") evaluates `lt - 1`
+        // and underflows usize → panics on slicing.
+        let result = super::extract_domain_from_address("<a@b.com>");
+        assert_eq!(result, Some("b.com".to_string()));
+    }
+
+    #[test]
+    fn extract_domain_from_address_handles_quoted_brackets() {
+        // Kills `< with ==` and `< with >` on the `lt < gt` guard.
+        // Original: "Name <a@b.com>" → inner = "a@b.com" → domain "b.com".
+        // Mut `==`: 5 == 13 false → inner = trimmed → domain "b.com>".
+        // Mut `>`:  5 > 13 false → same as `==`.
+        // The original-vs-mutated outputs differ on the trailing `>`.
+        let result = super::extract_domain_from_address("Name <a@b.com>");
+        assert_eq!(result, Some("b.com".to_string()));
     }
 }

--- a/crates/rimap-content/src/parse/attachments.rs
+++ b/crates/rimap-content/src/parse/attachments.rs
@@ -127,3 +127,46 @@ fn content_type_string(ct: &mail_parser::ContentType<'_>) -> String {
         None => ct.ctype().to_string(),
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may unwrap on constructed values")]
+#[expect(clippy::expect_used, reason = "tests may expect on constructed values")]
+mod attachments_tests {
+    use crate::parse::parse_message;
+
+    #[test]
+    fn parse_marks_inline_image_attachment() {
+        // Kills `is_inline -> bool with false`. Construct a multipart/mixed
+        // with an image/png attachment whose Content-Disposition is
+        // `inline`; mail-parser parses it as PartType::InlineBinary, which
+        // is_inline must report as true. The `false` mutant flips the bit.
+        let raw = b"From: a@example\r\n\
+                    Content-Type: multipart/mixed; boundary=\"B\"\r\n\
+                    \r\n\
+                    --B\r\n\
+                    Content-Type: text/plain\r\n\
+                    \r\n\
+                    body text\r\n\
+                    --B\r\n\
+                    Content-Type: image/png\r\n\
+                    Content-Disposition: inline\r\n\
+                    Content-Transfer-Encoding: base64\r\n\
+                    \r\n\
+                    iVBORw0KGgo=\r\n\
+                    --B--\r\n";
+        let content = parse_message(raw).unwrap();
+        let attachments = &content.meta.attachments;
+        assert!(
+            !attachments.is_empty(),
+            "expected at least one attachment, got {attachments:?}",
+        );
+        let inline = attachments
+            .iter()
+            .find(|a| a.content_type.starts_with("image/"))
+            .expect("image/png attachment must be present");
+        assert!(
+            inline.is_inline,
+            "image/png with Content-Disposition: inline must report is_inline=true, got {inline:?}",
+        );
+    }
+}

--- a/crates/rimap-content/src/parse/bodies.rs
+++ b/crates/rimap-content/src/parse/bodies.rs
@@ -240,3 +240,180 @@ fn depth_recursive(message: &Message<'_>, part_id: usize, current: usize) -> usi
         }
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may unwrap on constructed values")]
+#[expect(clippy::expect_used, reason = "tests may expect on constructed values")]
+#[expect(clippy::panic, reason = "test failure paths")]
+mod bodies_tests {
+    use std::fmt::Write as _;
+
+    use mail_parser::MessageParser;
+
+    use super::part_charset;
+    use crate::error::ContentError;
+    use crate::output::WarningCode;
+    use crate::parse::{MAX_BODY_BYTES, MAX_MIME_DEPTH, MAX_MIME_PARTS, parse_message};
+
+    /// Build an N-leaf multipart/mixed message: one root multipart
+    /// container plus `leaves` text/plain children. Total parts =
+    /// `leaves + 1` (the root counts).
+    fn build_flat_multipart(leaves: usize) -> Vec<u8> {
+        let mut raw = String::from(
+            "From: a@example\r\nContent-Type: multipart/mixed; boundary=\"B\"\r\n\r\n",
+        );
+        for i in 0..leaves {
+            write!(raw, "--B\r\nContent-Type: text/plain\r\n\r\nleaf{i}\r\n").unwrap();
+        }
+        raw.push_str("--B--\r\n");
+        raw.into_bytes()
+    }
+
+    #[test]
+    fn parse_accepts_part_count_at_max() {
+        // Kills both `> with ==` and `> with >=` mutations on the
+        // `part_count > MAX_MIME_PARTS` guard. With root + 99 leaves =
+        // 100 = MAX_MIME_PARTS:
+        //  - original `>` :  100 > 100 -> false  -> Ok
+        //  - `==` mutant  :  100 == 100 -> true  -> Err  (caught)
+        //  - `>=` mutant  :  100 >= 100 -> true  -> Err  (caught)
+        let raw = build_flat_multipart(MAX_MIME_PARTS - 1);
+        let content = parse_message(&raw).expect("100-part message must parse");
+        assert!(
+            !content
+                .security_warnings
+                .iter()
+                .any(|w| matches!(w.code, WarningCode::ParseMimePartCountExceeded)),
+            "no ParseMimePartCountExceeded warning at the boundary",
+        );
+    }
+
+    #[test]
+    fn part_charset_returns_explicit_charset() {
+        // Kills all three wholesale stubs at part_charset (None,
+        // Some(""), Some("xyzzy")) by asserting an explicit
+        // charset=iso-8859-1 round-trips through.
+        let raw = b"From: a@example\r\n\
+                    Content-Type: text/plain; charset=iso-8859-1\r\n\
+                    \r\n\
+                    body";
+        let message = MessageParser::default().parse(raw).unwrap();
+        let part = message.parts.first().expect("a single text/plain part");
+        let charset = part_charset(part).expect("Content-Type's charset attribute populates");
+        assert_eq!(charset, "iso-8859-1");
+    }
+
+    #[test]
+    fn parse_does_not_truncate_body_at_max_bytes() {
+        // Kills `> with >=` on `raw_bytes.len() > MAX_BODY_BYTES`. With
+        // an exactly-MAX_BODY_BYTES body:
+        //  - original `>` :  1MB > 1MB -> false -> no warning
+        //  - `>=` mutant  :  1MB >= 1MB -> true  -> ParseBodyTruncated  (caught)
+        let mut raw = Vec::from(&b"From: a@example\r\nContent-Type: text/plain\r\n\r\n"[..]);
+        raw.extend(std::iter::repeat_n(b'x', MAX_BODY_BYTES));
+        let content = parse_message(&raw).expect("MAX_BODY_BYTES body must parse");
+        assert!(
+            !content
+                .security_warnings
+                .iter()
+                .any(|w| matches!(w.code, WarningCode::ParseBodyTruncated)),
+            "no ParseBodyTruncated warning at the boundary",
+        );
+    }
+
+    /// Build a `depth`-deep multipart/mixed nesting with a leaf
+    /// text/plain at the bottom. mail-parser counts depth as the
+    /// number of nested levels reachable from part 0; a value of N
+    /// means N-1 nested multiparts plus the leaf (e.g. depth=8 ->
+    /// 7 multipart containers + 1 text leaf).
+    fn build_nested_multipart(depth: usize) -> Vec<u8> {
+        let mut raw = String::from("From: a@example\r\n");
+        write!(
+            raw,
+            "Content-Type: multipart/mixed; boundary=\"B0\"\r\n\r\n"
+        )
+        .unwrap();
+        for i in 0..depth.saturating_sub(2) {
+            write!(raw, "--B{i}\r\n").unwrap();
+            write!(
+                raw,
+                "Content-Type: multipart/mixed; boundary=\"B{}\"\r\n\r\n",
+                i + 1
+            )
+            .unwrap();
+        }
+        write!(raw, "--B{}\r\n", depth.saturating_sub(2)).unwrap();
+        raw.push_str("Content-Type: text/plain\r\n\r\nleaf\r\n");
+        for i in (0..depth.saturating_sub(1)).rev() {
+            write!(raw, "--B{i}--\r\n").unwrap();
+        }
+        raw.into_bytes()
+    }
+
+    #[test]
+    fn parse_accepts_mime_depth_at_max() {
+        // Kills `> with >=` on `depth > MAX_MIME_DEPTH`. With the
+        // 8-deep construction:
+        //  - original `>` :  8 > 8  -> false -> Ok
+        //  - `>=` mutant  :  8 >= 8 -> true  -> Err  (caught)
+        let raw = build_nested_multipart(MAX_MIME_DEPTH);
+        let content = parse_message(&raw).expect("MAX_MIME_DEPTH-deep message must parse");
+        assert!(
+            !content
+                .security_warnings
+                .iter()
+                .any(|w| matches!(w.code, WarningCode::ParseMimeDepthExceeded)),
+            "no ParseMimeDepthExceeded warning at the boundary",
+        );
+    }
+
+    /// Build a 7-multipart-deep wrapper around a `message/rfc822`
+    /// attachment. `depth_recursive` walks 7 multipart levels (`current`
+    /// climbs 1..7), then the Message handler returns
+    /// `current + 1 = 9` — one above `MAX_MIME_DEPTH`. Mutations on
+    /// that `+ 1` (`-` returns 7, `*` returns 8) drop max depth to
+    /// 7 or 8, both within the limit, so the error stops firing.
+    fn build_message_rfc822_at_depth_8() -> Vec<u8> {
+        let mut raw = String::from("From: outer@example\r\n");
+        write!(
+            raw,
+            "Content-Type: multipart/mixed; boundary=\"B0\"\r\n\r\n"
+        )
+        .unwrap();
+        for i in 0..6 {
+            write!(raw, "--B{i}\r\n").unwrap();
+            write!(
+                raw,
+                "Content-Type: multipart/mixed; boundary=\"B{}\"\r\n\r\n",
+                i + 1
+            )
+            .unwrap();
+        }
+        // B6 contains a single message/rfc822 attachment.
+        raw.push_str("--B6\r\n");
+        raw.push_str("Content-Type: message/rfc822\r\n\r\n");
+        raw.push_str("From: inner@example\r\n\r\ninner-body\r\n");
+        // Close all the multipart containers.
+        for i in (0..7).rev() {
+            write!(raw, "--B{i}--\r\n").unwrap();
+        }
+        raw.into_bytes()
+    }
+
+    #[test]
+    fn parse_rejects_message_rfc822_at_depth_above_max() {
+        // Kills both `+ with -` and `+ with *` mutations on
+        // `PartType::Message(_) => current + 1`. The construction
+        // places the message/rfc822 part at depth 9 in the original;
+        // both mutations drop it to <= 8, removing the error.
+        let raw = build_message_rfc822_at_depth_8();
+        let err = parse_message(&raw).expect_err("depth-9 via Message must error");
+        match err {
+            ContentError::LimitExceeded { kind, limit } => {
+                assert_eq!(kind, "mime_depth");
+                assert_eq!(limit, MAX_MIME_DEPTH);
+            }
+            other => panic!("expected LimitExceeded mime_depth, got {other:?}"),
+        }
+    }
+}

--- a/crates/rimap-content/src/parse/filename.rs
+++ b/crates/rimap-content/src/parse/filename.rs
@@ -175,7 +175,7 @@ pub(super) fn last_extension(filename: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod filename_helper_tests {
-    use super::sanitize_attachment_filename;
+    use super::{contains_bidi_override, detect_double_extension, sanitize_attachment_filename};
     use crate::output::{SecurityWarning, WarningCode};
 
     fn sanitize(name: &str) -> (String, Vec<SecurityWarning>) {
@@ -212,5 +212,93 @@ mod filename_helper_tests {
                 .any(|w| w.code == WarningCode::LookalikeFilenameExtensionSpoof),
             "expected a spoof warning for double extension",
         );
+    }
+
+    /// Sanitize the bare `sanitize_filename` helper without the
+    /// `sanitize_attachment_filename` wrapper's warning emission.
+    fn raw_sanitize(name: &str) -> (String, bool) {
+        super::sanitize_filename(name, 0)
+    }
+
+    #[test]
+    fn sanitize_filename_strips_leading_dot_and_whitespace() {
+        // Kills `||` -> `&&` mutation in the trim_start_matches predicate
+        // `c == '.' || c.is_ascii_whitespace()`. With `&&` the predicate
+        // matches no character (no char is both `.` and whitespace), so
+        // no leading bytes get trimmed.
+        let (out, rewritten) = raw_sanitize(" .secret.txt");
+        assert_eq!(out, "secret.txt", "expected leading dot+space trimmed");
+        assert!(rewritten, "name was rewritten so the flag must be true");
+    }
+
+    /// Each bidi-override codepoint maps to one `||` operator in
+    /// `contains_bidi_override`. Test each one individually to kill the
+    /// per-line `|| -> &&` mutations: one bidi codepoint flipping its
+    /// own `||` to `&&` short-circuits the entire chain to `false` (the
+    /// `&&` chain demands *every* literal-comparison succeed at once,
+    /// which is impossible since one `c` cannot equal multiple
+    /// codepoints simultaneously).
+    #[test]
+    fn contains_bidi_override_detects_lre_u202a() {
+        assert!(contains_bidi_override("\u{202A}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_rle_u202b() {
+        assert!(contains_bidi_override("\u{202B}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_pdf_u202c() {
+        assert!(contains_bidi_override("\u{202C}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_lro_u202d() {
+        assert!(contains_bidi_override("\u{202D}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_lri_u2067() {
+        assert!(contains_bidi_override("\u{2067}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_fsi_u2068() {
+        assert!(contains_bidi_override("\u{2068}"));
+    }
+    #[test]
+    fn contains_bidi_override_detects_pdi_u2069() {
+        assert!(contains_bidi_override("\u{2069}"));
+    }
+
+    #[test]
+    fn contains_bidi_override_rejects_plain_ascii() {
+        assert!(!contains_bidi_override("plain.txt"));
+    }
+
+    #[test]
+    fn detect_double_extension_returns_none_for_too_few_segments() {
+        // Kills `< with >` mutation on the `segments.len() < 3` guard.
+        // With `>`, len=1 falls through to `segments[len-2]` and panics
+        // on the unsigned wrap (debug) — which still fails the test, so
+        // the mutation is caught either way.
+        assert_eq!(detect_double_extension("nodot"), None);
+    }
+
+    #[test]
+    fn detect_double_extension_picks_penultimate_segment() {
+        // Kills `- with /` mutation on `segments.len() - 2`. With `-`,
+        // a 5-segment name picks segments[3] for penultimate; with `/`
+        // it picks segments[5/2]=segments[2]. The two yield different
+        // results when segments[2] happens to be a document extension
+        // and segments[3] is not — `a.b.pdf.x.exe` is constructed so
+        // the original returns None (penultimate "x" is not a document
+        // ext) but `/` returns Some (segments[2]=pdf, segments[4]=exe).
+        assert_eq!(detect_double_extension("a.b.pdf.x.exe"), None);
+    }
+
+    #[test]
+    fn detect_double_extension_requires_both_doc_and_executable() {
+        // Kills `&& with ||` mutation on the
+        // `DOCUMENT.contains(penultimate) && EXECUTABLE.contains(final)`
+        // guard. With `||`, `pdf.txt` (penultimate is doc, final is
+        // not executable) returns Some instead of None.
+        assert_eq!(detect_double_extension("a.pdf.txt"), None);
     }
 }

--- a/crates/rimap-content/src/parse/headers.rs
+++ b/crates/rimap-content/src/parse/headers.rs
@@ -204,3 +204,113 @@ pub(super) fn audit_addr_domain_bidi(
     };
     audit_domain_bidi_prestrip(domain, location, warnings);
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may unwrap on constructed values")]
+#[expect(clippy::expect_used, reason = "tests may expect on constructed values")]
+#[expect(clippy::panic, reason = "test failure paths")]
+mod headers_tests {
+    use crate::error::ContentError;
+    use crate::parse::{MAX_HEADER_COUNT, parse_message};
+
+    fn build_message_with_n_headers(n: usize) -> Vec<u8> {
+        let mut raw = Vec::from(&b"From: a@example\r\n"[..]);
+        for i in 0..n {
+            raw.extend_from_slice(format!("X-Pad-{i}: x\r\n").as_bytes());
+        }
+        raw.extend_from_slice(b"\r\nbody");
+        raw
+    }
+
+    #[test]
+    fn parse_rejects_header_count_above_max() {
+        // 1 (From) + 300 (X-Pad-*) = 301 headers, well above MAX_HEADER_COUNT=256.
+        // Kills: enforce_header_count -> Ok(()), and `> with ==` (since count != MAX).
+        let raw = build_message_with_n_headers(300);
+        let err = parse_message(&raw).unwrap_err();
+        match err {
+            ContentError::LimitExceeded { kind, limit } => {
+                assert_eq!(kind, "header_count");
+                assert_eq!(limit, MAX_HEADER_COUNT);
+            }
+            other => panic!("expected LimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_accepts_header_count_at_max() {
+        // From + 255 X-Pad headers = exactly 256 = MAX_HEADER_COUNT.
+        // Kills: `> with >=` (with `>=`, 256 >= 256 errors; with `>`, 256 > 256 is false).
+        let raw = build_message_with_n_headers(MAX_HEADER_COUNT - 1);
+        let content = parse_message(&raw).expect("256 headers must parse cleanly");
+        // Sanity: no LimitExceeded warning was attached either.
+        assert!(
+            !content
+                .security_warnings
+                .iter()
+                .any(|w| matches!(w.code, crate::output::WarningCode::ParseHeaderCountExceeded)),
+            "no ParseHeaderCountExceeded at the limit boundary",
+        );
+    }
+
+    #[test]
+    fn parse_extracts_in_reply_to_header() {
+        // Kills: header_value_first_text -> None (the wholesale stub).
+        let raw = b"From: a@example\r\n\
+                    In-Reply-To: <parent-msgid@example>\r\n\
+                    \r\n\
+                    body";
+        let content = parse_message(raw).unwrap();
+        let in_reply_to = content
+            .meta
+            .in_reply_to
+            .as_deref()
+            .expect("In-Reply-To populates meta.in_reply_to");
+        assert!(
+            in_reply_to.contains("parent-msgid@example"),
+            "in_reply_to should contain the message id, got {in_reply_to:?}",
+        );
+    }
+
+    #[test]
+    fn parse_extracts_references_header_with_multiple_ids() {
+        // Kills: header_value_all_text -> vec![] (the wholesale stub).
+        let raw = b"From: a@example\r\n\
+                    References: <one@example> <two@example> <three@example>\r\n\
+                    \r\n\
+                    body";
+        let content = parse_message(raw).unwrap();
+        assert!(
+            !content.meta.references.is_empty(),
+            "References must populate meta.references with at least one id",
+        );
+        let joined = content.meta.references.join(" ");
+        assert!(joined.contains("one@example"), "missing first id");
+        assert!(joined.contains("three@example"), "missing last id");
+    }
+
+    #[test]
+    fn parse_extracts_mailing_list_with_only_list_id() {
+        // Kills both `&& with ||` mutations in extract_mailing_list's
+        // is_none-AND-is_none-AND-is_none guard. With only list_id set, the
+        // original `false && true && true` is false (returns Some); both
+        // `||` mutants flip to true (return None).
+        let raw = b"From: a@example\r\n\
+                    List-ID: <only-id@example>\r\n\
+                    \r\n\
+                    body";
+        let content = parse_message(raw).unwrap();
+        let ml = content
+            .meta
+            .mailing_list
+            .expect("List-ID alone must produce Some(MailingListInfo)");
+        assert!(
+            ml.list_id
+                .as_deref()
+                .unwrap_or("")
+                .contains("only-id@example"),
+        );
+        assert!(ml.list_unsubscribe.is_none());
+        assert!(ml.list_post.is_none());
+    }
+}

--- a/crates/rimap-content/src/parse/meta.rs
+++ b/crates/rimap-content/src/parse/meta.rs
@@ -131,3 +131,35 @@ fn convert_datetime(dt: &mail_parser::DateTime) -> Option<OffsetDateTime> {
     }
     OffsetDateTime::from_unix_timestamp(dt.to_timestamp()).ok()
 }
+
+#[cfg(test)]
+mod meta_tests {
+    use std::borrow::Cow;
+
+    use super::format_addr;
+
+    #[test]
+    fn format_addr_falls_back_to_email_when_name_is_empty_string() {
+        // Kills the match-guard mutation `!name.is_empty() -> true`. With
+        // `true`, an Addr with `name = Some("")` would print as " <email>"
+        // (leading space + angle-bracketed email) instead of falling
+        // through to the bare-email arm.
+        let addr = mail_parser::Addr {
+            name: Some(Cow::Borrowed("")),
+            address: Some(Cow::Borrowed("only@example")),
+        };
+        assert_eq!(format_addr(&addr), "only@example");
+    }
+
+    #[test]
+    fn format_addr_uses_name_when_present_and_non_empty() {
+        // Anchor: ensures the original arm with the guard still fires
+        // for non-empty names. (The `Some(_) | None` arm is the
+        // fall-through and is exercised by the empty-name test above.)
+        let addr = mail_parser::Addr {
+            name: Some(Cow::Borrowed("Alice")),
+            address: Some(Cow::Borrowed("alice@example")),
+        };
+        assert_eq!(format_addr(&addr), "Alice <alice@example>");
+    }
+}

--- a/crates/rimap-content/src/parse/mime_scrub.rs
+++ b/crates/rimap-content/src/parse/mime_scrub.rs
@@ -121,6 +121,12 @@ fn locate_encoded_word_end(
     start_offset: usize,
 ) -> EncodedWordEnd {
     let first = logical[start_idx];
+    // cargo-mutants: known-equivalent — `< first.len()` vs `<= first.len()`
+    // are observably identical here. At `start_offset == first.len()`, the
+    // empty subslice yields no `windows(2)` element, so the `let Some(rel)`
+    // guard fails either way and control falls through to the outer scan.
+    // Beyond `first.len()`, both predicates evaluate to false. See
+    // `bodies_tests` and `parse::tests::scrub_*` for behavioural coverage.
     if start_offset < first.len()
         && let Some(rel) = first[start_offset..].windows(2).position(|w| w == b"?=")
     {
@@ -171,8 +177,117 @@ pub(super) fn split_header_lines(headers: &[u8]) -> Vec<&[u8]> {
         line_start = line_end;
         i = line_end;
     }
+    // cargo-mutants: known-equivalent — `< with >` here is observably
+    // identical to the original. The inner loop always sets
+    // `line_start = line_end` after each push, and the only `line_end`
+    // value reachable when the loop exits is `headers.len()` (the
+    // `None` branch of the `\n` search). On exit, `line_start ==
+    // headers.len()`, so the predicate is false under both `<` and
+    // `>`. The trailing block is defensive dead code in current usage.
     if line_start < headers.len() {
         out.push(&headers[line_start..]);
     }
     out
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests may expect on constructed values")]
+mod mime_scrub_tests {
+    use super::{detect_smuggling_spans, scrub_header_smuggling};
+    use crate::output::WarningCode;
+
+    #[test]
+    fn scrub_smuggling_caps_dropped_names_at_eight() {
+        // Kills `< with <=` on `dropped_names.len() < 8`. Build a header
+        // block with 9 distinct smuggled headers; assert the warning's
+        // `names=[...]` list has exactly 8 entries (original) — `<=`
+        // would let the 9th name in.
+        //
+        // Each smuggled header has a unique name (`H0..H8`) and a
+        // dangling `=?` that drops it. Headers without `?=` anywhere
+        // later in the block are flagged via `EncodedWordEnd::Missing`,
+        // which sets only that single line's mask bit — exactly the
+        // shape of one-line-per-name we need.
+        let mut raw = Vec::from(&b"From: real@example\r\n"[..]);
+        for i in 0..9 {
+            raw.extend_from_slice(format!("H{i}: =?\r\n").as_bytes());
+        }
+        raw.extend_from_slice(b"\r\nbody");
+        let mut warnings = Vec::new();
+        let _scrubbed = scrub_header_smuggling(&raw, &mut warnings);
+        assert_eq!(
+            warnings.len(),
+            1,
+            "exactly one aggregated smuggling warning"
+        );
+        assert_eq!(warnings[0].code, WarningCode::ParseHeaderSmugglingBlocked);
+        let detail = warnings[0].detail.as_deref().unwrap_or("");
+        // Original drops 9 headers with `count=9`, but lists at most 8 names.
+        assert!(
+            detail.contains("count=9"),
+            "expected count=9, got detail={detail:?}",
+        );
+        // names list should have exactly 8 entries (commas separate them).
+        let names_segment = detail
+            .split("names=[")
+            .nth(1)
+            .and_then(|s| s.strip_suffix(']'))
+            .expect("detail must include names=[...] when names list non-empty");
+        let name_count = names_segment.split(',').count();
+        assert_eq!(
+            name_count, 8,
+            "expected 8 names listed at the cap, got {name_count} from {names_segment:?}",
+        );
+    }
+
+    #[test]
+    fn detect_smuggling_does_not_revisit_processed_headers() {
+        // Kills `+ with -` on `idx = end_idx + 1`. With `-`, idx jumps
+        // backward to end_idx-1 = 0 after LaterHeader(1), causing
+        // detect_smuggling_spans to re-process logical[0] and re-emit
+        // LaterHeader(1) -> idx=0 -> infinite loop. The hung test then
+        // fails via cargo-mutants timeout.
+        //
+        // Construction: 2 logical headers, smuggling spans both — the
+        // minimal case where `end_idx == 1` and `end_idx - 1 == 0`.
+        let logical: Vec<&[u8]> = vec![
+            b"Subject: =?utf-8?B?x\r\n",
+            b"X-Spliced: y@e?=\r\n", // `?=` closes the smuggled encoded-word
+        ];
+        let mask = detect_smuggling_spans(&logical);
+        assert_eq!(mask, vec![true, true]);
+    }
+
+    #[test]
+    fn detect_smuggling_skips_logical_end_idx_after_later_header() {
+        // Kills `+ with *` on `idx = end_idx + 1`. With `*`, idx stays at
+        // end_idx and re-scans logical[end_idx]. If logical[end_idx]
+        // contains another `=?` whose closing falls in a later header,
+        // the mutation flips an additional mask bit — mask differs from
+        // the original.
+        //
+        // Construction:
+        //   logical[0]: opens encoded-word; closes in logical[1]
+        //   logical[1]: contains the closer `?=` AND a fresh opener `=?`
+        //               whose own closer is in logical[2]
+        //   logical[2]: closer `?=`; under original, never visited
+        //               because idx jumps to 2 (= end_idx+1 = 1+1)... wait,
+        //               LaterHeader(1) sets idx=2 which is the closer line;
+        //               that line is then walked but contains no fresh `=?`.
+        //               Under `*` mutant, idx=1: logical[1]'s fresh `=?`
+        //               is detected, closes in logical[2] -> mask[2]=true.
+        let logical: Vec<&[u8]> = vec![
+            b"A: =?u?B?p\r\n",
+            b"B: ?=garbage=?v?B?q\r\n",
+            b"C: ?=\r\n",
+            b"D: ok\r\n",
+        ];
+        let mask = detect_smuggling_spans(&logical);
+        // Original: only logical[0..=1] are smuggling.
+        assert_eq!(
+            mask,
+            vec![true, true, false, false],
+            "original mask must not flag logical[2]",
+        );
+    }
 }

--- a/crates/rimap-content/src/parse/mod.rs
+++ b/crates/rimap-content/src/parse/mod.rs
@@ -670,6 +670,44 @@ mod tests {
     }
 
     #[test]
+    fn parse_accepts_message_at_max_message_bytes() {
+        // Kills `> with >=` on `raw.len() > MAX_MESSAGE_BYTES`. With `>`,
+        // a 25 MiB raw is below-or-equal and proceeds to parse (may
+        // produce non-fatal warnings or a body LimitExceeded later); the
+        // `>=` mutant errors immediately with `kind = "message_bytes"`.
+        let mut raw = Vec::from(&b"From: a@example\r\nContent-Type: text/plain\r\n\r\n"[..]);
+        raw.resize(MAX_MESSAGE_BYTES, b'x');
+        let result = parse_message(&raw);
+        match result {
+            Ok(_) => (),
+            Err(ContentError::LimitExceeded { kind, .. }) => {
+                assert_ne!(
+                    kind, "message_bytes",
+                    "must not error with kind=message_bytes at exactly MAX_MESSAGE_BYTES",
+                );
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_keeps_long_subject_within_max_header_bytes() {
+        // Kills `* with +` on `MAX_HEADER_BYTES = 8 * 1024`. The mutant
+        // flips the constant to 8 + 1024 = 1032, well below 8 KiB. A
+        // Subject of 5000 ASCII bytes round-trips intact under the
+        // 8 KiB cap but gets sliced to ~1032 bytes under the mutant.
+        let long = "a".repeat(5000);
+        let raw = format!("From: a@example\r\nSubject: {long}\r\n\r\nbody");
+        let content = parse_message(raw.as_bytes()).unwrap();
+        let subject = content.meta.subject.unwrap();
+        assert!(
+            subject.len() >= 5000,
+            "subject must round-trip ~5000 bytes under MAX_HEADER_BYTES=8192, got {} bytes",
+            subject.len(),
+        );
+    }
+
+    #[test]
     fn parse_rejects_mime_depth_bomb() {
         // Build 12 properly nested multipart containers. Each level's
         // boundary opens a child whose own Content-Type declares the

--- a/crates/rimap-content/src/raw_parts.rs
+++ b/crates/rimap-content/src/raw_parts.rs
@@ -59,6 +59,15 @@ fn walk(
     out: &mut Vec<RawPart>,
     depth: u32,
 ) -> Result<(), ContentError> {
+    // cargo-mutants: known-equivalent — `> with ==` and `> with >=` are
+    // observably indistinguishable for any mail_parser-reachable input.
+    // Per `crates/rimap-content/src/parse/mod.rs`, `parse_message` already
+    // rejects messages whose MIME depth exceeds 8 (`MAX_MIME_DEPTH`)
+    // before any caller of `walk_attachment_parts` sees them; the 64-level
+    // defensive cap here therefore can never fire in production. The
+    // `==` mutation only differs from `>` at exactly `depth == 64`, and
+    // `>=` only at `depth in [64, max-tree-depth]`; both ranges are
+    // unreachable.
     if depth > MAX_MIME_DEPTH {
         return Ok(());
     }
@@ -77,6 +86,13 @@ fn walk(
             } else {
                 format!("{prefix}.{num}")
             };
+            // cargo-mutants: known-equivalent — `+ with *` on `depth + 1`
+            // is observably indistinguishable for any reachable input.
+            // `depth * 1 == depth` keeps the recursion at depth 0
+            // forever, but mail_parser-reachable trees have finite depth
+            // (capped well below the 64 defensive cap by `parse_message`),
+            // so both `+ 1` and `* 1` walk to the same set of leaves
+            // before recursion bottoms out on `sub_parts() == None`.
             walk(msg, child_idx as usize, &child_id, out, depth + 1)?;
         }
     } else {

--- a/crates/rimap-content/src/threading.rs
+++ b/crates/rimap-content/src/threading.rs
@@ -140,4 +140,39 @@ mod tests {
             assert!(!mid.contains('\r') && !mid.contains('\n'));
         }
     }
+
+    // `sanitize_msg_id` is exercised by the `extract_threading_headers`
+    // flow but `mail_parser` typically sanitizes the input string before
+    // our function sees it; these direct-call tests pin behaviour for
+    // each character class the filter is supposed to drop. Each test
+    // kills one of the four `&& with ||` mutations on the filter
+    // chain (`*c != '\r' && *c != '\n' && *c != '\0' && *c != '<' &&
+    // *c != '>'`), because under any single `&& -> ||` the chain
+    // short-circuits to `true` for an input containing any one of the
+    // special characters — which means the char is kept instead of
+    // dropped.
+    #[test]
+    fn sanitize_msg_id_strips_carriage_return() {
+        assert_eq!(sanitize_msg_id("id\rwith-cr", "test"), "idwith-cr");
+    }
+
+    #[test]
+    fn sanitize_msg_id_strips_line_feed() {
+        assert_eq!(sanitize_msg_id("id\nwith-lf", "test"), "idwith-lf");
+    }
+
+    #[test]
+    fn sanitize_msg_id_strips_nul() {
+        assert_eq!(sanitize_msg_id("id\0with-nul", "test"), "idwith-nul");
+    }
+
+    #[test]
+    fn sanitize_msg_id_strips_left_angle_bracket() {
+        assert_eq!(sanitize_msg_id("<id", "test"), "id");
+    }
+
+    #[test]
+    fn sanitize_msg_id_strips_right_angle_bracket() {
+        assert_eq!(sanitize_msg_id("id>", "test"), "id");
+    }
 }

--- a/crates/rimap-content/src/unicode.rs
+++ b/crates/rimap-content/src/unicode.rs
@@ -495,4 +495,23 @@ mod tests {
         assert_eq!(text, "こんにちは");
         assert!(warnings.is_empty());
     }
+
+    #[test]
+    fn filter_codepoints_strips_unicode_tag() {
+        // Kills `is_unicode_tag -> bool with false`. With `false`, a
+        // Unicode Tag char (U+E0001 LANGUAGE TAG) bypasses the
+        // zero-width-class filter and gets pushed into the output.
+        // Original: stripped via the same arm as ZERO_WIDTH chars,
+        // counted in `zero_width_stripped`.
+        let input = "ab\u{E0001}cd";
+        let result = filter_codepoints(input);
+        assert_eq!(
+            result.text, "abcd",
+            "Unicode Tag char must be stripped from output",
+        );
+        assert!(
+            result.zero_width_stripped >= 1,
+            "Unicode Tag char must increment zero_width_stripped, got {result:?}",
+        );
+    }
 }

--- a/crates/rimap-content/tests/epvme_integration.rs
+++ b/crates/rimap-content/tests/epvme_integration.rs
@@ -150,6 +150,43 @@ fn json_out_writes_valid_json() {
 }
 
 #[test]
+fn json_out_creates_missing_parent_dir_kills_mutant_delete_empty_parent_guard() {
+    let tmp = TempDir::new().unwrap();
+    write_eml(tmp.path(), "sample.eml", "JSON nested-dir test");
+
+    // Path whose parent directory does not yet exist — write_json_report must
+    // create it. The `!parent.as_os_str().is_empty()` guard exists to skip
+    // create_dir_all for bare filenames whose path.parent() returns Some(""),
+    // not to skip directory creation in the normal nested-path case.
+    let json_path = tmp
+        .path()
+        .join("reports")
+        .join("nightly")
+        .join("report.json");
+    assert!(!json_path.parent().unwrap().exists());
+
+    let output = Command::new(cargo_bin())
+        .args([
+            tmp.path().as_os_str(),
+            "--json-out".as_ref(),
+            json_path.as_os_str(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 with nested --json-out path, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        json_path.exists(),
+        "JSON report file should exist at the nested path",
+    );
+}
+
+#[test]
 fn no_args_exits_nonzero() {
     let output = Command::new(cargo_bin()).output().unwrap();
 

--- a/crates/rimap-content/tests/epvme_integration.rs
+++ b/crates/rimap-content/tests/epvme_integration.rs
@@ -158,3 +158,40 @@ fn no_args_exits_nonzero() {
         "expected non-zero exit with no arguments",
     );
 }
+
+#[test]
+fn help_flag_exits_zero_kills_mutant_delete_help_arm() {
+    let output = Command::new(cargo_bin()).arg("--help").output().unwrap();
+    assert!(
+        output.status.success(),
+        "expected exit 0 for --help, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn short_help_flag_exits_zero_kills_mutant_delete_help_arm() {
+    let output = Command::new(cargo_bin()).arg("-h").output().unwrap();
+    assert!(
+        output.status.success(),
+        "expected exit 0 for -h, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn unknown_flag_exits_nonzero_with_message_kills_mutant_flag_guard() {
+    let output = Command::new(cargo_bin()).arg("--bogus").output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for unknown flag --bogus, got {:?}",
+        output.status.code(),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown flag: --bogus"),
+        "stderr should contain 'unknown flag: --bogus':\n{stderr}",
+    );
+}

--- a/docs/superpowers/plans/2026-05-03-issue-225-rimap-content-mutation-waves-rextract.md
+++ b/docs/superpowers/plans/2026-05-03-issue-225-rimap-content-mutation-waves-rextract.md
@@ -1,0 +1,972 @@
+# Issue #225 — Re-extract `rimap-content` Mutation-Cleanup Waves Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-apply on `main` the mutation-cleanup test waves from archived PRs #196 (issue #192, `rimap-content` waves) and #198 (issue #193, `epvme_runner` waves) — pure test additions plus a small set of `// cargo-mutants: known-equivalent` annotations and the `mutation-baseline.md` survivor inventory. Drives the `rimap-content` non-`bin/` cargo-mutants survivor count back to 15 (all known-equivalent) and the `bin/epvme_runner.rs` count to 5 (all known-equivalent), matching the archive baseline.
+
+**Architecture:** Per-commit cherry-pick from `archive/daemon-experiment` for the test-only commits whose surrounding context matches `main`, with two exceptions handled by fresh-application:
+1. Commit `4e56b11` (lookalike.rs) — three of its four annotations and three of its four tests still apply, but the `scan_body_urls` `> with >=` annotation references an `is_char_boundary` walk that issue #224 deleted from main, and the `scan_body_urls_handles_multi_byte_char_at_scan_boundary` test already exists on main from #224. Fresh-applied, dropping the stale annotation and the duplicate test.
+2. Commit `300556c` (lookalike `-= with +=` annotation) — entirely stale; the annotated code path was deleted by #224. Skipped.
+
+For the mutation-baseline cherry-picks (`a5cdab3`, `2e69b7d`), three rows are dropped: two `lookalike.rs` rows referencing the deleted `is_char_boundary` walk and one `parse/mime_scrub.rs:105` row whose `+ 1` rationale doesn't hold for main's `+ 2` (the upstream fix `b7e8bfe` for back-to-back encoded-words shipped in archive between `974508b^` and main and was re-extracted to main via PR #232; archive's annotation site no longer applies). The remaining two `parse/mime_scrub.rs` rows have their line numbers renumbered (`:149` → `:124`, `:213` → `:174`) to match main's actual annotation sites. Task 19 (`cargo mutants`) will surface any real survivor at the dropped sites under main's current math; if found, a row gets added with rigorous rationale at that point.
+
+The reapplied tests are pure additions to existing `mod tests` blocks (and to one integration test file, `crates/rimap-content/tests/epvme_integration.rs`) plus six in-source `// cargo-mutants: known-equivalent` annotations on production code. No production-code logic changes. No new dependencies. No new files.
+
+**Tech Stack:** Rust 2024, MSRV 1.88.0, `cargo-mutants` (run via `just mutants-crate <name>` with `--jobs 2`).
+
+**Source issue:** [#225](https://github.com/randomparity/rusty-imap-mcp/issues/225) (Phase-2 re-extract of #192 and #193)
+
+**Original PRs (archived on `archive/daemon-experiment`):**
+- [#196](https://github.com/randomparity/rusty-imap-mcp/pull/196) `feat/issue-192-rimap-content-mutation-cleanup` — merged at `2410c38`. Contains 12 test-wave commits + 1 mutation-baseline finalization. Issue #192.
+- [#198](https://github.com/randomparity/rusty-imap-mcp/pull/198) `feat/issue-193-epvme-runner-mutation-cleanup` — merged at `f873db2`. Contains 2 planning-doc commits (skipped — see below), 5 test/annotation commits, and 1 mutation-baseline finalization. Issue #193.
+- PR #195 (`b2f833e`) added a now-stale follow-up plan that drove #196; not re-extracted because this plan supersedes it.
+
+**Reference commits on archive (chronological, with re-extract disposition):**
+
+| Archive SHA | Disposition | Subject |
+|---|---|---|
+| `f629f0d` | cherry-pick | `test(rimap-content): close mutation gaps in parse/headers.rs` |
+| `c69a984` | cherry-pick | `test(rimap-content): close mutation gaps in parse/filename.rs` |
+| `33a8df5` | cherry-pick | `test(rimap-content): close mutation gaps in parse/bodies.rs` |
+| `974508b` | cherry-pick + drop one annotation | `test(rimap-content): close mutation gaps in parse/mime_scrub.rs` (the `+ 1` annotation on `detect_smuggling_spans` is dropped — main has `+ 2` after PR #228) |
+| `655754a` | cherry-pick | `test(rimap-content): close mutation gaps in parse/{meta,attachments,mod}.rs` |
+| `a6a49ee` | cherry-pick | `test(rimap-content): close mutation gaps in html/style_parse.rs` |
+| `eee5a11` | cherry-pick | `test(rimap-content): close mutation gaps in html/mismatch.rs` |
+| `7643c5d` | cherry-pick + rename | `test(rimap-content): close mutation gaps in html/{extract,mod}.rs` (3 `sanitize_html(` call sites in test bodies must be renamed to `process(` — main renamed the function via PR #232) |
+| `4e56b11` | **fresh-apply** | `test(rimap-content): close mutation gaps in lookalike.rs` (drops `scan_body_urls` annotation and `scan_body_urls_handles_multi_byte_char_at_scan_boundary` test — both stale post-#224) |
+| `c147d78` | cherry-pick | `test(rimap-content): close mutation gaps in threading/unicode/plumbing` |
+| `300556c` | **skip** | `test(rimap-content): annotate -= with += in scan_body_urls as known-equivalent` (entire annotation site deleted by #224) |
+| `a5cdab3` | cherry-pick + edit | `docs(test-strategy): finalise rimap-content mutation-baseline` (drops two `lookalike.rs:195` and `lookalike.rs:205` rows; rewrites `mime_scrub.rs:105` row's `+ 1` to `+ 2`) |
+| `cd2c50e` | cherry-pick | `test(rimap-content): triage epvme_runner parse_args mutants` |
+| `bf83314` | cherry-pick | `test(rimap-content): triage epvme_runner dataset-loop mutants` |
+| `62589f4` | cherry-pick | `test(rimap-content): annotate epvme_runner print_summary mutants` |
+| `c52e3ed` | cherry-pick | `test(rimap-content): kill epvme_runner write_json_report empty-parent mutant` |
+| `d358f5e` | cherry-pick | `test(rimap-content): kill epvme_runner read_failure_count mutant` |
+| `2e69b7d` | cherry-pick | `docs(test-strategy): finalise mutation-baseline for issue #193` |
+
+Also-archived but **not re-extracted**:
+- `cbba4b7` (PR #195's followup plan) — superseded by this plan.
+- `00949ba` and `03093bf` (PR #198's planning docs) — historical artifacts; this plan supersedes.
+
+**Baseline test count (verified during plan write):** `cargo test --workspace --quiet` → **991 passed, 0 failed, 0 ignored**.
+
+**Expected test count after plan completes:** **991 + 66 = 1057** new tests across the 16 applied commits (4e56b11 contributes 3 net-new tests, not 4, because `scan_body_urls_handles_multi_byte_char_at_scan_boundary` is already on main). The new tests break down as:
+
+| Commit | New `#[test]` markers | Cumulative |
+|---|---|---|
+| `f629f0d` parse/headers.rs | 5 | 996 |
+| `c69a984` parse/filename.rs | 12 | 1008 |
+| `33a8df5` parse/bodies.rs | 5 | 1013 |
+| `974508b` parse/mime_scrub.rs | 3 | 1016 |
+| `655754a` parse/{meta,attachments,mod}.rs | 5 | 1021 |
+| `a6a49ee` html/style_parse.rs | 6 | 1027 |
+| `eee5a11` html/mismatch.rs | 5 | 1032 |
+| `7643c5d` html/{extract,mod}.rs | 5 | 1037 |
+| `4e56b11` lookalike.rs (fresh-apply) | 3 | 1040 |
+| `c147d78` threading/unicode/plumbing | 7 | 1047 |
+| `cd2c50e` epvme parse_args | 3 | 1050 |
+| `bf83314` epvme dataset-loop | 5 | 1055 |
+| `c52e3ed` epvme write_json_report | 1 | 1056 |
+| `d358f5e` epvme read_failure_count | 1 | 1057 |
+
+`62589f4` (epvme print_summary) and `a5cdab3`/`2e69b7d` (baseline docs) add no tests. Mutation-cleanup confirms via `cargo mutants` in Task 19.
+
+---
+
+## File Map
+
+**Modified — `rimap-content` test code (test additions inside `mod tests`):**
+- `crates/rimap-content/src/parse/headers.rs` — 5 tests (Task 1).
+- `crates/rimap-content/src/parse/filename.rs` — 12 tests (Task 2).
+- `crates/rimap-content/src/parse/bodies.rs` — 5 tests (Task 3).
+- `crates/rimap-content/src/parse/mime_scrub.rs` — 3 tests + 2 annotations (Task 4; archive's third annotation referencing `+ 1` is dropped — main has `+ 2` after PR #228).
+- `crates/rimap-content/src/parse/meta.rs` — 1 test (Task 5).
+- `crates/rimap-content/src/parse/attachments.rs` — 1 test (Task 5).
+- `crates/rimap-content/src/parse/mod.rs` — 3 tests (Task 5).
+- `crates/rimap-content/src/html/style_parse.rs` — 6 tests + 1 annotation (Task 6).
+- `crates/rimap-content/src/html/mismatch.rs` — 5 tests + 1 annotation (Task 7).
+- `crates/rimap-content/src/html/extract.rs` — 1 test (Task 8).
+- `crates/rimap-content/src/html/mod.rs` — 4 tests (Task 8; 3 call sites need `sanitize_html` → `process` rename).
+- `crates/rimap-content/src/lookalike.rs` — 3 tests + 4 annotations (Task 9; fresh-applied).
+- `crates/rimap-content/src/threading.rs` — 5 tests (Task 10).
+- `crates/rimap-content/src/unicode.rs` — 1 test (Task 10).
+- `crates/rimap-content/src/raw_parts.rs` — 3 annotations (Task 10).
+- `crates/rimap-content/src/lib.rs` — 1 test (Task 10).
+- `crates/rimap-content/src/bin/epvme_runner.rs` — 9 tests + 4 annotations (Tasks 12–16).
+- `crates/rimap-content/tests/epvme_integration.rs` — 4 tests (Tasks 13–15).
+
+**Modified — design/test-strategy docs:**
+- `docs/superpowers/specs/test-strategy/mutation-baseline.md` — created in Task 11 (was deleted in the daemon rollback); rimap-content table populated; bin/epvme_runner.rs subsection populated in Task 17.
+
+**No production-code logic changes.** 15 annotation comments on production code: 1 in `html/style_parse.rs`, 1 in `html/mismatch.rs`, 4 in `lookalike.rs`, 2 in `parse/mime_scrub.rs`, 3 in `raw_parts.rs`, 4 in `bin/epvme_runner.rs`. One archive annotation in `parse/mime_scrub.rs` (the `+ 1` rationale on `detect_smuggling_spans`) is deliberately dropped — main has `+ 2` after PR #228 (`b7e8bfe`), so the archive rationale doesn't hold; Task 19 will surface any real survivor under the new math. Zero new files apart from the re-created `mutation-baseline.md`.
+
+Each task produces one self-contained commit, except Tasks 12–14 which group small same-file epvme commits if conflicts surface — see task notes.
+
+---
+
+## Task 0: Branch and pre-flight verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm `main` is clean and up-to-date**
+
+Run: `git status && git log --oneline -1`
+Expected: working tree clean; HEAD at `2733705 Merge pull request #233 ...` or later. Stop if uncommitted changes exist.
+
+- [ ] **Step 2: Create the working branch off `main`**
+
+Run:
+```bash
+git checkout -b phase2/issue-225-rimap-content-mutation-waves-rextract main
+```
+Expected: `Switched to a new branch 'phase2/issue-225-rimap-content-mutation-waves-rextract'`. From this point forward, never commit directly to `main`.
+
+- [ ] **Step 3: Confirm the archive commits are reachable**
+
+Run: `for sha in f629f0d c69a984 33a8df5 974508b 655754a a6a49ee eee5a11 7643c5d 4e56b11 c147d78 a5cdab3 cd2c50e bf83314 62589f4 c52e3ed d358f5e 2e69b7d; do git log --oneline -1 "$sha" >/dev/null 2>&1 && echo "OK $sha" || echo "MISSING $sha"; done`
+Expected: 17 lines of `OK <sha>`. If any are missing, run `git fetch origin 'archive/daemon-experiment'` to pull them in.
+
+- [ ] **Step 4: Capture baseline test count**
+
+Run: `cargo test --workspace --quiet 2>&1 | grep -E "^test result:" | awk '{p+=$4; f+=$6; i+=$8} END {print "passed=" p " failed=" f " ignored=" i}'`
+Expected: `passed=991 failed=0 ignored=0`. Note the count for Task 18 verification.
+
+- [ ] **Step 5: Capture baseline clippy state**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1 | tail -5`
+Expected: no warnings. Stop and fix any pre-existing warnings before proceeding — they would otherwise mask new ones introduced by this work.
+
+- [ ] **Step 6: Confirm the `mutation-baseline.md` parent dir exists and the file is absent**
+
+Run: `ls docs/superpowers/specs/ 2>&1 | head -10; ls docs/superpowers/specs/test-strategy 2>&1`
+Expected: `test-strategy` directory does **not** exist (was deleted in the daemon rollback). `docs/superpowers/specs/` exists. Task 11 creates the directory and file.
+
+---
+
+## Task 1: Re-extract `parse/headers.rs` mutation-coverage tests (cherry-pick `f629f0d`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/headers.rs` (5 tests appended to `mod tests`).
+
+**Cherry-pick disposition:** clean — `974508b^:headers.rs` and `HEAD:headers.rs` are byte-identical, so the cherry-pick patch applies without fuzz.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x f629f0d`
+Expected: cherry-pick succeeds with no conflicts. The new commit message is the original subject + body + a `(cherry picked from commit f629f0d…)` line.
+
+- [ ] **Step 2: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib parse::headers::tests`
+Expected: all PASS, including the five new tests:
+- `parse_rejects_header_count_above_max`
+- `parse_accepts_header_count_at_max`
+- `parse_extracts_in_reply_to_header`
+- `parse_extracts_references_header_with_multiple_ids`
+- `parse_extracts_mailing_list_with_only_list_id`
+
+- [ ] **Step 3: Run the wider crate to catch any cross-module regression**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5`
+Expected: workspace passes (count rises by 5 over the baseline).
+
+- [ ] **Step 4: Lint**
+
+Run: `cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+---
+
+## Task 2: Re-extract `parse/filename.rs` mutation-coverage tests (cherry-pick `c69a984`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/filename.rs` (12 tests appended to `mod tests`).
+
+**Cherry-pick disposition:** clean — `c69a984^:filename.rs` and `HEAD:filename.rs` are byte-identical.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x c69a984`
+Expected: cherry-pick succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib parse::filename::tests`
+Expected: all PASS, including 12 new tests covering `extract_file_label`, `is_dangerous_filename`, `kind_of_filename`, and `infer_filename_from_part`.
+
+- [ ] **Step 3: Run the full crate**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5`
+Expected: cumulative count is now 996 + 12 = 1008.
+
+- [ ] **Step 4: Lint**
+
+Run: `cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+---
+
+## Task 3: Re-extract `parse/bodies.rs` mutation-coverage tests (cherry-pick `33a8df5`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/bodies.rs` (5 tests appended to `mod tests`).
+
+**Cherry-pick disposition:** **expect minor context drift**. `33a8df5^:bodies.rs` is byte-identical to current `main` for the test-block region (lines 240+ onward), but archive's pre-context for two hunks may include the `html::sanitize_html` doc-comment string while `main` reads `html::process` (renamed by PR #232). If the cherry-pick reports conflicts, resolve by keeping `main`'s `html::process` text and accepting the archive's test additions verbatim.
+
+- [ ] **Step 1: Attempt cherry-pick with provenance**
+
+Run: `git cherry-pick -x 33a8df5`
+Expected outcomes:
+- Best case: cherry-pick succeeds with no conflicts (test additions sit at end of `mod tests`, far from any docstring divergence).
+- If conflicts: continue to Step 2.
+
+- [ ] **Step 2: Resolve conflicts (if any) — keep main's API names, archive's test additions**
+
+If `git status` shows `bodies.rs` as `both modified`, open it. The conflict markers will surround the doc-comment hunk near `decode_text_part` and/or `sanitize_html_part`. The resolution rule: keep the side that says `html::process` (main's). Then run:
+```bash
+git add crates/rimap-content/src/parse/bodies.rs
+git cherry-pick --continue
+```
+The `--continue` will reuse the original commit message; verify the `(cherry picked from commit 33a8df5…)` line is preserved.
+
+- [ ] **Step 3: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib parse::bodies::tests`
+Expected: all PASS, including 5 new tests covering `decode_text_part`, `extract_bodies` charset handling, and the HTML-merge fallback path.
+
+- [ ] **Step 4: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative test count 1013; no warnings.
+
+---
+
+## Task 4: Re-extract `parse/mime_scrub.rs` mutation-coverage tests (cherry-pick `974508b`, drop one stale annotation)
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/mime_scrub.rs` — adds 3 tests inside a new `mod mime_scrub_tests` block plus 2 `// cargo-mutants: known-equivalent` annotations on `locate_encoded_word_end` (line 124 on main; archive line 143) and `split_header_lines` (line 174 on main; archive line 206). The third archive annotation, on `detect_smuggling_spans` (archive line 96), references `replacing + 1 with * 1` — **stale on main** because PR #228 (`b7e8bfe`, landed via #232) changed `scan_from = end_rel_to_header + 1` to `+ 2`. Drop that annotation.
+
+**Cherry-pick disposition:** **expect context drift on three production-code hunks**. `974508b^:mime_scrub.rs` includes archive-only commits `b7e8bfe` (back-to-back encoded-words fix; `+ 1` → `+ 2`) and `c96b3c1` (consolidate UTF-8 truncation), neither of which is on `main`. The patch's pre-context lines on the `detect_smuggling_spans` annotation hunk reference the deleted `Using +2 would skip the '=' at end_rel_to_header+1` comments and the `+ 1` line; those won't match. Tests append to the end of the file as a new `mod mime_scrub_tests`, which should apply cleanly because there's no pre-existing block at that position.
+
+- [ ] **Step 1: Attempt cherry-pick with provenance**
+
+Run: `git cherry-pick -x 974508b`
+Expected outcome: a conflict on `mime_scrub.rs` at the `detect_smuggling_spans` annotation hunk. The other two annotation hunks (`locate_encoded_word_end` and `split_header_lines`) and the test-block addition should apply via fuzz.
+
+- [ ] **Step 2: Resolve the `detect_smuggling_spans` conflict — drop the stale annotation**
+
+If `git status` shows `mime_scrub.rs` as `both modified`, open it. Any conflict markers around `scan_from = end_rel_to_header + 2` (line 86 on main) should be resolved by **keeping main's text exactly** — do NOT add the `+ 1` annotation. The annotation's rationale (`replacing + 1 with * 1 is observably indistinguishable`) does not hold for `+ 2` because the off-by-one math is different; Task 19 (`cargo mutants`) will surface a real survivor at this site if one exists, and the rationale will need to be rewritten then with rigorous justification.
+
+The other two annotations should land at:
+- Line 123 (above `if start_offset < first.len()` on line 124) — `// cargo-mutants: known-equivalent — < first.len() vs <= first.len() ...`
+- Line 173 (above `if line_start < headers.len()` on line 174) — `// cargo-mutants: known-equivalent — < with > here is observably ...`
+
+If either annotation is missing because of conflict-resolution shrapnel, manually paste the comment block (verbatim from `git show 974508b -- crates/rimap-content/src/parse/mime_scrub.rs`).
+
+- [ ] **Step 3: Verify the test block was added cleanly**
+
+The cherry-pick should append a `#[cfg(test)] mod mime_scrub_tests { … }` block to the end of the file with three tests:
+- `scrub_smuggling_caps_dropped_names_at_eight`
+- `detect_smuggling_does_not_revisit_processed_headers` (kills `+ with -` on `idx = end_idx + 1`)
+- `detect_smuggling_skips_logical_end_idx_after_later_header`
+
+Run: `rg -n '^mod mime_scrub_tests' crates/rimap-content/src/parse/mime_scrub.rs`
+Expected: one match. If zero, append the block manually from `git show 974508b -- crates/rimap-content/src/parse/mime_scrub.rs`.
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+git add crates/rimap-content/src/parse/mime_scrub.rs
+git cherry-pick --continue
+```
+The `--continue` reuses the original message; preserve the `(cherry picked from commit 974508b…)` line and add a one-line note above it: `Note: dropped the detect_smuggling_spans `+ 1` annotation — main has `+ 2` after PR #228; rationale doesn't hold.`
+
+- [ ] **Step 5: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib parse::mime_scrub::mime_scrub_tests`
+Expected: all PASS. Three new tests.
+
+- [ ] **Step 6: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative test count 1016; no warnings.
+
+---
+
+## Task 5: Re-extract `parse/{meta,attachments,mod}.rs` mutation-coverage tests (cherry-pick `655754a`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/meta.rs` (1 test).
+- Modify: `crates/rimap-content/src/parse/attachments.rs` (1 test).
+- Modify: `crates/rimap-content/src/parse/mod.rs` (3 tests).
+
+**Cherry-pick disposition:** mostly clean. `parse/mod.rs` is large (958 lines on main, 1021 on archive) and may have minor context drift in the docs-comment region above the test additions. `parse/meta.rs` and `parse/attachments.rs` are byte-identical to archive parents.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x 655754a`
+Expected: succeeds via fuzz. If conflicts on `parse/mod.rs`, keep `main`'s production-code text and the archive's test additions per the same rule as Task 3/4.
+
+- [ ] **Step 2: Run affected files' tests**
+
+Run: `cargo test -p rimap-content --lib parse::meta::tests parse::attachments::tests parse::tests`
+Expected: PASS. Five new tests above the baseline.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative test count 1021; no warnings.
+
+---
+
+## Task 6: Re-extract `html/style_parse.rs` mutation-coverage tests (cherry-pick `a6a49ee`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/html/style_parse.rs` (6 tests + 1 `// cargo-mutants: known-equivalent` annotation on `parse_translate_px` line 67).
+
+**Cherry-pick disposition:** clean — `a6a49ee^:style_parse.rs` is byte-identical to current `main`.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x a6a49ee`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib html::style_parse::tests`
+Expected: all PASS, including 6 new tests covering `parse_clip_rect`, `parse_translate_px`, and `to_zero_or_negative_or_too_small`.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1027; no warnings.
+
+---
+
+## Task 7: Re-extract `html/mismatch.rs` mutation-coverage tests (cherry-pick `eee5a11`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/html/mismatch.rs` (5 tests + 1 `// cargo-mutants: known-equivalent` annotation on `extract_registrable_domain`).
+
+**Cherry-pick disposition:** clean — `eee5a11^:mismatch.rs` is byte-identical to current `main`.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x eee5a11`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib html::mismatch::tests`
+Expected: all PASS, including 5 new tests covering `detect_mismatches` and `extract_registrable_domain`.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1032; no warnings.
+
+---
+
+## Task 8: Re-extract `html/{extract,mod}.rs` mutation-coverage tests (cherry-pick `7643c5d` with rename)
+
+**Files:**
+- Modify: `crates/rimap-content/src/html/extract.rs` (1 test).
+- Modify: `crates/rimap-content/src/html/mod.rs` (4 tests; 3 of them call `sanitize_html(...)` on archive — must be rewritten to `process(...)` on main).
+
+**Cherry-pick disposition:** **expect rename conflicts on `html/mod.rs`**. PR #232 (`mail-parser-panic-isolation`, merged on main as `1c394e6`) renamed `sanitize_html` to `process` and narrowed visibility from `pub` to `pub(crate)`. The archive's new tests use the old `sanitize_html(` symbol. Resolution: rewrite the test bodies to call `process(`.
+
+- [ ] **Step 1: Attempt cherry-pick with provenance**
+
+Run: `git cherry-pick -x 7643c5d`
+Expected: conflicts in `html/mod.rs` (the visibility/rename hunks at the top of the file confuse the patch's pre-context). `html/extract.rs` should apply cleanly.
+
+- [ ] **Step 2: Resolve conflicts in `html/mod.rs`**
+
+Open `crates/rimap-content/src/html/mod.rs`. The conflict markers will likely span the file header / `process` declaration. Resolution rule:
+- Keep `main`'s production code unchanged (`pub(crate) struct HtmlResult`, `pub(crate) fn process`, no `testutil` re-export comments).
+- Take the archive's added `mod tests` block content, but rewrite every occurrence of `sanitize_html(` in the new test bodies to `process(`.
+
+If easier, abort the cherry-pick and apply the test additions manually:
+```bash
+git cherry-pick --abort
+git show 7643c5d -- crates/rimap-content/src/html/extract.rs | git apply --3way
+git show 7643c5d -- crates/rimap-content/src/html/mod.rs | sed 's/sanitize_html(/process(/g' | git apply --3way --reject
+```
+Inspect any `*.rej` file and apply the surviving test additions by hand. The four new tests to add inside `mod tests` of `html/mod.rs` are:
+- `process_oversize_charset_label_returns_limit_exceeded`
+- `process_returns_html_warnings_for_dangerous_input`
+- `process_extracts_anchor_hrefs_for_lookalike_audit`
+- `process_passes_charset_through_to_decoder`
+
+(All four were named `sanitize_html_*` on archive — rename to `process_*` on main for consistency with PR #232's API and the existing `process_oversize_input_returns_limit_exceeded` test on main.)
+
+The one new test to add to `html/extract.rs` is `extract_text_with_visible_links_renders_anchor_text_then_url`.
+
+- [ ] **Step 3: Commit the merged result**
+
+```bash
+git add crates/rimap-content/src/html/extract.rs crates/rimap-content/src/html/mod.rs
+git cherry-pick --continue
+```
+The `--continue` reuses the original message; ensure the commit message ends with `(cherry picked from commit 7643c5d…)` and add a one-line note above that line: `rimap-content: rewrote sanitize_html → process call sites (renamed by #232).`
+
+- [ ] **Step 4: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib html::extract::tests html::tests`
+Expected: all PASS. The 5 new tests should appear in the count.
+
+- [ ] **Step 5: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1037; no warnings.
+
+---
+
+## Task 9: Re-extract `lookalike.rs` mutation-coverage tests (fresh-apply, drop stale parts of `4e56b11`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/lookalike.rs` (4 `// cargo-mutants: known-equivalent` annotations + 3 new tests).
+
+**Architecture note:** The archive commit `4e56b11` adds 6 annotations and 4 tests. Two of those don't apply on main:
+- The `scan_body_urls` `> with >=` annotation references the `is_char_boundary` walk that issue #224 deleted from `main` (the walk is now `crate::unicode::grapheme_cut`). Drop.
+- The `scan_body_urls_handles_multi_byte_char_at_scan_boundary` test already exists on `main` from #224 (lines 535–555). Drop.
+
+The other 4 annotations and 3 tests still apply unchanged. Fresh-apply rather than cherry-pick to avoid resolving conflicts on the deleted boundary-walk lines.
+
+- [ ] **Step 1: Add the `label_mixes_scripts` annotation**
+
+In `crates/rimap-content/src/lookalike.rs`, locate `fn label_mixes_scripts` (~line 100). Insert the following annotation immediately above the line `if c.is_ascii_digit() || c == '-' || c == '_' {` (currently line 103):
+
+```rust
+        // cargo-mutants: known-equivalent — `||` vs `&&` on either of the
+        // two `||` operators produces the same observable behaviour.
+        // Each char that the original `continue`s past — ASCII digits,
+        // `-`, `_` — has `Script::Common`, which the match below treats
+        // as a no-op (Common/Inherited/Unknown are not inserted into the
+        // `scripts` set). Whether the loop short-circuits or runs
+        // through, the set membership is unchanged.
+```
+
+- [ ] **Step 2: Add the two `extract_domain_from_address` annotations**
+
+Locate `fn extract_domain_from_address` (~line 205). Insert above the line `let inner = if let (Some(lt), Some(gt)) = (...)` (currently line 207):
+
+```rust
+    // cargo-mutants: known-equivalent — `< with <=` on `lt < gt` is
+    // observably identical: `lt == gt` is unreachable when both `rfind`
+    // results are `Some`, since `<` and `>` are different characters
+    // and a single byte cannot be both. Distinct positions exercise
+    // the same arm under either operator.
+```
+
+Insert above the line `&trimmed[lt + 1..gt]` (currently line 210):
+
+```rust
+        // cargo-mutants: known-equivalent — `+ with *` on `lt + 1` is
+        // observably identical for any reachable `lt`. `lt * 1 == lt`
+        // shifts the slice start by one byte to include the `<`
+        // delimiter; `rsplit_once('@')` then yields the same `(local,
+        // domain)` split because the leading `<` lands in the discarded
+        // local part, not the domain on the right of `@`.
+```
+
+- [ ] **Step 3: Add the `extract_domain_from_url` annotation**
+
+Locate `fn extract_domain_from_url` (~line 245). Insert above the line `if host.is_empty() || !host.contains('.') {` (the branch that early-returns `None`):
+
+```rust
+    // cargo-mutants: known-equivalent — `||` vs `&&` here is observably
+    // identical: `host.is_empty()` implies `!host.contains('.')`, so
+    // the only case the operators differ on is `is_empty=false &&
+    // !contains('.')=true` (a non-empty single-label host). Both
+    // branches hand control to `Some(host.to_string())` for `||` or
+    // skip the early return for `&&`; either way, single-label hosts
+    // are filtered downstream by `classify_domain` (which requires a
+    // registrable PSL match).
+```
+
+- [ ] **Step 4: Add three new tests inside `mod tests`**
+
+Locate the closing `}` of `mod tests` (currently line 556). Insert these three test functions immediately before it (preserving the existing `scan_body_urls_handles_multi_byte_char_at_scan_boundary` test that already lives at lines 535–555 — do NOT duplicate it):
+
+```rust
+    #[test]
+    fn audit_scans_url_at_byte_offset_2000() {
+        // Kills `* with +` on `MAX_LINKIFY_SCAN_BYTES = 64 * 1024`. The
+        // mutant flips the constant to 64 + 1024 = 1088, well below
+        // 64 KiB. A mixed-script URL placed at byte offset ~2000
+        // round-trips a warning under the original cap and is silently
+        // dropped under the mutant.
+        let prefix = "x".repeat(2000);
+        let body = format!("{prefix}https://p\u{0430}ypal.com/account");
+        let warnings = run_audit(&empty_meta(), &body, &[]);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w.code, WarningCode::LookalikeMixedScript)),
+            "expected a mixed-script warning for URL at byte ~2000, got {warnings:?}",
+        );
+    }
+
+    #[test]
+    fn extract_domain_from_address_strips_angle_brackets_at_position_zero() {
+        // Kills `+ with -` on `&trimmed[lt + 1..gt]` in
+        // extract_domain_from_address. With `-`, an input whose `<`
+        // sits at position 0 (e.g. "<a@b.com>") evaluates `lt - 1`
+        // and underflows usize → panics on slicing.
+        let result = super::extract_domain_from_address("<a@b.com>");
+        assert_eq!(result, Some("b.com".to_string()));
+    }
+
+    #[test]
+    fn extract_domain_from_address_handles_quoted_brackets() {
+        // Kills `< with ==` and `< with >` on the `lt < gt` guard.
+        // Original: "Name <a@b.com>" → inner = "a@b.com" → domain "b.com".
+        // Mut `==`: 5 == 13 false → inner = trimmed → domain "b.com>".
+        // Mut `>`:  5 > 13 false → same as `==`.
+        // The original-vs-mutated outputs differ on the trailing `>`.
+        let result = super::extract_domain_from_address("Name <a@b.com>");
+        assert_eq!(result, Some("b.com".to_string()));
+    }
+```
+
+- [ ] **Step 5: Run the affected file's tests**
+
+Run: `cargo test -p rimap-content --lib lookalike::tests`
+Expected: all PASS, including the three new tests. Total tests in `lookalike::tests` rises by 3.
+
+- [ ] **Step 6: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1040; no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-content/src/lookalike.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-content): close mutation gaps in lookalike.rs
+
+Adds 3 tests + 4 known-equivalent annotations for cargo-mutants
+survivors uncovered by the 2026-04-30 baseline refresh on
+lookalike.rs. Re-extract of archive commit 4e56b11 (PR #196), with
+two now-stale items dropped:
+
+- The `scan_body_urls` `> with >=` annotation referenced the
+  `is_char_boundary` walk that issue #224 (re-extracted via PR
+  #233) replaced with `crate::unicode::grapheme_cut`. The new code
+  has no equivalent surface for that mutant.
+- The `scan_body_urls_handles_multi_byte_char_at_scan_boundary`
+  regression test already exists on main from issue #224.
+
+Tests:
+- audit_scans_url_at_byte_offset_2000 kills * with + on
+  MAX_LINKIFY_SCAN_BYTES = 64 * 1024.
+- extract_domain_from_address_strips_angle_brackets_at_position_zero
+  kills + with - on `lt + 1` (panics with usize underflow when lt = 0).
+- extract_domain_from_address_handles_quoted_brackets kills < with ==
+  and < with > on the lt < gt guard.
+
+Annotations document the four remaining mathematically-equivalent
+mutations on label_mixes_scripts, extract_domain_from_address, and
+extract_domain_from_url.
+
+Refs: #225
+Refs: #192 (original work, PR #196 on archive/daemon-experiment)
+(re-extracted partial of commit 4e56b11)
+EOF
+)"
+```
+
+---
+
+## Task 10: Re-extract `threading.rs`, `unicode.rs`, `lib.rs`, `raw_parts.rs` mutation-coverage tests (cherry-pick `c147d78`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/threading.rs` (5 tests).
+- Modify: `crates/rimap-content/src/unicode.rs` (1 test: `filter_codepoints_strips_unicode_tag`).
+- Modify: `crates/rimap-content/src/raw_parts.rs` (3 `// cargo-mutants: known-equivalent` annotations on `walk` depth/recursion).
+- Modify: `crates/rimap-content/src/lib.rs` (1 test: `extract_returns_message_id_when_header_present`).
+
+**Cherry-pick disposition:** **expect minor context drift on `unicode.rs`**. Issue #224 (PR #233 on main) added `truncate_keeps_full_multibyte_cluster_when_exactly_fits` and `truncate_in_place_matches_owned_variant` tests inside `mod tests`, between archive's pre-context and the `filter_codepoints_strips_unicode_tag` insertion point. The cherry-pick should still fuzz onto the end of `mod tests` because the archive's hunk anchors on the closing `}` of `sanitize_multilingual_clean`, which still exists on main. `threading.rs`, `raw_parts.rs`, and `lib.rs` should apply cleanly.
+
+- [ ] **Step 1: Attempt cherry-pick with provenance**
+
+Run: `git cherry-pick -x c147d78`
+Expected:
+- Likely: succeeds with fuzz on `unicode.rs`.
+- If conflict on `unicode.rs`: the test addition is pure (single new test). Resolve by appending the new test inside `mod tests` (after `sanitize_multilingual_clean`) and removing conflict markers.
+
+- [ ] **Step 2: Resolve conflicts (if any)**
+
+If `unicode.rs` conflicts, open it. The new test to add is:
+```rust
+    #[test]
+    fn filter_codepoints_strips_unicode_tag() {
+        // Kills `is_unicode_tag -> bool with false`. With `false`, a
+        // Unicode Tag char (U+E0001 LANGUAGE TAG) bypasses the
+        // zero-width-class filter and gets pushed into the output.
+        // Original: stripped via the same arm as ZERO_WIDTH chars,
+        // counted in `zero_width_stripped`.
+        let input = "ab\u{E0001}cd";
+        let result = filter_codepoints(input);
+        assert_eq!(
+            result.text, "abcd",
+            "Unicode Tag char must be stripped from output",
+        );
+        assert_eq!(
+            result.zero_width_stripped, 1,
+            "Unicode Tag char must be counted in zero_width_stripped",
+        );
+    }
+```
+Place it after `sanitize_multilingual_clean` (last test in `mod tests` on main, around line 492). Then `git add` and `git cherry-pick --continue`.
+
+- [ ] **Step 3: Run affected files' tests**
+
+Run: `cargo test -p rimap-content --lib threading::tests unicode::tests raw_parts::tests tests::extract_returns_message_id_when_header_present`
+Expected: all PASS. Seven new tests above the previous task's count.
+
+- [ ] **Step 4: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --lib --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1047; no warnings.
+
+---
+
+## Task 11: Re-create `mutation-baseline.md` for `rimap-content` (cherry-pick `a5cdab3` with edits)
+
+**Files:**
+- Create: `docs/superpowers/specs/test-strategy/mutation-baseline.md` (was deleted in the daemon rollback; archive `a5cdab3` re-creates it with the rimap-content non-`bin/` table).
+
+**Cherry-pick disposition:** **expect "new file" treatment**. The cherry-pick will create the file fresh; no conflicts on the file itself, but two table rows must be deleted and one rationale rewritten before commit.
+
+- [ ] **Step 1: Cherry-pick the baseline-creation commit (do not commit yet)**
+
+Run: `git cherry-pick -n -x a5cdab3`
+Expected: file is created, no conflicts. Working tree shows `docs/superpowers/specs/test-strategy/mutation-baseline.md` as a new staged file.
+
+- [ ] **Step 2: Drop the two stale `lookalike.rs` rows**
+
+Open `docs/superpowers/specs/test-strategy/mutation-baseline.md`. Delete the two table rows whose `File:line` is `lookalike.rs:195` and `lookalike.rs:205`. Both reference the `is_char_boundary` walk in `scan_body_urls` that issue #224 removed; the mutation surface no longer exists.
+
+The remaining `lookalike.rs` rows (`110` × 2, `237`, `245`, `285`) still apply unchanged.
+
+- [ ] **Step 3: Drop the stale `parse/mime_scrub.rs:105` row and renumber the other two**
+
+Find the three rows whose `File:line` starts with `parse/mime_scrub.rs:`:
+- `:105` (`replace + with * in detect_smuggling_spans`) — **delete this row entirely**. Task 4 dropped the corresponding in-source annotation because main has `+ 2` (post-PR #228), and the archive rationale documents the `+ 1` form. If a real survivor reappears here under main's `+ 2` math, Task 19 will surface it and a new row with rigorous rationale gets added then.
+- `:149` (`replace < with <= in locate_encoded_word_end`) — **renumber to `:124`**, the actual annotation site on main. Update both `File:line` (`:149` → `:124`) and `Annotation site` (`:143` → `:123`) cells. The rationale is unchanged.
+- `:213` (`replace < with > in split_header_lines`) — **renumber to `:174`**, the actual annotation site on main. Update both `File:line` (`:213` → `:174`) and `Annotation site` (`:206` → `:173`) cells. The rationale is unchanged.
+
+(Verify with `rg -n 'cargo-mutants: known-equivalent' crates/rimap-content/src/parse/mime_scrub.rs`. The two annotations should sit one line above the `if start_offset < first.len()` and `if line_start < headers.len()` predicates respectively.)
+
+- [ ] **Step 4: Verify the file links resolve**
+
+Run: `rg -n '\[`2026-04-30-test-strategy-improvements-design.md`\]' docs/superpowers/specs/test-strategy/mutation-baseline.md`
+The link target is `../2026-04-30-test-strategy-improvements-design.md`. Run: `ls docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md`
+- If the file exists: nothing to do.
+- If the file does NOT exist (it was deleted in the daemon rollback): replace the link target inside `mutation-baseline.md` with the GitHub permalink to the spec on `archive/daemon-experiment`:
+  `[archive: 2026-04-30-test-strategy-improvements-design.md](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md)`
+
+The follow-up plan link inside the file (`[../../plans/2026-04-30-rimap-content-mutation-cleanup-followup.md]`) refers to the original PR #195 plan; that plan is intentionally not re-extracted. Replace the link target with the GitHub permalink under `archive/daemon-experiment`:
+  `[archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md)` and add a parenthetical note `(superseded by docs/superpowers/plans/2026-05-03-issue-225-rimap-content-mutation-waves-rextract.md)`.
+
+- [ ] **Step 5: Verify the in-source annotations referenced by the table all exist**
+
+Run: `rg -n 'cargo-mutants: known-equivalent' crates/rimap-content/src/ | wc -l`
+Expected: 11 annotations after Tasks 1–10 — `html/style_parse.rs` (1, Task 6), `html/mismatch.rs` (1, Task 7), `lookalike.rs` (4, Task 9), `parse/mime_scrub.rs` (2, Task 4 — `:124` and `:174`; the `+ 1` annotation was deliberately dropped), `raw_parts.rs` (3, Task 10), and zero in `unicode.rs`/`threading.rs`/`lib.rs`. If the count is lower, an earlier task missed an annotation — run `git diff main -- crates/rimap-content/src` and reconcile. (Tasks 12–17 will add 4 more in `bin/epvme_runner.rs` for a final total of 15.)
+
+- [ ] **Step 6: Stage and commit**
+
+```bash
+git add docs/superpowers/specs/test-strategy/mutation-baseline.md
+git cherry-pick --continue
+```
+The `--continue` will reuse the original commit message; verify the `(cherry picked from commit a5cdab3…)` line is preserved. Add a one-line note above that line in the editor:
+`Note: dropped two now-stale lookalike.rs rows (the is_char_boundary walk was removed by #224); rewrote mime_scrub.rs:105 rationale from "+ 1" to "+ 2" to match main's post-#228 code.`
+
+- [ ] **Step 7: Sanity-check the commit**
+
+Run: `git log -1 --stat`
+Expected: one file changed (`mutation-baseline.md`), ~78 lines added (a few less than archive's 79 owing to the two dropped rows).
+
+---
+
+## Task 12: Re-extract `epvme_runner` `parse_args` mutation-coverage tests (cherry-pick `cd2c50e`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/bin/epvme_runner.rs` (3 lines added: 1 `// cargo-mutants: known-equivalent` annotation on `usage()`).
+- Modify: `crates/rimap-content/tests/epvme_integration.rs` (3 integration tests).
+
+**Cherry-pick disposition:** clean — `cd2c50e^:epvme_runner.rs` and `cd2c50e^:epvme_integration.rs` are byte-identical to current `main`.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x cd2c50e`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cargo test -p rimap-content --test epvme_integration`
+Expected: all PASS, including 3 new tests:
+- `help_flag_exits_zero_kills_mutant_delete_help_arm`
+- `short_help_flag_exits_zero_kills_mutant_delete_help_arm`
+- `unknown_flag_exits_nonzero_with_message_kills_mutant_flag_guard`
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1050; no warnings.
+
+---
+
+## Task 13: Re-extract `epvme_runner` dataset-loop mutation-coverage tests (cherry-pick `bf83314`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/bin/epvme_runner.rs` (5 unit tests added inside `mod tests`).
+
+**Cherry-pick disposition:** clean — `bf83314^:epvme_runner.rs` is byte-identical to the post-Task-12 file.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x bf83314`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cargo test -p rimap-content --bin epvme_runner`
+Expected: all PASS, including 5 new unit tests covering `panic_message`, `unknown_warning_code_label`, and a `run_dataset` panic-recording assertion that adds an extra check to an existing test.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1055; no warnings.
+
+---
+
+## Task 14: Re-extract `epvme_runner` `print_summary` mutation annotations (cherry-pick `62589f4`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/bin/epvme_runner.rs` (12 lines added: 3 `// cargo-mutants: known-equivalent` annotations on `print_summary`).
+
+**Cherry-pick disposition:** clean — only annotation comments are added; no test changes.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x 62589f4`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Verify the annotations landed**
+
+Run: `rg -n 'cargo-mutants: known-equivalent.*Parse error kinds|Warning counts|Recorded failures' crates/rimap-content/src/bin/epvme_runner.rs`
+Expected: three matches, one per annotation.
+
+- [ ] **Step 3: Run tests and lint (no functional change)**
+
+Run: `cargo test -p rimap-content --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: same test count as Task 13 (1055; no new tests); no warnings.
+
+---
+
+## Task 15: Re-extract `epvme_runner` `write_json_report` empty-parent test (cherry-pick `c52e3ed`)
+
+**Files:**
+- Modify: `crates/rimap-content/tests/epvme_integration.rs` (1 integration test).
+
+**Cherry-pick disposition:** clean — `c52e3ed^:epvme_integration.rs` is byte-identical to the post-Task-12 file.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x c52e3ed`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `cargo test -p rimap-content --test epvme_integration json_out_creates_missing_parent_dir_kills_mutant_delete_empty_parent_guard`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1056; no warnings.
+
+---
+
+## Task 16: Re-extract `epvme_runner` `read_failure_count` test (cherry-pick `d358f5e`)
+
+**Files:**
+- Modify: `crates/rimap-content/src/bin/epvme_runner.rs` (1 unit test added inside `mod tests`).
+
+**Cherry-pick disposition:** clean — `d358f5e^:epvme_runner.rs` is byte-identical to the post-Task-13/14 file.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x d358f5e`
+Expected: succeeds with no conflicts.
+
+- [ ] **Step 2: Run the affected test**
+
+Run: `cargo test -p rimap-content --bin epvme_runner run_dataset_records_read_failures`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full crate and lint**
+
+Run: `cargo test -p rimap-content --quiet 2>&1 | tail -5 && cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`
+Expected: cumulative count 1057; no warnings.
+
+---
+
+## Task 17: Finalise `mutation-baseline.md` with the `bin/epvme_runner.rs` subsection (cherry-pick `2e69b7d`)
+
+**Files:**
+- Modify: `docs/superpowers/specs/test-strategy/mutation-baseline.md` (+22 lines: `### bin/epvme_runner.rs` subsection appended; the rimap-content header text is also updated to reflect the post-#193 survivor counts).
+
+**Cherry-pick disposition:** **expect minor conflict on the rimap-content header counts**. Archive `2e69b7d`'s patch updates the rimap-content section's "Surviving mutants" count from 15 (pre-#193) to 15 (unchanged for non-`bin/`) and rewrites the run-summary paragraph to mention the now-resolved bin survivors. Resolution: take archive's text verbatim — main's post-Task-11 `mutation-baseline.md` is already the pre-#193 version, so all archive's edits should apply.
+
+- [ ] **Step 1: Cherry-pick with provenance**
+
+Run: `git cherry-pick -x 2e69b7d`
+Expected: succeeds. If a conflict surfaces (most likely on the run-summary paragraph in the rimap-content section), accept archive's text verbatim.
+
+- [ ] **Step 2: Verify the bin subsection landed**
+
+Run: `rg -n '^### `bin/epvme_runner.rs`' docs/superpowers/specs/test-strategy/mutation-baseline.md`
+Expected: one match. The subsection should list 5 mutations (epvme_runner.rs:189 × 2, :381, :392, :403) all annotated as known-equivalent.
+
+- [ ] **Step 3: Verify the in-source annotations match the table**
+
+Run: `rg -nC 1 'cargo-mutants: known-equivalent' crates/rimap-content/src/bin/epvme_runner.rs | head -40`
+Expected: four annotation comments — one on `usage()` (Task 12) and three on `print_summary` (Task 14). The bin baseline table should reference all four annotation sites correctly. If line numbers differ from the `:189`, `:381`, `:392`, `:403` values, update the table to match.
+
+---
+
+## Task 18: Workspace-wide verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm the cumulative test count**
+
+Run: `cargo test --workspace --quiet 2>&1 | grep -E "^test result:" | awk '{p+=$4; f+=$6; i+=$8} END {print "passed=" p " failed=" f " ignored=" i}'`
+Expected: `passed=1057 failed=0 ignored=0`. If the count differs by ±1, locate the missing/extra test via `git diff main -- crates/rimap-content` and reconcile.
+
+- [ ] **Step 2: Confirm all in-source annotations are present**
+
+Run: `rg -n 'cargo-mutants: known-equivalent' crates/rimap-content/src/ | wc -l`
+Expected: 15 (1 in `html/style_parse.rs`, 1 in `html/mismatch.rs`, 4 in `lookalike.rs`, 2 in `parse/mime_scrub.rs` — `:124` and `:174`; the `+ 1` annotation on `:86` was deliberately dropped in Task 4, 3 in `raw_parts.rs`, 4 in `bin/epvme_runner.rs` — 1 from Task 12 + 3 from Task 14, 0 in `unicode.rs`, 0 in `threading.rs`, 0 in `lib.rs`). If the count differs, an earlier task dropped an annotation — `rg -nC 1 'cargo-mutants: known-equivalent' crates/rimap-content/src/` to inspect.
+
+- [ ] **Step 3: Workspace-wide clippy**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1 | tail -5`
+Expected: no warnings.
+
+- [ ] **Step 4: Workspace-wide format check**
+
+Run: `cargo fmt --all -- --check`
+Expected: clean. If formatting drifted on any cherry-pick, run `cargo fmt --all` and `git commit --amend --no-edit` (or, if the formatting fix touches multiple per-task commits, do a fresh `style: cargo fmt --all` commit).
+
+- [ ] **Step 5: Verify the mutation-baseline.md links and table coverage**
+
+Run: `rg -nF '| `' docs/superpowers/specs/test-strategy/mutation-baseline.md | wc -l`
+Expected: 17 table-data rows total — 12 in the rimap-content section (15 archive rows minus 2 dropped `lookalike.rs` rows minus 1 dropped `mime_scrub.rs:105` row, with the surviving two `mime_scrub.rs` rows renumbered to `:124` and `:174`) plus 5 in the `bin/epvme_runner.rs` subsection. Plus the table-header rows (`| File:line | …`) and separator rows (`|---|---|---|---|`) — adjust the expected number if the rg pattern catches those too.
+
+---
+
+## Task 19: cargo-mutants verification
+
+**Files:** none modified.
+
+**Why this task is in the plan:** The acceptance criterion `cargo mutants --jobs 2 survival rate matches the baseline recorded in the spec` requires a measured run. The expected survivor count after this plan is 15 in `rimap-content` non-`bin/` (all known-equivalent, table-documented) and 5 in `bin/epvme_runner.rs` (also all known-equivalent). `cargo-mutants` is slow (the archive baseline took ~30 minutes per crate); plan for this in a separate window or run overnight.
+
+**Important: per `~/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/feedback_cargo_mutants_jobs_cap.md`, always pass `--jobs 2`. Default parallelism has historically used 300 GB of RAM and frozen the host on this machine.**
+
+- [ ] **Step 1: Run `cargo-mutants` for `rimap-content` with the host's job cap**
+
+Run: `just mutants-crate rimap-content` (which expands to `cargo mutants --package rimap-content --jobs 2`).
+If `just` is not available: `cargo mutants --package rimap-content --jobs 2`.
+Expected: ~30 minutes wall clock. Final summary: 15 missed mutations (all in non-`bin/` code), 5 missed in `bin/epvme_runner.rs`. Total non-timeout missed: 20. Each missed mutation should match a row in `mutation-baseline.md`.
+
+- [ ] **Step 2: Reconcile any unexpected survivors**
+
+If a survivor surfaces that is **not** in the baseline table:
+- Determine whether it is a true test gap (write a test that kills it; commit; update the baseline if the mutation re-classifies as known-equivalent) or a known-equivalent (annotate the mutation site and add a row to the baseline with rigorous rationale).
+- A mutation that landed via this plan but was not in the archive baseline is a bug — investigate whether the cherry-pick ordering inadvertently re-introduced a code path the archive had killed.
+
+If a baseline row has no corresponding survivor (i.e., the mutation got caught by a new test):
+- Drop the row from the baseline. The tests are what the codebase needs; an over-cautious annotation is dead weight.
+
+- [ ] **Step 3: Update `mutation-baseline.md` if reconciliation surfaced changes**
+
+If Step 2 surfaced any reconciliation: amend the Task 11/17 commits with `git commit --fixup` and rebase, OR add a new commit `docs(test-strategy): reconcile mutation-baseline with measured rimap-content run`. The latter is preferred to keep the cherry-pick history intact.
+
+- [ ] **Step 4: Capture the run output for the PR description**
+
+Save the final summary line (`Found N mutants`, `M missed`, etc.) — paste it into the PR description in Task 20.
+
+(Optional) Step 5: If `cargo-mutants` is not available locally, defer this task to CI. The PR's required-checks include a mutation-baseline-comparison job (added in Phase-2 issue #226 / #227 if those land first); if not, document the deferral in the PR description.
+
+---
+
+## Task 20: Open PR
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin phase2/issue-225-rimap-content-mutation-waves-rextract`
+Expected: branch pushes cleanly.
+
+- [ ] **Step 2: Open the PR with `gh pr create`**
+
+```bash
+gh pr create --title "Phase-2: Re-extract rimap-content mutation-cleanup waves (#225)" --body "$(cat <<'EOF'
+## Summary
+
+Re-extracts the test-only mutation-cleanup waves from archived PRs #196 and #198 (issues #192 and #193), driving the `rimap-content` cargo-mutants survivor count back to the archive baseline (15 non-`bin/`, 5 in `bin/epvme_runner.rs`, all annotated as `known-equivalent`).
+
+- 14 commits cherry-picked with provenance from `archive/daemon-experiment` (`-x` lines preserved). One commit (`4e56b11`) was fresh-applied to drop a stale `scan_body_urls` annotation and a duplicate test that issue #224 had already brought back. One commit (`300556c`) was skipped entirely because the annotation site no longer exists. One commit (`a5cdab3`) had two `lookalike.rs` baseline rows surgically removed and one `mime_scrub.rs` rationale rewritten to match main's post-#228 `+ 2` form.
+- 66 net-new tests (workspace count 991 → 1057). Six new in-source `cargo-mutants: known-equivalent` annotation comments. Zero production-code logic changes. Zero new dependencies.
+- `mutation-baseline.md` re-created with a corrected `rimap-content` table (13 rows) and a new `bin/epvme_runner.rs` subsection (5 rows).
+
+## Test plan
+
+- [ ] `cargo test --workspace` passes (1057 / 0 failed / 0 ignored)
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] `cargo fmt --all -- --check` clean
+- [ ] `just mutants-crate rimap-content` (or `cargo mutants --package rimap-content --jobs 2`) survival rate matches the baseline: 15 non-`bin/` survivors (all annotated), 5 `bin/epvme_runner.rs` survivors (all annotated), 0 unannotated misses
+- [ ] All 8 required CI checks green
+
+## Acceptance criteria (issue #225)
+
+- [x] `mutation-baseline.md` in `docs/superpowers/specs/test-strategy/` present and updated
+- [x] All test additions from PRs #196 and #198 in place
+- [ ] `cargo mutants --jobs 2` survival rate matches the baseline recorded in the spec (verified in Task 19 above)
+- [ ] CI green on all 8 required checks
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks --watch`
+Expected: all 8 required checks pass. If any fail, address before marking the PR ready for merge.
+
+---
+
+## Self-review checklist (run before opening the PR)
+
+These verify the plan against issue #225's acceptance criteria.
+
+- [ ] **Spec coverage:**
+  - "All test additions from PRs #196 and #198 in place" → Tasks 1–10 (PR #196) and Tasks 12–16 (PR #198). Confirmed by per-task test counts and final 1057-test workspace count.
+  - "`mutation-baseline.md` in `docs/superpowers/specs/test-strategy/` present and updated" → Tasks 11 and 17.
+  - "`cargo mutants --jobs 2` survival rate matches the baseline" → Task 19.
+  - "CI green on all 8 required checks" → Task 20.
+- [ ] **No re-introduction of removed code:** the `scan_body_urls` `is_char_boundary` walk is NOT re-introduced (Task 9 explicitly skips that annotation; Task 11 explicitly drops the two corresponding baseline rows; the `300556c` commit is explicitly skipped).
+- [ ] **API rename respected:** `html::sanitize_html` is not re-introduced (Task 8 renames the 3 call sites in archive's new tests to `process`).
+- [ ] **No phantom tests:** the test-count math (991 + 66 = 1057) matches per-task additions.
+- [ ] **Baseline table consistency:** every row in `mutation-baseline.md` references an annotation site that exists in the source tree (verify with `rg 'cargo-mutants: known-equivalent'`).
+- [ ] **Annotation count math:** 15 in-source annotations expected at the end of Task 17; verify with `rg -c 'cargo-mutants: known-equivalent' crates/rimap-content/src/`.
+- [ ] **Cargo lockfile not touched:** none of these commits should touch `Cargo.lock`. If a cherry-pick brought in a stray lockfile change, drop it before committing.

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -20,19 +20,22 @@ adding a test, not annotated.
 **Last refresh:** 2026-05-01.
 **Surviving mutants in non-`bin/` code:** 15.
 
-Run summary (646 mutants total): 540 caught, 31 missed (15 outside
-`src/bin/`, 16 inside), 11 timeout, 64 unviable. Every survivor
+Run summary (644 mutants total): 550 caught, 20 missed (15 outside
+`src/bin/`, 5 inside), 10 timeout, 64 unviable. Every survivor
 outside `src/bin/` is a mathematically equivalent mutation
-documented in the table below; the 16 `src/bin/epvme_runner.rs`
-survivors are out of scope for this work.
+documented in the table below; the 5 `src/bin/epvme_runner.rs`
+survivors are documented in the `### bin/epvme_runner.rs` subsection
+below (issue #193 took the original 16 to 5 by killing 11 with tests
+and annotating the rest).
 
 The follow-up plan
-[`archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md) (superseded by docs/superpowers/plans/2026-05-03-issue-225-rimap-content-mutation-waves-rextract.md)
-drives this list to zero. The table below records every survivor whose
-mutation is mathematically equivalent to the original code — those are kept
-behind a `// cargo-mutants: known-equivalent — <rationale>` comment at the
-annotation site. Survivors that are real test-suite gaps are killed by
-adding a test, not annotated, and so do not appear here.
+[`archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md)
+drove the non-`bin/` list to zero. The table below records every
+survivor whose mutation is mathematically equivalent to the original
+code — those are kept behind a `// cargo-mutants: known-equivalent —
+<rationale>` comment at the annotation site. Survivors that are real
+test-suite gaps are killed by adding a test, not annotated, and so do
+not appear here.
 
 | File:line | Mutation | Reason kept | Annotation site |
 |---|---|---|---|
@@ -51,24 +54,23 @@ adding a test, not annotated, and so do not appear here.
 
 ### `bin/epvme_runner.rs`
 
-**Last refresh:** YYYY-MM-DD (replace with today's date when committing Task 9).
-**Surviving mutants:** N (replace with the line count of
-`/tmp/mutation-cleanup-193/bin-survivors.txt` from Task 1 — every
-surviving mutant either has a row in the table below (annotated as
-`known-equivalent`) or has been killed by a test added in Tasks 4–8).
+**Last refresh:** 2026-05-01.
+**Surviving mutants:** 5 (all annotated as `known-equivalent`; 11 of
+the 16 mutations recorded in the 2026-04-30 baseline were killed by
+tests added under issue #193).
 
 Issue [#193](https://github.com/randomparity/rusty-imap-mcp/issues/193)
-drives this list to zero. Triage bar: a mutation that affects the
-dataset's pass/fail signal (counts in `RunSummary`, `is_success`, the
-process exit code) or the JSON summary schema is killed by adding a
-test; everything else (stdout phrasing, log-style summary lines,
-diagnostic-only counter ordering) is annotated as `known-equivalent`
-with a one-line rationale.
+drove this list to its current state. Triage bar: a mutation that
+affects the dataset's pass/fail signal (counts in `RunSummary`,
+`is_success`, the process exit code) or the JSON summary schema was
+killed by adding a test; everything else (stdout phrasing, log-style
+summary lines, diagnostic-only counter ordering) is annotated as
+`known-equivalent` with a one-line rationale.
 
 | File:line | Mutation | Reason kept | Annotation site |
 |---|---|---|---|
-| `bin/epvme_runner.rs:186` | `replace usage -> String with String::new()` | usage() output is consumed only as stderr text; no test or production caller asserts its content. Mutation leaves exit codes and JSON schema unchanged. | `bin/epvme_runner.rs:185` |
-| `bin/epvme_runner.rs:186` | `replace usage -> String with "xyzzy".into()` | Same rationale as the String::new mutation — stderr-only diagnostic text. | `bin/epvme_runner.rs:185` |
+| `bin/epvme_runner.rs:188` | `replace usage -> String with String::new()` | usage() output is consumed only as stderr text; no test or production caller asserts its content. Mutation leaves exit codes and JSON schema unchanged. | `bin/epvme_runner.rs:185` |
+| `bin/epvme_runner.rs:188` | `replace usage -> String with "xyzzy".into()` | Same rationale as the String::new mutation — stderr-only diagnostic text. | `bin/epvme_runner.rs:185` |
 | `bin/epvme_runner.rs:381` | `delete ! in print_summary` (`if !summary.parse_error_counts.is_empty()` guard) | Guard inversion would print "Parse error kinds:" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:377` |
 | `bin/epvme_runner.rs:392` | `delete ! in print_summary` (`if !summary.warning_counts.is_empty()` guard) | Guard inversion would print "Warning counts:" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:388` |
 | `bin/epvme_runner.rs:403` | `delete ! in print_summary` (`if !summary.recorded_failures.is_empty()` guard) | Guard inversion would print "Recorded failures (showing up to 50):" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:399` |

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -69,6 +69,9 @@ with a one-line rationale.
 |---|---|---|---|
 | `bin/epvme_runner.rs:186` | `replace usage -> String with String::new()` | usage() output is consumed only as stderr text; no test or production caller asserts its content. Mutation leaves exit codes and JSON schema unchanged. | `bin/epvme_runner.rs:185` |
 | `bin/epvme_runner.rs:186` | `replace usage -> String with "xyzzy".into()` | Same rationale as the String::new mutation — stderr-only diagnostic text. | `bin/epvme_runner.rs:185` |
+| `bin/epvme_runner.rs:381` | `delete ! in print_summary` (`if !summary.parse_error_counts.is_empty()` guard) | Guard inversion would print "Parse error kinds:" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:377` |
+| `bin/epvme_runner.rs:392` | `delete ! in print_summary` (`if !summary.warning_counts.is_empty()` guard) | Guard inversion would print "Warning counts:" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:388` |
+| `bin/epvme_runner.rs:403` | `delete ! in print_summary` (`if !summary.recorded_failures.is_empty()` guard) | Guard inversion would print "Recorded failures (showing up to 50):" header with zero rows; stdout phrasing only, JSON schema unaffected. | `bin/epvme_runner.rs:399` |
 
 The other four trust-boundary crates (`rimap-authz`, `rimap-audit`,
 `rimap-server`, `rimap-imap`) get their own sections here when Sprints

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -1,0 +1,57 @@
+# Mutation-baseline — Targeted-trust-boundary survivor inventory
+
+**Updated:** 2026-05-01
+**Tool:** `cargo-mutants` (run via `just mutants-crate <name>`)
+**Scope:** Five trust-boundary crates — `rimap-content`, `rimap-authz`,
+`rimap-audit`, `rimap-server`, `rimap-imap`. Other workspace crates are
+out of scope per spec
+[`archive: 2026-04-30-test-strategy-improvements-design.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md).
+
+A survivor is recorded here when it is *not* a true bug in the test suite —
+either because the mutation is mathematically equivalent to the original
+code, or because it falls in a code path the spec explicitly classifies as
+"plumbing, best-effort." Survivors that *are* test-suite gaps are killed by
+adding a test, not annotated.
+
+---
+
+## `rimap-content`
+
+**Last refresh:** 2026-05-01.
+**Surviving mutants in non-`bin/` code:** 15.
+
+Run summary (646 mutants total): 540 caught, 31 missed (15 outside
+`src/bin/`, 16 inside), 11 timeout, 64 unviable. Every survivor
+outside `src/bin/` is a mathematically equivalent mutation
+documented in the table below; the 16 `src/bin/epvme_runner.rs`
+survivors are out of scope for this work.
+
+The follow-up plan
+[`archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md) (superseded by docs/superpowers/plans/2026-05-03-issue-225-rimap-content-mutation-waves-rextract.md)
+drives this list to zero. The table below records every survivor whose
+mutation is mathematically equivalent to the original code — those are kept
+behind a `// cargo-mutants: known-equivalent — <rationale>` comment at the
+annotation site. Survivors that are real test-suite gaps are killed by
+adding a test, not annotated, and so do not appear here.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+| `parse/mime_scrub.rs:130` | `replace < with <= in locate_encoded_word_end` (`if start_offset < first.len()`) | At `start_offset == first.len()`, the empty `&first[start_offset..]` produces no `windows(2)` element, so the `let Some(rel)` guard short-circuits and the function falls through to the outer scan — identical to the `<` branch. | `parse/mime_scrub.rs:124` |
+| `parse/mime_scrub.rs:187` | `replace < with > in split_header_lines` (`if line_start < headers.len()`) | The inner loop's only exit invariant is `line_start == headers.len()` — the `None` branch of the `\n` search sets `line_end = headers.len()` and the subsequent push sets `line_start = line_end`. On exit, the predicate is false under both `<` and `>`; the trailing push is defensive dead code in current usage. | `parse/mime_scrub.rs:180` |
+| `html/style_parse.rs:74` | `replace < with <= in parse_translate_px` (`if px_val < current`) | The `<` and `<=` predicates differ only when `px_val == current`; in that case both arms set `min = Some(px_val)` to a value already equal to `current`, leaving the running minimum unchanged. Distinct values pick the same minimum under either operator. | `html/style_parse.rs:68` |
+| `html/mismatch.rs:51` | `replace || with && in extract_registrable_domain` (`if host.is_empty() || !host.contains('.')`) | The `||` and `&&` predicates differ only when `host.is_empty()=false && !host.contains('.')=true` — a non-empty single-label host. Both branches then route control through the idna+addr lookup, which returns `None` for any single-label host (no registrable domain exists above a TLD). The opposite case (`is_empty=true && !contains('.')=false`) is unreachable: an empty string contains no `.`. | `html/mismatch.rs:43` |
+| `lookalike.rs:110` | `replace || with && in label_mixes_scripts` (the first `||` between `is_ascii_digit()` and `c == '-'`) | Each char that the original `continue`s past — ASCII digits, `-`, `_` — has `Script::Common`, which the match below treats as a no-op. Whether the loop short-circuits via `continue` or runs through to the match, the `scripts` set membership is unchanged. | `lookalike.rs:103` |
+| `lookalike.rs:110` | `replace || with && in label_mixes_scripts` (the second `||` between `c == '-'` and `c == '_'`) | Same reasoning as the first `||` mutation: the chars that the guard short-circuits on all classify as `Script::Common`, ignored by the match arm. | `lookalike.rs:103` |
+| `lookalike.rs:220` | `replace < with <= in extract_domain_from_address` (`lt < gt`) | `lt == gt` is unreachable when both `rfind` results are `Some`: a single byte cannot be both `<` and `>`. Distinct positions exercise the same arm under either operator. | `lookalike.rs:214` |
+| `lookalike.rs:228` | `replace + with * in extract_domain_from_address` (`&trimmed[lt + 1..gt]`) | `lt * 1 == lt` shifts the slice start by one byte to include the `<` delimiter; `rsplit_once('@')` then yields the same `(local, domain)` split because the leading `<` lands in the discarded local part, not the domain on the right of `@`. | `lookalike.rs:222` |
+| `lookalike.rs:268` | `replace || with && in extract_domain_from_url` (`if host.is_empty() || !host.contains('.')`) | Same equivalence as `html/mismatch.rs:51`: the only difference between `||` and `&&` is on non-empty single-label hosts, which `classify_domain` filters out anyway because no registrable PSL match exists above a TLD. | `lookalike.rs:260` |
+| `raw_parts.rs:71` | `replace > with == in walk` (`if depth > MAX_MIME_DEPTH`) | `parse_message` already rejects messages whose MIME depth exceeds 8 (`MAX_MIME_DEPTH`) before any caller of `walk_attachment_parts` sees them. The 64-level defensive cap here therefore can never fire in production; `==` only differs from `>` at exactly `depth == 64`, which is unreachable. | `raw_parts.rs:62` |
+| `raw_parts.rs:71` | `replace > with >= in walk` (same site) | Same reasoning as the `==` mutation: `>=` differs from `>` only on the unreachable range `depth in [64, max-tree-depth]`, which is gated out upstream by `parse_message`'s 8-level depth limit. | `raw_parts.rs:62` |
+| `raw_parts.rs:96` | `replace + with * in walk` (`walk(msg, child_idx, &child_id, out, depth + 1)?`) | `depth * 1 == depth` keeps the recursion depth at 0 forever, but mail_parser-reachable trees are bounded by `parse_message`'s 8-level depth limit, so both `+ 1` and `* 1` walk to the same set of leaves before recursion bottoms out on `sub_parts() == None`. | `raw_parts.rs:89` |
+
+The `bin/epvme_runner.rs` survivors are out of scope — that crate is
+diagnostic tooling, not production. Re-evaluate post-B4.
+
+The other four trust-boundary crates (`rimap-authz`, `rimap-audit`,
+`rimap-server`, `rimap-imap`) get their own sections here when Sprints
+B2–B3 land.

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -49,8 +49,26 @@ adding a test, not annotated, and so do not appear here.
 | `raw_parts.rs:71` | `replace > with >= in walk` (same site) | Same reasoning as the `==` mutation: `>=` differs from `>` only on the unreachable range `depth in [64, max-tree-depth]`, which is gated out upstream by `parse_message`'s 8-level depth limit. | `raw_parts.rs:62` |
 | `raw_parts.rs:96` | `replace + with * in walk` (`walk(msg, child_idx, &child_id, out, depth + 1)?`) | `depth * 1 == depth` keeps the recursion depth at 0 forever, but mail_parser-reachable trees are bounded by `parse_message`'s 8-level depth limit, so both `+ 1` and `* 1` walk to the same set of leaves before recursion bottoms out on `sub_parts() == None`. | `raw_parts.rs:89` |
 
-The `bin/epvme_runner.rs` survivors are out of scope — that crate is
-diagnostic tooling, not production. Re-evaluate post-B4.
+### `bin/epvme_runner.rs`
+
+**Last refresh:** YYYY-MM-DD (replace with today's date when committing Task 9).
+**Surviving mutants:** N (replace with the line count of
+`/tmp/mutation-cleanup-193/bin-survivors.txt` from Task 1 — every
+surviving mutant either has a row in the table below (annotated as
+`known-equivalent`) or has been killed by a test added in Tasks 4–8).
+
+Issue [#193](https://github.com/randomparity/rusty-imap-mcp/issues/193)
+drives this list to zero. Triage bar: a mutation that affects the
+dataset's pass/fail signal (counts in `RunSummary`, `is_success`, the
+process exit code) or the JSON summary schema is killed by adding a
+test; everything else (stdout phrasing, log-style summary lines,
+diagnostic-only counter ordering) is annotated as `known-equivalent`
+with a one-line rationale.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+| `bin/epvme_runner.rs:186` | `replace usage -> String with String::new()` | usage() output is consumed only as stderr text; no test or production caller asserts its content. Mutation leaves exit codes and JSON schema unchanged. | `bin/epvme_runner.rs:185` |
+| `bin/epvme_runner.rs:186` | `replace usage -> String with "xyzzy".into()` | Same rationale as the String::new mutation — stderr-only diagnostic text. | `bin/epvme_runner.rs:185` |
 
 The other four trust-boundary crates (`rimap-authz`, `rimap-audit`,
 `rimap-server`, `rimap-imap`) get their own sections here when Sprints


### PR DESCRIPTION
## Summary

Re-extracts the test-only mutation-cleanup waves from archived PRs #196 (issue #192) and #198 (issue #193), driving the `rimap-content` cargo-mutants survivor count back to the archive baseline.

- 15 commits cherry-picked with provenance from `archive/daemon-experiment` (`-x` lines preserved). 1 commit (`4e56b11`) was fresh-applied to drop a stale `scan_body_urls` annotation and a duplicate test that issue #224 had already brought back. 1 commit (`300556c`) was skipped entirely (annotation site no longer exists post-#224). 1 commit (`a5cdab3`) had three baseline rows surgically removed (two stale `lookalike.rs` rows for the deleted `is_char_boundary` walk, one stale `mime_scrub.rs:105` row whose `+ 1` rationale doesn't apply to main's `+ 2` after PR #228).
- All annotation-site line numbers in the baseline table renumbered to match main (mime_scrub renumbered after PR #228; html/mismatch/style_parse and lookalike renumbered to match current source positions).
- 66 net-new tests (workspace count 991 → 1057). 14 in-source `// cargo-mutants: known-equivalent` annotation comments. Zero production-code logic changes. Zero new dependencies.
- `mutation-baseline.md` re-created with a corrected `rimap-content` table (12 rows) and a new `bin/epvme_runner.rs` subsection (5 rows). Broken doc-links replaced with archive permalinks.

## Test plan

- [x] `cargo test --workspace` passes (1057 / 0 failed / 0 ignored)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All 8 required CI checks pass (SonarQube, cargo-deny, check (macOS), clippy, rustfmt, test (MSRV 1.88.0), test (stable), zizmor self-check)
- [⚠️] `cargo mutants --package rimap-content --jobs 2` — partial run only; cargo-mutants 27.0.0 has a reproducible `sniff.rs is not a file` worker bug that prevents complete runs. See PR comment for partial-run reconciliation: 14/17 baseline rows confirmed, 0 false positives. 3 NEW survivors in post-archive code (#228/#232 surface) deferred to a follow-up issue.

## Acceptance criteria (issue #225)

- [x] `mutation-baseline.md` in `docs/superpowers/specs/test-strategy/` present and updated
- [x] All test additions from PRs #196 and #198 in place (66 tests; workspace 991 → 1057)
- [⚠️] `cargo mutants --jobs 2` survival rate matches the baseline — partially verified (14/17 baseline rows confirmed; cargo-mutants tool bug prevents complete run; 3 untested baseline rows are unchanged production code)
- [x] CI green on all 8 required checks

## Notable departures from a verbatim cherry-pick

1. **Skipped `300556c`** — annotated `-= with +=` on `scan_body_urls` boundary walk; that walk was deleted by issue #224, so the annotation has no surface.
2. **Fresh-applied `4e56b11`** — dropped the `scan_body_urls > with >=` annotation (deleted code path) and the duplicate `scan_body_urls_handles_multi_byte_char_at_scan_boundary` test (already on main from #224). Replaced `matches!(w.code, ...)` with `==` to match project style (CLAUDE.md no-`matches!` rule).
3. **`974508b` partial** — dropped the `+ 1` annotation on `detect_smuggling_spans` because main has `+ 2` after PR #228; the archive rationale doesn't apply.
4. **`7643c5d` with rename** — three test bodies use `process(...)` instead of `sanitize_html(...)`, and three test fns are renamed `sanitize_html_*` → `process_*` to match PR #232's API.
5. **`a5cdab3` and `2e69b7d` baseline edits** — three rows dropped, all surviving rows renumbered to match main's actual annotation sites and mutated-code lines.

## Recommended follow-up issues

- **cargo-mutants `sniff.rs` worker bug** — file an upstream cargo-mutants issue (the worker can't find the `parse/sniff.rs` file in its temp staging dir; reproducible across `--jobs 1` and `--jobs 2`). Until fixed, complete mutation runs against this project will require a workaround.
- **Phase-3 mutation cleanup of post-archive code** — three NEW survivors found in code added after the archive baseline (`testutil.rs:57`, `mime_scrub.rs:83`, `mime_scrub.rs:84`). These are out of scope for this re-extract but should be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)