### PR TITLE
Phase-3: kill three rimap-content mutation survivors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing",
+ "tracing-subscriber",
  "unicode-normalization",
  "unicode-script",
  "unicode-segmentation",

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -54,6 +54,7 @@ required-features = ["test-util"]
 proptest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies.rimap-content]
 path = "."

--- a/crates/rimap-content/src/html/mismatch.rs
+++ b/crates/rimap-content/src/html/mismatch.rs
@@ -153,7 +153,7 @@ mod mismatch_tests {
     use scraper::Html;
 
     use super::{detect_mismatches, extract_registrable_domain};
-    use crate::html::MAX_MISMATCH_HITS;
+    use crate::html::{MAX_ANCHOR_TEXT_SCAN, MAX_MISMATCH_HITS};
 
     #[test]
     fn extract_registrable_domain_rejects_mailto_scheme() {
@@ -207,20 +207,25 @@ mod mismatch_tests {
         Html::parse_document(&format!("<html><body>{body}</body></html>"))
     }
 
+    /// Build an anchor document whose text is `MAX_ANCHOR_TEXT_SCAN + 1`
+    /// padding bytes followed by `https://evil.example` — i.e. the URL
+    /// sits past the truncation cap. Used to exercise both
+    /// `detect_mismatches` truncation guards (parsable + unparsable href
+    /// branches): the original truncates and linkify finds no URL; the
+    /// `< with` and `> with ==` mutations skip truncation and linkify
+    /// then sees the post-cap URL.
+    fn build_anchor_with_url_past_cap(href: &str) -> Html {
+        let padding = "x".repeat(MAX_ANCHOR_TEXT_SCAN + 1);
+        Html::parse_document(&format!(
+            "<html><body><a href=\"{href}\">{padding} https://evil.example</a></body></html>",
+        ))
+    }
+
     #[test]
     fn detect_mismatches_truncates_anchor_text_for_parsable_href() {
         // Kills `> with <` and `> with ==` on the parsable-href branch
-        // truncation guard. Construct an anchor whose text is well past
-        // MAX_ANCHOR_TEXT_SCAN with a mismatched URL placed *beyond*
-        // the truncation point. Original truncates -> linkify finds no
-        // URL -> no mismatch hit. Mutation `<` or `==` skips truncation
-        // -> linkify finds the post-cap URL -> mismatch hit added.
-        use crate::html::MAX_ANCHOR_TEXT_SCAN;
-        let padding = "x".repeat(MAX_ANCHOR_TEXT_SCAN + 1);
-        let html = format!(
-            "<html><body><a href=\"https://actual.com\">{padding} https://evil.example</a></body></html>",
-        );
-        let document = Html::parse_document(&html);
+        // truncation guard.
+        let document = build_anchor_with_url_past_cap("https://actual.com");
         let (hits, _overflow, _unparsable) = detect_mismatches(&document);
         assert!(
             hits.is_empty(),
@@ -231,17 +236,9 @@ mod mismatch_tests {
     #[test]
     fn detect_mismatches_truncates_anchor_text_for_unparsable_href() {
         // Kills `> with <` and `> with ==` on the unparsable-href branch
-        // truncation guard. Same shape as the parsable-href test above,
-        // but with a single-label `href` that PSL rejects so control
-        // takes the unparsable branch. Original truncates -> no URL in
-        // text -> unparsable_hrefs stays empty. Mutation `<` or `==`
-        // skips truncation -> URL detected -> entry pushed.
-        use crate::html::MAX_ANCHOR_TEXT_SCAN;
-        let padding = "x".repeat(MAX_ANCHOR_TEXT_SCAN + 1);
-        let html = format!(
-            "<html><body><a href=\"https://noserver/path\">{padding} https://evil.example</a></body></html>",
-        );
-        let document = Html::parse_document(&html);
+        // truncation guard. The single-label host fails PSL parsing so
+        // control takes the unparsable branch.
+        let document = build_anchor_with_url_past_cap("https://noserver/path");
         let (_hits, _overflow, unparsable) = detect_mismatches(&document);
         assert!(
             unparsable.is_empty(),

--- a/crates/rimap-content/src/html/mismatch.rs
+++ b/crates/rimap-content/src/html/mismatch.rs
@@ -98,6 +98,12 @@ pub(super) fn detect_mismatches(
         };
         let Some(href_domain) = extract_registrable_domain(href) else {
             let mut text: String = anchor.text().collect::<Vec<&str>>().join(" ");
+            // cargo-mutants: known-equivalent — `> with >=` here is
+            // observably identical. At `text.len() == MAX_ANCHOR_TEXT_SCAN`,
+            // `truncate(MAX_ANCHOR_TEXT_SCAN)` is a documented no-op
+            // (`String::truncate` does nothing when `new_len >= len`),
+            // so the only case the operators differ on produces no
+            // mutation in `text`.
             if text.len() > MAX_ANCHOR_TEXT_SCAN {
                 text.truncate(MAX_ANCHOR_TEXT_SCAN);
             }
@@ -110,6 +116,10 @@ pub(super) fn detect_mismatches(
             continue;
         };
         let mut text: String = anchor.text().collect::<Vec<&str>>().join(" ");
+        // cargo-mutants: known-equivalent — `> with >=` is observably
+        // identical here for the same reason as the unparsable-branch
+        // truncation above: `truncate(MAX_ANCHOR_TEXT_SCAN)` is a no-op
+        // at `text.len() == MAX_ANCHOR_TEXT_SCAN`.
         if text.len() > MAX_ANCHOR_TEXT_SCAN {
             text.truncate(MAX_ANCHOR_TEXT_SCAN);
         }
@@ -195,6 +205,48 @@ mod mismatch_tests {
             .unwrap();
         }
         Html::parse_document(&format!("<html><body>{body}</body></html>"))
+    }
+
+    #[test]
+    fn detect_mismatches_truncates_anchor_text_for_parsable_href() {
+        // Kills `> with <` and `> with ==` on the parsable-href branch
+        // truncation guard. Construct an anchor whose text is well past
+        // MAX_ANCHOR_TEXT_SCAN with a mismatched URL placed *beyond*
+        // the truncation point. Original truncates -> linkify finds no
+        // URL -> no mismatch hit. Mutation `<` or `==` skips truncation
+        // -> linkify finds the post-cap URL -> mismatch hit added.
+        use crate::html::MAX_ANCHOR_TEXT_SCAN;
+        let padding = "x".repeat(MAX_ANCHOR_TEXT_SCAN + 1);
+        let html = format!(
+            "<html><body><a href=\"https://actual.com\">{padding} https://evil.example</a></body></html>",
+        );
+        let document = Html::parse_document(&html);
+        let (hits, _overflow, _unparsable) = detect_mismatches(&document);
+        assert!(
+            hits.is_empty(),
+            "URL placed past MAX_ANCHOR_TEXT_SCAN must be truncated away; got {hits:?}",
+        );
+    }
+
+    #[test]
+    fn detect_mismatches_truncates_anchor_text_for_unparsable_href() {
+        // Kills `> with <` and `> with ==` on the unparsable-href branch
+        // truncation guard. Same shape as the parsable-href test above,
+        // but with a single-label `href` that PSL rejects so control
+        // takes the unparsable branch. Original truncates -> no URL in
+        // text -> unparsable_hrefs stays empty. Mutation `<` or `==`
+        // skips truncation -> URL detected -> entry pushed.
+        use crate::html::MAX_ANCHOR_TEXT_SCAN;
+        let padding = "x".repeat(MAX_ANCHOR_TEXT_SCAN + 1);
+        let html = format!(
+            "<html><body><a href=\"https://noserver/path\">{padding} https://evil.example</a></body></html>",
+        );
+        let document = Html::parse_document(&html);
+        let (_hits, _overflow, unparsable) = detect_mismatches(&document);
+        assert!(
+            unparsable.is_empty(),
+            "URL placed past MAX_ANCHOR_TEXT_SCAN must be truncated before linkify; got {unparsable:?}",
+        );
     }
 
     #[test]

--- a/crates/rimap-content/src/parse/mime_scrub.rs
+++ b/crates/rimap-content/src/parse/mime_scrub.rs
@@ -259,6 +259,40 @@ mod mime_scrub_tests {
     }
 
     #[test]
+    fn detect_smuggling_uses_addition_for_start_pos() {
+        // Kills `+ with *` on `start_pos = search_start + rel`. With `*`,
+        // the second-pass search after the first encoded-word closes
+        // computes start_pos = search_start * rel — wildly larger than
+        // the additive offset — and overshoots the end of the header,
+        // so locate_encoded_word_end returns Missing and flags the
+        // line. The original adds and finds the second closer cleanly.
+        let logical: Vec<&[u8]> = vec![b"X: =?u?B?p?= q =?v?B?r?=\r\n"];
+        let mask = detect_smuggling_spans(&logical);
+        assert_eq!(
+            mask,
+            vec![false],
+            "two complete inline encoded-words are not smuggling",
+        );
+    }
+
+    #[test]
+    fn detect_smuggling_locates_encoded_word_end_using_addition() {
+        // Kills `+ with -` on `start_pos + 2` in the call to
+        // locate_encoded_word_end. With `-`, the closer search starts
+        // four bytes earlier and picks up a stray `?=` immediately
+        // before the genuine `=?` opener — classifying the dangling
+        // encoded-word as SameHeader rather than Missing, and flipping
+        // mask[0] from true to false.
+        let logical: Vec<&[u8]> = vec![b"X: a?=?garbage\r\n"];
+        let mask = detect_smuggling_spans(&logical);
+        assert_eq!(
+            mask,
+            vec![true],
+            "dangling `=?` opener with no `?=` after it must be flagged",
+        );
+    }
+
+    #[test]
     fn detect_smuggling_skips_logical_end_idx_after_later_header() {
         // Kills `+ with *` on `idx = end_idx + 1`. With `*`, idx stays at
         // end_idx and re-scans logical[end_idx]. If logical[end_idx]

--- a/crates/rimap-content/src/parse/safe_parser.rs
+++ b/crates/rimap-content/src/parse/safe_parser.rs
@@ -109,4 +109,78 @@ mod tests {
         // updates is a well-defined hash of the empty string.
         log_parser_panic(b"");
     }
+
+    #[test]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "test asserts side-effect of log_parser_panic via captured tracing events"
+    )]
+    fn log_parser_panic_emits_structured_tracing_event() {
+        // Kills `replace log_parser_panic with ()` mutation. The function
+        // is pure side-effect: its only observable behavior is the
+        // structured tracing event. Install a thread-local Layer that
+        // records every event's target and field values, then assert the
+        // expected target and required fields appear.
+        use std::fmt::Write as _;
+        use std::sync::{Arc, Mutex};
+        use tracing::Subscriber;
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::registry::Registry;
+
+        struct Capture {
+            events: Arc<Mutex<Vec<String>>>,
+        }
+        struct V<'a>(&'a mut String);
+        impl Visit for V<'_> {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                write!(self.0, " {}={value:?}", field.name()).ok();
+            }
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                write!(self.0, " {}={value}", field.name()).ok();
+            }
+            fn record_str(&mut self, field: &Field, value: &str) {
+                write!(self.0, " {}={value}", field.name()).ok();
+            }
+        }
+        impl<S: Subscriber> Layer<S> for Capture {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                let mut record = format!("target={}", event.metadata().target());
+                event.record(&mut V(&mut record));
+                self.events.lock().unwrap().push(record);
+            }
+        }
+
+        let events: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let layer = Capture {
+            events: Arc::clone(&events),
+        };
+        let subscriber = Registry::default().with(layer);
+        let dispatch = tracing::Dispatch::new(subscriber);
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            log_parser_panic(b"abc");
+        });
+
+        let captured = events.lock().unwrap();
+        assert_eq!(
+            captured.len(),
+            1,
+            "expected exactly one event, got {captured:?}"
+        );
+        let record = &captured[0];
+        assert!(
+            record.contains("target=rimap_content::parser_panic"),
+            "expected target in event record, got: {record:?}",
+        );
+        assert!(
+            record.contains("input_len=3"),
+            "expected input_len=3 field, got: {record:?}",
+        );
+        assert!(
+            record.contains("input_sha256_prefix="),
+            "expected input_sha256_prefix field, got: {record:?}",
+        );
+    }
 }

--- a/crates/rimap-content/src/parse/safe_parser.rs
+++ b/crates/rimap-content/src/parse/safe_parser.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     #[expect(
         clippy::unwrap_used,
-        reason = "test asserts side-effect of log_parser_panic via captured tracing events"
+        reason = "Mutex::lock() poison-propagation in test-only event-capture layer"
     )]
     fn log_parser_panic_emits_structured_tracing_event() {
         // Kills `replace log_parser_panic with ()` mutation. The function

--- a/crates/rimap-content/src/testutil.rs
+++ b/crates/rimap-content/src/testutil.rs
@@ -154,9 +154,28 @@ mod tests {
 
     #[test]
     fn error_kind_label_stable_for_known_variants() {
-        let malformed = ContentError::Malformed {
-            reason: "x".to_string(),
-        };
-        assert_eq!(error_kind_label(&malformed), Some("Malformed"));
+        let cases: &[(ContentError, &str)] = &[
+            (
+                ContentError::Malformed {
+                    reason: "x".to_string(),
+                },
+                "Malformed",
+            ),
+            (
+                ContentError::LimitExceeded {
+                    kind: "mime_depth",
+                    limit: 8,
+                },
+                "LimitExceeded",
+            ),
+            (ContentError::ParserPanic, "ParserPanic"),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(
+                error_kind_label(err),
+                Some(*expected),
+                "label for {err:?} changed",
+            );
+        }
     }
 }

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -1,7 +1,7 @@
 # Mutation-baseline — Targeted-trust-boundary survivor inventory
 
-**Updated:** 2026-05-01
-**Tool:** `cargo-mutants` (run via `just mutants-crate <name>`)
+**Updated:** 2026-05-04
+**Tool:** `cargo-mutants` (run via `just mutants --package <name>`)
 **Scope:** Five trust-boundary crates — `rimap-content`, `rimap-authz`,
 `rimap-audit`, `rimap-server`, `rimap-imap`. Other workspace crates are
 out of scope per spec
@@ -17,16 +17,19 @@ adding a test, not annotated.
 
 ## `rimap-content`
 
-**Last refresh:** 2026-05-01.
-**Surviving mutants in non-`bin/` code:** 15.
+**Last refresh:** 2026-05-04.
+**Surviving mutants in non-`bin/` code:** 14.
 
-Run summary (644 mutants total): 550 caught, 20 missed (15 outside
-`src/bin/`, 5 inside), 10 timeout, 64 unviable. Every survivor
+Run summary (652 mutants total): 563 caught, 19 missed (14 outside
+`src/bin/`, 5 inside), 6 timeout, 64 unviable. Every survivor
 outside `src/bin/` is a mathematically equivalent mutation
 documented in the table below; the 5 `src/bin/epvme_runner.rs`
 survivors are documented in the `### bin/epvme_runner.rs` subsection
 below (issue #193 took the original 16 to 5 by killing 11 with tests
-and annotating the rest).
+and annotating the rest). Issue #236 killed three post-archive
+survivors in `testutil.rs` and `parse/mime_scrub.rs` and added two
+new known-equivalent rows for the `> with >=` mutations on the
+`MAX_ANCHOR_TEXT_SCAN` truncation guards in `html/mismatch.rs`.
 
 The follow-up plan
 [`archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md)
@@ -43,6 +46,8 @@ not appear here.
 | `parse/mime_scrub.rs:187` | `replace < with > in split_header_lines` (`if line_start < headers.len()`) | The inner loop's only exit invariant is `line_start == headers.len()` — the `None` branch of the `\n` search sets `line_end = headers.len()` and the subsequent push sets `line_start = line_end`. On exit, the predicate is false under both `<` and `>`; the trailing push is defensive dead code in current usage. | `parse/mime_scrub.rs:180` |
 | `html/style_parse.rs:74` | `replace < with <= in parse_translate_px` (`if px_val < current`) | The `<` and `<=` predicates differ only when `px_val == current`; in that case both arms set `min = Some(px_val)` to a value already equal to `current`, leaving the running minimum unchanged. Distinct values pick the same minimum under either operator. | `html/style_parse.rs:68` |
 | `html/mismatch.rs:51` | `replace || with && in extract_registrable_domain` (`if host.is_empty() || !host.contains('.')`) | The `||` and `&&` predicates differ only when `host.is_empty()=false && !host.contains('.')=true` — a non-empty single-label host. Both branches then route control through the idna+addr lookup, which returns `None` for any single-label host (no registrable domain exists above a TLD). The opposite case (`is_empty=true && !contains('.')=false`) is unreachable: an empty string contains no `.`. | `html/mismatch.rs:43` |
+| `html/mismatch.rs:107` | `replace > with >= in detect_mismatches` (unparsable-href branch `if text.len() > MAX_ANCHOR_TEXT_SCAN`) | `>` and `>=` differ only at `text.len() == MAX_ANCHOR_TEXT_SCAN`. In that case, `String::truncate(MAX_ANCHOR_TEXT_SCAN)` is a documented no-op (does nothing when `new_len >= len`), so the predicate flip produces no observable change in `text` or in the downstream linkify scan. | `html/mismatch.rs:101` |
+| `html/mismatch.rs:123` | `replace > with >= in detect_mismatches` (parsable-href branch `if text.len() > MAX_ANCHOR_TEXT_SCAN`) | Same reasoning as the unparsable-branch row above: `truncate(MAX_ANCHOR_TEXT_SCAN)` is a no-op at the boundary value, so the operator flip is observably equivalent. | `html/mismatch.rs:119` |
 | `lookalike.rs:110` | `replace || with && in label_mixes_scripts` (the first `||` between `is_ascii_digit()` and `c == '-'`) | Each char that the original `continue`s past — ASCII digits, `-`, `_` — has `Script::Common`, which the match below treats as a no-op. Whether the loop short-circuits via `continue` or runs through to the match, the `scripts` set membership is unchanged. | `lookalike.rs:103` |
 | `lookalike.rs:110` | `replace || with && in label_mixes_scripts` (the second `||` between `c == '-'` and `c == '_'`) | Same reasoning as the first `||` mutation: the chars that the guard short-circuits on all classify as `Script::Common`, ignored by the match arm. | `lookalike.rs:103` |
 | `lookalike.rs:220` | `replace < with <= in extract_domain_from_address` (`lt < gt`) | `lt == gt` is unreachable when both `rfind` results are `Some`: a single byte cannot be both `<` and `>`. Distinct positions exercise the same arm under either operator. | `lookalike.rs:214` |


### PR DESCRIPTION
## Summary
- Closes #236.
- Adds three tests in `rimap-content` that kill the post-archive mutation survivors flagged in #236.
- Preemptively also kills the latent `LimitExceeded` arm survivor in `error_kind_label`.
- A full `just mutants --package rimap-content` sweep on a 256GB host (652 mutants in 46m) surfaced 7 additional new survivors beyond the 3 from #236; this PR kills 5 of them with tests and annotates the other 2 as known-equivalent in `mutation-baseline.md`.

## Issue #236 survivors (killed)

| Site | Mutation | Test |
|---|---|---|
| `testutil.rs:57` | delete `ContentError::ParserPanic` arm | `error_kind_label_stable_for_known_variants` extended to all variants |
| `mime_scrub.rs:83` | `+` → `*` in `start_pos = search_start + rel` | `detect_smuggling_uses_addition_for_start_pos` |
| `mime_scrub.rs:84` | `+` → `-` in `locate_encoded_word_end(.., start_pos + 2)` | `detect_smuggling_locates_encoded_word_end_using_addition` |

## Additional survivors found in the full sweep (killed)

| Site | Mutation | Test |
|---|---|---|
| `parse/safe_parser.rs:48` | `replace log_parser_panic with ()` | `log_parser_panic_emits_structured_tracing_event` (Layer-based capture; required adding `tracing-subscriber` dev-dep) |
| `html/mismatch.rs:107` | `> with <`, `> with ==` (unparsable-href truncation guard) | `detect_mismatches_truncates_anchor_text_for_unparsable_href` |
| `html/mismatch.rs:123` | `> with <`, `> with ==` (parsable-href truncation guard) | `detect_mismatches_truncates_anchor_text_for_parsable_href` |

## Annotated known-equivalent (added to `mutation-baseline.md`)

| Site | Mutation | Reason |
|---|---|---|
| `html/mismatch.rs:107` | `> with >=` | `>` and `>=` differ only at `text.len() == MAX_ANCHOR_TEXT_SCAN`; `truncate(MAX)` is a documented no-op at that length, so the predicate flip is unobservable. |
| `html/mismatch.rs:123` | `> with >=` | Same reasoning, parsable-href branch. |

## Verification

`just mutants --package rimap-content` (full sweep, 256GB host, 46 minutes):
- Pre-fix: 558 caught, 24 missed, 6 timeouts, 64 unviable.
- Post-fix (5 additional kills): 563 caught, 19 missed, 6 timeouts, 64 unviable. The 19 remaining MISSED are 5 pre-existing `bin/epvme_runner.rs` known-equivalents + 12 pre-existing non-bin known-equivalents + 2 new non-bin known-equivalents added by this PR.

Targeted re-verification post-fix:
```
just mutants --package rimap-content -F 'testutil\.rs:57'         -> 1/1 caught
just mutants --package rimap-content -F 'mime_scrub\.rs:83'       -> 2/2 caught
just mutants --package rimap-content -F 'mime_scrub\.rs:84'       -> 2/2 caught
just mutants --package rimap-content -F 'safe_parser\.rs'         -> 3/3 caught
just mutants --package rimap-content -F 'mismatch\.rs:107'        -> 2/3 (>= equiv)
just mutants --package rimap-content -F 'mismatch\.rs:123'        -> 2/3 (>= equiv)
```

`cargo test -p rimap-content`: 231 lib + 1 integration passed.
`cargo clippy -p rimap-content --all-targets --all-features -- -D warnings`: clean.
`cargo fmt --all -- --check`: clean.

## Notes

- The full sweep ran in 46 minutes on a 256GB Linux host, well under the runbook's 3.5h estimate (which was based on the macOS reference dev box). RAM topped out at ~80 MB per worker — no pressure at all on this machine. Suggests the macOS-side RAM ballooning was indeed an artifact of the cargo-mutants 27.0.0 reflink/dirhelper interaction documented in #235, not the workload itself.
- `tracing::subscriber::with_default(subscriber, ..)` produced intermittent test failures in parallel runs (subscriber not firing when other parse:: tests ran concurrently). Switching to the lower-level `tracing::dispatcher::with_default(&Dispatch, ..)` resolved it. Worth knowing for future tracing-event tests.

## Test plan
- [x] `cargo test -p rimap-content` passes
- [x] `cargo clippy -p rimap-content --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full `just mutants --package rimap-content` sweep complete; only known-equivalent survivors remain
- [x] Targeted `just mutants -F` confirms each prior survivor site is killed or annotated

🤖 Generated with [Claude Code](https://claude.com/claude-code)