### PR TITLE
tooling: dodge cargo-mutants 27.0.0 temp-tree bug with --in-place

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -6,7 +6,7 @@
 # key). The `just mutants` recipe wraps the correct invocation. See:
 #   - docs/security/cargo-mutants-runbook.md
 #   - https://github.com/randomparity/rusty-imap-mcp/issues/235
-#   - upstream sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>
+#   - upstream sourcefrog/cargo-mutants#611
 #
 # Keep this comment block until #235 is closed and `--in-place` is no
 # longer load-bearing. cargo-mutants reads this file from

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,20 +1,12 @@
-# cargo-mutants configuration.
+# cargo-mutants configuration. See docs/security/cargo-mutants-runbook.md.
 #
-# IMPORTANT: until upstream cargo-mutants ships a fix for the temp-tree
-# regression that strands worker copies missing source files mid-run,
-# `--in-place` must be passed at the CLI (it is not exposed as a config
-# key). The `just mutants` recipe wraps the correct invocation. See:
-#   - docs/security/cargo-mutants-runbook.md
+# `--in-place` must be passed at the CLI (it is not a config key) until
+# the macOS-only temp-tree bug is fixed upstream. The `just mutants`
+# recipe wraps the correct invocation.
 #   - https://github.com/randomparity/rusty-imap-mcp/issues/235
-#   - upstream sourcefrog/cargo-mutants#611
-#
-# Keep this comment block until #235 is closed and `--in-place` is no
-# longer load-bearing. cargo-mutants reads this file from
-# `.cargo/mutants.toml` at the workspace root by default.
+#   - https://github.com/sourcefrog/cargo-mutants/issues/611
 
-# Tests in this workspace exercise async runtimes and a few network
-# integration paths; the default 20s minimum is too aggressive for
-# mutants that push timeouts close to the wall-clock limit. 60s
-# matches the cadence baseline in docs/security/fuzzing-coverage.md.
+# Async runtimes and a few network-integration paths in this workspace
+# push past the default 20s test-timeout floor; bump to 60s.
 minimum_test_timeout = 60
 timeout_multiplier = 5.0

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,20 @@
+# cargo-mutants configuration.
+#
+# IMPORTANT: until upstream cargo-mutants ships a fix for the temp-tree
+# regression that strands worker copies missing source files mid-run,
+# `--in-place` must be passed at the CLI (it is not exposed as a config
+# key). The `just mutants` recipe wraps the correct invocation. See:
+#   - docs/security/cargo-mutants-runbook.md
+#   - https://github.com/randomparity/rusty-imap-mcp/issues/235
+#   - upstream sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>
+#
+# Keep this comment block until #235 is closed and `--in-place` is no
+# longer load-bearing. cargo-mutants reads this file from
+# `.cargo/mutants.toml` at the workspace root by default.
+
+# Tests in this workspace exercise async runtimes and a few network
+# integration paths; the default 20s minimum is too aggressive for
+# mutants that push timeouts close to the wall-clock limit. 60s
+# matches the cadence baseline in docs/security/fuzzing-coverage.md.
+minimum_test_timeout = 60
+timeout_multiplier = 5.0

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@
 | [Security model](security-model.md) | Threat model, content pipeline, defense layers |
 | [SECURITY.md](../SECURITY.md) | Vulnerability disclosure policy, supported versions |
 | [Supply-chain watchlist](security/supply-chain-watchlist.md) | Dependency risk tracking |
+| [cargo-mutants runbook](security/cargo-mutants-runbook.md) | macOS workaround for sourcefrog/cargo-mutants#611 |
 
 ## Architecture (for contributors)
 

--- a/docs/security/cargo-mutants-runbook.md
+++ b/docs/security/cargo-mutants-runbook.md
@@ -10,7 +10,7 @@ operates on the live source tree and sidesteps the temp-copy path
 entirely. This runbook is the canonical source for invocations,
 caveats, and the cleanup checklist for when upstream lands a fix. See
 [issue #235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
-and upstream `sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>`.
+and upstream [`sourcefrog/cargo-mutants#611`](https://github.com/sourcefrog/cargo-mutants/issues/611).
 
 ## Blessed invocations
 
@@ -55,12 +55,15 @@ Error: ".../crates/rimap-content/src/parse/sniff.rs" is not a file
 `crates/rimap-content/src/parse/sniff.rs` is a regular UTF-8 source
 file declared by `mod sniff;` in `parse/mod.rs` with no `#[path]`
 attribute, no symlinks, and no sibling subdirectories. The bug is in
-cargo-mutants' temp-tree handling: a worker's per-mutant scratch tree
-is missing `sniff.rs` even though the source has it. Three runs on
-macOS 25.4.0 / APFS stop deterministically at the same mutant index;
-`--jobs 1` and `--jobs 2` both fail. The 26.0.0 release notes
-introduced reflink-based copying, which is the leading hypothesis for
-the regression.
+cargo-mutants' temp-tree handling on macOS: a worker's per-mutant
+scratch tree is missing `sniff.rs` (and other files — multiple vanish
+silently) even though the source has them. Per the upstream
+investigation in [#611](https://github.com/sourcefrog/cargo-mutants/issues/611),
+the macOS `dirhelper` background process unlinks the reflink copies
+that [#557](https://github.com/sourcefrog/cargo-mutants/pull/557)
+(landed in 26.0.0) introduced. Linux/btrfs, which also supports
+reflinks, does not reproduce — so this is macOS-specific, not generic
+to reflinks.
 
 Diagnostic capture procedure (run from a clean tree):
 
@@ -103,7 +106,7 @@ Cleanup checklist (do all in one PR, close [#235](https://github.com/randomparit
 2. Drop `--in-place` from the `mutants` recipe in `justfile` (or
    delete the recipe and document the bare command if no other
    wrapping is needed).
-3. Remove the `<UPSTREAM_NUMBER>` workaround comment block from
+3. Remove the `#611` workaround comment block from
    `.cargo/mutants.toml`. Decide whether the remaining
    `minimum_test_timeout` / `timeout_multiplier` entries are still
    load-bearing; delete the file if not.

--- a/docs/security/cargo-mutants-runbook.md
+++ b/docs/security/cargo-mutants-runbook.md
@@ -1,0 +1,114 @@
+# cargo-mutants runbook
+
+## Why this exists
+
+cargo-mutants 27.0.0 has a temp-tree handling bug that strands worker
+copies missing source files mid-run, surfacing as `Worker thread failed:
+"<file>" is not a file` even when the named file is a regular UTF-8
+source on disk. The project-default workaround is `--in-place`, which
+operates on the live source tree and sidesteps the temp-copy path
+entirely. This runbook is the canonical source for invocations,
+caveats, and the cleanup checklist for when upstream lands a fix. See
+[issue #235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
+and upstream `sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>`.
+
+## Blessed invocations
+
+All commands assume a clean working tree (`git status` shows nothing).
+`--in-place` mutates the live tree, so any local edits will collide.
+
+| Situation | Command |
+|---|---|
+| Quarterly workspace survey (per `fuzzing-coverage.md`) | `just mutants --workspace --timeout 60 -- --test-threads 1` |
+| Single-package survey | `just mutants --package <crate>` |
+| Single-mutant inspection (regex on mutant name) | `just mutants --package <crate> -F '<regex>'` |
+
+The `just mutants` recipe is a thin wrapper around `cargo mutants
+--in-place`. Pass any extra flags after the recipe name; they are
+forwarded verbatim.
+
+## What `--in-place` costs you
+
+- **Locked to `--jobs 1`.** cargo-mutants refuses parallel jobs in
+  `--in-place` mode because they would race on the same files. Survey
+  runs are correspondingly slower.
+- **Mutates the live tree.** A `Ctrl-C` mid-run can leave a mutated
+  source file in place. Recover with `git restore <file>` (or
+  `git restore .` if you do not know which file).
+- **Cannot edit the same files concurrently.** Do not run `just
+  mutants` against a crate you are actively editing; either finish
+  your edit and commit, or stash first.
+- **Conflicts with rust-analyzer / IDE rebuilds.** Either disable the
+  language server for the run or expect noisy diagnostics while the
+  tree is briefly mutated.
+
+## The bug, in detail
+
+Symptom (from [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235),
+verbatim):
+
+```
+ERROR Worker thread failed: ".../cargo-mutants-rusty-imap-mcp-XXXXXX.tmp/crates/rimap-content/src/parse/sniff.rs" is not a file
+Error: ".../crates/rimap-content/src/parse/sniff.rs" is not a file
+```
+
+`crates/rimap-content/src/parse/sniff.rs` is a regular UTF-8 source
+file declared by `mod sniff;` in `parse/mod.rs` with no `#[path]`
+attribute, no symlinks, and no sibling subdirectories. The bug is in
+cargo-mutants' temp-tree handling: a worker's per-mutant scratch tree
+is missing `sniff.rs` even though the source has it. Three runs on
+macOS 25.4.0 / APFS stop deterministically at the same mutant index;
+`--jobs 1` and `--jobs 2` both fail. The 26.0.0 release notes
+introduced reflink-based copying, which is the leading hypothesis for
+the regression.
+
+Diagnostic capture procedure (run from a clean tree):
+
+```bash
+mkdir -p /tmp/issue-235
+cargo mutants --package rimap-content --jobs 1 --leak-dirs \
+  2>&1 | tee /tmp/issue-235/repro-temp-copy.log
+
+# If the bug fires, the leaked tempdir survives for inspection:
+LEAKED=$(rg -o 'cargo-mutants-rusty-imap-mcp-[A-Za-z0-9]+\.tmp' \
+  /tmp/issue-235/repro-temp-copy.log | head -1)
+ls -la "/tmp/$LEAKED/crates/rimap-content/src/parse/"
+diff <(ls crates/rimap-content/src/parse/) \
+     <(ls "/tmp/$LEAKED/crates/rimap-content/src/parse/")
+```
+
+The diff identifies which files the worker is missing. Attach this to
+any upstream report.
+
+## Troubleshooting
+
+- **`Worker thread failed: ... is not a file` on a clean run.** You
+  forgot `--in-place` (or used bare `cargo mutants` instead of `just
+  mutants`). Re-run via the recipe.
+- **Mutated file left after Ctrl-C.** `git status` will show the
+  mutated file as modified. `git restore <file>` to recover.
+- **`error: cannot run --in-place with --jobs N` for N > 1.** Drop
+  the `--jobs` flag; in-place mode is single-threaded by design.
+- **Run takes too long.** Scope to a single package
+  (`--package <crate>`) or a single regex (`-F '<regex>'`). The
+  workspace survey is intentionally a quarterly cadence, not a
+  per-PR check.
+
+## When the upstream fix lands
+
+Cleanup checklist (do all in one PR, close [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)):
+
+1. Bump cargo-mutants in any pinned tooling and confirm the bare
+   `cargo mutants --package rimap-content` command runs to completion.
+2. Drop `--in-place` from the `mutants` recipe in `justfile` (or
+   delete the recipe and document the bare command if no other
+   wrapping is needed).
+3. Remove the `<UPSTREAM_NUMBER>` workaround comment block from
+   `.cargo/mutants.toml`. Decide whether the remaining
+   `minimum_test_timeout` / `timeout_multiplier` entries are still
+   load-bearing; delete the file if not.
+4. Strike the "Known issue" subsection from
+   `docs/security/fuzzing-coverage.md`.
+5. Delete this runbook.
+6. Comment on [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
+   with the upstream fix release tag, then close.

--- a/docs/security/cargo-mutants-runbook.md
+++ b/docs/security/cargo-mutants-runbook.md
@@ -42,6 +42,32 @@ forwarded verbatim.
   language server for the run or expect noisy diagnostics while the
   tree is briefly mutated.
 
+## Why not just downgrade to 25.x?
+
+cargo-mutants 25.x predates the reflink path and so does not hit the
+macOS `dirhelper` race at all. It would also unlock `--jobs N` on
+macOS, taking a workspace survey from ~3.5 hours to ~50 minutes. We
+chose `--in-place` over the downgrade for four reasons:
+
+- The project has a documented RAM ceiling on the development host
+  (see `feedback_cargo_mutants_jobs_cap.md`); high `--jobs` settings
+  freeze the box. `--in-place` forces `--jobs 1`, which neutralises
+  that hazard for free.
+- 25.x is roughly 18 months of missed mutant operators and bug fixes;
+  the survey would catch a strictly smaller (and different) set of
+  mutants than 26+.
+- We do not pin cargo-mutants in this repo (it is `cargo install`-ed
+  by `just setup`). Pinning to `=25.x` adds a maintenance step on
+  every contributor box and a re-test when we eventually unpin.
+- Cleanup when upstream lands a fix is one line (drop `--in-place`
+  from the recipe). A version pin would mean an unpin + a fresh
+  version-bump retest.
+
+If wall-clock time on macOS becomes the binding constraint before
+upstream fixes [#611](https://github.com/sourcefrog/cargo-mutants/issues/611),
+the right move is to revisit this — but defaulting to 25.x today
+trades a short-lived problem for a long-lived one.
+
 ## The bug, in detail
 
 Symptom (from [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235),

--- a/docs/security/cargo-mutants-runbook.md
+++ b/docs/security/cargo-mutants-runbook.md
@@ -1,21 +1,14 @@
 # cargo-mutants runbook
 
-## Why this exists
-
-cargo-mutants 27.0.0 has a temp-tree handling bug that strands worker
-copies missing source files mid-run, surfacing as `Worker thread failed:
-"<file>" is not a file` even when the named file is a regular UTF-8
-source on disk. The project-default workaround is `--in-place`, which
-operates on the live source tree and sidesteps the temp-copy path
-entirely. This runbook is the canonical source for invocations,
-caveats, and the cleanup checklist for when upstream lands a fix. See
-[issue #235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
-and upstream [`sourcefrog/cargo-mutants#611`](https://github.com/sourcefrog/cargo-mutants/issues/611).
+cargo-mutants 27.0.0 hits a macOS-specific temp-tree bug
+([sourcefrog/cargo-mutants#611](https://github.com/sourcefrog/cargo-mutants/issues/611),
+project tracker [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235))
+that strands worker copies missing source files mid-run. The
+project-default workaround is `--in-place`, which sidesteps the
+temp-copy path entirely. See "The bug, in detail" below for the
+mechanism.
 
 ## Blessed invocations
-
-All commands assume a clean working tree (`git status` shows nothing).
-`--in-place` mutates the live tree, so any local edits will collide.
 
 | Situation | Command |
 |---|---|
@@ -30,8 +23,10 @@ forwarded verbatim.
 ## What `--in-place` costs you
 
 - **Locked to `--jobs 1`.** cargo-mutants refuses parallel jobs in
-  `--in-place` mode because they would race on the same files. Survey
-  runs are correspondingly slower.
+  `--in-place` mode because they would race on the same files. A
+  workspace survey at `--jobs 1` runs in roughly 3.5 hours on the
+  reference dev host (compare ~50 minutes if the temp-copy path were
+  usable with `--jobs 4`).
 - **Mutates the live tree.** A `Ctrl-C` mid-run can leave a mutated
   source file in place. Recover with `git restore <file>` (or
   `git restore .` if you do not know which file).
@@ -46,13 +41,13 @@ forwarded verbatim.
 
 cargo-mutants 25.x predates the reflink path and so does not hit the
 macOS `dirhelper` race at all. It would also unlock `--jobs N` on
-macOS, taking a workspace survey from ~3.5 hours to ~50 minutes. We
-chose `--in-place` over the downgrade for four reasons:
+macOS, recovering most of the wall-clock cost above. We chose
+`--in-place` for four reasons:
 
-- The project has a documented RAM ceiling on the development host
-  (see `feedback_cargo_mutants_jobs_cap.md`); high `--jobs` settings
-  freeze the box. `--in-place` forces `--jobs 1`, which neutralises
-  that hazard for free.
+- The development host has a documented RAM ceiling that high
+  `--jobs` settings push past, freezing the box.
+  `--in-place` forces `--jobs 1`, which neutralises that hazard for
+  free.
 - 25.x is roughly 18 months of missed mutant operators and bug fixes;
   the survey would catch a strictly smaller (and different) set of
   mutants than 26+.
@@ -64,14 +59,13 @@ chose `--in-place` over the downgrade for four reasons:
   version-bump retest.
 
 If wall-clock time on macOS becomes the binding constraint before
-upstream fixes [#611](https://github.com/sourcefrog/cargo-mutants/issues/611),
-the right move is to revisit this — but defaulting to 25.x today
-trades a short-lived problem for a long-lived one.
+[#611](https://github.com/sourcefrog/cargo-mutants/issues/611) is
+fixed, revisit this.
 
 ## The bug, in detail
 
-Symptom (from [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235),
-verbatim):
+Symptom (verbatim from
+[#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)):
 
 ```
 ERROR Worker thread failed: ".../cargo-mutants-rusty-imap-mcp-XXXXXX.tmp/crates/rimap-content/src/parse/sniff.rs" is not a file
@@ -79,35 +73,42 @@ Error: ".../crates/rimap-content/src/parse/sniff.rs" is not a file
 ```
 
 `crates/rimap-content/src/parse/sniff.rs` is a regular UTF-8 source
-file declared by `mod sniff;` in `parse/mod.rs` with no `#[path]`
-attribute, no symlinks, and no sibling subdirectories. The bug is in
+file declared by `mod sniff;` in `parse/mod.rs` with no `#[path]`,
+no symlinks, and no sibling subdirectories. The bug is in
 cargo-mutants' temp-tree handling on macOS: a worker's per-mutant
 scratch tree is missing `sniff.rs` (and other files — multiple vanish
 silently) even though the source has them. Per the upstream
-investigation in [#611](https://github.com/sourcefrog/cargo-mutants/issues/611),
-the macOS `dirhelper` background process unlinks the reflink copies
-that [#557](https://github.com/sourcefrog/cargo-mutants/pull/557)
-(landed in 26.0.0) introduced. Linux/btrfs, which also supports
-reflinks, does not reproduce — so this is macOS-specific, not generic
-to reflinks.
+investigation in
+[#611](https://github.com/sourcefrog/cargo-mutants/issues/611), the
+macOS `dirhelper` background process unlinks the reflink copies that
+[#557](https://github.com/sourcefrog/cargo-mutants/pull/557) (landed
+in 26.0.0) introduced. Linux/btrfs, which also supports reflinks,
+does not reproduce — so this is macOS-specific, not generic to
+reflinks.
 
-Diagnostic capture procedure (run from a clean tree):
+Diagnostic capture procedure (run from a clean tree; produces a log
+plus a `diff` of source vs. leaked tempdir):
 
 ```bash
+set -euo pipefail
 mkdir -p /tmp/issue-235
 cargo mutants --package rimap-content --jobs 1 --leak-dirs \
   2>&1 | tee /tmp/issue-235/repro-temp-copy.log
 
-# If the bug fires, the leaked tempdir survives for inspection:
-LEAKED=$(rg -o 'cargo-mutants-rusty-imap-mcp-[A-Za-z0-9]+\.tmp' \
+LEAKED=$(rg -o 'cargo-mutants-[A-Za-z0-9-]+\.tmp' \
   /tmp/issue-235/repro-temp-copy.log | head -1)
+[ -n "$LEAKED" ] || { echo "no leaked tempdir found in log" >&2; exit 1; }
 ls -la "/tmp/$LEAKED/crates/rimap-content/src/parse/"
 diff <(ls crates/rimap-content/src/parse/) \
      <(ls "/tmp/$LEAKED/crates/rimap-content/src/parse/")
+
+# Tempdirs are workspace-sized; delete once you have what you need.
+# trash "/tmp/$LEAKED"   # if you have trash-cli
+# rm -r "/tmp/$LEAKED"   # otherwise
 ```
 
-The diff identifies which files the worker is missing. Attach this to
-any upstream report.
+The diff identifies which files the worker is missing. Attach to any
+upstream report.
 
 ## Troubleshooting
 
@@ -125,7 +126,8 @@ any upstream report.
 
 ## When the upstream fix lands
 
-Cleanup checklist (do all in one PR, close [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)):
+Cleanup checklist (do all in one PR, close
+[#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)):
 
 1. Bump cargo-mutants in any pinned tooling and confirm the bare
    `cargo mutants --package rimap-content` command runs to completion.
@@ -133,11 +135,16 @@ Cleanup checklist (do all in one PR, close [#235](https://github.com/randomparit
    delete the recipe and document the bare command if no other
    wrapping is needed).
 3. Remove the `#611` workaround comment block from
-   `.cargo/mutants.toml`. Decide whether the remaining
-   `minimum_test_timeout` / `timeout_multiplier` entries are still
-   load-bearing; delete the file if not.
+   `.cargo/mutants.toml` (and the cross-link to this runbook in that
+   comment). Decide whether the remaining `minimum_test_timeout` /
+   `timeout_multiplier` entries are still load-bearing; delete the
+   file if not.
 4. Strike the "Known issue" subsection from
-   `docs/security/fuzzing-coverage.md`.
-5. Delete this runbook.
-6. Comment on [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
+   `docs/security/fuzzing-coverage.md`, restore the bare
+   `cargo mutants` survey command.
+5. Delete this runbook (the "Why not downgrade to 25.x?" subsection
+   and the diagnostic capture procedure go with it).
+6. Remove the runbook row from `docs/INDEX.md`.
+7. Comment on
+   [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235)
    with the upstream fix release tag, then close.

--- a/docs/security/fuzzing-coverage.md
+++ b/docs/security/fuzzing-coverage.md
@@ -39,7 +39,16 @@ hard to track manually.
 
 Once a quarter, run:
 
-    cargo mutants --in-place --workspace --timeout 60 -- --test-threads 1
+    just mutants --workspace --timeout 60 -- --test-threads 1
 
 and update the "Last survey" column for any module whose mutation score
 changed by more than 5%.
+
+### Known issue (cargo-mutants 27.0.0)
+
+Worker-tree corruption causes `<file> is not a file` mid-run when the
+temp-copy mode is used. The `--in-place` flag baked into `just mutants`
+is required, not optional, until upstream fix lands. See the
+[cargo-mutants runbook](cargo-mutants-runbook.md). Tracking issues:
+[#235](https://github.com/randomparity/rusty-imap-mcp/issues/235),
+upstream `sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>`.

--- a/docs/security/fuzzing-coverage.md
+++ b/docs/security/fuzzing-coverage.md
@@ -46,9 +46,11 @@ changed by more than 5%.
 
 ### Known issue (cargo-mutants 27.0.0)
 
-Worker-tree corruption causes `<file> is not a file` mid-run when the
-temp-copy mode is used. The `--in-place` flag baked into `just mutants`
-is required, not optional, until upstream fix lands. See the
+Worker-tree corruption causes `<file> is not a file` mid-run on
+macOS when the temp-copy mode is used (macOS `dirhelper` unlinks the
+reflink copies introduced in cargo-mutants 26.0.0). The `--in-place`
+flag baked into `just mutants` is required, not optional, until
+upstream fix lands. See the
 [cargo-mutants runbook](cargo-mutants-runbook.md). Tracking issues:
 [#235](https://github.com/randomparity/rusty-imap-mcp/issues/235),
-upstream `sourcefrog/cargo-mutants#<UPSTREAM_NUMBER>`.
+upstream [`sourcefrog/cargo-mutants#611`](https://github.com/sourcefrog/cargo-mutants/issues/611).

--- a/justfile
+++ b/justfile
@@ -185,7 +185,7 @@ test-msrv:
     cargo +{{MSRV}} check --workspace --all-targets --all-features --locked
     cargo +{{MSRV}} nextest run --workspace --locked --no-tests=pass
 
-# Cargo-mutants survey (in-place; see docs/security/cargo-mutants-runbook.md for #235 context).
+# Cargo-mutants survey. In-place is required on macOS; see docs/security/cargo-mutants-runbook.md.
 mutants *args:
     cargo mutants --in-place {{args}}
 

--- a/justfile
+++ b/justfile
@@ -185,6 +185,10 @@ test-msrv:
     cargo +{{MSRV}} check --workspace --all-targets --all-features --locked
     cargo +{{MSRV}} nextest run --workspace --locked --no-tests=pass
 
+# Cargo-mutants survey (in-place; see docs/security/cargo-mutants-runbook.md for #235 context).
+mutants *args:
+    cargo mutants --in-place {{args}}
+
 # Proton Bridge integration suite (gated on PROTON_BRIDGE_TEST=1).
 test-integration:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

cargo-mutants 27.0.0 reproducibly fails on macOS/APFS with `Worker thread failed: ".../<file>" is not a file` mid-run. Upstream investigation in [`sourcefrog/cargo-mutants#611`](https://github.com/sourcefrog/cargo-mutants/issues/611) traced it to macOS `dirhelper` unlinking the reflink copies introduced in [#557](https://github.com/sourcefrog/cargo-mutants/pull/557) (cargo-mutants 26.0.0). Linux/btrfs also supports reflinks but does not reproduce — the issue is macOS-specific.

`--in-place` skips the temp-copy path entirely and is the project-default workaround until upstream ships a fix.

- New `just mutants *args` recipe wrapping `cargo mutants --in-place`.
- New `.cargo/mutants.toml` with `minimum_test_timeout = 60` and `timeout_multiplier = 5.0` (auto-discovered, no CLI flag needed) and a comment block linking the upstream + downstream issues.
- New `docs/security/cargo-mutants-runbook.md`: blessed invocations, `--in-place` costs (~3.5h workspace survey at `--jobs 1`), the diagnostic capture procedure, "Why not just downgrade to 25.x?" decision record, and the cleanup checklist for when upstream ships a fix.
- `docs/security/fuzzing-coverage.md` survey command updated to `just mutants` with a "Known issue" subsection linking back to the runbook.
- `docs/INDEX.md` indexes the new runbook.

## Acceptance criteria for #235

- **Root cause identified.** Upstream pinned the bug to macOS `dirhelper` reaping reflink copies. Documented in the runbook and linked from the toml + fuzzing-coverage.
- **Workaround documented in `docs/`.** `docs/security/cargo-mutants-runbook.md` is canonical and indexed from `docs/INDEX.md` and `docs/security/fuzzing-coverage.md`.
- **Upstream issue filed and linked.** [`sourcefrog/cargo-mutants#611`](https://github.com/sourcefrog/cargo-mutants/issues/611), linked from three places.

## Test plan

- [x] `just ci` passes locally (formatting + lint + 991 tests + deny + typos).
- [x] `just --list` shows the new `mutants *args` recipe.
- [x] `just mutants --package rimap-content --list` returns the same 652 mutants the bare command would.
- [x] `just mutants --package rimap-content -F 'parse/sniff.rs'` runs `--in-place` end-to-end against the file at the heart of the bug — 9/9 mutants caught in 55s, no `Worker thread failed`, clean tree afterward.

## Out of scope

- The three new survivors flagged in #234. Tracked separately under #225's follow-up.
- Bumping cargo-mutants past 27.0.0. We do not pin cargo-mutants in this repo, so contributors pick up upstream fixes when they update their own install.

Closes #235