### PR TITLE
test(rimap-content): fix flaky log_parser_panic tracing test (#239)

### DIFF
--- a/crates/rimap-content/src/parse/safe_parser.rs
+++ b/crates/rimap-content/src/parse/safe_parser.rs
@@ -63,6 +63,26 @@ fn log_parser_panic(raw: &[u8]) {
 mod tests {
     use super::*;
 
+    /// Install a permissive `Registry` as the global default subscriber on
+    /// the first call (#239). Without this, the *first* test thread to fire
+    /// the `tracing::error!` macro at `log_parser_panic` registers the
+    /// callsite against the still-default `NoSubscriber`, caching
+    /// `Interest::never` for the lifetime of the test process. Any later
+    /// test that installs a thread-local capture layer via `with_default`
+    /// then sees the macro short-circuit before its layer is consulted.
+    /// Calling this from every test that fires the macro guarantees the
+    /// callsite is registered against a permissive subscriber the first
+    /// time, regardless of test ordering.
+    fn install_permissive_global_default() {
+        use std::sync::OnceLock;
+        use tracing_subscriber::registry::Registry;
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            let subscriber = Registry::default();
+            let _ = tracing::dispatcher::set_global_default(tracing::Dispatch::new(subscriber));
+        });
+    }
+
     #[test]
     #[expect(
         clippy::expect_used,
@@ -82,6 +102,7 @@ mod tests {
         reason = "test exercises the catch_unwind error arm with a synthetic panic"
     )]
     fn catch_unwind_error_arm_produces_parser_panic() {
+        install_permissive_global_default();
         // We cannot synthesize a panic from inside mail_parser without
         // hitting the actual upstream bug, so we exercise the error-arm
         // logic by mirroring what safe_parse does: catch_unwind on a
@@ -104,6 +125,7 @@ mod tests {
 
     #[test]
     fn log_parser_panic_handles_empty_input() {
+        install_permissive_global_default();
         // Boundary: zero-byte input still produces a valid sha256 and
         // does not panic the logger. `Sha256::new()` + finalize on no
         // updates is a well-defined hash of the empty string.
@@ -116,11 +138,6 @@ mod tests {
         reason = "Mutex::lock() poison-propagation in test-only event-capture layer"
     )]
     fn log_parser_panic_emits_structured_tracing_event() {
-        // Kills `replace log_parser_panic with ()` mutation. The function
-        // is pure side-effect: its only observable behavior is the
-        // structured tracing event. Install a thread-local Layer that
-        // records every event's target and field values, then assert the
-        // expected target and required fields appear.
         use std::fmt::Write as _;
         use std::sync::{Arc, Mutex};
         use tracing::Subscriber;
@@ -129,6 +146,11 @@ mod tests {
         use tracing_subscriber::layer::{Context, SubscriberExt};
         use tracing_subscriber::registry::Registry;
 
+        // Kills `replace log_parser_panic with ()` mutation. The function
+        // is pure side-effect: its only observable behavior is the
+        // structured tracing event. Install a thread-local Layer that
+        // records every event's target and field values, then assert the
+        // expected target and required fields appear.
         struct Capture {
             events: Arc<Mutex<Vec<String>>>,
         }
@@ -152,6 +174,7 @@ mod tests {
             }
         }
 
+        install_permissive_global_default();
         let events: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let layer = Capture {
             events: Arc::clone(&events),

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -20,26 +20,21 @@ adding a test, not annotated.
 **Last refresh:** 2026-05-04.
 **Surviving mutants in non-`bin/` code:** 14.
 
-Run summary (652 mutants total, 2026-05-04 full single-threaded run
-via `just mutants --package rimap-content`): 566 caught, 16 missed, 6
-timeout, 64 unviable in 40 minutes wall clock. Three of the 19
-known-equivalent rows below report "caught" in this run only because
-a flaky callsite-cache interaction in
-`parse::safe_parser::tests::log_parser_panic_emits_structured_tracing_event`
-([#239](https://github.com/randomparity/rusty-imap-mcp/issues/239))
-fails the per-mutant runs for `lookalike.rs:220` (`< with <=`),
-`lookalike.rs:228` (`+ with *`), and `bin/epvme_runner.rs:189`
-(`"xyzzy".into()`); the mutations themselves remain genuinely
-mathematically equivalent. Counting all 19 the deterministic
-survivor floor is 14 outside `src/bin/` and 5 inside. Every
-non-`bin/` survivor is a mathematically equivalent mutation
-documented in the table below; the 5 `src/bin/epvme_runner.rs`
-survivors are documented in the `### bin/epvme_runner.rs` subsection
-below (issue #193 took the original 16 to 5 by killing 11 with tests
-and annotating the rest). Issue #236 killed three post-archive
-survivors in `testutil.rs` and `parse/mime_scrub.rs` and added two
-new known-equivalent rows for the `> with >=` mutations on the
-`MAX_ANCHOR_TEXT_SCAN` truncation guards in `html/mismatch.rs`.
+Run summary (652 mutants total, 2026-05-04 full run via `just mutants
+--package rimap-content`): 563 caught, 19 missed, 6 timeout, 64
+unviable in 44 minutes wall clock. The deterministic survivor floor
+is 14 outside `src/bin/` and 5 inside; both numbers match this run's
+output exactly after the
+[#239](https://github.com/randomparity/rusty-imap-mcp/issues/239)
+flaky-tracing-test fix landed. Every non-`bin/` survivor is a
+mathematically equivalent mutation documented in the table below;
+the 5 `src/bin/epvme_runner.rs` survivors are documented in the
+`### bin/epvme_runner.rs` subsection below (issue #193 took the
+original 16 to 5 by killing 11 with tests and annotating the rest).
+Issue #236 killed three post-archive survivors in `testutil.rs` and
+`parse/mime_scrub.rs` and added two new known-equivalent rows for
+the `> with >=` mutations on the `MAX_ANCHOR_TEXT_SCAN` truncation
+guards in `html/mismatch.rs`.
 
 The follow-up plan
 [`archive: 2026-04-30-rimap-content-mutation-cleanup-followup.md`](https://github.com/randomparity/rusty-imap-mcp/blob/archive/daemon-experiment/docs/superpowers/plans/2026-04-30-rimap-content-mutation-cleanup-followup.md)


### PR DESCRIPTION
## Summary

- Fix the flaky `parse::safe_parser::tests::log_parser_panic_emits_structured_tracing_event` test (#239) by installing a permissive `Registry` as the global default subscriber via `OnceLock` from every `safe_parser::tests` test that fires `log_parser_panic`. This prevents sibling tests from poisoning the per-callsite `Interest` cache with `Interest::never` against the no-op `NoSubscriber`.
- Drop the `[#239]` caveat paragraph from `docs/superpowers/specs/test-strategy/mutation-baseline.md` — the post-fix mutation run lands at the deterministic survivor floor exactly.
- The issue's option 1 (`tracing::callsite::rebuild_interest_cache()` from inside the `with_default` closure) was tried first and **did not work** — verified empirically (still 4/10 fails) and via debug instrumentation that `events.len() == 0` even with the rebuild call. Option 2 (permissive global default before any sibling test fires the macro) is the reliable fix.

## Test plan

- [x] `cargo test -p rimap-content --lib` clean (231 passed)
- [x] 50 consecutive runs of the lib-test suite: 50/50 pass (baseline ~40% flake rate)
- [x] `cargo clippy -p rimap-content --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just mutants --package rimap-content` — 652 mutants, **19 missed (matching the documented floor exactly), 563 caught, 6 timeouts, 64 unviable in 44 min**. The three rows previously caveated as flake-killed (`lookalike.rs:220`, `lookalike.rs:228`, `bin/epvme_runner.rs:189`) now correctly report as missed/known-equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)