### PR TITLE
docs: re-extract test-strategy spec + B1 plan (#227)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-test-strategy-b1-rimap-content.md
+++ b/docs/superpowers/plans/2026-04-30-test-strategy-b1-rimap-content.md
@@ -1,0 +1,1399 @@
+# Sprint B1: rimap-content Fuzz + Mutation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land four `cargo-fuzz` harnesses on the `rimap-content` trust boundary, refresh `cargo-mutants` against current `main`, kill every surviving mutant in non-binary code, and wire ClusterFuzzLite into CI for PR-smoke + nightly fuzzing.
+
+**Architecture:** New top-level `fuzz/` directory (workspace-excluded) holds the `cargo-fuzz` crate with four targets. Two private functions inside `rimap-content` (`html::sanitize_html`, `parse::mime_scrub::scrub_header_smuggling`) get re-exported under the existing `test-util` feature so the fuzz crate can call them without duplicating the upper-layer machinery. Mutation cleanup proceeds module-by-module after a fresh baseline run; survivors that are equivalent mutants get inline annotations rather than fixes. CI gets a new `.github/workflows/fuzz.yml` driving ClusterFuzzLite for PR smoke (10 min) and nightly cron (60 min).
+
+**Tech Stack:** `cargo-fuzz` (nightly-only), `libfuzzer-sys`, `cargo-mutants` 25.x, `ClusterFuzzLite` (Google), `actionlint`, `zizmor`, GitHub Actions on `ubuntu-24.04`.
+
+**Spec reference:** [`docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md`](../specs/2026-04-30-test-strategy-improvements-design.md), Sprint B1 — Section 4.
+
+**Branch:** `feat/test-strategy-b1-rimap-content` (cut from current `main` after this plan's PR lands).
+
+## Phase split
+
+During execution this plan was split into two PRs to keep blast radius bounded and let the security-class fixes (char-boundary panic, encoded-word smuggling gap) ship as soon as they were ready:
+
+- **Phase 1 — Pre-flight + Tasks 1–6 + /simplify cleanup.** Fuzz infrastructure + four harnesses + two security-relevant bug fixes the harnesses surfaced. PR opens once Tasks 1–6 are complete.
+- **Phase 2 — Tasks 7–11 + Wrap-up.** `cargo-mutants` baseline refresh, mutation cleanup, ClusterFuzzLite workflow, draft-PR smoke test, done-criteria validation. Branch will be cut from `main` after Phase 1 merges.
+
+Tasks below are tagged `[P1]` or `[P2]` accordingly. The split is described here, not in the spec — the spec's Sprint B1 acceptance criteria still require both phases.
+
+---
+
+## Pre-flight
+
+Confirm the working branch isn't `main`/`master`, the worktree is clean, and the local toolchain is ready.
+
+- [ ] **Step 0: Verify branch, clean state, and tooling**
+
+Run:
+```bash
+git branch --show-current
+git status --short
+which actionlint zizmor cargo-mutants
+rustup toolchain list | grep -F nightly
+cargo install --list 2>/dev/null | grep -E "cargo-fuzz|cargo-mutants"
+```
+
+Expected:
+- `git branch --show-current` prints `feat/test-strategy-b1-rimap-content` (NOT `main`). If on `main`, stop and create the branch: `git checkout -b feat/test-strategy-b1-rimap-content`.
+- `git status --short` is empty.
+- `actionlint`, `zizmor`, `cargo-mutants` are on PATH. Install missing tools per the global `~/.claude/CLAUDE.md` "CLI tools" table or `just setup`.
+- A `nightly-*` toolchain is listed. If not, run `rustup toolchain install nightly --component rust-src`.
+- `cargo-fuzz` and `cargo-mutants` are listed. If not, run `cargo install --locked cargo-fuzz cargo-mutants`.
+
+---
+
+## Task 1 [P1]: Scaffold the `fuzz/` workspace member
+
+**Why:** `cargo-fuzz` needs a standalone Cargo crate with a known directory layout (`fuzz/Cargo.toml` + `fuzz/fuzz_targets/`). The repo workspace must explicitly exclude it because `libfuzzer-sys` is nightly-only and must not be pulled into stable workspace builds.
+
+**Files:**
+- Create: `fuzz/Cargo.toml`
+- Create: `fuzz/.gitignore`
+- Create: `fuzz/fuzz_targets/.gitkeep` (placeholder, removed by Task 3)
+- Modify: `Cargo.toml` (workspace root, add `exclude = ["fuzz"]`)
+- Modify: `justfile` (add `fuzz`, `fuzz-list` recipes)
+
+- [ ] **Step 1: Create the fuzz crate manifest**
+
+Create `fuzz/Cargo.toml`:
+```toml
+[package]
+name = "rusty-imap-mcp-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+rust-version = "1.94.0"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.rimap-content]
+path = "../crates/rimap-content"
+features = ["test-util"]
+
+[dependencies.rimap-audit]
+path = "../crates/rimap-audit"
+
+[dependencies.rimap-server]
+path = "../crates/rimap-server"
+
+# Targets are added in later tasks. Until at least one fuzz target exists,
+# `cargo +nightly fuzz list` returns an empty list, which is correct.
+
+[workspace]
+# Standalone — not part of the rusty-imap-mcp workspace because
+# libfuzzer-sys is nightly-only and the workspace stable build must
+# not pull it in.
+```
+
+`rimap-audit` and `rimap-server` deps are declared up front so the manifest does not churn each time a future sprint adds a target. They have zero cost when no target consumes them.
+
+- [ ] **Step 2: Create the fuzz-crate gitignore**
+
+Create `fuzz/.gitignore`:
+```
+target/
+Cargo.lock
+artifacts/
+coverage/
+```
+
+`corpus/` is **not** gitignored — seed corpora are version-controlled.
+
+- [ ] **Step 3: Create a placeholder so the directory tracks**
+
+Create empty `fuzz/fuzz_targets/.gitkeep` (it's removed in Task 3 when the first real target lands).
+
+- [ ] **Step 4: Exclude the fuzz crate from the workspace**
+
+Edit `Cargo.toml` (workspace root). Find the `[workspace]` section and add the `exclude` key:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/rimap-core",
+    "crates/rimap-config",
+    "crates/rimap-imap",
+    "crates/rimap-content",
+    "crates/rimap-audit",
+    "crates/rimap-authz",
+    "crates/rimap-smtp",
+    "crates/rimap-server",
+]
+exclude = ["fuzz"]
+```
+
+If `members = [...]` already exists, add only the `exclude = ["fuzz"]` line beneath it. Do not duplicate the `[workspace]` heading.
+
+- [ ] **Step 5: Add `fuzz` recipes to the justfile**
+
+Edit `justfile`. Find the `test-injection` recipe and insert immediately after it:
+
+```make
+# Run a single fuzz target for a fixed time budget. Requires nightly.
+# Example: just fuzz content_mime
+fuzz TARGET *ARGS:
+    cd fuzz && cargo +nightly fuzz run {{TARGET}} -- -max_total_time=30 {{ARGS}}
+
+# List the available fuzz targets.
+fuzz-list:
+    cd fuzz && cargo +nightly fuzz list
+```
+
+- [ ] **Step 6: Verify the workspace still builds**
+
+Run:
+```bash
+cargo check --workspace --locked --all-targets
+```
+
+Expected: clean exit. The `fuzz/` directory must not be picked up by `--workspace` (verifies `exclude = ["fuzz"]` works). If `cargo check` errors on `libfuzzer-sys` or anything in `fuzz/`, the exclude is wrong — re-check Step 4.
+
+- [ ] **Step 7: Verify the fuzz crate builds standalone on nightly**
+
+Run:
+```bash
+cd fuzz && cargo +nightly check
+```
+
+Expected: clean exit. (The crate has no targets yet but the manifest must parse.)
+
+Return to repo root: `cd ..`.
+
+- [ ] **Step 8: Verify `just fuzz-list` runs (returns empty list)**
+
+Run:
+```bash
+just fuzz-list
+```
+
+Expected: empty output (no targets yet) or a message like `<empty>`. The command must exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/.gitignore fuzz/fuzz_targets/.gitkeep Cargo.toml justfile
+git commit -m "test(fuzz): scaffold cargo-fuzz workspace member
+
+Add an excluded-from-workspace fuzz/ crate so future tasks can land
+cargo-fuzz harnesses without contaminating the stable workspace
+build with libfuzzer-sys (nightly-only).
+
+Adds 'just fuzz <target>' and 'just fuzz-list' for local invocation.
+Sprint B1 of the test-strategy-improvements plan.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 2 [P1]: Expose `rimap-content` private entry points under `test-util`
+
+**Why:** Two of the four fuzz targets need to call functions that are currently `pub(crate)` or `pub(super)` inside `rimap-content`. Re-exporting them under the existing `test-util` feature keeps the production API surface unchanged and matches the `epvme_runner`/dev-dep precedent already in `crates/rimap-content/Cargo.toml`.
+
+**Files:**
+- Modify: `crates/rimap-content/src/parse/mod.rs` (bump `mod mime_scrub` visibility to `pub(crate)`)
+- Modify: `crates/rimap-content/src/parse/mime_scrub.rs` (bump `scrub_header_smuggling` from `pub(super)` to `pub(crate)`)
+- Modify: `crates/rimap-content/src/testutil.rs` (re-export the two functions plus a small helper struct)
+- Test: a single doc-tested use site in `testutil.rs` that proves the re-exports compile.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `crates/rimap-content/src/testutil.rs` (existing file — preserve everything already there):
+
+```rust
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod test_util_reexports {
+    use crate::output::SecurityWarning;
+
+    #[test]
+    fn fuzz_entries_are_callable_via_testutil() {
+        // sanitize_html: minimal HTML body should round-trip without panic.
+        let result = super::sanitize_html(b"<p>hi</p>", Some("utf-8"))
+            .expect("sanitize_html on minimal HTML must succeed");
+        assert!(!result.body_text.is_empty());
+
+        // scrub_header_smuggling: a clean encoded-word produces no warnings.
+        let mut warnings: Vec<SecurityWarning> = Vec::new();
+        let raw = b"Subject: =?utf-8?B?aGVsbG8=?=\r\n\r\nbody";
+        let scrubbed = super::scrub_header_smuggling(raw, &mut warnings);
+        assert!(warnings.is_empty(), "clean encoded word should not warn");
+        assert!(!scrubbed.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (compile error)**
+
+Run:
+```bash
+cargo test --package rimap-content --features test-util test_util_reexports -- --nocapture
+```
+
+Expected: compile error with `cannot find function 'sanitize_html' in this scope` (or similar) — proves the re-exports don't exist yet.
+
+- [ ] **Step 3: Bump module visibility for `mime_scrub`**
+
+Edit `crates/rimap-content/src/parse/mod.rs`. Find this line:
+```rust
+mod mime_scrub;
+```
+
+Change to:
+```rust
+pub(crate) mod mime_scrub;
+```
+
+- [ ] **Step 4: Bump function visibility for `scrub_header_smuggling`**
+
+Edit `crates/rimap-content/src/parse/mime_scrub.rs`. Find this line:
+```rust
+pub(super) fn scrub_header_smuggling(raw: &[u8], warnings: &mut Vec<SecurityWarning>) -> Vec<u8> {
+```
+
+Change to:
+```rust
+pub(crate) fn scrub_header_smuggling(raw: &[u8], warnings: &mut Vec<SecurityWarning>) -> Vec<u8> {
+```
+
+The other `pub(super)` function in the same file (`detect_smuggling_spans`) is intentionally left at its current visibility — only `scrub_header_smuggling` is needed by the fuzz target.
+
+- [ ] **Step 5: Add the re-exports to `testutil.rs`**
+
+Open `crates/rimap-content/src/testutil.rs`. At the top of the file (after the existing module-level doc comment and any existing `use` statements), add:
+
+```rust
+/// Re-export of [`crate::html::sanitize_html`] for fuzz harnesses and
+/// out-of-tree integration tests. Production code must continue to
+/// reach `sanitize_html` through the [`crate::parse::parse_message`]
+/// pipeline.
+pub use crate::html::sanitize_html;
+
+/// Re-export of [`crate::parse::mime_scrub::scrub_header_smuggling`]
+/// for fuzz harnesses. Production code reaches this function through
+/// [`crate::parse::parse_message`].
+pub use crate::parse::mime_scrub::scrub_header_smuggling;
+
+/// Re-export of [`crate::html::HtmlResult`] so external callers of the
+/// re-exported `sanitize_html` can name the return type.
+pub use crate::html::HtmlResult;
+```
+
+- [ ] **Step 6: Make `HtmlResult` `pub(crate)`-visible**
+
+Open `crates/rimap-content/src/html/mod.rs`. Find the `HtmlResult` struct declaration (around line 30):
+
+```rust
+#[derive(Debug, Clone)]
+pub(crate) struct HtmlResult {
+```
+
+It's already `pub(crate)`, so no edit is needed — but verify by running:
+```bash
+grep -n "pub(crate) struct HtmlResult\|pub struct HtmlResult\|struct HtmlResult" crates/rimap-content/src/html/mod.rs
+```
+
+Expected: exactly one line, `pub(crate) struct HtmlResult {`. If the visibility is different, change it to `pub(crate)`.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run:
+```bash
+cargo test --package rimap-content --features test-util test_util_reexports -- --nocapture
+```
+
+Expected: PASS. The test calls `super::sanitize_html` and `super::scrub_header_smuggling` and both compile + execute.
+
+- [ ] **Step 8: Run the full rimap-content test suite to confirm no regressions**
+
+Run:
+```bash
+cargo nextest run --package rimap-content --all-features --locked
+```
+
+Expected: every test passes (the change is visibility-only, no behavioral change).
+
+- [ ] **Step 9: Run clippy on the workspace**
+
+Run:
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+```
+
+Expected: clean exit. The visibility bump must not trip any pedantic lint.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/rimap-content/src/parse/mod.rs \
+        crates/rimap-content/src/parse/mime_scrub.rs \
+        crates/rimap-content/src/testutil.rs
+git commit -m "test(rimap-content): expose sanitize_html and scrub_header_smuggling under test-util
+
+The B1 fuzz harnesses for HTML and RFC 2047 header smuggling need
+to call these two functions directly. Re-export them through the
+existing test-util feature gate so production callers still reach
+them only via parse_message().
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 3 [P1]: `content_mime` fuzz harness
+
+**Why:** Whole-message MIME parse is the highest-value entry point — the v1 spec calls it the #1 attacker surface. A coverage-guided fuzzer explores edge cases that proptest's structured-string generation will not find.
+
+**Files:**
+- Delete: `fuzz/fuzz_targets/.gitkeep`
+- Create: `fuzz/fuzz_targets/content_mime.rs`
+- Create: `fuzz/corpus/content_mime/` (seeded from existing corpora — see Step 4)
+- Modify: `fuzz/Cargo.toml` (register the target)
+
+- [ ] **Step 1: Register the target in `fuzz/Cargo.toml`**
+
+Edit `fuzz/Cargo.toml`. Append (after the `[workspace]` block at the very end):
+
+```toml
+
+[[bin]]
+name = "content_mime"
+path = "fuzz_targets/content_mime.rs"
+test = false
+doc = false
+bench = false
+```
+
+- [ ] **Step 2: Write the harness**
+
+Create `fuzz/fuzz_targets/content_mime.rs`:
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Drive the public entry point. parse_message must:
+    //   - never panic
+    //   - reject input over MAX_MESSAGE_BYTES with a clean LimitExceeded error
+    //   - never allocate beyond the configured per-part / total caps
+    //
+    // Crashes/panics surface as libfuzzer findings. Resource caps are
+    // verified by the existing unit tests in parse/mod.rs; the fuzzer's
+    // job is to find the inputs that bypass those caps.
+    let _ = rimap_content::parse_message(data);
+});
+```
+
+The harness intentionally discards the `Result`. A successful parse, a `ContentError::LimitExceeded`, and a `ContentError::Malformed` are all valid outcomes; the harness asserts only that *some* outcome is reached without panic, OOM, or stack overflow.
+
+- [ ] **Step 3: Remove the placeholder**
+
+Run:
+```bash
+rm fuzz/fuzz_targets/.gitkeep
+```
+
+- [ ] **Step 4: Seed the corpus from the adversarial fixture set**
+
+Run:
+```bash
+mkdir -p fuzz/corpus/content_mime
+# 25 adversarial fixtures
+for d in tests/injection-corpus/*/; do
+    name=$(basename "$d")
+    cp "$d/input.eml" "fuzz/corpus/content_mime/${name}.eml"
+done
+# 3 dovecot integration fixtures
+cp crates/rimap-imap/tests/integration/dovecot/fixtures/plain.eml      fuzz/corpus/content_mime/dovecot-plain.eml
+cp crates/rimap-imap/tests/integration/dovecot/fixtures/multipart.eml  fuzz/corpus/content_mime/dovecot-multipart.eml
+cp crates/rimap-imap/tests/integration/dovecot/fixtures/attachment.eml fuzz/corpus/content_mime/dovecot-attachment.eml
+ls fuzz/corpus/content_mime | wc -l
+```
+
+Expected: `28` (25 injection-corpus + 3 dovecot fixtures). If less, an entry in `tests/injection-corpus/` is missing its `input.eml` — investigate before moving on.
+
+- [ ] **Step 5: Verify the harness builds on nightly**
+
+Run:
+```bash
+cd fuzz && cargo +nightly fuzz build content_mime && cd ..
+```
+
+Expected: clean build. Errors typically come from a missing feature flag on `rimap-content` (the `test-util` feature must be enabled in `fuzz/Cargo.toml` — Task 1 Step 1 set this up).
+
+- [ ] **Step 6: Run the harness for 60 seconds, no crash**
+
+Run:
+```bash
+cd fuzz && cargo +nightly fuzz run content_mime -- -max_total_time=60 && cd ..
+```
+
+Expected: 60 seconds of fuzzing with no crash. libfuzzer prints stats every few seconds; on completion it logs `Done $time runs in $time second(s)`. Any crash, abort, or hang is an unexpected finding — stop and triage before proceeding (a panic in `parse_message` is a real bug).
+
+- [ ] **Step 7: Verify the corpus was traversed**
+
+Inspect the libfuzzer stats from Step 6's output. The line beginning `INITED` should report `corpus:` greater than or equal to 28 (the seeded count). If it reports `corpus: 0`, the seed corpus was not found — verify `fuzz/corpus/content_mime/` exists relative to the `cd fuzz` working directory.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/fuzz_targets/content_mime.rs fuzz/corpus/content_mime/
+git rm fuzz/fuzz_targets/.gitkeep
+git commit -m "test(fuzz): add content_mime harness for parse_message
+
+Drives rimap_content::parse_message on raw bytes. Seeded with the 25
+adversarial fixtures from tests/injection-corpus and the 3 dovecot
+integration fixtures (28 seeds total).
+
+Asserts: no panic on any input; resource limits in parse::limits are
+the only enforcement (the fuzzer's job is to find inputs that bypass
+them). Resource-limit unit tests live in parse/mod.rs already.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 4 [P1]: `content_html` fuzz harness
+
+**Why:** The HTML sanitizer has its own attack surface (DOM-tree traversal, ammonia filtering, link extraction) distinct from the MIME parser. The existing proptest harness uses structured string generation; libfuzzer's coverage-guided exploration finds different bugs.
+
+**Files:**
+- Create: `fuzz/fuzz_targets/content_html.rs`
+- Create: `fuzz/corpus/content_html/` (extract HTML bodies from fixtures)
+- Modify: `fuzz/Cargo.toml` (register the target)
+
+- [ ] **Step 1: Register the target**
+
+Edit `fuzz/Cargo.toml`. After the `content_mime` `[[bin]]` block, append:
+
+```toml
+
+[[bin]]
+name = "content_html"
+path = "fuzz_targets/content_html.rs"
+test = false
+doc = false
+bench = false
+```
+
+- [ ] **Step 2: Write the harness**
+
+Create `fuzz/fuzz_targets/content_html.rs`:
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // sanitize_html(raw: &[u8], charset: Option<&str>) -> Result<HtmlResult, ContentError>
+    //
+    // The fuzzer drives both arguments. The first byte (modulo a small
+    // table) selects a charset label so the input space includes
+    // realistic charset routing; the rest is the body.
+    if data.is_empty() {
+        return;
+    }
+    let charset = match data[0] % 5 {
+        0 => None,
+        1 => Some("utf-8"),
+        2 => Some("iso-8859-1"),
+        3 => Some("windows-1252"),
+        _ => Some("us-ascii"),
+    };
+    let body = &data[1..];
+    let _ = rimap_content::testutil::sanitize_html(body, charset);
+});
+```
+
+The harness uses the `test-util` re-export (`rimap_content::testutil::sanitize_html`), which is the path Task 2 made public.
+
+- [ ] **Step 3: Seed the corpus**
+
+A small-scale extraction script. Run:
+
+```bash
+mkdir -p fuzz/corpus/content_html
+
+# Extract HTML bodies from injection-corpus fixtures. Each .eml may have
+# zero or more text/html parts; this naive extractor pulls anything
+# between a "Content-Type: text/html" line and the next blank line +
+# next part boundary. It's a seed-corpus seeder — fidelity is irrelevant,
+# diversity matters.
+python3 - <<'EOF'
+import email
+import os
+import pathlib
+
+src_dir = pathlib.Path("tests/injection-corpus")
+out_dir = pathlib.Path("fuzz/corpus/content_html")
+
+for case in sorted(src_dir.iterdir()):
+    eml = case / "input.eml"
+    if not eml.is_file():
+        continue
+    try:
+        msg = email.message_from_bytes(eml.read_bytes())
+    except Exception:
+        continue
+    idx = 0
+    for part in msg.walk():
+        if part.get_content_type() != "text/html":
+            continue
+        payload = part.get_payload(decode=True) or b""
+        if not payload.strip():
+            continue
+        out = out_dir / f"{case.name}-{idx}.html"
+        out.write_bytes(b"\x01" + payload)  # leading byte chooses charset
+        idx += 1
+EOF
+
+ls fuzz/corpus/content_html | wc -l
+```
+
+Expected: at least 5 files. (Not every fixture has an HTML part; expect roughly 8–12.) If 0 files, the extractor failed silently — re-run interactively.
+
+- [ ] **Step 4: Add a hand-crafted floor of edge cases**
+
+Run:
+```bash
+cat > fuzz/corpus/content_html/empty.html <<'EOF'
+EOF
+
+printf '\x01<html></html>'                                 > fuzz/corpus/content_html/empty-doc.html
+printf '\x01<script>x</script>'                            > fuzz/corpus/content_html/script-only.html
+printf '\x01<style>.x{}</style>'                           > fuzz/corpus/content_html/style-only.html
+printf '\x01<a href="http://e.com">x</a>'                  > fuzz/corpus/content_html/anchor.html
+printf '\x01<a href="javascript:alert(1)">x</a>'           > fuzz/corpus/content_html/js-href.html
+printf '\x01<img src="https://tracker.example/p.gif">'     > fuzz/corpus/content_html/remote-img.html
+printf '\x01<div style="display:none">hidden</div>'        > fuzz/corpus/content_html/hidden.html
+printf '\x01<p style="color:white;background:white">w</p>' > fuzz/corpus/content_html/white-on-white.html
+printf '\x01<p>%s</p>' "$(printf 'A%.0s' {1..2000})"        > fuzz/corpus/content_html/long-text.html
+
+ls fuzz/corpus/content_html | wc -l
+```
+
+Expected: at least 14 files (5 extracted + 9 hand-crafted edge cases). The leading `\x01` byte selects `Some("utf-8")` per the harness's charset-mux at Step 2.
+
+- [ ] **Step 5: Build and run for 60 seconds**
+
+Run:
+```bash
+cd fuzz && cargo +nightly fuzz build content_html && \
+  cargo +nightly fuzz run content_html -- -max_total_time=60 && cd ..
+```
+
+Expected: clean build, 60 seconds of fuzzing, no crash.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/fuzz_targets/content_html.rs fuzz/corpus/content_html/
+git commit -m "test(fuzz): add content_html harness for sanitize_html
+
+Drives the HTML→text sanitizer on raw bytes with a fuzzer-chosen
+charset label (5-way mux off the first byte). Seed corpus extracts
+HTML parts from tests/injection-corpus plus 9 hand-crafted edge
+cases (empty, script-only, javascript: hrefs, remote images,
+hidden/white-on-white, long bodies).
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 5 [P1]: `content_rfc2047` fuzz harness
+
+**Why:** The RFC 2047 encoded-word path is a known attack surface — `tests/injection-corpus/rfc2047-crlf-smuggling/` documents that a maliciously-encoded `=?...?=` token can carry CRLF bytes that splice unintended headers into the message. The smuggling-detection function `scrub_header_smuggling` is the load-bearing defense.
+
+**Files:**
+- Create: `fuzz/fuzz_targets/content_rfc2047.rs`
+- Create: `fuzz/corpus/content_rfc2047/`
+- Modify: `fuzz/Cargo.toml`
+
+- [ ] **Step 1: Register the target**
+
+Edit `fuzz/Cargo.toml`. Append:
+
+```toml
+
+[[bin]]
+name = "content_rfc2047"
+path = "fuzz_targets/content_rfc2047.rs"
+test = false
+doc = false
+bench = false
+```
+
+- [ ] **Step 2: Write the harness**
+
+Create `fuzz/fuzz_targets/content_rfc2047.rs`:
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rimap_content::output::SecurityWarning;
+
+fuzz_target!(|data: &[u8]| {
+    let mut warnings: Vec<SecurityWarning> = Vec::new();
+    let scrubbed = rimap_content::testutil::scrub_header_smuggling(data, &mut warnings);
+
+    // Invariant: the scrubbed output never contains a bare LF inside an
+    // encoded-word run. (CRLF sequences are normal header continuation;
+    // bare LF inside =?...?= is the smuggling signal that must have been
+    // removed.) The function's contract is to either remove the smuggled
+    // bytes or emit a SecurityWarning::HeaderSmuggling — the harness
+    // asserts the *output* never carries the attack pattern when no
+    // warning was raised.
+    if warnings.is_empty() {
+        let mut in_eword = false;
+        let mut prev = 0u8;
+        for &b in &scrubbed {
+            if !in_eword && b == b'=' {
+                // peek not available; track via state.
+            }
+            if b == b'?' && prev == b'=' {
+                in_eword = true;
+            }
+            if in_eword && b == b'\n' && prev != b'\r' {
+                panic!("bare LF inside encoded-word slipped through scrub_header_smuggling");
+            }
+            if b == b'=' && prev == b'?' {
+                in_eword = false;
+            }
+            prev = b;
+        }
+    }
+});
+```
+
+This is a stronger assertion than the other harnesses — `content_rfc2047` actively probes a known bug class. If a future change to the scrubber regresses, the harness panics and libfuzzer flags it as a finding.
+
+- [ ] **Step 3: Seed the corpus from the existing CRLF-smuggling fixture**
+
+Run:
+```bash
+mkdir -p fuzz/corpus/content_rfc2047
+
+# The dedicated fixture for this attack class
+cp tests/injection-corpus/rfc2047-crlf-smuggling/input.eml \
+   fuzz/corpus/content_rfc2047/known-attack.eml
+
+# A handful of clean RFC 2047 encoded-words
+printf 'Subject: =?utf-8?B?aGVsbG8=?=\r\n\r\nbody'  > fuzz/corpus/content_rfc2047/clean-b64.eml
+printf 'Subject: =?utf-8?Q?hello?=\r\n\r\nbody'     > fuzz/corpus/content_rfc2047/clean-q.eml
+printf 'Subject: plain text\r\n\r\nbody'             > fuzz/corpus/content_rfc2047/no-eword.eml
+printf 'Subject: =?utf-8?B?\r\nbody'                 > fuzz/corpus/content_rfc2047/truncated.eml
+printf 'Subject: =?\r\n\r\nbody'                     > fuzz/corpus/content_rfc2047/dangling-open.eml
+printf 'Subject: ?=\r\n\r\nbody'                     > fuzz/corpus/content_rfc2047/dangling-close.eml
+
+ls fuzz/corpus/content_rfc2047 | wc -l
+```
+
+Expected: 7 files.
+
+- [ ] **Step 4: Build and run for 60 seconds**
+
+Run:
+```bash
+cd fuzz && cargo +nightly fuzz build content_rfc2047 && \
+  cargo +nightly fuzz run content_rfc2047 -- -max_total_time=60 && cd ..
+```
+
+Expected: clean build, 60 seconds of fuzzing, no crash. **If the harness panics with the bare-LF assertion**, this is a real bug — stop and file an issue before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/fuzz_targets/content_rfc2047.rs fuzz/corpus/content_rfc2047/
+git commit -m "test(fuzz): add content_rfc2047 harness for header smuggling scrubber
+
+Drives scrub_header_smuggling on raw bytes; asserts that any output
+emitted without an accompanying SecurityWarning never contains a
+bare LF inside an encoded-word run (the CRLF-smuggling attack class
+documented in tests/injection-corpus/rfc2047-crlf-smuggling).
+
+Seed corpus: known-attack fixture + 6 hand-crafted edge cases.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 6 [P1]: `content_charset` fuzz harness
+
+**Why:** Charset label parsing has historically been a source of bugs in mail clients. `unicode::decode(bytes, charset_label)` is the entry point that turns server-controlled label strings into encoding decisions; a panic here is a remote DoS vector.
+
+**Files:**
+- Create: `fuzz/fuzz_targets/content_charset.rs`
+- Create: `fuzz/corpus/content_charset/`
+- Modify: `fuzz/Cargo.toml`
+
+- [ ] **Step 1: Register the target**
+
+Edit `fuzz/Cargo.toml`. Append:
+
+```toml
+
+[[bin]]
+name = "content_charset"
+path = "fuzz_targets/content_charset.rs"
+test = false
+doc = false
+bench = false
+```
+
+- [ ] **Step 2: Write the harness**
+
+Create `fuzz/fuzz_targets/content_charset.rs`:
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Wire format: first byte = label length L (0..=63), next L bytes = label
+    // (UTF-8 if valid, otherwise None), remainder = bytes to decode.
+    if data.is_empty() {
+        return;
+    }
+    let label_len = (data[0] & 0x3f) as usize;
+    if 1 + label_len > data.len() {
+        return;
+    }
+    let label_bytes = &data[1..1 + label_len];
+    let body = &data[1 + label_len..];
+
+    let label = std::str::from_utf8(label_bytes).ok();
+    let _ = rimap_content::unicode::decode(body, label);
+});
+```
+
+The wire-format split (length-prefixed label + body) gives libfuzzer a structured input space without needing a custom mutator.
+
+- [ ] **Step 3: Seed the corpus with charset+bytes pairs**
+
+Run (Python — bash heredocs cannot reliably emit a leading length byte):
+```bash
+mkdir -p fuzz/corpus/content_charset
+
+python3 - <<'PY'
+import pathlib
+
+OUT = pathlib.Path("fuzz/corpus/content_charset")
+
+def seed(name: str, label: str, body: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    assert len(label_bytes) <= 0x3f, f"label {label!r} exceeds 6-bit length cap"
+    payload = bytes([len(label_bytes)]) + label_bytes + body
+    (OUT / name).write_bytes(payload)
+
+# encoding_rs's named set, sampled across script families. The fuzzer
+# will explore from these seeds; the goal is breadth, not exhaustiveness.
+SEEDS = [
+    # ASCII-superset Latin
+    ("utf8-ascii",        "utf-8",         b"hello world"),
+    ("utf8-emoji",        "utf-8",         b"\xf0\x9f\x98\x80"),  # U+1F600
+    ("utf8-bom",          "utf-8",         b"\xef\xbb\xbfhello"),
+    ("utf8-overlong",     "utf-8",         b"\xc0\x80"),
+    ("utf8-truncated",    "utf-8",         b"\xc3"),
+    ("utf8-invalid",      "utf-8",         b"\xff\xfe\xfd"),
+    ("ascii",             "us-ascii",      b"plain"),
+    ("iso8859-1",         "iso-8859-1",    b"\xa3 sterling"),
+    ("iso8859-2",         "iso-8859-2",    b"\xb1\xc4"),
+    ("iso8859-15",        "iso-8859-15",   b"\xa4 euro"),
+    ("windows-1250",      "windows-1250",  b"\xa1\xa3"),
+    ("windows-1251",      "windows-1251",  b"\xc0\xc1\xc2"),
+    ("windows-1252",      "windows-1252",  b"\x80 euro"),
+    ("windows-1255",      "windows-1255",  b"\xe0\xe1"),
+    ("macintosh",         "macintosh",     b"\xc7\xb1"),
+    # CJK
+    ("shift-jis",         "shift_jis",     b"\x82\xa0"),
+    ("euc-jp",            "euc-jp",        b"\xa4\xa2"),
+    ("iso-2022-jp",       "iso-2022-jp",   b"\x1b$B$\"\x1b(B"),
+    ("euc-kr",            "euc-kr",        b"\xb0\xa1"),
+    ("big5",              "big5",          b"\xa5\x40"),
+    ("gb18030",           "gb18030",       b"\xa1\xa1"),
+    ("gbk",               "gbk",           b"\xb0\xa1"),
+    # Cyrillic
+    ("koi8-r",            "koi8-r",        b"\xc1\xc2\xc3"),
+    ("koi8-u",            "koi8-u",        b"\xa4\xa6"),
+    # Empty
+    ("utf8-empty",        "utf-8",         b""),
+    ("empty-empty",       "",              b""),
+    ("empty-body",        "us-ascii",      b""),
+    # Garbage labels
+    ("garbage-1",         "not-a-charset", b"anything"),
+    ("garbage-2",         "x-mac-vendor",  b"data"),
+    ("garbage-3",         "   ",           b"spaces"),
+    ("garbage-4",         "UTF-8 ",        b"trailing space"),
+    ("garbage-5",         "utf_8",         b"underscore"),
+    # Mismatch (declared label, payload from a different encoding)
+    ("mismatch-1",        "utf-8",         b"\xa3 sterling"),
+    ("mismatch-2",        "iso-8859-1",    b"\xf0\x9f\x98\x80"),
+]
+
+for name, label, body in SEEDS:
+    seed(name, label, body)
+
+print(len(SEEDS))
+PY
+
+ls fuzz/corpus/content_charset | wc -l
+```
+
+Expected: `34` printed by Python, and `34` from `ls | wc -l`. If the count differs, the Python script aborted partway — re-run interactively.
+
+- [ ] **Step 4: Build and run for 60 seconds**
+
+Run:
+```bash
+cd fuzz && cargo +nightly fuzz build content_charset && \
+  cargo +nightly fuzz run content_charset -- -max_total_time=60 && cd ..
+```
+
+Expected: clean build, 60 seconds of fuzzing, no crash.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/fuzz_targets/content_charset.rs fuzz/corpus/content_charset/
+git commit -m "test(fuzz): add content_charset harness for unicode::decode
+
+Drives unicode::decode with length-prefixed (label, bytes) pairs.
+Seed corpus covers common charsets (utf-8, iso-8859-1, windows-1252,
+shift_jis, koi8-r, big5, gb18030), empty bodies, garbage labels, and
+invalid byte sequences for utf-8 (lone surrogates, overlong forms).
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 7 [P2]: Refresh `cargo-mutants` baseline on `rimap-content`
+
+**Why:** The current `mutants.out/` snapshot is from 2026-04-08 and predates `desloppify`/BootError/rotation-clock-seam landings. The 67 reported survivors in non-`bin/` code are the starting list — but we must refresh first to filter false positives caused by code that has since changed.
+
+**Files:**
+- Create: `docs/superpowers/specs/test-strategy/mutation-baseline.md`
+
+- [ ] **Step 1: Run the targeted mutation suite**
+
+Run:
+```bash
+cargo mutants --package rimap-content --no-shuffle 2>&1 | tee /tmp/mutants-rimap-content.log
+```
+
+Expected runtime: 30–90 minutes depending on host. The command prints a per-mutant outcome (`caught`, `missed`, `unviable`, `timeout`). Output is also written to `mutants.out/`.
+
+- [ ] **Step 2: Snapshot the survivors**
+
+Run:
+```bash
+mkdir -p docs/superpowers/specs/test-strategy
+SURVIVORS=$(grep -E "^crates/rimap-content/src/[^b]" mutants.out/missed.txt | grep -v "^crates/rimap-content/src/bin/" | wc -l | tr -d ' ')
+echo "Surviving mutants outside src/bin/: $SURVIVORS"
+grep -E "^crates/rimap-content/src/" mutants.out/missed.txt | grep -v "^crates/rimap-content/src/bin/" > /tmp/rimap-content-survivors.txt
+wc -l /tmp/rimap-content-survivors.txt
+```
+
+If the survivor count is **> 30**, stop and write a follow-up plan: B1's mutation cleanup is scoped to "manageable inline cleanup," and >30 is the cap that signals the work warrants its own plan. Document the count in the commit message and skip Tasks 8–9 in this PR; the fuzz harnesses + ClusterFuzzLite still ship in this sprint.
+
+If the survivor count is ≤ 30, proceed.
+
+- [ ] **Step 3: Write the baseline document**
+
+Create `docs/superpowers/specs/test-strategy/mutation-baseline.md`:
+
+````markdown
+# Mutation-baseline — Targeted-trust-boundary survivor inventory
+
+**Updated:** YYYY-MM-DD (replace with today's date)
+**Tool:** `cargo-mutants` (run via `just mutants-crate <name>`)
+**Scope:** Five trust-boundary crates — `rimap-content`, `rimap-authz`,
+`rimap-audit`, `rimap-server`, `rimap-imap`. Other workspace crates are
+out of scope per spec
+[`2026-04-30-test-strategy-improvements-design.md`](../2026-04-30-test-strategy-improvements-design.md).
+
+A survivor is recorded here when it is *not* a true bug in the test suite —
+either because the mutation is mathematically equivalent to the original
+code, or because it falls in a code path the spec explicitly classifies as
+"plumbing, best-effort." Survivors that *are* test-suite gaps are killed by
+adding a test, not annotated.
+
+---
+
+## `rimap-content`
+
+**Last refresh:** YYYY-MM-DD (replace).
+**Surviving mutants in non-`bin/` code:** N (replace with Step 2 count).
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+| _populated by Task 8/9_ |  |  |  |
+
+The `bin/epvme_runner.rs` survivors are out of scope for B1 — that crate is
+diagnostic tooling, not production. Re-evaluate post-B4.
+
+## `rimap-authz`
+
+_Populated in Sprint B2._
+
+## `rimap-audit`
+
+_Populated in Sprint B2._
+
+## `rimap-server`
+
+_Populated in Sprint B3._
+
+## `rimap-imap`
+
+_Populated in Sprint B3._
+````
+
+Replace the two `YYYY-MM-DD` placeholders with the current date and `N` with the count from Step 2.
+
+- [ ] **Step 4: Commit the baseline doc and the survivor list**
+
+```bash
+git add docs/superpowers/specs/test-strategy/mutation-baseline.md
+git commit -m "docs(test-strategy): create mutation-baseline scaffold for B1
+
+Refreshed cargo-mutants on rimap-content; recorded the survivor count
+as the starting point for Tasks 8-9. Per-survivor annotations land
+inline in subsequent commits as each module gets cleaned up.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 8 [P2]: Mutation cleanup — `parse/`, `html/`, `unicode.rs`, `lookalike.rs`
+
+**Why:** These four modules implement the active sanitization pipeline. Per the spec, every survivor here must be killed (a test added that catches the mutation) — there is no "best-effort" branch in security-critical paths.
+
+**Files:**
+- Create or modify: tests under `crates/rimap-content/tests/` and `crates/rimap-content/src/{parse,html,unicode,lookalike}.rs` `#[cfg(test)]` modules.
+- Modify: `docs/superpowers/specs/test-strategy/mutation-baseline.md`
+
+This task is **iterative** — there is no upfront list of N steps because the survivor inventory is data-dependent. The task pattern is:
+
+- [ ] **Step 1: Filter the survivor list to this task's modules**
+
+Run:
+```bash
+grep -E "^crates/rimap-content/src/(parse/|html/|unicode\.rs|lookalike\.rs)" \
+  /tmp/rimap-content-survivors.txt | tee /tmp/task8-survivors.txt
+wc -l /tmp/task8-survivors.txt
+```
+
+Note the count — call it `K`. The next steps execute K times (one per surviving mutant), in the order they appear.
+
+- [ ] **Step 2 (loop, K iterations): Kill one mutant**
+
+For each line in `/tmp/task8-survivors.txt`:
+
+  1. **Read the mutation.** The line is formatted `path:line:col: <mutation description>`. Open the named file at the named line. Read enough surrounding code to understand what the mutation changes.
+
+  2. **Decide: real gap, or equivalent mutant?** Most mutations are real gaps — the mutant changes observable behavior and the test suite has a hole. A few are equivalent — the mutated code produces output indistinguishable from the original under the function's contract.
+
+  3. **If real gap, write a failing test.** Pick the test file that already exercises this module (`crates/rimap-content/src/<module>.rs` `#[cfg(test)]`, or one of the `crates/rimap-content/tests/*.rs` integration tests). Add a test that asserts the precise behavior the mutation breaks. Run it under the original code and confirm it passes; run it under a temporary local hand-application of the mutation and confirm it fails.
+
+     Run:
+     ```bash
+     cargo nextest run --package rimap-content --all-features -- <test_name>
+     ```
+
+     The test must pass under unmutated code. If it passes against the mutated code too, it's not actually catching the mutation — go back and tighten it.
+
+  4. **If equivalent mutant, annotate.** Add a comment immediately above the line:
+     ```rust
+     // cargo-mutants: known-equivalent — <one-line rationale>
+     ```
+     Annotation rationales must explain *why* the mutation is observably indistinguishable, not just "it doesn't matter." Example:
+     ```rust
+     // cargo-mutants: known-equivalent — replaces `+= 1` with `+= 0` on a
+     // counter only consumed for an internal `tracing::debug!`, never read
+     // by tests or production code.
+     ```
+
+  5. **Update the baseline doc.** Add a row to the appropriate table in `docs/superpowers/specs/test-strategy/mutation-baseline.md` *only if* the mutant is annotated as equivalent (real fixes don't get rows — they don't survive any more).
+
+  6. **Commit.** Group by module (one commit per `parse/`, one per `html/`, etc.) — commit all that module's fixes together once the module is empty of survivors.
+
+     ```bash
+     git add crates/rimap-content/src/<module>/ crates/rimap-content/tests/<related>.rs \
+             docs/superpowers/specs/test-strategy/mutation-baseline.md
+     git commit -m "test(rimap-content): close mutation gaps in <module>
+
+     Adds N tests covering specific mutation survivors uncovered by
+     cargo-mutants on the 2026-04-30 baseline refresh. M known-equivalent
+     mutants annotated inline in mutation-baseline.md.
+
+     Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+     ```
+
+- [ ] **Step 3: Re-run mutation tests on the cleaned modules to verify**
+
+Run:
+```bash
+cargo mutants --package rimap-content \
+  --file 'crates/rimap-content/src/parse/**' \
+  --file 'crates/rimap-content/src/html/**' \
+  --file 'crates/rimap-content/src/unicode.rs' \
+  --file 'crates/rimap-content/src/lookalike.rs' \
+  --no-shuffle
+```
+
+Expected: zero `MISSED` mutations. If any remain, return to Step 2 — they are either gaps the prior loop missed or equivalent mutants that need annotation.
+
+- [ ] **Step 4: Verify the workspace still builds clean**
+
+Run:
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-content --all-features --locked
+```
+
+Expected: both clean.
+
+---
+
+## Task 9 [P2]: Mutation cleanup — `output.rs`, `error.rs`, `raw_parts.rs`, `testutil.rs`
+
+**Why:** Per the spec, these are "plumbing" — survivors that change observable output get killed; survivors equivalent under serialization round-trip get annotated. The bar is lower than Task 8.
+
+**Files:** same pattern as Task 8 — adds tests under `#[cfg(test)]` modules in the four named files (or `crates/rimap-content/tests/*.rs` for integration coverage), plus annotations and `mutation-baseline.md` updates.
+
+- [ ] **Step 1: Filter the survivor list**
+
+Run:
+```bash
+grep -E "^crates/rimap-content/src/(output|error|raw_parts|testutil)\.rs" \
+  /tmp/rimap-content-survivors.txt | tee /tmp/task9-survivors.txt
+wc -l /tmp/task9-survivors.txt
+```
+
+Call this count `K2`.
+
+- [ ] **Step 2 (loop, K2 iterations): Triage one mutant**
+
+For each line, decide:
+
+  - **Changes observable output / API contract** → kill with a test (Task 8 sub-procedure).
+  - **Equivalent under a documented round-trip** → annotate inline + baseline-doc row.
+  - **Pure cosmetic** (e.g., `tracing::debug!` formatting) → annotate inline + baseline-doc row.
+
+The rationale lines for plumbing-code annotations get more leeway than Task 8 — "internal-only counter, never observed externally" is a complete justification here.
+
+- [ ] **Step 3: Re-run on the cleaned files**
+
+Run:
+```bash
+cargo mutants --package rimap-content \
+  --file 'crates/rimap-content/src/output.rs' \
+  --file 'crates/rimap-content/src/error.rs' \
+  --file 'crates/rimap-content/src/raw_parts.rs' \
+  --file 'crates/rimap-content/src/testutil.rs' \
+  --no-shuffle
+```
+
+Expected: zero unannotated `MISSED` mutations.
+
+- [ ] **Step 4: Final mutation-cleanup commit**
+
+```bash
+git add crates/rimap-content/ docs/superpowers/specs/test-strategy/mutation-baseline.md
+git commit -m "test(rimap-content): close mutation gaps in plumbing modules
+
+Closes the long tail of cargo-mutants survivors in output.rs, error.rs,
+raw_parts.rs, testutil.rs. Real gaps killed with targeted tests;
+equivalent mutants annotated inline with rationale.
+
+After this commit: cargo mutants --package rimap-content (excluding
+src/bin/epvme_runner.rs) reports zero unannotated survivors.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 10 [P2]: ClusterFuzzLite workflow (PR smoke + nightly)
+
+**Why:** Continuous fuzzing in CI is the runtime artifact that completes Sprint B1's done criteria. The PR-smoke job runs `content_mime` + `content_html` for 5 minutes each on every PR (the other two stay nightly-only per spec §4.4). The nightly job runs all four targets at 30 minutes each on `main`.
+
+**Files:**
+- Create: `.github/workflows/fuzz.yml`
+
+ClusterFuzzLite documentation: <https://google.github.io/clusterfuzzlite/>. The `actions/build_fuzzers` and `actions/run_fuzzers` actions live at `github.com/google/clusterfuzzlite/actions/...`. SHAs must be looked up at execution time (zizmor enforces 40-char SHA pins per repo policy).
+
+- [ ] **Step 1: Look up the current ClusterFuzzLite action SHAs**
+
+Run:
+```bash
+gh api repos/google/clusterfuzzlite/branches/main --jq '.commit.sha'
+```
+
+Record the SHA — it's used in three `uses:` lines below. Also resolve the corresponding tag via:
+```bash
+gh api repos/google/clusterfuzzlite/git/refs/tags --jq '.[-1].ref'
+```
+
+If a stable tag like `v1` exists and is pinned to a recent SHA, prefer that. Document the (SHA, tag) pair as a comment on each `uses:` line.
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/fuzz.yml`:
+
+```yaml
+name: Fuzz
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/rimap-content/**'
+      - 'crates/rimap-audit/**'
+      - 'crates/rimap-server/**'
+      - 'fuzz/**'
+      - '.github/workflows/fuzz.yml'
+  schedule:
+    # Nightly at 03:17 UTC. The odd minute spreads load on shared GHA
+    # cron schedulers (top-of-the-hour cron jobs queue heavily).
+    - cron: '17 3 * * *'
+
+concurrency:
+  # PR-smoke runs share a per-PR group so a force-push cancels the prior run.
+  # Nightly runs share a single global group so two nightly cycles cannot
+  # overlap if one runs long.
+  group: fuzz-${{ github.event_name == 'schedule' && 'nightly' || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  # 'security-events: write' would be needed to upload SARIF; not used here
+  # because crash artifacts are sufficient for B1's scope.
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  pr-smoke:
+    name: pr-smoke (${{ matrix.target }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [content_mime, content_html]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build fuzzers
+        # Pin: replace <SHA> with the SHA captured in Step 1.
+        uses: google/clusterfuzzlite/actions/build_fuzzers@<SHA>  # <tag/date>
+        with:
+          language: rust
+          sanitizer: address
+      - name: Run fuzzer (${{ matrix.target }})
+        uses: google/clusterfuzzlite/actions/run_fuzzers@<SHA>  # <tag/date>
+        with:
+          language: rust
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: address
+          # Restrict to a single target per matrix slot so a crash in one
+          # does not mask a regression in the other.
+          parallel-fuzzing: false
+
+  nightly:
+    name: nightly (${{ matrix.target }})
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [content_mime, content_html, content_rfc2047, content_charset]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@<SHA>  # <tag/date>
+        with:
+          language: rust
+          sanitizer: address
+      - name: Run fuzzer (${{ matrix.target }})
+        uses: google/clusterfuzzlite/actions/run_fuzzers@<SHA>  # <tag/date>
+        with:
+          language: rust
+          fuzz-seconds: 1800  # 30 minutes per target
+          mode: batch
+          sanitizer: address
+          parallel-fuzzing: false
+```
+
+Replace **all four** `<SHA>` placeholders with the SHA from Step 1 and the trailing `# <tag/date>` comments with the matching ref.
+
+- [ ] **Step 3: actionlint must pass**
+
+Run:
+```bash
+actionlint .github/workflows/fuzz.yml
+```
+
+Expected: no output. If actionlint flags `<SHA>`, the placeholder substitution from Step 2 was missed.
+
+- [ ] **Step 4: zizmor must pass**
+
+Run:
+```bash
+zizmor .github/workflows/fuzz.yml
+```
+
+Expected: zero new findings. If zizmor flags `superfluous-actions` on the ClusterFuzzLite calls, add a per-line `# zizmor: ignore[superfluous-actions]` trailer on each — the actions are not replaceable with shell commands here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/fuzz.yml
+git commit -m "ci(fuzz): add ClusterFuzzLite workflow for PR smoke + nightly
+
+PR smoke runs content_mime + content_html for 5 min each on every
+PR that touches the fuzzed crates or fuzz/. Nightly runs all four
+B1 targets at 30 min each on main. Crash artifacts upload to GHA;
+reproducer files persist 90 days per ClusterFuzzLite default.
+
+Other content_* targets stay nightly-only per spec §4.4 — their
+input space is largely subsumed by content_mime's deeper code paths.
+
+Refs: docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md"
+```
+
+---
+
+## Task 11 [P2]: Smoke-test the workflow on a draft PR
+
+**Why:** ClusterFuzzLite has many quiet failure modes (missing `language` keyword, wrong sanitizer, corpus path resolution). A draft PR is the cheapest way to verify the wiring on a real GHA runner before the work merges to `main`.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/test-strategy-b1-rimap-content
+```
+
+- [ ] **Step 2: Open a draft PR**
+
+```bash
+gh pr create --draft --title "test: B1 — rimap-content fuzz harnesses + mutation cleanup" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Sprint B1 of the test-strategy-improvements plan. Adds:
+
+- Four cargo-fuzz harnesses (content_mime, content_html, content_rfc2047, content_charset) under a new workspace-excluded `fuzz/` crate.
+- Seed corpora pulled from `tests/injection-corpus/` plus hand-crafted edge cases.
+- Targeted mutation cleanup on `rimap-content` (refreshed baseline at the start of this PR; survivors killed module-by-module; equivalent mutants annotated inline).
+- ClusterFuzzLite CI workflow for PR-smoke (10 min) and nightly cron (60 min).
+
+## Test plan
+
+- [ ] All seven existing `just ci` checks pass (rustfmt, clippy, check (macOS), test (stable), test (MSRV 1.88.0), cargo-deny, zizmor self-check).
+- [ ] `just fuzz content_mime` runs ≥ 60 s locally without crash.
+- [ ] `just fuzz content_html` runs ≥ 60 s locally without crash.
+- [ ] `just fuzz content_rfc2047` runs ≥ 60 s locally without crash.
+- [ ] `just fuzz content_charset` runs ≥ 60 s locally without crash.
+- [ ] `cargo mutants --package rimap-content` reports zero unannotated survivors outside `src/bin/`.
+- [ ] The `fuzz / pr-smoke` job appears in this PR's status checks and runs to completion green.
+- [ ] `mutation-baseline.md` documents the new state for `rimap-content`.
+
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run:
+```bash
+gh pr checks --watch
+```
+
+Expected: all eight existing checks plus two new `fuzz / pr-smoke (content_mime)` and `fuzz / pr-smoke (content_html)` checks pass. If a fuzz-smoke check fails:
+- "build_fuzzers failed" → most likely a missing dep in `fuzz/Cargo.toml` (e.g., `rimap-content` feature not enabled). Fix locally, push, watch again.
+- "run_fuzzers found a crash" → libfuzzer reproduced a real bug. Triage: this PR cannot merge until the crash is fixed *or* a known-issue branch documents the deferral.
+
+- [ ] **Step 4: Mark the PR ready for review**
+
+Once CI is green:
+```bash
+gh pr ready
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Step 1: Tick off Sprint B1's spec done-criteria**
+
+Per spec §4.5:
+
+- [ ] `just fuzz content_mime` runs locally for ≥ 5 minutes without finding a new crash.
+- [ ] Same for `content_html`, `content_rfc2047`, `content_charset`.
+- [ ] `cargo mutants --package rimap-content` reports 0 surviving mutants in non-`bin/` code, or every survivor has a `known-equivalent` annotation.
+- [ ] ClusterFuzzLite smoke job is green on the PR.
+- [ ] `mutation-baseline.md` documents the new state.
+
+- [ ] **Step 2: Run the long-form fuzz validation locally before requesting review**
+
+5 minutes per target (the spec's actual done-criterion runtime, not Task 3–6's 60-second smoke):
+
+```bash
+just fuzz content_mime    -- -max_total_time=300
+just fuzz content_html    -- -max_total_time=300
+just fuzz content_rfc2047 -- -max_total_time=300
+just fuzz content_charset -- -max_total_time=300
+```
+
+Expected: all four exit clean after 5 min. Any crash here is a bug, not a flake — file before requesting review.
+
+- [ ] **Step 3: Request review**
+
+```bash
+gh pr comment --body "Ready for review — Sprint B1 done-criteria verified locally and in CI."
+```
+
+- [ ] **Step 4: After merge — open follow-up issues for deferred work**
+
+Two issues if applicable:
+1. **`bin/epvme_runner.rs` mutation survivors** — out of scope for B1 per spec; ~44 survivors as of 2026-04-08 baseline. Issue title: `test(epvme_runner): triage cargo-mutants survivors in diagnostic binary`. Body cites this plan and the relevant lines in the baseline doc.
+2. **B1 over-cap split** (only if Task 7 hit the >30 cap) — issue title: `test(rimap-content): finish mutation cleanup deferred from Sprint B1`. Body cites this PR and explains the cap was hit.
+
+---
+
+## Self-review checklist (writer-side, do not skip)
+
+- **Spec coverage:** every Sprint B1 sub-section in the spec maps to a task in this plan — fuzz harnesses (Tasks 3–6), mutation refresh (Task 7), mutation cleanup (Tasks 8–9), CFL wiring (Task 10), done-criteria validation (Wrap-up Step 1). The "no fuzz target for X" carve-outs are not in B1's scope.
+- **No placeholders:** every code block contains literal text, not `<TBD>`. The two exceptions — ClusterFuzzLite SHAs in Task 10 — are explicit Step-1 lookups with a verification step that catches missed substitutions.
+- **Type/name consistency:** `sanitize_html`, `scrub_header_smuggling`, `parse_message`, `unicode::decode` are referenced consistently across Tasks 2–6 and the harnesses use the exact paths Task 2 set up (`rimap_content::testutil::sanitize_html`, `rimap_content::parse_message`, `rimap_content::unicode::decode`).
+- **TDD-shape:** Task 2 (the only behavioral change) is shaped as failing-test-first. Tasks 3–6 (fuzz harnesses) are shaped as build-then-run-then-verify because there is no obvious "failing test" framing for a fuzz harness — the test *is* the long-running fuzzer.
+- **One commit per logical change:** each task ends in a single commit. Task 8/9's loops are explicit about grouping by module so the history reads as one commit per module's mutation cleanup.
+- **Out-of-band actions are flagged:** the >30 survivor cap in Task 7 is called out in-place; the follow-up issues are called out in Wrap-up Step 4 (operator action, not silently expected).
+- **Cost/value tradeoffs documented:** Task 4's hand-crafted edge cases, Task 5's panic-on-LF assertion, and Task 10's per-target matrix layout are all motivated inline.

--- a/docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md
@@ -1,0 +1,663 @@
+# Test Strategy Improvements — April 2026
+
+**Status:** Draft 2026-04-30 · re-extracted to `main` 2026-05-04 (issue #227)
+**Scope:** Three test-strategy gaps in `rusty-imap-mcp` v1.x — fuzzing
+infrastructure (`cargo-fuzz` + OSS-Fuzz), targeted mutation hardening on
+trust-boundary crates, and macOS-Apple-Silicon Dovecot-integration enablement.
+This spec drives a family of four sprint-shaped implementation plans, not a
+single monolithic plan.
+
+## 0. Re-extraction status (2026-05-04)
+
+This spec was originally written and merged on the
+`archive/daemon-experiment` branch in PR #187, then rolled back with the
+multi-client daemon (see
+`2026-05-02-multi-client-stdio-design.md` §12). The rollback re-extraction
+landed the implementation work before this spec, inverting the order
+proposed at the top of issue #227. As a result, baseline numbers in §2 and
+some implementation details in §3–§4 are historical; the live state is
+tracked in `docs/superpowers/specs/test-strategy/mutation-baseline.md`.
+
+| Sprint | Status (2026-05-04) | Landing context |
+| --- | --- | --- |
+| B1 — `rimap-content` fuzz + mutation | **Done** | Mutation cleanup re-extracted via #225 (PRs #195/#196/#198). Fuzz harnesses + ClusterFuzzLite re-extracted via #226 (PRs through #242). All four targets (`content_mime`, `content_html`, `content_charset`, `content_rfc2047`) live; `mutation-baseline.md` is the source of truth for survivor counts. |
+| B2 — `rimap-authz` + `rimap-audit` | **Open** | No tracking issue yet at the time of re-extraction. |
+| B3 — `rimap-server` + `rimap-imap` | **Open** | No tracking issue yet at the time of re-extraction. |
+| B4 — OSS-Fuzz upstream + macOS integration | **Open** | ClusterFuzzLite is the in-tree continuous-fuzzing path today; OSS-Fuzz upstream submission and the macOS-Apple-Silicon Dovecot path remain unscheduled. |
+
+The §2 baseline numbers ("67 / 111 surviving mutants", "stale 2026-04-08
+snapshot"), the §3.4 Justfile recipe names (live: `just mutants
+--package <name>`, not `just mutants-crate <crate>`), and the §4.4
+PR-smoke target list (live: all four `content_*` targets share one
+600-second smoke job, not a `content_mime`-plus-`content_html` subset)
+are kept verbatim as historical context. The current `cargo-mutants`
+survivor inventory and the as-landed ClusterFuzzLite job shape are
+documented in `mutation-baseline.md` and `.github/workflows/fuzz.yml`
+respectively.
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Current State](#2-current-state)
+3. [Architecture & Cross-Cutting Infrastructure](#3-architecture--cross-cutting-infrastructure)
+4. [Sprint B1 — `rimap-content` Fuzz + Mutation](#4-sprint-b1--rimap-content-fuzz--mutation)
+5. [Sprint B2 — `rimap-authz` + `rimap-audit`](#5-sprint-b2--rimap-authz--rimap-audit)
+6. [Sprint B3 — `rimap-server` + `rimap-imap`](#6-sprint-b3--rimap-server--rimap-imap)
+7. [Sprint B4 — OSS-Fuzz Upstream + macOS Integration](#7-sprint-b4--oss-fuzz-upstream--macos-integration)
+8. [Cross-Cutting Concerns](#8-cross-cutting-concerns)
+9. [Next Steps](#9-next-steps)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Add coverage-guided fuzzing to every untrusted-input boundary the codebase
+  owns, with continuous fuzzing infrastructure in CI.
+- Refresh the `cargo-mutants` baseline (last run 2026-04-08, 3+ weeks stale)
+  and kill every surviving mutant in security-critical paths of the five
+  trust-boundary crates (`rimap-content`, `rimap-authz`, `rimap-audit`,
+  `rimap-server`, `rimap-imap`).
+- Enable Dovecot integration tests on macOS Apple Silicon developer hosts and
+  in CI, eliminating the silent-skip path that today hides regressions from
+  Apple-Silicon developers until they reach the Linux CI runner.
+- Sequence the work as four small, independently mergeable sprints keyed to
+  trust boundaries, mirroring the pattern from
+  `2026-04-19-open-issues-roadmap-design.md`.
+
+### Non-Goals
+
+- Mutation-score CI gate. Targeted hardening (per-crate cleanup) is the
+  scope; promotion to a CI gate requires at least one quarter of stable
+  baseline data and is out of scope here.
+- Criterion benchmarks. Listed as deferred in
+  `2026-04-08-sprint-4b-html-lookalike-design.md`; no consumer signals it as
+  a current need.
+- Differential HTML-sanitizer oracle. Genuinely valuable but warrants its
+  own spec; not bundled here.
+- Property tests beyond the existing five harnesses in `rimap-content`.
+  Lower-value than fuzzing for the other crates; revisit if mutation
+  cleanup surfaces a bug class better caught by proptest.
+- Dovecot 2.4 config migration unless the B4 spike requires it (Path A is
+  reactive, not speculative).
+- Public corpus persistence outside OSS-Fuzz's own infrastructure.
+
+---
+
+## 2. Current State
+
+**Test surface today.** 42 integration test files across the eight member
+crates (~6,142 LOC of tests vs. 157 source files). Layers:
+
+- **Unit + integration:** in-crate `#[cfg(test)]` modules plus `tests/` per
+  crate.
+- **Property tests** via `proptest` — 10,000 cases on the
+  `rimap-content` Unicode and HTML pipelines, plus charset and lookalike
+  properties.
+- **Snapshot tests** via `insta` for sanitizer output.
+- **Adversarial corpus** at `tests/injection-corpus/` — 24+ `.eml` fixtures
+  with `expected.json` declaring required security warnings and forbidden
+  content. Corpus only grows.
+- **Container integration** via a docker-or-podman autodetect harness in
+  `crates/rimap-imap/tests/integration/dovecot/`. Skips silently on
+  non-x86_64 hosts because the pinned `dovecot/dovecot:2.3.21` image is
+  amd64-only.
+- **Proton Bridge integration** behind `PROTON_BRIDGE_TEST=1` (local-only).
+- **`cargo-mutants`** has been run once (2026-04-08); `mutants.out/missed.txt`
+  records 111 surviving mutants. 67 of those are in non-binary
+  `rimap-content` code; the remainder are in the `epvme_runner` diagnostic
+  binary.
+- **Coverage** via `cargo-llvm-cov` in the SonarQube CI job.
+
+**Gaps targeted by this spec.**
+
+- **Fuzzing.** `cargo-fuzz` is referenced as deferred in three earlier specs
+  (Sprint 4b, Sprint 5 phase 1, Sprint 5 phase 2) but no harnesses, `fuzz/`
+  directory, or fuzz CI job exist.
+- **Mutation.** The 2026-04-08 snapshot is stale; main has had heavy churn
+  since (`desloppify` review batches, BootError introduction, daemon
+  transport, rotation clock seam). A targeted refresh on trust-boundary
+  crates will surface real survivors today.
+- **macOS integration.** `DovecotHarness::check_prerequisites` returns
+  `DockerUnavailable` on any host where `std::env::consts::ARCH != "x86_64"`,
+  so Apple Silicon developers and `macos-latest` CI both silently skip the
+  Dovecot suite. The pinned dovecot 2.3.21 image is amd64-only; the current
+  multi-arch `dovecot/dovecot:2.4.x` line ships both `linux/amd64` and
+  `linux/arm64`.
+
+---
+
+## 3. Architecture & Cross-Cutting Infrastructure
+
+### 3.1 Workspace layout addition
+
+A new top-level `fuzz/` directory holds the `cargo-fuzz` crate. It is
+deliberately **not** a workspace member — `cargo-fuzz` is nightly-only and
+does not need to compile under stable.
+
+```
+fuzz/
+├── Cargo.toml          # standalone, links libfuzzer-sys and the crates under test
+├── fuzz_targets/
+│   ├── content_mime.rs
+│   ├── content_html.rs
+│   ├── content_rfc2047.rs
+│   ├── content_charset.rs
+│   ├── audit_jsonl.rs
+│   └── server_jsonrpc.rs
+└── corpus/
+    └── <target>/       # seed corpora, version-controlled
+```
+
+The workspace root `Cargo.toml` gets `exclude = ["fuzz"]` so
+`cargo build --workspace` does not pull `libfuzzer-sys`.
+
+### 3.2 Mutation testing layout
+
+`cargo-mutants` runs are per-crate (`cargo mutants --package <crate>`) rather
+than workspace-wide. Per-crate baseline survivor lists are documented at
+`docs/superpowers/specs/test-strategy/mutation-baseline.md`. The runtime
+scratch directory `mutants.out/` stays gitignored (already configured); only
+the curated baseline doc is committed.
+
+### 3.3 CI changes (cumulative across sprints)
+
+- **`.github/workflows/fuzz.yml`** — new file. `cfl-build` and `cfl-fuzz`
+  jobs from ClusterFuzzLite. Triggered on `pull_request` (10-min smoke
+  per target subset) and `schedule` (60-min nightly on `main`). All
+  pinned to ClusterFuzzLite SHAs per existing zizmor policy. Corpus
+  persisted to a private GitHub Actions cache, not pushed back to the
+  repo.
+- **`.github/workflows/mutants.yml`** — new file. `cargo-mutants` targeted,
+  `workflow_dispatch` only initially. Promotion to scheduled or required
+  is explicitly out of scope (see Section 8).
+- **`.github/workflows/ci.yml`** — unchanged in B1–B3. Sprint B4 adds
+  `test (macOS, integration)` to the existing matrix.
+
+### 3.4 Justfile additions
+
+```
+fuzz TARGET *ARGS:                    # cargo +nightly fuzz run TARGET ARGS
+    cd fuzz && cargo +nightly fuzz run {{TARGET}} -- -max_total_time=30 {{ARGS}}
+
+fuzz-list:                             # enumerate harnesses
+    cd fuzz && cargo +nightly fuzz list
+
+mutants-crate CRATE:                   # targeted mutation run
+    cargo mutants --package {{CRATE}} --no-shuffle
+```
+
+### 3.5 OSS-Fuzz prerequisites
+
+- Maintainer email plus GPG key for vulnerability disclosures.
+- Project description for `project.yaml` `homepage` and `main_repo`.
+- License confirmation: project is dual-licensed Apache-2.0/MIT; both are
+  OSS-Fuzz-acceptable.
+
+The upstream PR happens in Sprint B4; B1–B3 build the prerequisites.
+
+### 3.6 Trust-boundary mapping
+
+Each fuzz target maps to exactly one crate's untrusted-input boundary so a
+crash report fingerprint immediately identifies the responsible owner.
+
+| Target | Crate | Boundary |
+| --- | --- | --- |
+| `content_mime` | rimap-content | `mail-parser` feed of raw bytes |
+| `content_html` | rimap-content | HTML→text sanitizer entry |
+| `content_rfc2047` | rimap-content | encoded-word header decoder |
+| `content_charset` | rimap-content | charset label + bytes → UTF-8 |
+| `audit_jsonl` | rimap-audit | JSONL line parser + redactor |
+| `server_jsonrpc` | rimap-server | JSON-RPC envelope + dispatch |
+
+`rimap-authz` and `rimap-imap` intentionally have no fuzz targets — their
+input surfaces are typed enums or already-fuzzed upstream wire formats. See
+Sprints B2 and B3 for the rationale.
+
+---
+
+## 4. Sprint B1 — `rimap-content` Fuzz + Mutation
+
+**Goal.** Land four `cargo-fuzz` harnesses for the trust boundary that
+consumes adversarial email content, refresh `cargo-mutants` on this crate,
+and kill every surviving mutant in non-binary code.
+
+### 4.1 Fuzz harnesses
+
+| Target | Entry point | Asserted invariants |
+| --- | --- | --- |
+| `content_mime` | `rimap_content::parse::parse_message(raw: &[u8])` | No panic; respects existing depth/size caps in `parse::limits`; no unbounded allocation. |
+| `content_html` | `rimap_content::html::sanitize_html(input: &str)` | Already proptested; libfuzzer's coverage-guided exploration finds different bugs. Output never re-introduces a stripped tag. |
+| `content_rfc2047` | `rimap_content::parse::header::decode_encoded_word(raw: &[u8])` | The CRLF-smuggling fixture in `tests/injection-corpus/` proves this is a real attack class — output never contains an unescaped CRLF. |
+| `content_charset` | `rimap_content::parse::charset::decode(label: &str, bytes: &[u8])` | Drives label parsing and decoding side-by-side. No panic on garbage labels. |
+
+### 4.2 Seed corpora
+
+- `content_mime`: every `.eml` from `tests/injection-corpus/` and
+  `crates/rimap-imap/tests/integration/dovecot/fixtures/` (24+ + 3 files).
+- `content_html`: HTML bodies extracted from the corpus, plus a small
+  one-time pull of W3C HTML5 conformance edge cases.
+- `content_rfc2047`: header lines extracted from the same corpus plus
+  RFC 2047 examples.
+- `content_charset`: 50–100 short `(label, bytes)` pairs covering every
+  charset in `encoding_rs`'s named set plus a handful of garbage labels.
+
+The `epvme_runner` 200-message dataset is **not** copied into seed corpora —
+fuzz seeds need to be small (libfuzzer prefers <4 KB) and minimized.
+
+### 4.3 Mutation cleanup
+
+67 of the 111 stale survivors live in `crates/rimap-content/src/` outside
+`bin/`. Refresh against current `main` first (the snapshot is
+false-positive-prone), then triage:
+
+- **`parse/`, `html/`, `unicode.rs`, `lookalike.rs`** — kill all surviving
+  mutants.
+- **`output.rs`, `error.rs`, `raw_parts.rs`, `testutil.rs`** — kill if the
+  surviving mutant changes observable behavior; document equivalent mutants
+  with `// cargo-mutants: known-equivalent` comments and a one-line
+  rationale.
+- **`bin/epvme_runner.rs`** — survivors stay open. Diagnostic tooling, not
+  production.
+
+### 4.4 ClusterFuzzLite wiring
+
+The PR-smoke job runs `content_mime` plus `content_html` for 5 minutes each
+on every PR. The other two `content_*` targets stay nightly-only — their
+input space is largely subsumed by `content_mime`'s deeper code paths, so
+adding them to PR-smoke costs runner minutes without buying meaningful new
+coverage. Nightly job runs all four targets at 30 minutes each. Crashes
+upload to GHA artifacts; reproducer files persist 90 days.
+
+### 4.5 Done criteria
+
+1. `just fuzz content_mime` runs locally for ≥ 5 minutes without finding a
+   new crash.
+2. Same for the other three targets.
+3. `cargo mutants --package rimap-content` reports 0 surviving mutants in
+   non-`bin/` code, or every survivor has a `known-equivalent` annotation
+   with rationale.
+4. ClusterFuzzLite smoke job is green on the PR.
+5. `mutation-baseline.md` documents the new state.
+
+### 4.6 Rough size
+
+~7–10 PR-sized commits on one focused branch: 4 fuzz-harness commits (one
+per target with seed corpus), 1 ClusterFuzzLite-config commit, 1
+mutation-baseline-refresh commit, ~3 mutation-fix commits batched by module.
+
+---
+
+## 5. Sprint B2 — `rimap-authz` + `rimap-audit`
+
+**Goal.** Land the audit-log JSONL fuzz harness, refresh `cargo-mutants` on
+both crates, kill survivors. Lighter than B1 — the input surfaces are
+narrower.
+
+### 5.1 Fuzz harness
+
+| Target | Entry point | Asserted invariants |
+| --- | --- | --- |
+| `audit_jsonl` | `rimap_audit::reader::parse_line(raw: &[u8])` plus `rimap_audit::redact::redact(record: AuditRecord)` | Parse failures are clean errors, not panics; redacted output round-trips through serde without losing the redaction marker; no original-secret bytes appear in redacted output (substring check against the input). |
+
+### 5.2 No fuzz target for `rimap-authz`
+
+The crate's input boundary is already-typed values (`Posture`, `ToolName`,
+`RateLimiterClock`). The matrix lookup is a pure function of two enums.
+Fuzzing typed enum inputs is enumeration, which `cargo-mutants` already
+exercises better. If a textual config form of the matrix is added, that
+becomes a future fuzz target.
+
+### 5.3 Seed corpus for `audit_jsonl`
+
+- Real audit-log lines captured during the existing daemon-Dovecot
+  integration tests (one-time extract, sanitized, ~50 lines).
+- Hand-crafted edge cases: truncated JSON, unknown `kind`, missing required
+  fields, oversized strings, NUL bytes, BOMs, mixed line endings, embedded
+  newlines inside strings.
+
+### 5.4 Mutation cleanup
+
+The stale snapshot reports zero survivors in either crate, but predates
+several commits (desloppify review batches, BootError, rotation clock seam).
+Refresh will likely surface new survivors.
+
+1. **Refresh first.** `cargo mutants --package rimap-authz` and
+   `cargo mutants --package rimap-audit` against current `main`.
+2. **Kill all survivors in security-sensitive paths:**
+   - `rimap-authz`: `matrix.rs`, `breaker.rs`, `rate_limit.rs`,
+     `folder_guard.rs`, `folder_name.rs`.
+   - `rimap-audit`: `writer/`, `redact/`, `reader/`.
+3. **Best-effort on plumbing:** `cancellation.rs`, `fs.rs`, `record/`. Kill
+   survivors that change observable output; annotate equivalent mutants with
+   rationale.
+
+### 5.5 ClusterFuzzLite wiring
+
+`audit_jsonl` joins the PR-smoke set (now 3 targets at 5 min each = ~15 min
+PR-smoke; under the CFL budget). Nightly run includes it at 30 min.
+
+### 5.6 Why these two crates together
+
+Both are pure-Rust with no IMAP/network dependencies, and both feed the same
+audit-record type. A change in `rimap-audit::record` shapes affects what
+`rimap-authz` decisions get logged; bundling them surfaces that coupling in
+one review. They're also the smallest two trust-boundary crates — keeping
+B2 small leaves headroom for B3, which is the heaviest sprint.
+
+### 5.7 Done criteria
+
+1. `just fuzz audit_jsonl` runs ≥ 5 minutes locally without crash.
+2. `cargo mutants --package rimap-audit` reports 0 unannotated survivors.
+3. `cargo mutants --package rimap-authz` reports 0 unannotated survivors.
+4. CFL PR-smoke is green with all 3 targets.
+5. `mutation-baseline.md` updated.
+
+### 5.8 Rough size
+
+~5 commits: 1 fuzz harness + corpus, 1 baseline refresh, 2 mutation-fix
+commits (one per crate), 1 CFL-config bump.
+
+---
+
+## 6. Sprint B3 — `rimap-server` + `rimap-imap`
+
+**Goal.** Land the JSON-RPC envelope fuzz harness, refresh `cargo-mutants`
+on both crates, kill survivors in security-sensitive paths.
+
+### 6.1 Fuzz harness
+
+| Target | Entry point | Asserted invariants |
+| --- | --- | --- |
+| `server_jsonrpc` | `rimap_server::mcp::dispatch::handle_request(raw: &[u8])` (or the lowest-level public bytes-to-response shim — wrap if necessary) | No panic; every accepted request produces a serializable `Response`; rejected requests return a structured error code; the stub `ToolCallSink` never receives a tool name absent from the active posture. |
+
+If `handle_request` is not currently a public entry point, B3's first commit
+refactors the dispatch entry point to expose a `pub(crate)` byte-buffer shim
+usable from the fuzz crate via the `test-util` feature pattern that
+`rimap-content` already uses. The harness runs synchronously with a stub
+`ToolCallSink`, never a live IMAP connection.
+
+### 6.2 No fuzz target for `rimap-imap`
+
+The crate is pure transport — its inputs are typed `ConnectionConfig` values
+and the wire bytes are consumed by upstream `async-imap`. Fuzzing the IMAP
+wire side fuzzes async-imap, not this crate. The TLS verifier's input is
+structured (`&[CertificateDer]`) and rustls itself is heavily fuzzed
+upstream. Mutation testing covers the surface adequately.
+
+### 6.3 Seed corpus for `server_jsonrpc`
+
+- Captured request/response pairs from the existing `dispatch_ticket.rs`
+  and `e2e.rs` integration tests (one-time extract, ~30–50 envelopes
+  covering each of the 24 `ToolName` variants).
+- Hand-crafted edge cases: oversized fields, deeply nested JSON, unknown
+  method names, malformed `id` field, batch requests, requests with extra
+  fields.
+
+### 6.4 Mutation cleanup
+
+The stale snapshot reports zero survivors in either crate, but `rimap-server`
+has had heavy churn (the entire daemon transport landed after April 8). The
+refresh will surface real work.
+
+**`rimap-server` security-critical paths — kill all unannotated survivors:**
+
+- `mcp/dispatch.rs` (request routing, posture enforcement).
+- `mcp/posture_context.rs` (active-posture decision).
+- `mcp/audit_envelope.rs` (audit-record construction).
+- `mcp/tool_catalog.rs`, `mcp/tool_name.rs` (tool advertisement,
+  posture-gated visibility).
+- `daemon/transport*.rs` (wire framing).
+- `daemon/audit_sink.rs` (cross-process audit forwarding).
+- `boot/`, `daemon/run.rs` (startup paths that touch credentials).
+- `shim.rs` (process boundary).
+
+**`rimap-server` plumbing — best-effort:** `cli/`, `daemon/state.rs`,
+`daemon/shutdown.rs`. Survivors there change observable behavior but not
+security posture; kill the easy ones, annotate the rest.
+
+**`rimap-imap` security-critical paths — kill all unannotated survivors:**
+
+- `tls.rs` (custom `ServerCertVerifier`).
+- `auth.rs`.
+- `connection.rs` (state machine for IDLE / reconnect).
+- `ops/` (FETCH / SEARCH / APPEND wrappers — UID arithmetic and literal-size
+  handling).
+- `preflight.rs`.
+
+**`rimap-imap` plumbing — best-effort:** `error.rs`, `types.rs`, `time.rs`,
+`special_use.rs`, `test_support.rs`.
+
+### 6.5 ClusterFuzzLite wiring
+
+`server_jsonrpc` joins the PR-smoke set. PR-smoke now exercises 4 of 6
+targets — the remaining two are the `content_*` targets from B1 that stay on
+nightly to keep PR-smoke under 30 min. By end of B3, the full 6-target
+nightly is live.
+
+### 6.6 Done criteria
+
+1. `just fuzz server_jsonrpc` runs ≥ 5 minutes locally without crash.
+2. `cargo mutants --package rimap-server` reports 0 unannotated survivors in
+   the security-critical paths above.
+3. Same for `cargo mutants --package rimap-imap`.
+4. CFL nightly is green and exercises all 6 targets.
+5. `mutation-baseline.md` updated; the document now covers all four
+   trust-boundary crates.
+
+### 6.7 Rough size
+
+~10 commits — heaviest sprint. 1 dispatch-entry-point refactor (if needed),
+1 fuzz harness + corpus, 1 baseline refresh, ~5 mutation-fix commits split
+by module (dispatch+posture, transport, TLS, ops, plumbing), 1 CFL-config
+bump, 1 doc update.
+
+---
+
+## 7. Sprint B4 — OSS-Fuzz Upstream + macOS Integration
+
+**Goal.** Land the OSS-Fuzz upstream submission and unblock the
+macOS-Apple-Silicon integration test path. Pairing them is deliberate —
+both are external-facing and lower-risk to land late: the value of every
+prior sprint is captured even if B4 slips.
+
+### 7.1 OSS-Fuzz upstream submission
+
+#### Prerequisite check
+
+Before the upstream PR opens, B1–B3 must be complete: 6 fuzz targets exist,
+ClusterFuzzLite has been running ≥ 1 full nightly cycle on `main` without
+crashes, and the mutation baseline doc is current. OSS-Fuzz reviewers ask
+"is the project actively fuzzed and the harnesses maintained?" — those are
+the answer.
+
+#### Upstream PR contents
+
+A new `projects/rusty-imap-mcp/` directory in `google/oss-fuzz`:
+
+```
+projects/rusty-imap-mcp/
+├── project.yaml      # language: rust; sanitizers: address; fuzzing_engines: libfuzzer
+├── Dockerfile        # FROM gcr.io/oss-fuzz-base/base-builder-rust; clones our repo
+└── build.sh          # cd fuzz && cargo +nightly fuzz build --release
+```
+
+`project.yaml` declares:
+
+- `homepage`: this repo's URL.
+- `main_repo`: same.
+- `auto_ccs`: maintainer email(s) for crash notifications.
+- `vendor_ccs`: empty (no downstream vendor).
+- `language: rust`, `sanitizers: [address]`,
+  `fuzzing_engines: [libfuzzer]` (the only engine `cargo-fuzz` supports).
+
+#### Local-side support
+
+A new `oss-fuzz/` directory in this repo mirrors what the upstream PR will
+reference. Two files: `oss-fuzz-build.sh` and `oss-fuzz-Dockerfile.fragment`.
+Keeping these in-tree gives maintainers a single place to edit when a fuzz
+target is added/renamed and prevents drift between the OSS-Fuzz upstream and
+this project.
+
+#### `SECURITY.md` update
+
+Add a "Reporting fuzz-discovered crashes" subsection: OSS-Fuzz crashes are
+reported to the `auto_ccs` list with a 90-day disclosure clock; the existing
+vuln-disclosure policy already covers that timeline, but the source of the
+bug needs to be unambiguous.
+
+#### Acceptance handling
+
+OSS-Fuzz acceptance is upstream's call. The plan includes opening the PR,
+responding to reviewer feedback for one round, and accepting the outcome.
+If acceptance is deferred, the done criterion is "PR is open and awaiting
+upstream review" — not "PR is merged."
+
+### 7.2 macOS-Apple-Silicon integration
+
+#### Step 1 — spike
+
+A 30–60 minute test:
+
+1. Set `RIMAP_REQUIRE_DOCKER=1` and remove the `ARCH != "x86_64"` guard
+   locally (do not commit).
+2. Run `just test-integration` (or the rimap-imap dovecot integration suite
+   directly).
+3. Observe: does the existing `dovecot/dovecot:2.3.21` image run under
+   Docker Desktop's Rosetta-for-Linux on this host? If yes, are dovecot's
+   worker processes stable across the full suite?
+
+#### Step 2 — fork
+
+- **Path B (Rosetta works):** single PR. Remove the `ARCH != "x86_64"`
+  guard. Add a `RIMAP_DOVECOT_PLATFORM` env var that defaults to host arch
+  but can be set to `linux/amd64` to force Rosetta. Add a small CI matrix
+  entry — `test (macOS, integration)` on `macos-latest` with the Dovecot
+  suite enabled. Document the requirement (Docker Desktop ≥ 4.16,
+  Rosetta-for-Linux enabled) in the `AGENTS.md` "Container runtime for
+  integration tests" section.
+- **Path A (Rosetta still crashes):** two-PR sequence. PR-1 bumps the image
+  to `dovecot/dovecot:2.4.x` (multi-arch native), migrates `dovecot.conf` to
+  2.4 syntax, validates that the existing Linux integration suite stays
+  green. PR-2 (after PR-1 merges) removes the arch guard and adds the
+  `test (macOS, integration)` CI job.
+
+The decision between Path A and Path B is recorded inline in the spike
+commit message; it's a one-test-run question, not a planning question.
+
+#### CI runner cost
+
+Adding `test (macOS, integration)` is a real cost — macOS minutes are ~10×
+the Linux rate. Mitigations:
+
+- Run on `pull_request` only when files in `crates/rimap-imap/` change
+  (`paths:` filter), plus a nightly cron.
+- Single concurrency group so two PRs do not both pin a macOS runner.
+- Job is non-blocking initially (`continue-on-error: true`). Promote to
+  required only after two consecutive weeks of green runs. Acceptable here
+  because the Linux integration suite already provides the load-bearing
+  signal — the macOS run is incremental hardening.
+
+### 7.3 Done criteria
+
+1. OSS-Fuzz upstream PR open with all three files; reviewer engagement
+   begun.
+2. `oss-fuzz-build.sh` and `oss-fuzz-Dockerfile.fragment` committed in-tree.
+3. `SECURITY.md` updated with fuzz-disclosure subsection.
+4. Spike result documented; chosen path (A or B) implemented.
+5. `test (macOS, integration)` CI job exists and ran green at least once.
+6. `AGENTS.md` "Container runtime for integration tests" section updated.
+
+### 7.4 Rough size
+
+~6 commits: 1 oss-fuzz/ directory commit, 1 SECURITY.md update, 1
+spike-result documentation commit, 1 macOS CI job commit, 1 docs sync
+commit, 1 (Path A only) image-bump commit.
+
+---
+
+## 8. Cross-Cutting Concerns
+
+### 8.1 Out of scope (explicit deferrals)
+
+- **Criterion benchmarks.** Mentioned as deferred in
+  `2026-04-08-sprint-4b-html-lookalike-design.md`. Performance regressions
+  are detectable today via Sonar's coverage delta and `cargo nextest`
+  runtime; criterion adds a maintenance burden without a clear consumer.
+  Re-evaluate post-B4 if a real perf bug ships.
+- **Differential HTML oracle.** Comparing `ammonia`/`scraper` output against
+  a second sanitizer (e.g., `html5ever` raw). Genuinely valuable, but
+  defining "equivalent sanitization" between two engines is a sprint of its
+  own.
+- **Mutation-score CI gate.** Targeted hardening was the chosen scope.
+  Promotion to a CI gate requires at least one quarter of stable
+  baseline data to set a non-flaky threshold.
+- **Property tests beyond `rimap-content`.** Adding proptest harnesses to
+  `rimap-authz`, `rimap-audit`, `rimap-imap` is reasonable but lower-value
+  than fuzzing for those crates. Revisit if mutation cleanup surfaces a bug
+  class better caught by proptest.
+- **Dovecot 2.4 config migration unless the B4 spike requires it.** Path A
+  is reactive, not speculative.
+- **Public corpus persistence outside OSS-Fuzz's own infrastructure.**
+  OSS-Fuzz manages its own corpus per accepted project; the project does
+  not run a parallel public corpus.
+
+### 8.2 Success metrics
+
+1. **Fuzzing.** All 6 targets pass a 30-min nightly run on `main` for two
+   consecutive weeks. OSS-Fuzz PR open. ClusterFuzzLite green on every PR
+   for one full sprint cycle.
+2. **Mutation.** `cargo mutants --package <crate>` reports 0 unannotated
+   survivors in security-critical paths of all five trust-boundary crates
+   (`rimap-content`, `rimap-authz`, `rimap-audit`, `rimap-server`,
+   `rimap-imap`). `mutation-baseline.md` is current as of the latest tagged
+   release.
+3. **macOS integration.** `test (macOS, integration)` exists and runs green
+   nightly. Local Apple-Silicon developers can run `just test-integration`
+   without setting bypass env vars.
+4. **No regressions.** `just ci` runtime grows by less than 20% across the
+   full plan. PR-smoke fuzz time stays under 30 min total.
+
+### 8.3 Risks and mitigations
+
+- **OSS-Fuzz acceptance is upstream's decision.** Mitigation: the
+  done-criterion is "PR open + reviewer engaged," not "merged."
+  ClusterFuzzLite captures the runtime value independently.
+- **macOS CI minutes cost overrun.** Mitigation: `paths:` filter + nightly
+  cron + initial `continue-on-error: true`; promote to required only after
+  two clean weeks.
+- **Mutation refresh discovers many survivors in B2/B3.** Likely — the
+  snapshot is 3+ weeks stale. Mitigation: each sprint's done-criterion is
+  "0 survivors *in named security-critical paths*", not "0 survivors
+  anywhere." Plumbing-code survivors get annotated, not fixed.
+- **Nightly runner exhaustion at peak GHA load.** Mitigation: nightly fuzz
+  job is a single concurrency group with retry-once-on-runner-pickup-timeout.
+- **Adding a fuzz target later requires editing both `fuzz/` and
+  `oss-fuzz/`.** Mitigation: short `oss-fuzz/README.md` with "when adding
+  a target, also add it to..." checklist.
+
+### 8.4 Why this ordering
+
+B1 first because `rimap-content` is the largest attacker-surface crate and
+has the largest backlog of stale mutants. B2 second because it is the
+smallest sprint — landing it after B1 keeps momentum without burning the
+budget needed for B3. B3 third because the dispatch-entry-point refactor it
+may need is the only structural change in the plan and benefits from the
+mutation-cleanup discipline practiced in B1/B2 first. B4 last because
+OSS-Fuzz acceptance benefits from a non-empty fuzzing track record on
+`main`, and macOS integration is the only piece that touches CI runner cost
+materially — landing it last minimizes blast radius.
+
+---
+
+## 9. Next Steps
+
+1. Land this spec on `main` via the standard feature-branch + PR workflow.
+2. Generate per-sprint implementation plans on demand via the
+   `superpowers:writing-plans` skill, one per sprint (B1, B2, B3, B4).
+   Each plan is independently mergeable; sprints sequence by dependency
+   (B3 may depend on B2's audit-record refactor work, B4 depends on B1–B3
+   being live).
+3. Open tracking issues for the deferrals listed in Section 8.1 so they
+   are visible in the issues list rather than buried in this spec.


### PR DESCRIPTION
## Summary

- Restore `docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md` and `docs/superpowers/plans/2026-04-30-test-strategy-b1-rimap-content.md` from `origin/archive/daemon-experiment` — the two remaining documentation pieces from the multi-client-daemon rollback re-extraction.
- Add a new §0 status block to the spec recording that the implementation work landed before this spec, inverting the order proposed in #227. Sprint B1 is marked done; Sprints B2–B4 are listed as open. Stale spec sections (§3.4 Justfile recipe names, §4.4 PR-smoke target list, §2 baseline numbers) are flagged with pointers to the live sources of truth (`mutation-baseline.md`, `.github/workflows/fuzz.yml`).

## Why this is just docs

The fuzz infrastructure, ClusterFuzzLite workflow, and `rimap-content` mutation cleanup already landed on `main` via:

- #225 (PRs #195/#196/#198) — `rimap-content` + EPVME-runner mutation cleanup
- #226 / #242 — ClusterFuzzLite + four fuzz harnesses (`content_mime`, `content_html`, `content_charset`, `content_rfc2047`)

`mutation-baseline.md` on `main` is dated 2026-05-04 (newer than the archive copy), and the four fuzz harnesses on `main` are ahead of archive. So #227 reduces to landing the two missing design documents.

## Acceptance criteria from #227

- [x] `docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md` present
- [x] `docs/superpowers/specs/test-strategy/` directory contents present (already on `main` before this PR)
- [x] PR #190 + #191 test additions in place (already on `main` via #225 / #226)
- [ ] CI green on all 8 required checks — pending CI

## Follow-up

Per the spec's §9 step 3, three tracking issues for the remaining sprints (B2 `rimap-authz`+`rimap-audit`, B3 `rimap-server`+`rimap-imap`, B4 OSS-Fuzz upstream + macOS-Apple-Silicon Dovecot integration) will be opened once this PR lands.

## Test plan

- [ ] `prek run` clean on the two restored files (passed locally)
- [ ] All 8 required CI checks green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)