### PR TITLE
feat: release versioning with -dev+gSHA suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,8 +224,12 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           VERSION="${TAG#v}"
-          awk "/^## \\[${VERSION}\\]/,/^## \\[[^\\]]+\\]/" CHANGELOG.md \
-            | head -n -1 > RELEASE_NOTES.md
+          awk -v v="$VERSION" '
+              $0 ~ "^## \\[" v "\\]" { p=1; next }
+              p && /^## \[/         { exit }
+              p && /^\[[^]]+\]: /    { exit }
+              p                     { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
           if [ ! -s RELEASE_NOTES.md ]; then
             echo "Warning: no release notes extracted for ${TAG}"
             cp CHANGELOG.md RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run verify-tag only; skip build and release jobs."
+        type: boolean
+        default: true
+      tag:
+        description: "Tag to validate (e.g. v0.1.0). Used only on workflow_dispatch."
+        type: string
+        required: true
 
 permissions: {}
 
@@ -12,9 +22,30 @@ env:
   BINARY_NAME: rusty-imap-mcp
 
 jobs:
+  verify-tag:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.verify.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Verify tag
+        id: verify
+        env:
+          TAG_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          ./scripts/check-release-version.sh "$TAG_REF"
+          echo "version=${TAG_REF#v}" >> "$GITHUB_OUTPUT"
+
   build-linux-x86_64:
     name: build (x86_64-unknown-linux-gnu)
+    needs: verify-tag
     runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     permissions:
       contents: read
     steps:
@@ -38,7 +69,9 @@ jobs:
 
   build-linux-aarch64:
     name: build (aarch64-unknown-linux-gnu)
+    needs: verify-tag
     runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     permissions:
       contents: read
     steps:
@@ -66,7 +99,9 @@ jobs:
 
   build-macos-aarch64:
     name: build (aarch64-apple-darwin)
+    needs: verify-tag
     runs-on: macos-latest
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     permissions:
       contents: read
     steps:
@@ -88,7 +123,9 @@ jobs:
 
   build-linux-ppc64le:
     name: build (powerpc64le-unknown-linux-gnu)
+    needs: verify-tag
     runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     permissions:
       contents: read
     steps:
@@ -115,7 +152,9 @@ jobs:
 
   build-linux-s390x:
     name: build (s390x-unknown-linux-gnu)
+    needs: verify-tag
     runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     permissions:
       contents: read
     steps:
@@ -143,12 +182,14 @@ jobs:
   release:
     name: Create GitHub Release
     needs:
+      - verify-tag
       - build-linux-x86_64
       - build-linux-aarch64
       - build-macos-aarch64
       - build-linux-ppc64le
       - build-linux-s390x
     runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
     environment: release
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,17 @@ env:
   BINARY_NAME: rusty-imap-mcp
 
 jobs:
+  # Gates every build/release job below via `needs: verify-tag`. Fails fast on
+  # tag/Cargo.toml drift, malformed tag formats, or a `-dev` literal in the
+  # manifest. workflow_dispatch with `dry_run: true` exercises just this job.
   verify-tag:
     name: Verify tag matches Cargo.toml
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    # Exposed for future jobs that need the parsed version. Currently unused; the
+    # tag itself is what gates the build, so removing this output is fine if no
+    # consumer materializes.
     outputs:
       version: ${{ steps.verify.outputs.version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - Unreleased
+
 ### Changed
 
 - **Breaking (keyring):** Credential keyring entries are now namespaced by
@@ -35,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`keyring` / `legacy_keyring` / `env_var`) for post-incident analysis.
 - `rusty-imap-mcp migrate-keyring` CLI subcommand to migrate credentials
   from the legacy keyring key format to the new namespaced format.
-
-## [1.0.0] - 2026-04-13
-
-### Added
 
 #### Multi-account support
 
@@ -241,4 +239,5 @@ Pre-built binaries for five targets:
 - Replace `Mutex<Option<AccountId>>` in the account registry with
   `ArcSwapOption` to eliminate async-refactor footguns and mutex poisoning.
 
-## [Unreleased]
+[Unreleased]: https://github.com/randomparity/rusty-imap-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/randomparity/rusty-imap-mcp/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,7 +2091,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rimap-audit"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "async-channel 2.5.0",
  "fs4",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-authz"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "governor",
  "parking_lot",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-config"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "directories",
  "keyring",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-content"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "addr",
  "ammonia",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-core"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "proptest",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-imap"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "async-channel 2.5.0",
  "async-imap",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-server"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "rimap-smtp"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "lettre",
  "rimap-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,16 @@ parking_lot = "0.12"
 # Lock-free Arc swap for session-scoped mutable state. MIT OR Apache-2.0.
 arc-swap = "1"
 
+# rimap-core ships a workspace-internal build script at
+# crates/rimap-core/build.rs that shells out to `git describe`,
+# `rev-parse`, and `status` via std::process::Command (constant argv,
+# no shell). It emits RIMAP_VERSION / RIMAP_COMMIT / RIMAP_RELEASE via
+# cargo:rustc-env, consumed by the CLI --version, MCP server_info, and
+# audit-log process_start. Every git failure path falls through to a
+# safe `gunknown` default — the build never fails on missing git or
+# vendored sources. Re-audit on substantive logic changes to build.rs
+# (SC-PROC-01).
+
 # Async runtime
 tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
 

--- a/crates/rimap-audit/Cargo.toml
+++ b/crates/rimap-audit/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 test-injection = []
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rimap-audit/src/writer/log.rs
+++ b/crates/rimap-audit/src/writer/log.rs
@@ -232,8 +232,9 @@ impl From<ToolStartInputs> for crate::record::ToolStart {
 pub struct ProcessStartInputs {
     /// `CARGO_PKG_VERSION` of the running binary.
     pub version: String,
-    /// Git commit SHA at build time. Empty string until `vergen` lands in
-    /// Sprint 5.
+    /// Short git SHA of the running binary (7 hex chars, optionally
+    /// suffixed `-dirty`, or `unknown` when no git information is
+    /// available). Populated by callers via `rimap_core::version::commit`.
     pub git_commit: String,
     /// Effective base posture at startup (single-account mode).
     /// Typed at the construction seam to keep the on-disk string form

--- a/crates/rimap-authz/Cargo.toml
+++ b/crates/rimap-authz/Cargo.toml
@@ -12,8 +12,8 @@ description = "Posture-based authorization, rate limiting, and circuit breaker f
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
-rimap-config = { path = "../rimap-config", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
+rimap-config = { path = "../rimap-config", version = "0.1.0" }
 thiserror = { workspace = true }
 governor = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/rimap-config/Cargo.toml
+++ b/crates/rimap-config/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 test-support = []
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
 utf7-imap = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -16,7 +16,7 @@ description = "MIME parsing, Unicode-safe sanitization, and look-alike detection
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -58,7 +58,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies.rimap-content]
 path = "."
-version = "1.0.0"
+version = "0.1.0"
 features = ["test-util"]
 
 # `phf` is consumed by the `include!`-expanded output of `build.rs`, so

--- a/crates/rimap-core/Cargo.toml
+++ b/crates/rimap-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Shared core types for rusty-imap-mcp: Message, Folder, Posture, audit records."
+build = "build.rs"
 
 [lints]
 workspace = true

--- a/crates/rimap-core/build.rs
+++ b/crates/rimap-core/build.rs
@@ -1,0 +1,61 @@
+//! Compile-time version composer for rusty-imap-mcp.
+//!
+//! Emits three `cargo:rustc-env` variables consumed by `src/version.rs`:
+//!
+//! - `RIMAP_VERSION` — the user-facing version string. Bare `CARGO_PKG_VERSION`
+//!   when HEAD is exactly the tag `v<CARGO_PKG_VERSION>`; otherwise
+//!   `<CARGO_PKG_VERSION>-dev+g<short-sha>[.dirty]`.
+//! - `RIMAP_COMMIT` — the short SHA (or `unknown` outside a git checkout).
+//! - `RIMAP_RELEASE` — `"true"` or `"false"` depending on the release/dev path.
+//!
+//! Every git failure path falls back to `RIMAP_VERSION =
+//! <CARGO_PKG_VERSION>-dev+gunknown`, so vendored or `cargo package` builds
+//! still compile without surprise breakage.
+
+use std::process::Command;
+
+fn main() {
+    let base = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let expected_tag = format!("v{base}");
+
+    let exact_tag = run_git(&["describe", "--tags", "--exact-match", "HEAD"]);
+    let short_sha =
+        run_git(&["rev-parse", "--short=7", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = run_git(&["status", "--porcelain"]).is_some_and(|s| !s.is_empty());
+
+    let is_release = exact_tag.as_deref() == Some(expected_tag.as_str());
+    let (version, commit) = if is_release {
+        (base.clone(), short_sha.clone())
+    } else {
+        let suffix = if dirty {
+            format!("+g{short_sha}.dirty")
+        } else {
+            format!("+g{short_sha}")
+        };
+        let commit = if dirty {
+            format!("{short_sha}-dirty")
+        } else {
+            short_sha.clone()
+        };
+        (format!("{base}-dev{suffix}"), commit)
+    };
+
+    println!("cargo:rustc-env=RIMAP_VERSION={version}");
+    println!("cargo:rustc-env=RIMAP_COMMIT={commit}");
+    println!(
+        "cargo:rustc-env=RIMAP_RELEASE={}",
+        if is_release { "true" } else { "false" }
+    );
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}

--- a/crates/rimap-core/build.rs
+++ b/crates/rimap-core/build.rs
@@ -46,8 +46,10 @@ fn main() {
         "cargo:rustc-env=RIMAP_RELEASE={}",
         if is_release { "true" } else { "false" }
     );
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-changed=.git/packed-refs");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 }
 

--- a/crates/rimap-core/src/lib.rs
+++ b/crates/rimap-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod posture_matrix;
 pub mod tls;
 pub mod tool;
 pub mod uid_selector;
+pub mod version;
 pub mod warning;
 
 pub use crate::auth_event::{AuthEvent, AuthResult};

--- a/crates/rimap-core/src/version.rs
+++ b/crates/rimap-core/src/version.rs
@@ -1,0 +1,30 @@
+//! Build-injected version metadata.
+//!
+//! Values are produced by `build.rs` and embedded via `env!`. They are
+//! string slices with `'static` lifetime, suitable for direct use in
+//! `clap`'s `version = ...` attribute and any other place that wants a
+//! `&'static str`.
+
+/// The user-facing version string.
+///
+/// `X.Y.Z` for release builds (HEAD is exactly the tag `v<X.Y.Z>`);
+/// `X.Y.Z-dev+g<short-sha>[.dirty]` otherwise. Outside a git checkout
+/// the suffix is `-dev+gunknown`.
+#[must_use]
+pub fn version() -> &'static str {
+    env!("RIMAP_VERSION")
+}
+
+/// Short git SHA of the build (`abc1234`), `abc1234-dirty` for dirty
+/// worktrees, or `unknown` when no git information is available.
+#[must_use]
+pub fn commit() -> &'static str {
+    env!("RIMAP_COMMIT")
+}
+
+/// `true` when this build was produced from a `vX.Y.Z` git tag whose
+/// version matches the workspace `Cargo.toml`.
+#[must_use]
+pub fn is_release() -> bool {
+    matches!(env!("RIMAP_RELEASE"), "true")
+}

--- a/crates/rimap-core/tests/version.rs
+++ b/crates/rimap-core/tests/version.rs
@@ -1,0 +1,43 @@
+//! Smoke tests for the build-injected version metadata.
+
+use rimap_core::version::{commit, is_release, version};
+
+#[test]
+fn version_is_non_empty() {
+    let v = version();
+    assert!(!v.is_empty(), "version() must not be empty");
+}
+
+#[test]
+fn version_starts_with_workspace_base() {
+    let v = version();
+    assert!(
+        v.starts_with(env!("CARGO_PKG_VERSION")),
+        "version() = {v:?} should start with CARGO_PKG_VERSION = {:?}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn commit_matches_expected_shape() {
+    let c = commit();
+    // Either the sentinel `unknown` or a 7-hex SHA with an optional `-dirty` suffix.
+    let body = c.strip_suffix("-dirty").unwrap_or(c);
+    let valid =
+        body == "unknown" || (body.len() == 7 && body.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert!(
+        valid,
+        "commit() = {c:?} should be `unknown`, `<7hex>`, or `<7hex>-dirty`"
+    );
+}
+
+#[test]
+fn release_flag_agrees_with_version_shape() {
+    let v = version();
+    let has_dev = v.contains("-dev");
+    assert_eq!(
+        is_release(),
+        !has_dev,
+        "is_release() must be true exactly when version() lacks a -dev suffix"
+    );
+}

--- a/crates/rimap-imap/Cargo.toml
+++ b/crates/rimap-imap/Cargo.toml
@@ -24,7 +24,7 @@ workspace = true
 # Transport-only: rimap-imap depends on rimap-core for the AuthEventSink
 # and CredentialResolver trait seams; rimap-audit and rimap-config sit
 # on the other side of those seams and are wired by rimap-server.
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
 
 # Async runtime
 tokio = { workspace = true }
@@ -53,8 +53,8 @@ tracing = { workspace = true }
 # Integration tests build the production wiring (AuditWriter implementing
 # AuthEventSink, KeyringCredentialResolver implementing CredentialResolver)
 # to drive Connection through a real Dovecot/Proton container.
-rimap-audit = { path = "../rimap-audit", version = "1.0.0" }
-rimap-config = { path = "../rimap-config", version = "1.0.0" }
+rimap-audit = { path = "../rimap-audit", version = "0.1.0" }
+rimap-config = { path = "../rimap-config", version = "0.1.0" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -761,6 +761,9 @@ mod tests {
 
     use super::*;
 
+    const PORT_COLLISION_STDERR: &str =
+        "Bind for 127.0.0.1:12345 failed: port is already allocated";
+
     #[test]
     fn is_port_collision_matches_docker_engine_error() {
         let stderr = "Error response from daemon: failed to set up container networking: \
@@ -847,9 +850,7 @@ mod tests {
             Self {
                 fail_first_n: AtomicU32::new(n),
                 observed_ports: Mutex::new(Vec::new()),
-                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
-                                        port is already allocated"
-                    .into(),
+                port_collision_stderr: PORT_COLLISION_STDERR.into(),
                 terminal_error: None,
             }
         }
@@ -859,9 +860,7 @@ mod tests {
             Self {
                 fail_first_n: AtomicU32::new(u32::MAX),
                 observed_ports: Mutex::new(Vec::new()),
-                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
-                                        port is already allocated"
-                    .into(),
+                port_collision_stderr: PORT_COLLISION_STDERR.into(),
                 terminal_error: None,
             }
         }

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -391,12 +391,12 @@ fn compose_up(
 /// Covers three observed phrasings:
 ///   - docker engine: "Bind for 127.0.0.1:NNNN failed: port is already allocated"
 ///   - libc EADDRINUSE: "address already in use"
-///   - podman rootlessport: "Bind for ..."
+///   - podman rootlessport: "Bind for 127.0.0.1:NNNN failed"
 fn is_port_collision(stderr: &str) -> bool {
     let s = stderr.to_lowercase();
     s.contains("port is already allocated")
         || s.contains("address already in use")
-        || s.contains("bind for")
+        || s.contains("bind for 127.0.0.1")
 }
 
 fn wait_for_ready(

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -276,7 +276,7 @@ fn compose_up(
     host_port: u16,
     host_starttls_port: u16,
 ) -> Result<(), HarnessError> {
-    let status = Command::new(runtime())
+    let output = Command::new(runtime())
         .arg("compose")
         .arg("-p")
         .arg(project)
@@ -288,11 +288,14 @@ fn compose_up(
             host_starttls_port.to_string(),
         )
         .current_dir(compose_dir)
-        .status()
+        .output()
         .map_err(|e| HarnessError::DockerCommandFailed(e.to_string()))?;
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(HarnessError::DockerCommandFailed(format!(
-            "compose up exit {status}"
+            "compose up exit {}: {}",
+            output.status,
+            stderr.trim()
         )));
     }
     Ok(())

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -755,7 +755,9 @@ pub enum PinChoice {
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::unwrap_used, reason = "tests")]
     #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::panic, reason = "test failure path")]
 
     use super::*;
 
@@ -823,5 +825,168 @@ mod tests {
         let mut p = ReservedPort::acquire().expect("acquire");
         p.release();
         p.release(); // must not panic
+    }
+
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Test double for `ComposeRunner`. Records every observed
+    /// `(tls_port, starttls_port)` pair and returns a programmable
+    /// sequence of results.
+    struct FlakyComposeRunner {
+        fail_first_n: AtomicU32,
+        observed_ports: Mutex<Vec<(u16, u16)>>,
+        port_collision_stderr: String,
+        terminal_error: Option<String>,
+    }
+
+    impl FlakyComposeRunner {
+        /// Fail the first `n` attempts with a port-collision stderr;
+        /// succeed afterward.
+        fn fail_first_n_with_port_collision(n: u32) -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(n),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
+                                        port is already allocated"
+                    .into(),
+                terminal_error: None,
+            }
+        }
+
+        /// Always fail with a port-collision stderr.
+        fn always_fail_with_port_collision() -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(u32::MAX),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
+                                        port is already allocated"
+                    .into(),
+                terminal_error: None,
+            }
+        }
+
+        /// Always fail with a non-collision stderr.
+        fn always_fail_with(msg: &str) -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(u32::MAX),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: String::new(),
+                terminal_error: Some(msg.into()),
+            }
+        }
+
+        fn observed_ports(&self) -> Vec<(u16, u16)> {
+            self.observed_ports.lock().unwrap().clone()
+        }
+
+        fn attempts(&self) -> usize {
+            self.observed_ports.lock().unwrap().len()
+        }
+    }
+
+    impl ComposeRunner for FlakyComposeRunner {
+        fn up(
+            &self,
+            _project: &str,
+            _compose_dir: &Path,
+            tls_port: u16,
+            starttls_port: u16,
+        ) -> Result<(), HarnessError> {
+            self.observed_ports
+                .lock()
+                .unwrap()
+                .push((tls_port, starttls_port));
+
+            if let Some(msg) = self.terminal_error.as_ref() {
+                return Err(HarnessError::DockerCommandFailed(msg.clone()));
+            }
+
+            let remaining = self.fail_first_n.load(Ordering::SeqCst);
+            if remaining > 0 {
+                self.fail_first_n.fetch_sub(1, Ordering::SeqCst);
+                return Err(HarnessError::DockerCommandFailed(
+                    self.port_collision_stderr.clone(),
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn dummy_compose_dir() -> &'static Path {
+        Path::new("/tmp/rimap-it-test")
+    }
+
+    #[test]
+    fn compose_up_retries_on_port_collision_then_succeeds() {
+        let runner = FlakyComposeRunner::fail_first_n_with_port_collision(2);
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        assert!(
+            result.is_ok(),
+            "should succeed on third attempt: {:?}",
+            result.err()
+        );
+        let ports = runner.observed_ports();
+        assert_eq!(ports.len(), 3, "should have attempted three times");
+        // Each retry uses a fresh port pair (proves the reacquire path).
+        assert_ne!(ports[0], ports[1], "attempt 1 vs 2 ports identical");
+        assert_ne!(ports[1], ports[2], "attempt 2 vs 3 ports identical");
+    }
+
+    #[test]
+    fn compose_up_gives_up_after_max_attempts() {
+        let runner = FlakyComposeRunner::always_fail_with_port_collision();
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        let Err(HarnessError::DockerCommandFailed(msg)) = result else {
+            panic!("expected DockerCommandFailed, got: {result:?}");
+        };
+        assert!(msg.contains("exhausted"), "missing 'exhausted' in {msg:?}");
+        assert!(
+            msg.contains("port is already allocated"),
+            "underlying stderr should be preserved in {msg:?}"
+        );
+        assert_eq!(runner.attempts(), 3, "should have attempted three times");
+    }
+
+    #[test]
+    fn compose_up_propagates_non_port_errors_immediately() {
+        let runner = FlakyComposeRunner::always_fail_with("no such image: dovecot:9.9.9");
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            runner.attempts(),
+            1,
+            "non-collision errors should not retry"
+        );
     }
 }

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -108,15 +108,13 @@ impl DovecotHarness {
         let mut host_port = ReservedPort::acquire()?;
         let mut host_starttls_port = ReservedPort::acquire()?;
 
-        // Release the kernel-level port leases just before docker binds them.
-        // Task 5 will move this release into the retry wrapper.
-        host_port.release();
-        host_starttls_port.release();
-        compose_up(
+        let runner = DockerComposeRunner;
+        compose_up_with_retry(
+            &runner,
             &project,
             &compose_dir,
-            host_port.port(),
-            host_starttls_port.port(),
+            &mut host_port,
+            &mut host_starttls_port,
         )?;
 
         let result = wait_for_ready(
@@ -309,6 +307,51 @@ impl ComposeRunner for DockerComposeRunner {
     ) -> Result<(), HarnessError> {
         compose_up(project, compose_dir, tls_port, starttls_port)
     }
+}
+
+/// Drive `runner.up(...)` with a bounded retry on host-port collisions.
+///
+/// Three attempts total (initial + 2 retries). Each retry tears down
+/// the partial compose project, sleeps with jittered backoff, and
+/// acquires fresh `ReservedPort`s. Non-collision errors propagate
+/// immediately on the first failure. If all three attempts hit
+/// collisions, the most recent stderr is preserved in the error
+/// message.
+fn compose_up_with_retry(
+    runner: &dyn ComposeRunner,
+    project: &str,
+    compose_dir: &Path,
+    tls: &mut ReservedPort,
+    starttls: &mut ReservedPort,
+) -> Result<(), HarnessError> {
+    const BACKOFF_MS: [u64; 2] = [50, 250];
+    const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
+    let mut last_collision: Option<String> = None;
+
+    // Attempt 0 is the initial try (no prior sleep). Attempts 1 and 2 are
+    // retries preceded by teardown + backoff sleep + fresh port acquisition.
+    for attempt in 0..MAX_ATTEMPTS {
+        if attempt > 0 {
+            compose_down(project, compose_dir);
+            std::thread::sleep(Duration::from_millis(BACKOFF_MS[attempt - 1]));
+            *tls = ReservedPort::acquire()?;
+            *starttls = ReservedPort::acquire()?;
+        }
+        tls.release();
+        starttls.release();
+        let result = runner.up(project, compose_dir, tls.port(), starttls.port());
+        match result {
+            Ok(()) => return Ok(()),
+            Err(HarnessError::DockerCommandFailed(s)) if is_port_collision(&s) => {
+                last_collision = Some(s);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(HarnessError::DockerCommandFailed(format!(
+        "compose up: exhausted {MAX_ATTEMPTS} attempts on port collision; last error: {}",
+        last_collision.unwrap_or_else(|| "<no error captured>".into()),
+    )))
 }
 
 fn compose_up(

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -284,6 +284,33 @@ fn check_prerequisites() -> Result<(), HarnessError> {
     Ok(())
 }
 
+/// Minimal interface over `docker compose up` so the retry wrapper
+/// can be unit-tested without a real docker.
+trait ComposeRunner {
+    fn up(
+        &self,
+        project: &str,
+        compose_dir: &Path,
+        tls_port: u16,
+        starttls_port: u16,
+    ) -> Result<(), HarnessError>;
+}
+
+/// Production runner: shells out to `docker compose up -d` (or podman).
+struct DockerComposeRunner;
+
+impl ComposeRunner for DockerComposeRunner {
+    fn up(
+        &self,
+        project: &str,
+        compose_dir: &Path,
+        tls_port: u16,
+        starttls_port: u16,
+    ) -> Result<(), HarnessError> {
+        compose_up(project, compose_dir, tls_port, starttls_port)
+    }
+}
+
 fn compose_up(
     project: &str,
     compose_dir: &Path,

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -105,19 +105,33 @@ impl DovecotHarness {
         prune_stale_projects(&compose_dir);
 
         let project = format!("rimap-it-{}", uuid_like());
-        let host_port = pick_free_port()?;
-        let host_starttls_port = pick_free_port()?;
+        let mut host_port = ReservedPort::acquire()?;
+        let mut host_starttls_port = ReservedPort::acquire()?;
 
-        compose_up(&project, &compose_dir, host_port, host_starttls_port)?;
+        // Release the kernel-level port leases just before docker binds them.
+        // Task 5 will move this release into the retry wrapper.
+        host_port.release();
+        host_starttls_port.release();
+        compose_up(
+            &project,
+            &compose_dir,
+            host_port.port(),
+            host_starttls_port.port(),
+        )?;
 
-        let result = wait_for_ready(&project, &compose_dir, host_port, host_starttls_port);
+        let result = wait_for_ready(
+            &project,
+            &compose_dir,
+            host_port.port(),
+            host_starttls_port.port(),
+        );
         match result {
             Ok((fingerprint, port)) => Ok(Self {
                 project,
                 compose_dir,
                 fingerprint,
                 port,
-                starttls_port: host_starttls_port,
+                starttls_port: host_starttls_port.port(),
             }),
             Err(e) => {
                 compose_down(&project, &compose_dir);
@@ -497,17 +511,44 @@ fn read_fingerprint(project: &str) -> Result<TlsFingerprint, HarnessError> {
     TlsFingerprint::from_hex(&s).map_err(|e| HarnessError::FingerprintReadFailed(e.to_string()))
 }
 
-/// Bind to `127.0.0.1:0`, read the kernel-assigned port, and drop the
-/// listener. Technically racy (another process could claim the same port
-/// in the gap before docker binds it) but acceptable for integration
-/// tests — the port is passed immediately to `docker compose up`.
-fn pick_free_port() -> Result<u16, HarnessError> {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")
-        .map_err(|e| HarnessError::PortReadFailed(format!("bind: {e}")))?;
-    let addr = listener
-        .local_addr()
-        .map_err(|e| HarnessError::PortReadFailed(format!("local_addr: {e}")))?;
-    Ok(addr.port())
+/// A host port reserved by binding `127.0.0.1:0` and reading the
+/// kernel-assigned number. The `TcpListener` is kept open until
+/// `release()` is called, holding the kernel-level lease so docker
+/// (or any other process) cannot bind the same port in the meantime.
+///
+/// Lifecycle: callers acquire two `ReservedPort`s, then pass `&mut`
+/// references to the retry wrapper, which releases them just before
+/// invoking `docker compose up`. If `compose up` fails with a port
+/// collision (the residual race window), the wrapper drops the
+/// reservations and acquires fresh ones for the next attempt.
+struct ReservedPort {
+    port: u16,
+    listener: Option<std::net::TcpListener>,
+}
+
+impl ReservedPort {
+    fn acquire() -> Result<Self, HarnessError> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| HarnessError::PortReadFailed(format!("bind: {e}")))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| HarnessError::PortReadFailed(format!("local_addr: {e}")))?
+            .port();
+        Ok(Self {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Drop the underlying `TcpListener`, releasing the kernel-level
+    /// port lease. Idempotent.
+    fn release(&mut self) {
+        self.listener.take();
+    }
 }
 
 /// Maximum age of a `rimap-it-*` compose project before it is considered
@@ -644,6 +685,8 @@ pub enum PinChoice {
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+
     use super::*;
 
     #[test]
@@ -678,5 +721,37 @@ mod tests {
     fn is_port_collision_is_case_insensitive() {
         assert!(is_port_collision("PORT IS ALREADY ALLOCATED"));
         assert!(is_port_collision("Bind FOR 127.0.0.1:80 failed"));
+    }
+
+    #[test]
+    fn reserved_port_acquires_distinct_ports() {
+        let a = ReservedPort::acquire().expect("acquire a");
+        let b = ReservedPort::acquire().expect("acquire b");
+        assert_ne!(
+            a.port(),
+            b.port(),
+            "two reservations must yield different ports"
+        );
+    }
+
+    #[test]
+    fn reserved_port_release_drops_lease() {
+        let mut p = ReservedPort::acquire().expect("acquire");
+        let port = p.port();
+        p.release();
+        // After release, another bind on the same port should succeed.
+        let bound_again = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(
+            bound_again.is_ok(),
+            "should be able to bind {port} after release: {:?}",
+            bound_again.err()
+        );
+    }
+
+    #[test]
+    fn reserved_port_release_is_idempotent() {
+        let mut p = ReservedPort::acquire().expect("acquire");
+        p.release();
+        p.release(); // must not panic
     }
 }

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -312,7 +312,7 @@ impl ComposeRunner for DockerComposeRunner {
 /// Drive `runner.up(...)` with a bounded retry on host-port collisions.
 ///
 /// Three attempts total (initial + 2 retries). Each retry tears down
-/// the partial compose project, sleeps with jittered backoff, and
+/// the partial compose project, sleeps with increasing backoff, and
 /// acquires fresh `ReservedPort`s. Non-collision errors propagate
 /// immediately on the first failure. If all three attempts hit
 /// collisions, the most recent stderr is preserved in the error

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -301,6 +301,20 @@ fn compose_up(
     Ok(())
 }
 
+/// Classify a stderr blob from a failed `compose up`: `true` when the
+/// failure looks like a host-port bind collision, `false` otherwise.
+///
+/// Covers three observed phrasings:
+///   - docker engine: "Bind for 127.0.0.1:NNNN failed: port is already allocated"
+///   - libc EADDRINUSE: "address already in use"
+///   - podman rootlessport: "Bind for ..."
+fn is_port_collision(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("port is already allocated")
+        || s.contains("address already in use")
+        || s.contains("bind for")
+}
+
 fn wait_for_ready(
     project: &str,
     compose_dir: &Path,
@@ -626,4 +640,43 @@ pub enum PinChoice {
     Correct,
     Wrong,
     None,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_port_collision_matches_docker_engine_error() {
+        let stderr = "Error response from daemon: failed to set up container networking: \
+            driver failed programming external connectivity on endpoint rimap-it-abc-dovecot \
+            (...): Bind for 127.0.0.1:35615 failed: port is already allocated";
+        assert!(is_port_collision(stderr));
+    }
+
+    #[test]
+    fn is_port_collision_matches_libc_eaddrinuse() {
+        assert!(is_port_collision("bind: address already in use"));
+    }
+
+    #[test]
+    fn is_port_collision_matches_podman_variant() {
+        assert!(is_port_collision(
+            "Error: rootlessport listen tcp 127.0.0.1:1234: bind: address already in use"
+        ));
+    }
+
+    #[test]
+    fn is_port_collision_rejects_unrelated_error() {
+        assert!(!is_port_collision(
+            "no such image: docker.io/dovecot/dovecot:9.9.9"
+        ));
+        assert!(!is_port_collision("dovecot exited with non-zero status"));
+    }
+
+    #[test]
+    fn is_port_collision_is_case_insensitive() {
+        assert!(is_port_collision("PORT IS ALREADY ALLOCATED"));
+        assert!(is_port_collision("Bind FOR 127.0.0.1:80 failed"));
+    }
 }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -27,13 +27,13 @@ name = "rusty-imap-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
-rimap-config = { path = "../rimap-config", version = "1.0.0" }
-rimap-authz = { path = "../rimap-authz", version = "1.0.0" }
-rimap-audit = { path = "../rimap-audit", version = "1.0.0" }
-rimap-content = { path = "../rimap-content", version = "1.0.0" }
-rimap-imap = { path = "../rimap-imap", version = "1.0.0" }
-rimap-smtp = { path = "../rimap-smtp", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
+rimap-config = { path = "../rimap-config", version = "0.1.0" }
+rimap-authz = { path = "../rimap-authz", version = "0.1.0" }
+rimap-audit = { path = "../rimap-audit", version = "0.1.0" }
+rimap-content = { path = "../rimap-content", version = "0.1.0" }
+rimap-imap = { path = "../rimap-imap", version = "0.1.0" }
+rimap-smtp = { path = "../rimap-smtp", version = "0.1.0" }
 mail-builder = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
@@ -57,12 +57,12 @@ tempfile = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 mail-parser = { workspace = true }
-rimap-audit = { path = "../rimap-audit", version = "1.0.0", features = ["test-injection"] }
-rimap-config = { path = "../rimap-config", version = "1.0.0", features = ["test-support"] }
-rimap-imap = { path = "../rimap-imap", version = "1.0.0", features = ["test-support"] }
+rimap-audit = { path = "../rimap-audit", version = "0.1.0", features = ["test-injection"] }
+rimap-config = { path = "../rimap-config", version = "0.1.0", features = ["test-support"] }
+rimap-imap = { path = "../rimap-imap", version = "0.1.0", features = ["test-support"] }
 # Self dev-dep enables the `test-support` feature unconditionally for
 # integration tests, so `ImapMcpServer::execute_tool_for_test` is in
 # scope without every test harness passing `--features test-support`.
-rimap-server = { path = ".", version = "1.0.0", features = ["test-support"] }
+rimap-server = { path = ".", version = "0.1.0", features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }

--- a/crates/rimap-server/src/boot/audit_init.rs
+++ b/crates/rimap-server/src/boot/audit_init.rs
@@ -63,8 +63,8 @@ pub fn init_audit_writer_multi(
     };
 
     writer.log_process_start(ProcessStartInputs {
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        git_commit: String::new(),
+        version: rimap_core::version::version().to_string(),
+        git_commit: rimap_core::version::commit().to_string(),
         posture,
         accounts,
         config_path: config_file_path.to_path_buf(),

--- a/crates/rimap-server/src/cli/mod.rs
+++ b/crates/rimap-server/src/cli/mod.rs
@@ -21,7 +21,6 @@ use rimap_core::account::DEFAULT_ACCOUNT_NAME;
 #[derive(Debug, Parser)]
 #[command(
     name = "rusty-imap-mcp",
-    version,
     about = "Security-first MCP server for IMAP email access"
 )]
 pub struct Cli {

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use rimap_authz::DispatchGuard;
 use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, SystemClock};
 use rimap_authz::matrix::EffectiveMatrix;
@@ -28,9 +28,21 @@ use secrecy::ExposeSecret;
 
 use crate::cli::{AuditAction, Cli, Command};
 
+fn parse_cli() -> Result<Cli, clap::Error> {
+    let matches = Cli::command()
+        .version(rimap_core::version::version())
+        .get_matches();
+    Cli::from_arg_matches(&matches)
+}
+
 fn main() -> ExitCode {
     logging::init();
-    let cli = Cli::parse();
+    let cli = match parse_cli() {
+        Ok(cli) => cli,
+        Err(e) => {
+            e.exit();
+        }
+    };
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -225,7 +225,7 @@ impl ServerHandler for ImapMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::default().with_server_info(Implementation::new(
             "rusty-imap-mcp",
-            env!("CARGO_PKG_VERSION"),
+            rimap_core::version::version(),
         ))
     }
 

--- a/crates/rimap-server/tests/cli_smoke.rs
+++ b/crates/rimap-server/tests/cli_smoke.rs
@@ -1,0 +1,19 @@
+//! Smoke tests for the user-visible `--version` output.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn version_flag_prints_expected_shape() {
+    #[expect(
+        clippy::expect_used,
+        reason = "test scaffold: panic on missing binary is intentional"
+    )]
+    Command::cargo_bin("rusty-imap-mcp")
+        .expect("binary exists")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("rusty-imap-mcp "))
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -91,6 +91,9 @@ struct DovecotHarness {
 
 impl DovecotHarness {
     fn try_start() -> Option<Self> {
+        const BACKOFF_MS: [u64; 2] = [50, 250];
+        const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
+
         if std::env::consts::ARCH != "x86_64" {
             return None;
         }
@@ -114,23 +117,42 @@ impl DovecotHarness {
                 .unwrap_or(0)
         );
 
-        let host_port = pick_free_port()?;
+        let mut host_port = ReservedPort::acquire()?;
 
-        let status = Command::new(runtime())
-            .arg("compose")
-            .arg("-p")
-            .arg(&project)
-            .arg("up")
-            .arg("-d")
-            .env("RIMAP_DOVECOT_HOST_PORT", host_port.to_string())
-            .current_dir(&compose_dir)
-            .status()
-            .ok()?;
-        if !status.success() {
-            return None;
+        // Attempt 0 is the initial try (no prior sleep). Attempts 1 and 2
+        // are retries preceded by teardown + backoff sleep + fresh port.
+        for attempt in 0..MAX_ATTEMPTS {
+            if attempt > 0 {
+                compose_down(&project, &compose_dir);
+                std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS[attempt - 1]));
+                host_port = ReservedPort::acquire()?;
+            }
+            host_port.release();
+
+            let output = Command::new(runtime())
+                .arg("compose")
+                .arg("-p")
+                .arg(&project)
+                .arg("up")
+                .arg("-d")
+                .env("RIMAP_DOVECOT_HOST_PORT", host_port.port().to_string())
+                .current_dir(&compose_dir)
+                .output()
+                .ok()?;
+
+            if output.status.success() {
+                return wait_for_ready(&project, host_port.port(), &compose_dir);
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !is_port_collision(&stderr) {
+                // Non-collision failure: stop retrying.
+                return None;
+            }
         }
 
-        wait_for_ready(&project, host_port, &compose_dir)
+        // All attempts hit port collisions.
+        None
     }
 
     /// Create a mailbox via `doveadm` inside the container.
@@ -212,9 +234,43 @@ fn read_fingerprint(project: &str) -> Result<TlsFingerprint, String> {
     TlsFingerprint::from_hex(&s).map_err(|e| e.to_string())
 }
 
-fn pick_free_port() -> Option<u16> {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
-    Some(listener.local_addr().ok()?.port())
+/// Host port reserved by binding `127.0.0.1:0` and reading the
+/// kernel-assigned number. The `TcpListener` is kept open until
+/// `release()` is called, holding the kernel-level lease so docker
+/// (or any other process) cannot bind the same port in the meantime.
+struct ReservedPort {
+    port: u16,
+    listener: Option<std::net::TcpListener>,
+}
+
+impl ReservedPort {
+    fn acquire() -> Option<Self> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+        let port = listener.local_addr().ok()?.port();
+        Some(Self {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Drop the underlying `TcpListener`, releasing the kernel-level
+    /// port lease. Idempotent.
+    fn release(&mut self) {
+        self.listener.take();
+    }
+}
+
+/// Classify a stderr blob from a failed `compose up`: `true` when the
+/// failure looks like a host-port bind collision.
+fn is_port_collision(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("port is already allocated")
+        || s.contains("address already in use")
+        || s.contains("bind for 127.0.0.1")
 }
 
 struct StaticCreds(String);

--- a/crates/rimap-smtp/Cargo.toml
+++ b/crates/rimap-smtp/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["smtp", "email", "mcp"]
 workspace = true
 
 [dependencies]
-rimap-core = { path = "../rimap-core", version = "1.0.0" }
-rimap-config = { path = "../rimap-config", version = "1.0.0" }
+rimap-core = { path = "../rimap-core", version = "0.1.0" }
+rimap-config = { path = "../rimap-config", version = "0.1.0" }
 
 lettre = { workspace = true }
 thiserror = { workspace = true }

--- a/docs/superpowers/plans/2026-05-11-dovecot-port-race-fix.md
+++ b/docs/superpowers/plans/2026-05-11-dovecot-port-race-fix.md
@@ -1,0 +1,898 @@
+# Dovecot Integration Test Port-Race Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the docker `compose up` port-bind race in the dovecot integration harness so `case_05_list_returns_seeded_folders` (and every other dovecot case) stops flaking under nextest parallelism.
+
+**Architecture:** A new `ReservedPort` type owns its `TcpListener` until the moment docker is invoked, narrowing the bind race from indefinite to microseconds. A `ComposeRunner` trait abstracts the `docker compose up` shell-out so a `FlakyComposeRunner` test double can drive a bounded retry wrapper (`compose_up_with_retry`) deterministically. The wrapper handles the residual collision window with 50ms/250ms backoff and gives up after three attempts, preserving the underlying stderr.
+
+**Tech Stack:** Rust 1.88.0 MSRV (edition 2024), `std::process::Command`, `std::net::TcpListener`, nextest, docker/podman compose.
+
+**Spec:** [`docs/superpowers/specs/2026-05-11-dovecot-port-race-design.md`](../specs/2026-05-11-dovecot-port-race-design.md)
+
+---
+
+## File Map
+
+**Modify (single file):**
+- `crates/rimap-imap/tests/integration/support/container.rs` — all changes land here. The file has one responsibility (driving the dovecot compose lifecycle); the new pieces (port reservation, runner trait, retry wrapper, test double, unit tests) all serve that responsibility and do not warrant a split.
+
+**No new files. No changes outside `container.rs`. No production-code changes.**
+
+---
+
+## Task 1: Capture stderr in `compose_up`
+
+The current `compose_up` uses `Command::...status()`, which discards stdout/stderr. The retry wrapper in later tasks needs the stderr text to classify port collisions. This task does the strictly-additive diagnostic improvement first, in isolation, so the diff is clear and bisectable.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs:273-299`
+
+- [ ] **Step 1: Switch `compose_up` to `output()` and fold stderr into the error payload**
+
+Replace the body of `fn compose_up` (currently at lines 273–299) with:
+
+```rust
+fn compose_up(
+    project: &str,
+    compose_dir: &Path,
+    host_port: u16,
+    host_starttls_port: u16,
+) -> Result<(), HarnessError> {
+    let output = Command::new(runtime())
+        .arg("compose")
+        .arg("-p")
+        .arg(project)
+        .arg("up")
+        .arg("-d")
+        .env("RIMAP_DOVECOT_HOST_PORT", host_port.to_string())
+        .env(
+            "RIMAP_DOVECOT_HOST_PORT_STARTTLS",
+            host_starttls_port.to_string(),
+        )
+        .current_dir(compose_dir)
+        .output()
+        .map_err(|e| HarnessError::DockerCommandFailed(e.to_string()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(HarnessError::DockerCommandFailed(format!(
+            "compose up exit {}: {}",
+            output.status,
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+```
+
+The signature is unchanged. Only the body switches from `.status()` to `.output()` and includes the trimmed stderr in the error message.
+
+- [ ] **Step 2: Verify the workspace still compiles**
+
+Run from the repo root:
+
+```bash
+cargo check -p rimap-imap --tests --locked
+```
+
+Expected: clean. No clippy or fmt warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): capture compose-up stderr in error payload
+
+Switch the integration-test harness's compose_up from Command::status()
+to Command::output() and fold the captured stderr into the
+DockerCommandFailed payload. Previously a compose failure produced an
+exit-code-only message, hiding the actual docker engine error (e.g.
+'port is already allocated'). Strictly additive diagnostic improvement;
+no behavior change on the happy path."
+```
+
+---
+
+## Task 2: Add `is_port_collision` classifier
+
+The retry wrapper needs a small predicate that inspects a stderr string and decides whether it represents a port-bind collision. This is the smallest atomic unit; landing it standalone keeps the retry-wrapper task focused on control flow.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs` (append a private fn near `compose_up`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add the following test inside an existing test module in `container.rs`, OR if no such module exists yet, create one at the bottom of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used, reason = "tests")]
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::panic, reason = "test failure path")]
+
+    use super::*;
+
+    #[test]
+    fn is_port_collision_matches_docker_engine_error() {
+        let stderr = "Error response from daemon: failed to set up container networking: \
+            driver failed programming external connectivity on endpoint rimap-it-abc-dovecot \
+            (...): Bind for 127.0.0.1:35615 failed: port is already allocated";
+        assert!(is_port_collision(stderr));
+    }
+
+    #[test]
+    fn is_port_collision_matches_libc_eaddrinuse() {
+        assert!(is_port_collision("bind: address already in use"));
+    }
+
+    #[test]
+    fn is_port_collision_matches_podman_variant() {
+        assert!(is_port_collision("Error: rootlessport listen tcp 127.0.0.1:1234: bind: address already in use"));
+    }
+
+    #[test]
+    fn is_port_collision_rejects_unrelated_error() {
+        assert!(!is_port_collision("no such image: docker.io/dovecot/dovecot:9.9.9"));
+        assert!(!is_port_collision("dovecot exited with non-zero status"));
+    }
+
+    #[test]
+    fn is_port_collision_is_case_insensitive() {
+        assert!(is_port_collision("PORT IS ALREADY ALLOCATED"));
+        assert!(is_port_collision("Bind FOR 127.0.0.1:80 failed"));
+    }
+}
+```
+
+Check whether `container.rs` already has a `#[cfg(test)] mod tests` block. If so, add only the five `#[test] fn` items inside that block. If not, add the whole module at the bottom of the file.
+
+- [ ] **Step 2: Run tests to confirm they fail with "is_port_collision not defined"**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests::is_port_collision -- --nocapture 2>&1 | tail -20
+```
+
+Expected: compile error mentioning `is_port_collision` cannot be found.
+
+- [ ] **Step 3: Add the `is_port_collision` function**
+
+Insert this private function immediately after `fn compose_up` (it will sit near line ~300 in `container.rs`):
+
+```rust
+/// Classify a stderr blob from a failed `compose up`: `true` when the
+/// failure looks like a host-port bind collision, `false` otherwise.
+///
+/// Covers three observed phrasings:
+///   - docker engine: "Bind for 127.0.0.1:NNNN failed: port is already allocated"
+///   - libc EADDRINUSE: "address already in use"
+///   - podman rootlessport: "Bind for ..."
+fn is_port_collision(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("port is already allocated")
+        || s.contains("address already in use")
+        || s.contains("bind for")
+}
+```
+
+- [ ] **Step 4: Run tests to confirm all five pass**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests::is_port_collision -- --nocapture 2>&1 | tail -15
+```
+
+Expected: `test result: ok. 5 passed; 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): is_port_collision stderr classifier + tests
+
+Adds a small private predicate that decides whether a compose-up stderr
+blob represents a host-port bind collision. Covers docker engine,
+libc EADDRINUSE, and podman rootlessport phrasings; case-insensitive.
+Used by the upcoming retry wrapper to decide when to retry vs.
+propagate the original error."
+```
+
+---
+
+## Task 3: Introduce `ReservedPort`
+
+Replace the racy `pick_free_port -> u16` with a `ReservedPort` value that owns its `TcpListener` lease. The harness keeps the listeners alive across the compose-up call; the retry wrapper (Task 5) releases them at the last possible moment.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs:107-127,487-494`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests to the `#[cfg(test)] mod tests` block added in Task 2:
+
+```rust
+    #[test]
+    fn reserved_port_acquires_distinct_ports() {
+        let a = ReservedPort::acquire().expect("acquire a");
+        let b = ReservedPort::acquire().expect("acquire b");
+        assert_ne!(a.port(), b.port(), "two reservations must yield different ports");
+    }
+
+    #[test]
+    fn reserved_port_release_drops_lease() {
+        let mut p = ReservedPort::acquire().expect("acquire");
+        let port = p.port();
+        p.release();
+        // After release, another bind on the same port should succeed.
+        let bound_again = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(
+            bound_again.is_ok(),
+            "should be able to bind {port} after release: {:?}",
+            bound_again.err()
+        );
+    }
+
+    #[test]
+    fn reserved_port_release_is_idempotent() {
+        let mut p = ReservedPort::acquire().expect("acquire");
+        p.release();
+        p.release(); // must not panic
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail with "ReservedPort not defined"**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests::reserved_port 2>&1 | tail -15
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Replace `pick_free_port` with `ReservedPort`**
+
+Locate `fn pick_free_port` (currently at lines 487–494) and replace it with the type definition below. Move it to live next to `is_port_collision` for proximity to its users.
+
+Delete this current block:
+
+```rust
+/// Bind to `127.0.0.1:0`, read the kernel-assigned port, and drop the
+/// listener. Technically racy (another process could claim the same port
+/// in the gap before docker binds it) but acceptable for integration
+/// tests — the port is passed immediately to `docker compose up`.
+fn pick_free_port() -> Result<u16, HarnessError> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| HarnessError::PortReadFailed(format!("bind: {e}")))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| HarnessError::PortReadFailed(format!("local_addr: {e}")))?;
+    Ok(addr.port())
+}
+```
+
+Insert this replacement somewhere logically reasonable — placing it directly above `fn is_port_collision` works well:
+
+```rust
+/// A host port reserved by binding `127.0.0.1:0` and reading the
+/// kernel-assigned number. The `TcpListener` is kept open until
+/// `release()` is called, holding the kernel-level lease so docker
+/// (or any other process) cannot bind the same port in the meantime.
+///
+/// Lifecycle: callers acquire two `ReservedPort`s, then pass `&mut`
+/// references to the retry wrapper, which releases them just before
+/// invoking `docker compose up`. If `compose up` fails with a port
+/// collision (the residual race window), the wrapper drops the
+/// reservations and acquires fresh ones for the next attempt.
+struct ReservedPort {
+    port: u16,
+    listener: Option<std::net::TcpListener>,
+}
+
+impl ReservedPort {
+    fn acquire() -> Result<Self, HarnessError> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| HarnessError::PortReadFailed(format!("bind: {e}")))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| HarnessError::PortReadFailed(format!("local_addr: {e}")))?
+            .port();
+        Ok(Self {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Drop the underlying `TcpListener`, releasing the kernel-level
+    /// port lease. Idempotent.
+    fn release(&mut self) {
+        self.listener.take();
+    }
+}
+```
+
+- [ ] **Step 4: Update `try_start` to use `ReservedPort`**
+
+Locate the `try_start` body around lines 107–112:
+
+```rust
+let project = format!("rimap-it-{}", uuid_like());
+let host_port = pick_free_port()?;
+let host_starttls_port = pick_free_port()?;
+
+compose_up(&project, &compose_dir, host_port, host_starttls_port)?;
+```
+
+Replace with:
+
+```rust
+let project = format!("rimap-it-{}", uuid_like());
+let mut host_port = ReservedPort::acquire()?;
+let mut host_starttls_port = ReservedPort::acquire()?;
+
+// Release the kernel-level port leases just before docker binds them.
+// The retry wrapper (next task) will move this release into a tighter
+// loop; for now, release explicitly and call the plain compose_up.
+host_port.release();
+host_starttls_port.release();
+compose_up(&project, &compose_dir, host_port.port(), host_starttls_port.port())?;
+```
+
+And update the subsequent `wait_for_ready` call and the `Ok(Self { ... })` block that uses the port numbers — replace `host_port` (now a `ReservedPort` rather than `u16`) in those expressions with `host_port.port()`:
+
+```rust
+let result = wait_for_ready(&project, &compose_dir, host_port.port(), host_starttls_port.port());
+match result {
+    Ok((fingerprint, port)) => Ok(Self {
+        project,
+        compose_dir,
+        fingerprint,
+        port,
+        starttls_port: host_starttls_port.port(),
+    }),
+    Err(e) => {
+        compose_down(&project, &compose_dir);
+        Err(e)
+    }
+}
+```
+
+(The comment about "the retry wrapper (next task)" stays in the code only briefly; Task 5 removes it when wiring the wrapper in.)
+
+- [ ] **Step 5: Verify compile + run the three reservation tests**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests::reserved_port 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Verify the full unit-test suite still passes**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests 2>&1 | tail -10
+```
+
+Expected: all tests pass (5 from Task 2 + 3 from Task 3 = 8 passing).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): ReservedPort owns TcpListener until release
+
+Replace pick_free_port (which dropped its listener before returning)
+with a ReservedPort type that keeps the kernel-level port lease until
+release() is called explicitly. try_start now releases just before
+invoking compose_up; the next commit moves that release into a retry
+loop. Three unit tests cover acquire (distinct ports), release (port
+is bindable again), and idempotency."
+```
+
+---
+
+## Task 4: Add `ComposeRunner` trait + production impl
+
+Extract the compose-up shell-out behind a trait so the retry wrapper (next task) can be exercised by a deterministic test double. The production runner does exactly what `compose_up` does today; the difference is only that it's reached through a trait object.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs`
+
+- [ ] **Step 1: Add the trait and the production implementation**
+
+Insert above `fn compose_up` (around line ~273):
+
+```rust
+/// Minimal interface over `docker compose up` so the retry wrapper
+/// can be unit-tested without a real docker.
+trait ComposeRunner {
+    fn up(
+        &self,
+        project: &str,
+        compose_dir: &Path,
+        tls_port: u16,
+        starttls_port: u16,
+    ) -> Result<(), HarnessError>;
+}
+
+/// Production runner: shells out to `docker compose up -d` (or podman).
+struct DockerComposeRunner;
+
+impl ComposeRunner for DockerComposeRunner {
+    fn up(
+        &self,
+        project: &str,
+        compose_dir: &Path,
+        tls_port: u16,
+        starttls_port: u16,
+    ) -> Result<(), HarnessError> {
+        compose_up(project, compose_dir, tls_port, starttls_port)
+    }
+}
+```
+
+Keep the existing free `fn compose_up` exactly as it is (with the stderr capture from Task 1). The trait impl delegates to it so behavior is provably identical.
+
+- [ ] **Step 2: Verify compile**
+
+```bash
+cargo check -p rimap-imap --tests --locked
+```
+
+Expected: clean.
+
+`DockerComposeRunner` may trigger `dead_code` because nothing constructs it yet — Task 5 wires it in. The workspace bans `#[allow]` (via `clippy::allow_attributes = "deny"`), so the only sanctioned suppression is `#[expect]`. If `cargo check` fails on the struct, add a scoped expectation directly above the `struct DockerComposeRunner;` line:
+
+```rust
+#[expect(dead_code, reason = "wired up in the next commit (compose_up_with_retry)")]
+struct DockerComposeRunner;
+```
+
+Task 5 removes the attribute as part of wiring the struct into `try_start`. (`#[expect]` self-cleans: once the struct is used, the unfulfilled-expectation lint fires, surfacing the leftover attribute as a clean diagnostic.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): ComposeRunner trait + DockerComposeRunner impl
+
+Extracts the compose-up shell-out behind a one-method trait so the
+upcoming retry wrapper can be unit-tested with a flaky test double.
+DockerComposeRunner delegates to the existing free fn compose_up so
+production behavior is byte-identical; the wire-up lands in the next
+commit."
+```
+
+---
+
+## Task 5: Implement `compose_up_with_retry` and wire it in
+
+Add the retry wrapper, swap `try_start` over to it, and remove the temporary "release explicitly" comment / dead-code expect.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs`
+
+- [ ] **Step 1: Add the retry wrapper**
+
+Insert immediately after the `DockerComposeRunner` impl (or anywhere between `compose_up` and `try_start`'s call site):
+
+```rust
+/// Drive `runner.up(...)` with a bounded retry on host-port collisions.
+///
+/// Three attempts total (initial + 2 retries). Each retry tears down
+/// the partial compose project, sleeps with jittered backoff, and
+/// acquires fresh `ReservedPort`s. Non-collision errors propagate
+/// immediately on the first failure. If all three attempts hit
+/// collisions, the most recent stderr is preserved in the error
+/// message.
+fn compose_up_with_retry(
+    runner: &dyn ComposeRunner,
+    project: &str,
+    compose_dir: &Path,
+    tls: &mut ReservedPort,
+    starttls: &mut ReservedPort,
+) -> Result<(), HarnessError> {
+    const BACKOFF_MS: [u64; 2] = [50, 250];
+    let mut last_collision: Option<String> = None;
+
+    for attempt in 0..=BACKOFF_MS.len() {
+        tls.release();
+        starttls.release();
+        let result = runner.up(project, compose_dir, tls.port(), starttls.port());
+        match result {
+            Ok(()) => return Ok(()),
+            Err(HarnessError::DockerCommandFailed(s)) if is_port_collision(&s) => {
+                last_collision = Some(s);
+                if attempt == BACKOFF_MS.len() {
+                    break;
+                }
+                compose_down(project, compose_dir);
+                std::thread::sleep(Duration::from_millis(BACKOFF_MS[attempt]));
+                *tls = ReservedPort::acquire()?;
+                *starttls = ReservedPort::acquire()?;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(HarnessError::DockerCommandFailed(format!(
+        "compose up: exhausted {} attempts on port collision; last error: {}",
+        BACKOFF_MS.len() + 1,
+        last_collision.unwrap_or_else(|| "<no error captured>".into()),
+    )))
+}
+```
+
+- [ ] **Step 2: Update `try_start` to use the wrapper**
+
+The `try_start` body currently looks like (after Task 3):
+
+```rust
+let project = format!("rimap-it-{}", uuid_like());
+let mut host_port = ReservedPort::acquire()?;
+let mut host_starttls_port = ReservedPort::acquire()?;
+
+// Release the kernel-level port leases just before docker binds them.
+// The retry wrapper (next task) will move this release into a tighter
+// loop; for now, release explicitly and call the plain compose_up.
+host_port.release();
+host_starttls_port.release();
+compose_up(&project, &compose_dir, host_port.port(), host_starttls_port.port())?;
+```
+
+Replace with:
+
+```rust
+let project = format!("rimap-it-{}", uuid_like());
+let mut host_port = ReservedPort::acquire()?;
+let mut host_starttls_port = ReservedPort::acquire()?;
+
+let runner = DockerComposeRunner;
+compose_up_with_retry(
+    &runner,
+    &project,
+    &compose_dir,
+    &mut host_port,
+    &mut host_starttls_port,
+)?;
+```
+
+The wrapper releases the ports internally. Note: after `compose_up_with_retry` succeeds, `host_port.port()` still returns the correct value (we kept the `u16` in the struct even after `release()` consumed the listener).
+
+- [ ] **Step 3: Remove the `#[expect(dead_code)]` from `DockerComposeRunner`**
+
+If Task 4 added an `#[expect(dead_code, reason = "wired up in next commit")]` attribute to `DockerComposeRunner`, remove it now — the struct is in use.
+
+- [ ] **Step 4: Verify the whole crate compiles and existing tests still pass**
+
+```bash
+cargo check -p rimap-imap --tests --locked
+cargo test -p rimap-imap --test dovecot support::container::tests 2>&1 | tail -10
+```
+
+Expected: clean compile, 8 unit tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): compose_up_with_retry closes the port-bind race
+
+Wire DovecotHarness::try_start through a bounded retry wrapper that
+releases the kernel-level port leases just before invoking docker, and
+retries with fresh ports on EADDRINUSE-style stderr signatures. Three
+attempts total, 50ms then 250ms backoff. Non-collision errors
+propagate immediately. The author's previously-acknowledged race
+(see the doc comment now removed from pick_free_port) is closed:
+the race window shrinks from indefinite to microseconds, and the
+residual gap is self-healing."
+```
+
+---
+
+## Task 6: `FlakyComposeRunner` and retry tests
+
+Add a deterministic test double and the three unit tests that exercise the retry behavior end-to-end. No docker required.
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs` (extend the `#[cfg(test)] mod tests` block)
+
+- [ ] **Step 1: Add `FlakyComposeRunner` inside the test module**
+
+Inside the existing `#[cfg(test)] mod tests` block, add:
+
+```rust
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Test double for `ComposeRunner`. Records every observed
+    /// `(tls_port, starttls_port)` pair and returns a programmable
+    /// sequence of results.
+    struct FlakyComposeRunner {
+        fail_first_n: AtomicU32,
+        observed_ports: Mutex<Vec<(u16, u16)>>,
+        port_collision_stderr: String,
+        terminal_error: Option<String>,
+    }
+
+    impl FlakyComposeRunner {
+        /// Fail the first `n` attempts with a port-collision stderr;
+        /// succeed afterward.
+        fn fail_first_n_with_port_collision(n: u32) -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(n),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
+                                        port is already allocated"
+                    .into(),
+                terminal_error: None,
+            }
+        }
+
+        /// Always fail with a port-collision stderr.
+        fn always_fail_with_port_collision() -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(u32::MAX),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: "Bind for 127.0.0.1:12345 failed: \
+                                        port is already allocated"
+                    .into(),
+                terminal_error: None,
+            }
+        }
+
+        /// Always fail with a non-collision stderr.
+        fn always_fail_with(msg: &str) -> Self {
+            Self {
+                fail_first_n: AtomicU32::new(u32::MAX),
+                observed_ports: Mutex::new(Vec::new()),
+                port_collision_stderr: String::new(),
+                terminal_error: Some(msg.into()),
+            }
+        }
+
+        fn observed_ports(&self) -> Vec<(u16, u16)> {
+            self.observed_ports.lock().unwrap().clone()
+        }
+
+        fn attempts(&self) -> usize {
+            self.observed_ports.lock().unwrap().len()
+        }
+    }
+
+    impl ComposeRunner for FlakyComposeRunner {
+        fn up(
+            &self,
+            _project: &str,
+            _compose_dir: &Path,
+            tls_port: u16,
+            starttls_port: u16,
+        ) -> Result<(), HarnessError> {
+            self.observed_ports
+                .lock()
+                .unwrap()
+                .push((tls_port, starttls_port));
+
+            if let Some(msg) = self.terminal_error.as_ref() {
+                return Err(HarnessError::DockerCommandFailed(msg.clone()));
+            }
+
+            let remaining = self.fail_first_n.load(Ordering::SeqCst);
+            if remaining > 0 {
+                self.fail_first_n.fetch_sub(1, Ordering::SeqCst);
+                return Err(HarnessError::DockerCommandFailed(
+                    self.port_collision_stderr.clone(),
+                ));
+            }
+            Ok(())
+        }
+    }
+```
+
+Note: `Path` is already imported at the top of `container.rs`; if the test module doesn't see it, add `use super::*;` near the top of the module — which is already there from Task 2.
+
+The `.unwrap()` calls on the `Mutex` are inside `#[cfg(test)]` code, which the workspace allows.
+
+- [ ] **Step 2: Write the three retry-behavior tests**
+
+Append these inside the same test module:
+
+```rust
+    fn dummy_compose_dir() -> &'static Path {
+        Path::new("/tmp/rimap-it-test")
+    }
+
+    #[test]
+    fn compose_up_retries_on_port_collision_then_succeeds() {
+        let runner = FlakyComposeRunner::fail_first_n_with_port_collision(2);
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        assert!(result.is_ok(), "should succeed on third attempt: {:?}", result.err());
+        let ports = runner.observed_ports();
+        assert_eq!(ports.len(), 3, "should have attempted three times");
+        // Each retry uses a fresh port pair (proves the reacquire path).
+        assert_ne!(ports[0], ports[1], "attempt 1 vs 2 ports identical");
+        assert_ne!(ports[1], ports[2], "attempt 2 vs 3 ports identical");
+    }
+
+    #[test]
+    fn compose_up_gives_up_after_max_attempts() {
+        let runner = FlakyComposeRunner::always_fail_with_port_collision();
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        let Err(HarnessError::DockerCommandFailed(msg)) = result else {
+            panic!("expected DockerCommandFailed, got: {result:?}");
+        };
+        assert!(msg.contains("exhausted"), "missing 'exhausted' in {msg:?}");
+        assert!(
+            msg.contains("port is already allocated"),
+            "underlying stderr should be preserved in {msg:?}"
+        );
+        assert_eq!(runner.attempts(), 3, "should have attempted three times");
+    }
+
+    #[test]
+    fn compose_up_propagates_non_port_errors_immediately() {
+        let runner = FlakyComposeRunner::always_fail_with("no such image: dovecot:9.9.9");
+        let mut tls = ReservedPort::acquire().expect("tls");
+        let mut starttls = ReservedPort::acquire().expect("starttls");
+
+        let result = compose_up_with_retry(
+            &runner,
+            "test-proj",
+            dummy_compose_dir(),
+            &mut tls,
+            &mut starttls,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(runner.attempts(), 1, "non-collision errors should not retry");
+    }
+```
+
+Caveat: `compose_up_with_retry` calls `compose_down` between collision retries. `compose_down` in this codebase silently discards errors from `Command::...status()` (line 396 of the file), so it will be a no-op when called against a project that doesn't have a real docker behind it. The tests run cleanly even though no docker is involved.
+
+- [ ] **Step 3: Run the three retry tests**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests::compose_up 2>&1 | tail -15
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 4: Run the full unit-test module**
+
+```bash
+cargo test -p rimap-imap --test dovecot support::container::tests 2>&1 | tail -10
+```
+
+Expected: 11 passed (5 classifier + 3 ReservedPort + 3 retry).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "test(rimap-imap): unit tests for compose_up_with_retry
+
+A FlakyComposeRunner test double records every observed port pair and
+returns a programmable sequence of results. Three tests cover the
+retry path end-to-end without requiring docker: (a) two failures then
+success exercises the reacquire-fresh-ports path, (b) three failures
+asserts the 'exhausted' error preserves the underlying stderr, (c)
+non-collision errors propagate without retrying. These tests catch
+regressions in the retry logic that the dovecot suite would only
+surface as an intermittent CI flake."
+```
+
+---
+
+## Task 7: Run local CI, push, and confirm CI is green
+
+Validate the fix end-to-end and update the existing PR.
+
+**Files:** none (no further code changes)
+
+- [ ] **Step 1: Run the full local-CI suite**
+
+```bash
+just ci
+```
+
+Expected: all stages pass — `fmt-check`, `lint`, `test`, `test-msrv`, `deny`, `typos`.
+
+The dovecot integration tests themselves are not exercised by `just test` (they require docker and silently skip otherwise via `HarnessError::DockerUnavailable`). The new unit tests inside the integration test crate do execute under `cargo nextest` and verify the retry logic.
+
+- [ ] **Step 2: Run pre-commit hooks across all files**
+
+```bash
+just hooks
+```
+
+Expected: every hook passes.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push origin feat/release-versioning
+```
+
+The branch already has an open PR (#257); pushing updates it.
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+gh pr checks 257 --watch
+```
+
+Or, if you don't want to block on the terminal, poll periodically:
+
+```bash
+gh pr checks 257
+```
+
+Expected: every check is `pass`, including the `test (MSRV 1.88.0)` lane that previously failed.
+
+- [ ] **Step 5: If CI is green, leave a brief PR comment summarizing the fix**
+
+```bash
+gh pr comment 257 --body "$(cat <<'EOF'
+Fix for the MSRV-lane port-bind race landed in commits ${COMMITS}. Summary:
+
+- `ReservedPort` keeps the `TcpListener` lease open until docker is invoked.
+- `compose_up_with_retry` handles the residual collision window with 50ms/250ms backoff and propagates the underlying stderr on exhausted retries.
+- A `ComposeRunner` trait + `FlakyComposeRunner` test double cover the retry logic in unit tests (no docker needed).
+- `compose_up` now captures stderr so failures are diagnosable on first inspection.
+
+Spec: `docs/superpowers/specs/2026-05-11-dovecot-port-race-design.md`.
+EOF
+)"
+```
+
+Replace `${COMMITS}` with the SHAs of Tasks 1–6 commits (`git log --oneline -7` of the new commits).
+
+- [ ] **Step 6: If CI is still red, capture the failing log and report DONE_WITH_CONCERNS**
+
+If a different test now fails (e.g. a real bug exposed by the new diagnostic, or an unrelated flake): do NOT propose re-running the job. Investigate the failure, escalate to the user with the captured log, and decide whether to fix in this PR or open a follow-up.
+
+If the same test still fails: the retry policy may be insufficient (e.g. CI is under heavier collision pressure than expected). Capture the run URL, the failed-job log, and any new "exhausted attempts" error message, then escalate to the user. The fix path would be to widen the retry policy or switch to option C (file-locked port allocator) from the brainstorm.
+
+---
+
+## Verification checklist
+
+After all tasks complete and CI is green:
+
+- [ ] `pick_free_port` is gone; `ReservedPort` is its replacement (`grep -n 'pick_free_port' crates/rimap-imap/tests/integration/support/container.rs` returns nothing).
+- [ ] `compose_up` captures stderr; failing `compose up` errors include the underlying docker message.
+- [ ] `compose_up_with_retry` is called from `DovecotHarness::try_start`.
+- [ ] The `#[cfg(test)] mod tests` block in `container.rs` has 11 passing tests.
+- [ ] PR #257's `test (MSRV 1.88.0)` lane is green across at least two consecutive runs (a single green run proves nothing about flakiness — two consecutive proves the bound).
+- [ ] No production-code or other-crate files are touched in this PR.
+
+---
+
+## Out of scope (do not touch in this PR)
+
+- `STALE_PROJECT_AGE` (currently 30 min). Touching it requires measuring parallel-run wall time first.
+- SMTP integration harness wiring (the dormant compose file). When SMTP grows a Rust consumer, it should reuse `ReservedPort` + `compose_up_with_retry`.
+- File-locked process-wide port allocator (option C). Deferred unless the retry pattern still flakes.
+- `restart()` code path. It reuses an already-bound port and doesn't traverse the race.
+- Nextest parallelism tuning (e.g. `test-threads` override for the integration lane). Orthogonal to the bind race.

--- a/docs/superpowers/plans/2026-05-11-release-versioning.md
+++ b/docs/superpowers/plans/2026-05-11-release-versioning.md
@@ -1,0 +1,1056 @@
+# Release Versioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a semver-compliant release workflow where tagged builds identify as `X.Y.Z` and untagged builds identify as `X.Y.Z-dev+g<sha>[.dirty]`, with the version computed once in `rimap-core` and flowing to the CLI, MCP server_info, and audit-log records. Drop the workspace version from the aspirational `1.0.0` to `0.1.0`.
+
+**Architecture:** A new `crates/rimap-core/build.rs` shells out to `git` to compute the version at compile time and emits `RIMAP_VERSION` / `RIMAP_COMMIT` / `RIMAP_RELEASE` via `cargo:rustc-env`. A new `rimap_core::version::{version, commit, is_release}` API exposes those values. Three runtime sites (clap, MCP `server_info`, audit `process_start`) switch from `env!("CARGO_PKG_VERSION")` to the new helpers. The release workflow gains a `verify-tag` job that hard-fails on tag/Cargo.toml drift, plus a local mirror script `scripts/check-release-version.sh` invoked through a `just release-check` recipe.
+
+**Tech Stack:** Rust 1.88.0 MSRV (edition 2024), Cargo workspace, clap 4.5, GitHub Actions, bash (`set -euo pipefail`), `just`, `prek` pre-commit hooks.
+
+**Spec:** [`docs/superpowers/specs/2026-05-11-release-versioning-design.md`](../specs/2026-05-11-release-versioning-design.md)
+
+---
+
+## File Map
+
+**Create:**
+- `crates/rimap-core/build.rs` — git-describe-based version string composer
+- `crates/rimap-core/src/version.rs` — public `version()` / `commit()` / `is_release()` helpers
+- `crates/rimap-core/tests/version.rs` — unit tests for the helpers
+- `scripts/check-release-version.sh` — local tag/Cargo.toml comparison
+- `.github/workflows/release.yml` (modify) — `verify-tag` job + `workflow_dispatch` trigger
+
+**Modify:**
+- `Cargo.toml` — workspace version `1.0.0` → `0.1.0`
+- `crates/rimap-core/Cargo.toml` — add `build = "build.rs"` line, declare `version` module
+- `crates/rimap-core/src/lib.rs` — add `pub mod version;` and re-exports
+- `crates/rimap-content/Cargo.toml` — two `1.0.0` literals (lines 19, 61)
+- `crates/rimap-audit/Cargo.toml` — one literal (line 18)
+- `crates/rimap-config/Cargo.toml` — one literal (line 20)
+- `crates/rimap-authz/Cargo.toml` — two literals (lines 15, 16)
+- `crates/rimap-smtp/Cargo.toml` — two literals (lines 18, 19)
+- `crates/rimap-imap/Cargo.toml` — three literals (lines 27, 56, 57)
+- `crates/rimap-server/Cargo.toml` — eleven literals (lines 30-36, 60-62, 66)
+- `crates/rimap-server/src/cli/mod.rs:24` — `version` → `version = rimap_core::version::version()`
+- `crates/rimap-server/src/mcp/server.rs:228` — `env!("CARGO_PKG_VERSION")` → `rimap_core::version::version()`
+- `crates/rimap-server/src/boot/audit_init.rs:66-67` — populate `version` and `git_commit` from helpers
+- `crates/rimap-server/tests/cli_smoke.rs` (create or extend) — assert `--version` output shape
+- `CHANGELOG.md` — relabel `[1.0.0]` → `[0.1.0]`, fold `[Unreleased]` content, remove duplicate trailing heading, add reference-link footer
+- `justfile` — add `release-check` recipe
+
+---
+
+## Task 1: Bump workspace version to 0.1.0 and update path-dep literals
+
+**Files:**
+- Modify: `Cargo.toml:16`
+- Modify: `crates/rimap-content/Cargo.toml:19,61`
+- Modify: `crates/rimap-audit/Cargo.toml:18`
+- Modify: `crates/rimap-config/Cargo.toml:20`
+- Modify: `crates/rimap-authz/Cargo.toml:15-16`
+- Modify: `crates/rimap-smtp/Cargo.toml:18-19`
+- Modify: `crates/rimap-imap/Cargo.toml:27,56-57`
+- Modify: `crates/rimap-server/Cargo.toml:30-36,60-62,66`
+
+- [ ] **Step 1: Change the workspace version**
+
+In `Cargo.toml`, change line 16 from:
+
+```toml
+version = "1.0.0"
+```
+
+to:
+
+```toml
+version = "0.1.0"
+```
+
+- [ ] **Step 2: Update all 22 path-dep version literals**
+
+Use a single targeted replacement across the seven crate manifests. Run from the repo root:
+
+```bash
+sed -i.bak -E 's/(path = "\.\.\/rimap-[a-z]+", version = )"1\.0\.0"/\1"0.1.0"/g' crates/*/Cargo.toml
+sed -i.bak -E 's/^version = "1\.0\.0"$/version = "0.1.0"/g' crates/*/Cargo.toml
+sed -i.bak -E 's/(path = "\.", version = )"1\.0\.0"/\1"0.1.0"/g' crates/*/Cargo.toml
+rm crates/*/Cargo.toml.bak
+```
+
+On macOS, GNU sed is not present by default — the `-i.bak` form works on both BSD and GNU sed.
+
+- [ ] **Step 3: Verify no `1.0.0` literals remain in the workspace**
+
+Run:
+
+```bash
+grep -rn 'version = "1\.0\.0"' Cargo.toml crates/*/Cargo.toml
+```
+
+Expected: no output. If any remain, inspect and update by hand.
+
+- [ ] **Step 4: Verify the workspace still resolves and compiles**
+
+Run:
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean compile. Cargo.lock will be regenerated with the new version everywhere.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/*/Cargo.toml
+git commit -m "chore: drop workspace version to 0.1.0
+
+The project is pre-release; the aspirational 1.0.0 was never tagged or
+published. Reset to 0.1.0 so the first cut release matches reality.
+Path-dep version literals updated in lockstep."
+```
+
+---
+
+## Task 2: Add build.rs to rimap-core
+
+**Files:**
+- Create: `crates/rimap-core/build.rs`
+- Modify: `crates/rimap-core/Cargo.toml`
+
+- [ ] **Step 1: Wire the build script into `rimap-core/Cargo.toml`**
+
+Edit `crates/rimap-core/Cargo.toml`. Add `build = "build.rs"` to the `[package]` section directly below the existing `description` line. The result should look like:
+
+```toml
+[package]
+name = "rimap-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Shared core types for rusty-imap-mcp: Message, Folder, Posture, audit records."
+build = "build.rs"
+```
+
+- [ ] **Step 2: Write the build script**
+
+Create `crates/rimap-core/build.rs` with the following exact contents:
+
+```rust
+//! Compile-time version composer for rusty-imap-mcp.
+//!
+//! Emits three `cargo:rustc-env` variables consumed by `src/version.rs`:
+//!
+//! - `RIMAP_VERSION` — the user-facing version string. Bare `CARGO_PKG_VERSION`
+//!   when HEAD is exactly the tag `v<CARGO_PKG_VERSION>`; otherwise
+//!   `<CARGO_PKG_VERSION>-dev+g<short-sha>[.dirty]`.
+//! - `RIMAP_COMMIT` — the short SHA (or `unknown` outside a git checkout).
+//! - `RIMAP_RELEASE` — `"true"` or `"false"` depending on the release/dev path.
+//!
+//! Every git failure path falls back to `RIMAP_VERSION =
+//! <CARGO_PKG_VERSION>-dev+gunknown`, so vendored or `cargo package` builds
+//! still compile without surprise breakage.
+
+use std::process::Command;
+
+fn main() {
+    let base = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let expected_tag = format!("v{base}");
+
+    let exact_tag = run_git(&["describe", "--tags", "--exact-match", "HEAD"]);
+    let short_sha = run_git(&["rev-parse", "--short=7", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = run_git(&["status", "--porcelain"]).map(|s| !s.is_empty()).unwrap_or(false);
+
+    let is_release = exact_tag.as_deref() == Some(expected_tag.as_str());
+    let (version, commit) = if is_release {
+        (base.clone(), short_sha.clone())
+    } else {
+        let suffix = if dirty { format!("+g{short_sha}.dirty") } else { format!("+g{short_sha}") };
+        let commit = if dirty { format!("{short_sha}-dirty") } else { short_sha.clone() };
+        (format!("{base}-dev{suffix}"), commit)
+    };
+
+    println!("cargo:rustc-env=RIMAP_VERSION={version}");
+    println!("cargo:rustc-env=RIMAP_COMMIT={commit}");
+    println!("cargo:rustc-env=RIMAP_RELEASE={}", if is_release { "true" } else { "false" });
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+```
+
+- [ ] **Step 3: Verify the build script runs and emits the env vars**
+
+Run:
+
+```bash
+cargo build -p rimap-core --locked 2>&1 | head -40
+```
+
+Then, on a clean local worktree:
+
+```bash
+cargo clean -p rimap-core
+RUSTFLAGS='--cfg unused_for_now' cargo build -p rimap-core --locked -vv 2>&1 | grep -E 'RIMAP_VERSION|RIMAP_COMMIT|RIMAP_RELEASE' | head -5
+```
+
+Expected: lines of the form
+
+```
+[rimap-core 0.1.0] cargo:rustc-env=RIMAP_VERSION=0.1.0-dev+g<7hex>
+[rimap-core 0.1.0] cargo:rustc-env=RIMAP_COMMIT=<7hex>
+[rimap-core 0.1.0] cargo:rustc-env=RIMAP_RELEASE=false
+```
+
+(The `RUSTFLAGS` trick forces a full rebuild so the `-vv` output shows the cargo directives.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-core/Cargo.toml crates/rimap-core/build.rs
+git commit -m "feat(rimap-core): add build.rs to compose version string
+
+Shells out to git describe/rev-parse/status at compile time and emits
+RIMAP_VERSION, RIMAP_COMMIT, RIMAP_RELEASE as cargo:rustc-env variables.
+Tag-exact builds get bare CARGO_PKG_VERSION; all others get a -dev+gSHA
+suffix with .dirty when the worktree has uncommitted changes.
+
+Acknowledged under SC-PROC-01: this is a new build script, but it runs
+git with constant argv via std::process::Command (no sh -c), and never
+fails the build — every error path falls through to a gunknown
+fallback. Worst-case behavior on a malicious git on \$PATH is identical
+to the rest of cargo build."
+```
+
+---
+
+## Task 3: Add the public version helpers
+
+**Files:**
+- Create: `crates/rimap-core/src/version.rs`
+- Modify: `crates/rimap-core/src/lib.rs`
+- Create: `crates/rimap-core/tests/version.rs`
+
+- [ ] **Step 1: Write the helpers**
+
+Create `crates/rimap-core/src/version.rs` with:
+
+```rust
+//! Build-injected version metadata.
+//!
+//! Values are produced by `build.rs` and embedded via `env!`. They are
+//! string slices with `'static` lifetime, suitable for direct use in
+//! `clap`'s `version = ...` attribute and any other place that wants a
+//! `&'static str`.
+
+/// The user-facing version string.
+///
+/// `X.Y.Z` for release builds (HEAD is exactly the tag `v<X.Y.Z>`);
+/// `X.Y.Z-dev+g<short-sha>[.dirty]` otherwise. Outside a git checkout
+/// the suffix is `-dev+gunknown`.
+#[must_use]
+pub fn version() -> &'static str {
+    env!("RIMAP_VERSION")
+}
+
+/// Short git SHA of the build (`abc1234`), `abc1234-dirty` for dirty
+/// worktrees, or `unknown` when no git information is available.
+#[must_use]
+pub fn commit() -> &'static str {
+    env!("RIMAP_COMMIT")
+}
+
+/// `true` when this build was produced from a `vX.Y.Z` git tag whose
+/// version matches the workspace `Cargo.toml`.
+#[must_use]
+pub fn is_release() -> bool {
+    matches!(env!("RIMAP_RELEASE"), "true")
+}
+```
+
+- [ ] **Step 2: Re-export from the crate root**
+
+Edit `crates/rimap-core/src/lib.rs`. Add `pub mod version;` to the module list (alphabetically just before `pub mod warning;`), and add a re-export line so callers can write `rimap_core::version()` directly. The relevant region should look like:
+
+```rust
+pub mod tls;
+pub mod tool;
+pub mod uid_selector;
+pub mod version;
+pub mod warning;
+```
+
+No `pub use crate::version::*;` — keeping the helpers namespaced under `rimap_core::version` avoids polluting the crate root with three generic identifiers. Call sites use `rimap_core::version::version()`.
+
+- [ ] **Step 3: Write the unit tests**
+
+Create `crates/rimap-core/tests/version.rs`:
+
+```rust
+//! Smoke tests for the build-injected version metadata.
+
+use rimap_core::version::{commit, is_release, version};
+
+#[test]
+fn version_is_non_empty() {
+    let v = version();
+    assert!(!v.is_empty(), "version() must not be empty");
+}
+
+#[test]
+fn version_starts_with_workspace_base() {
+    let v = version();
+    assert!(
+        v.starts_with(env!("CARGO_PKG_VERSION")),
+        "version() = {v:?} should start with CARGO_PKG_VERSION = {:?}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn commit_matches_expected_shape() {
+    let c = commit();
+    // Either the sentinel `unknown` or a 7-hex SHA with an optional `-dirty` suffix.
+    let body = c.strip_suffix("-dirty").unwrap_or(c);
+    let valid = body == "unknown" || (body.len() == 7 && body.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert!(valid, "commit() = {c:?} should be `unknown`, `<7hex>`, or `<7hex>-dirty`");
+}
+
+#[test]
+fn release_flag_agrees_with_version_shape() {
+    let v = version();
+    let has_dev = v.contains("-dev");
+    assert_eq!(
+        is_release(),
+        !has_dev,
+        "is_release() must be true exactly when version() lacks a -dev suffix"
+    );
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+cargo test -p rimap-core --test version --locked
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-core/src/version.rs crates/rimap-core/src/lib.rs crates/rimap-core/tests/version.rs
+git commit -m "feat(rimap-core): public version()/commit()/is_release() helpers
+
+Expose the build-injected metadata via a small module. Three runtime
+sites (clap, MCP server_info, audit process_start) will switch to these
+in the next task. Smoke tests assert non-empty version, base-version
+prefix, valid commit shape, and consistency between is_release() and
+the -dev suffix."
+```
+
+---
+
+## Task 4: Wire the helpers into the three runtime surfaces
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/mod.rs` (remove the `version` attribute)
+- Modify: `crates/rimap-server/src/main.rs:31-34` (switch to builder-pattern parse with dynamic version)
+- Modify: `crates/rimap-server/src/mcp/server.rs:225-230`
+- Modify: `crates/rimap-server/src/boot/audit_init.rs:65-67`
+
+**Why the clap setup is two edits:** clap 4's derive macro accepts `#[command(version = "literal")]` or a path to a `const`, but not a function-call expression. And `cargo:rustc-env=RIMAP_VERSION=...` emitted by `rimap-core/build.rs` is only visible inside `rimap-core`'s compilation — `env!("RIMAP_VERSION")` from `rimap-server` would fail to resolve. The cleanest fix is to drop the static `version` attribute and override the version dynamically at parse time via clap's builder API.
+
+- [ ] **Step 1: Drop the static `version` attribute from `Cli`**
+
+Edit `crates/rimap-server/src/cli/mod.rs`. The `#[command(...)]` block currently reads:
+
+```rust
+#[command(
+    name = "rusty-imap-mcp",
+    version,
+    about = "Security-first MCP server for IMAP email access"
+)]
+```
+
+Change to:
+
+```rust
+#[command(
+    name = "rusty-imap-mcp",
+    about = "Security-first MCP server for IMAP email access"
+)]
+```
+
+The `version` attribute is removed entirely so the builder pattern in `main.rs` (Step 2) can set it dynamically without conflict.
+
+- [ ] **Step 2: Switch `main.rs` to the builder-pattern parse**
+
+Edit `crates/rimap-server/src/main.rs`. Add `use clap::{CommandFactory, FromArgMatches};` near the top with the other `use` lines (just above `use crate::cli::{AuditAction, Cli, Command};`), then change the body of `fn main()` from:
+
+```rust
+fn main() -> ExitCode {
+    logging::init();
+    let cli = Cli::parse();
+    match run(cli) {
+```
+
+to:
+
+```rust
+fn main() -> ExitCode {
+    logging::init();
+    let cli = match parse_cli() {
+        Ok(cli) => cli,
+        Err(e) => {
+            e.exit();
+        }
+    };
+    match run(cli) {
+```
+
+And add a new free function above `fn main()`:
+
+```rust
+fn parse_cli() -> Result<Cli, clap::Error> {
+    let matches = Cli::command()
+        .version(rimap_core::version::version())
+        .get_matches();
+    Cli::from_arg_matches(&matches)
+}
+```
+
+The existing in-crate `Cli::try_parse_from([...])` calls in `cli/mod.rs:122,134,159,186,193` are unit-test helpers that exercise the derive macro directly — they keep working because `try_parse_from` does not invoke the `version` flag. No test changes needed for them.
+
+- [ ] **Step 3: Switch the MCP `server_info`**
+
+Edit `crates/rimap-server/src/mcp/server.rs` around line 228. Change:
+
+```rust
+ServerInfo::default().with_server_info(Implementation::new(
+    "rusty-imap-mcp",
+    env!("CARGO_PKG_VERSION"),
+))
+```
+
+to:
+
+```rust
+ServerInfo::default().with_server_info(Implementation::new(
+    "rusty-imap-mcp",
+    rimap_core::version::version(),
+))
+```
+
+- [ ] **Step 4: Switch the audit-record fields**
+
+Edit `crates/rimap-server/src/boot/audit_init.rs` lines 65-67. Change:
+
+```rust
+writer.log_process_start(ProcessStartInputs {
+    version: env!("CARGO_PKG_VERSION").to_string(),
+    git_commit: String::new(),
+```
+
+to:
+
+```rust
+writer.log_process_start(ProcessStartInputs {
+    version: rimap_core::version::version().to_string(),
+    git_commit: rimap_core::version::commit().to_string(),
+```
+
+The `git_commit` field was previously stubbed as `String::new()`; this populates it with the same short-SHA that the version string carries, so a captured audit record uniquely identifies the build.
+
+- [ ] **Step 5: Verify the workspace compiles**
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Smoke-test the CLI**
+
+```bash
+cargo run --quiet -p rimap-server --bin rusty-imap-mcp -- --version
+```
+
+Expected output (worktree is currently on `feat/release-versioning`, dirty or clean depending on intermediate state):
+
+```
+rusty-imap-mcp 0.1.0-dev+g<7hex>
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/mod.rs crates/rimap-server/src/main.rs crates/rimap-server/src/mcp/server.rs crates/rimap-server/src/boot/audit_init.rs
+git commit -m "feat(rimap-server): consume rimap_core::version at runtime surfaces
+
+clap --version (set via CommandFactory builder override in main.rs),
+MCP server_info, and the audit-log process_start record all switch
+from env!(\"CARGO_PKG_VERSION\") to rimap_core::version::*. The audit
+record's previously-stubbed git_commit field is now populated with the
+short SHA, so a captured audit log uniquely identifies the exact build
+it came from.
+
+The derive-time \`version\` attribute is dropped because clap 4 does not
+accept a function-call expression there, and \`cargo:rustc-env\`
+RIMAP_VERSION emitted by rimap-core's build.rs is not visible to
+rimap-server's compilation. The builder override is the standard clap
+pattern for this case."
+```
+
+---
+
+## Task 5: CLI smoke test
+
+**Files:**
+- Create: `crates/rimap-server/tests/cli_smoke.rs` (or extend if it exists)
+- Modify: `crates/rimap-server/Cargo.toml` (if the dev-deps aren't wired yet)
+
+The richer `long_version` (commit + target triple + release flag) is intentionally out of scope: clap 4 derive does not accept a function-call expression for `long_version` either, and rimap-server cannot see `RIMAP_VERSION` directly. Wiring `long_version` through the same builder pattern as `version` would require a runtime `format!`, which means `Cli::command().long_version(...)` would build a `String` per parse — fine, but adds a `Box::leak` or `'static` workaround. Defer this until a real user asks for it.
+
+- [ ] **Step 1: Check whether `cli_smoke.rs` already exists**
+
+```bash
+ls crates/rimap-server/tests/ 2>/dev/null
+```
+
+If `cli_smoke.rs` exists, append to it instead of creating a new file.
+
+- [ ] **Step 2: Write the smoke test**
+
+Create `crates/rimap-server/tests/cli_smoke.rs` (or append the test to the existing file):
+
+```rust
+//! Smoke tests for the user-visible `--version` output.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn version_flag_prints_expected_shape() {
+    Command::cargo_bin("rusty-imap-mcp")
+        .expect("binary exists")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("rusty-imap-mcp "))
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+```
+
+`assert_cmd` and `predicates` are already declared in `[workspace.dependencies]`. Verify the dev-dependency wiring on `rimap-server`:
+
+```bash
+grep -nE 'assert_cmd|predicates' crates/rimap-server/Cargo.toml
+```
+
+If neither appears under `[dev-dependencies]`, add them:
+
+```toml
+[dev-dependencies]
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
+```
+
+- [ ] **Step 3: Run the smoke test**
+
+```bash
+cargo test -p rimap-server --test cli_smoke --locked
+```
+
+Expected: PASS. The test asserts the output starts with `rusty-imap-mcp ` and contains the base `CARGO_PKG_VERSION` (`0.1.0`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/cli_smoke.rs crates/rimap-server/Cargo.toml
+git commit -m "test(rimap-server): smoke test --version output shape
+
+Asserts that \`rusty-imap-mcp --version\` succeeds, starts with the
+binary name, and contains the workspace base version. Catches accidental
+regressions in either the clap wiring or rimap_core::version::version()."
+```
+
+---
+
+## Task 6: Local release-version mirror script
+
+**Files:**
+- Create: `scripts/check-release-version.sh`
+- Modify: `justfile`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/check-release-version.sh` with the following exact contents:
+
+```bash
+#!/usr/bin/env bash
+# Compare a tag-style argument against the workspace version in Cargo.toml.
+#
+# Usage:
+#   scripts/check-release-version.sh v0.1.0
+#
+# Exits 0 when the tag matches the workspace version, non-zero otherwise.
+# Mirrors the verify-tag job in .github/workflows/release.yml so contributors
+# can sanity-check before pushing a tag.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $(basename "$0") <vX.Y.Z>" >&2
+    exit 64
+fi
+
+tag="$1"
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: tag must match ^v[0-9]+\.[0-9]+\.[0-9]+\$ (got '$tag')" >&2
+    exit 65
+fi
+
+# Strip the leading 'v'.
+tag_version="${tag#v}"
+
+# Parse workspace version. Match `version = "X.Y.Z"` only under [workspace.package].
+# awk pattern: enter range on [workspace.package], exit on next section header.
+workspace_version=$(
+    awk '
+        /^\[workspace\.package\]/ {in_section=1; next}
+        in_section && /^\[/ {in_section=0}
+        in_section && /^version = / {
+            sub(/^version = "/, "")
+            sub(/"$/, "")
+            print
+            exit
+        }
+    ' Cargo.toml
+)
+
+if [ -z "$workspace_version" ]; then
+    echo "error: could not parse [workspace.package].version from Cargo.toml" >&2
+    exit 66
+fi
+
+if [[ "$workspace_version" == *-* ]]; then
+    echo "error: Cargo.toml workspace version contains '-' (got '$workspace_version'); release tags must point at a clean semver" >&2
+    exit 67
+fi
+
+if [ "$tag_version" != "$workspace_version" ]; then
+    echo "error: tag '$tag' does not match Cargo.toml workspace version '$workspace_version'" >&2
+    exit 68
+fi
+
+echo "ok: tag '$tag' matches Cargo.toml workspace version '$workspace_version'"
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x scripts/check-release-version.sh
+```
+
+- [ ] **Step 3: Run shellcheck and shfmt**
+
+```bash
+shellcheck scripts/check-release-version.sh
+shfmt -d scripts/check-release-version.sh
+```
+
+Expected: shellcheck reports no issues; shfmt produces no diff. If shfmt reports a diff, run `shfmt -w scripts/check-release-version.sh` and re-run the diff check.
+
+- [ ] **Step 4: Manually exercise the script**
+
+Positive case:
+
+```bash
+./scripts/check-release-version.sh v0.1.0
+```
+
+Expected: `ok: tag 'v0.1.0' matches Cargo.toml workspace version '0.1.0'` (exit 0).
+
+Negative cases — confirm each fails:
+
+```bash
+./scripts/check-release-version.sh v9.9.9        # expect exit 68
+./scripts/check-release-version.sh v0.1          # expect exit 65
+./scripts/check-release-version.sh v0.1.0-rc1    # expect exit 65
+./scripts/check-release-version.sh               # expect exit 64
+```
+
+- [ ] **Step 5: Add the `release-check` recipe to `justfile`**
+
+Append to `justfile` (just after the existing `hooks:` recipe):
+
+```just
+# Verify a candidate tag against the Cargo.toml workspace version.
+# Run this before pushing a `vX.Y.Z` tag.
+#   just release-check v0.1.0
+release-check TAG:
+    ./scripts/check-release-version.sh {{TAG}}
+```
+
+- [ ] **Step 6: Verify the recipe**
+
+```bash
+just release-check v0.1.0
+```
+
+Expected: same `ok:` line as Step 4.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/check-release-version.sh justfile
+git commit -m "build: scripts/check-release-version.sh + just release-check
+
+Local-side mirror of the verify-tag CI job (added in the next commit):
+parses the workspace version from Cargo.toml, compares to a vX.Y.Z
+argument, and exits non-zero on any mismatch, malformed tag, or
+\`-dev\` literal in the manifest. Pure bash, shellcheck-clean."
+```
+
+---
+
+## Task 7: Release-workflow verify-tag job
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add a `workflow_dispatch` trigger with a `dry_run` input**
+
+Edit `.github/workflows/release.yml`. Replace the existing `on:` block at the top:
+
+```yaml
+on:
+  push:
+    tags: ["v*"]
+```
+
+with:
+
+```yaml
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run verify-tag only; skip build and release jobs."
+        type: boolean
+        default: true
+      tag:
+        description: "Tag to validate (e.g. v0.1.0). Used only on workflow_dispatch."
+        type: string
+        required: true
+```
+
+- [ ] **Step 2: Add the `verify-tag` job**
+
+Immediately under the `jobs:` line (so it runs before any of the build jobs), insert:
+
+```yaml
+  verify-tag:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.verify.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Verify tag
+        id: verify
+        env:
+          TAG_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          ./scripts/check-release-version.sh "$TAG_REF"
+          echo "version=${TAG_REF#v}" >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 3: Gate every existing build job on `verify-tag`**
+
+For each of the five build jobs (`build-linux-x86_64`, `build-linux-aarch64`, `build-macos-aarch64`, `build-linux-ppc64le`, `build-linux-s390x`) and the `release` job, add a `needs:` directive. For the five build jobs, the directive is `needs: verify-tag`. For the existing `release` job, **prepend** `verify-tag` to its existing `needs:` list. After the change, the `release` job's `needs:` should read:
+
+```yaml
+    needs:
+      - verify-tag
+      - build-linux-x86_64
+      - build-linux-aarch64
+      - build-macos-aarch64
+      - build-linux-ppc64le
+      - build-linux-s390x
+```
+
+- [ ] **Step 4: Make build and release jobs skip on dry-run**
+
+For each of the five build jobs and the `release` job, add an `if:` directive at the job level that skips when `workflow_dispatch` set `dry_run` to true:
+
+```yaml
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
+```
+
+- [ ] **Step 5: Lint the workflow**
+
+```bash
+actionlint .github/workflows/release.yml
+zizmor .github/workflows/release.yml
+```
+
+Expected: both clean. If zizmor flags anything new, address it (or add a targeted `# zizmor: ignore[...]` comment with justification, matching the pattern already in the file).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): verify-tag guard + workflow_dispatch dry-run trigger
+
+verify-tag runs scripts/check-release-version.sh against the pushed tag
+(or the manually-supplied tag input under workflow_dispatch) and gates
+every build/release job via 'needs'. workflow_dispatch with dry_run=true
+runs the guard alone, allowing the check logic to be exercised without
+cutting a real tag. Hard-fails on tag/Cargo.toml drift, malformed tag
+formats, or a -dev literal in the manifest."
+```
+
+---
+
+## Task 8: CHANGELOG migration
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Re-read the current CHANGELOG**
+
+```bash
+wc -l CHANGELOG.md
+grep -n '^## ' CHANGELOG.md
+```
+
+Expected: heading list shows `[Unreleased]` (line 8), `[1.0.0] - 2026-04-13` (line 39), and a duplicate `[Unreleased]` (line 244).
+
+- [ ] **Step 2: Rewrite the file**
+
+In a single edit pass:
+
+1. Delete the duplicate `## [Unreleased]` at line 244 (the last line of the file as observed during exploration). If there is any content under it, fold it into the main `[Unreleased]` section before deleting the heading.
+2. Take the content currently under the top `## [Unreleased]` heading (the multi-account credential-namespacing entries, lines 8–37) and merge it into the existing `## [1.0.0]` section. Place the new entries under appropriate Keep-a-Changelog subheadings (`### Changed`, `### Added`) within `[1.0.0]`, deduplicating if any topic overlaps.
+3. Rename the merged section's heading from `## [1.0.0] - 2026-04-13` to `## [0.1.0] - Unreleased`.
+4. Leave a fresh, empty `## [Unreleased]` heading at the top of the file (immediately under the introduction paragraph) for future post-0.1.0 work.
+5. At the bottom of the file, add or update the reference-link footer:
+
+```markdown
+[Unreleased]: https://github.com/randomparity/rusty-imap-mcp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/randomparity/rusty-imap-mcp/releases/tag/v0.1.0
+```
+
+- [ ] **Step 3: Verify the changelog now contains only the expected headings**
+
+```bash
+grep -n '^## ' CHANGELOG.md
+```
+
+Expected output (exact line numbers will vary):
+
+```
+8:## [Unreleased]
+12:## [0.1.0] - Unreleased
+```
+
+No `[1.0.0]` heading anywhere. No duplicate `[Unreleased]`.
+
+- [ ] **Step 4: Verify the per-tag extraction still works**
+
+The release workflow extracts release notes via:
+
+```bash
+awk "/^## \\[0.1.0\\]/,/^## \\[[^\\]]+\\]/" CHANGELOG.md | head -n -1 | head -40
+```
+
+Expected: shows the full `[0.1.0]` section, stopping before the next `## [` heading. The `Unreleased` heading sits above `[0.1.0]` in the file, so the awk pattern (which starts at `[0.1.0]` and stops at the next bracketed heading) is unaffected by it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): relabel [1.0.0] to [0.1.0]; fold [Unreleased]
+
+The 1.0.0 heading was aspirational — no tag, no release. Renaming the
+section to 0.1.0 and folding the in-flight credential-namespacing
+entries into it gives the first real release a coherent changelog
+entry. Duplicate trailing [Unreleased] heading removed. Reference-link
+footer added at the bottom in Keep-a-Changelog style."
+```
+
+---
+
+## Task 9: Full local CI pass and dry-run workflow
+
+**Files:** none
+
+- [ ] **Step 1: Run the local-CI equivalent**
+
+```bash
+just ci
+```
+
+Expected: `fmt-check`, `lint`, `test`, `test-msrv`, `deny`, and `typos` all pass. If `cargo-deny` flags anything (license, advisory, ban, source), address before proceeding.
+
+- [ ] **Step 2: Run the pre-commit hooks across all files**
+
+```bash
+just hooks
+```
+
+Expected: all hooks pass on the full tree.
+
+- [ ] **Step 3: Verify final version output**
+
+```bash
+cargo run --quiet -p rimap-server --bin rusty-imap-mcp -- --version
+```
+
+Expected (worktree clean):
+
+```
+rusty-imap-mcp 0.1.0-dev+g<7hex>
+```
+
+Expected (worktree dirty): the same with a trailing `.dirty`.
+
+- [ ] **Step 4: Run the workflow dry-run from the PR branch**
+
+After pushing the branch and opening the PR (Task 10), use `gh` to dispatch the workflow against the branch:
+
+```bash
+gh workflow run release.yml --ref feat/release-versioning -f tag=v0.1.0 -f dry_run=true
+gh run watch
+```
+
+Expected: the `verify-tag` job runs and passes; the build/release jobs are skipped (visible as "Skipped" in the run summary). Negative variant:
+
+```bash
+gh workflow run release.yml --ref feat/release-versioning -f tag=v9.9.9 -f dry_run=true
+gh run watch
+```
+
+Expected: `verify-tag` fails with exit 68; downstream jobs skip.
+
+- [ ] **Step 5: Commit any incidental fixes**
+
+If `just ci` or `just hooks` produced fixes (formatting, typos, etc.), commit them as a follow-on:
+
+```bash
+git add -A
+git commit -m "chore: incidental fixes surfaced by local-CI pass"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Task 10: Open the pull request
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/release-versioning
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat: release versioning with -dev+gSHA suffix" --body "$(cat <<'EOF'
+## Summary
+
+- Workspace version drops from the aspirational `1.0.0` to `0.1.0`. Every
+  `version = "1.0.0"` literal on the 22 cross-crate path-deps follows.
+- New `rimap-core/build.rs` shells out to `git describe --tags
+  --exact-match HEAD`, `rev-parse --short=7`, and `status --porcelain` to
+  compute a semver-compliant version string at compile time:
+  `X.Y.Z` for tag-exact builds, `X.Y.Z-dev+g<sha>[.dirty]` otherwise.
+- The CLI `--version`, MCP `server_info.version`, and audit-log
+  `process_start.version` / `.git_commit` fields all consume the new
+  `rimap_core::version` helpers, so a captured audit log identifies the
+  exact commit a dev build came from.
+- `.github/workflows/release.yml` gains a `verify-tag` job that
+  hard-fails before any build job runs if the pushed tag does not match
+  the workspace version, and a `workflow_dispatch` trigger with
+  `dry_run: true` that exercises the guard without cutting a real tag.
+- `scripts/check-release-version.sh` mirrors the CI guard locally via
+  `just release-check vX.Y.Z`.
+- `CHANGELOG.md` relabels `[1.0.0]` → `[0.1.0]`, folds the in-flight
+  `[Unreleased]` entries into it, and adds reference-link footers.
+
+Spec: `docs/superpowers/specs/2026-05-11-release-versioning-design.md`.
+
+## Test plan
+
+- [x] `just ci` passes locally (fmt, lint, test, test-msrv, deny, typos)
+- [x] `just hooks` passes across the whole tree
+- [x] `cargo test -p rimap-core --test version` passes
+- [x] `cargo test -p rimap-server --test cli_smoke` passes
+- [x] `rusty-imap-mcp --version` prints `rusty-imap-mcp 0.1.0-dev+g<sha>`
+- [x] `./scripts/check-release-version.sh v0.1.0` exits 0
+- [x] `./scripts/check-release-version.sh v9.9.9` exits 68
+- [x] `./scripts/check-release-version.sh v0.1.0-rc1` exits 65
+- [x] `gh workflow run release.yml -f tag=v0.1.0 -f dry_run=true` -> verify-tag passes
+- [x] `gh workflow run release.yml -f tag=v9.9.9 -f dry_run=true` -> verify-tag fails
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm CI is green**
+
+```bash
+gh pr checks
+```
+
+Expected: all CI jobs report success. Address any failures before requesting review.
+
+---
+
+## Verification checklist
+
+After all tasks complete and CI is green:
+
+- [ ] `grep -rn 'version = "1\.0\.0"' Cargo.toml crates/*/Cargo.toml` returns no output.
+- [ ] `cargo run -p rimap-server --bin rusty-imap-mcp -- --version` prints `rusty-imap-mcp 0.1.0-dev+g<7hex>` on a clean worktree.
+- [ ] `cargo run -p rimap-server --bin rusty-imap-mcp -- --version` prints `…dirty` when the worktree is dirty.
+- [ ] The audit log written by a smoke `--dry-run` run contains `"version": "0.1.0-dev+g<sha>"` and a non-empty `"git_commit"`.
+- [ ] A `workflow_dispatch` of `release.yml` with `dry_run=true` and a matching tag passes `verify-tag` and skips the rest.
+- [ ] A `workflow_dispatch` of `release.yml` with `dry_run=true` and a non-matching tag fails `verify-tag`.
+- [ ] `CHANGELOG.md` has exactly one `[Unreleased]` heading (the new empty one at the top) and one `[0.1.0]` heading.
+
+---
+
+## Out of scope (do not touch in this PR)
+
+- Pre-release identifiers other than `-dev` (no `-rc.N`, `-beta.N`, `-alpha`).
+- Automatic version-bump tooling (`cargo-release`, `cargo-edit`).
+- crates.io publish flow.
+- Reproducible-build flags beyond honoring `SOURCE_DATE_EPOCH` as a rerun trigger.
+- Richer clap `long_version` output (commit + target triple + release flag).

--- a/docs/superpowers/specs/2026-05-11-dovecot-port-race-design.md
+++ b/docs/superpowers/specs/2026-05-11-dovecot-port-race-design.md
@@ -1,0 +1,299 @@
+# Dovecot Integration Test Port-Race Fix
+
+Date: 2026-05-11
+Status: Approved (pending implementation plan)
+
+## Summary
+
+The dovecot integration suite in `crates/rimap-imap/tests/integration/`
+flakes under nextest parallelism because `pick_free_port` releases its
+TCP listener before docker can bind the kernel-assigned port. CI run
+`25691882071` failed with `Bind for 127.0.0.1:35615 failed: port is
+already allocated` mid-suite. The author flagged the race in a doc
+comment but accepted it; the observed failure rate disproves the
+acceptance.
+
+This change closes the race by holding the listener until the moment
+docker is invoked, and adds a bounded retry loop that handles the
+residual collision window. A `ComposeRunner` trait makes the retry
+logic unit-testable without a real docker.
+
+## Goals
+
+- Eliminate the bind race that produces the recurrent CI failure.
+- Keep the change small and local to the integration harness — no
+  changes to production code or to other test suites.
+- Add deterministic test coverage so the retry logic survives future
+  refactors.
+- Improve diagnostic output for failed `compose up` calls (stderr was
+  previously discarded).
+
+## Non-goals
+
+- Tightening `STALE_PROJECT_AGE` (30 min). The current threshold
+  protects parallel runs; changing it needs measurement.
+- Wiring the dormant SMTP compose harness — it has no Rust consumer
+  yet. When it lands, it should reuse `ReservedPort` and the retry
+  wrapper.
+- A process-wide port-lease file. Brainstormed as option C; deferred
+  unless the retry pattern still flakes.
+- Reducing nextest's parallelism floor. Orthogonal to the bind race.
+- Changes to the `restart()` code path. It reuses an already-bound
+  port and does not traverse the race.
+
+## Architecture
+
+### ReservedPort
+
+Replace `pick_free_port() -> Result<u16, HarnessError>` with a
+`ReservedPort` type that owns the listener for the lifetime of the
+reservation:
+
+```rust
+struct ReservedPort {
+    port: u16,
+    listener: Option<TcpListener>,
+}
+
+impl ReservedPort {
+    fn acquire() -> Result<Self, HarnessError> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| HarnessError::PortReadFailed(format!("bind: {e}")))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| HarnessError::PortReadFailed(format!("local_addr: {e}")))?
+            .port();
+        Ok(Self { port, listener: Some(listener) })
+    }
+
+    fn port(&self) -> u16 { self.port }
+
+    /// Release the kernel-level port lease. After this, docker can
+    /// bind the port. Idempotent.
+    fn release(&mut self) { self.listener.take(); }
+}
+```
+
+The harness holds two `ReservedPort` values across the call to
+`compose_up_with_retry`. The wrapper releases both immediately before
+invoking docker — narrowing the race window from indefinite to a few
+microseconds.
+
+### Retry wrapper
+
+```rust
+fn compose_up_with_retry(
+    runner: &dyn ComposeRunner,
+    project: &str,
+    compose_dir: &Path,
+    tls: &mut ReservedPort,
+    starttls: &mut ReservedPort,
+) -> Result<(), HarnessError> {
+    const BACKOFF_MS: [u64; 2] = [50, 250];
+    let mut last_collision: Option<String> = None;
+
+    for attempt in 0..=BACKOFF_MS.len() {
+        tls.release();
+        starttls.release();
+        let result = runner.up(project, compose_dir, tls.port(), starttls.port());
+        match result {
+            Ok(()) => return Ok(()),
+            Err(HarnessError::DockerCommandFailed(s)) if is_port_collision(&s) => {
+                last_collision = Some(s);
+                if attempt == BACKOFF_MS.len() {
+                    break;
+                }
+                // Tear down partial project + back off + reacquire fresh ports.
+                compose_down(project, compose_dir);
+                std::thread::sleep(Duration::from_millis(BACKOFF_MS[attempt]));
+                *tls = ReservedPort::acquire()?;
+                *starttls = ReservedPort::acquire()?;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(HarnessError::DockerCommandFailed(format!(
+        "compose up: exhausted {} attempts on port collision; last error: {}",
+        BACKOFF_MS.len() + 1,
+        last_collision.unwrap_or_else(|| "<no error captured>".into()),
+    )))
+}
+```
+
+Three attempts total (initial + 2 retries). Backoffs of 50 ms and 250 ms
+cover the typical kernel-scheduling gap. After the loop, the most
+recent collision error is replaced with a clearer
+"exhausted retries" message; non-collision errors propagate unchanged
+on the first failure.
+
+The `unreachable!()` form is avoided so the workspace's
+`clippy::unreachable = "deny"` lint stays clean.
+
+### Stderr capture
+
+`compose_up` currently uses `Command::...status()`, which discards
+stdout/stderr. To classify a collision the wrapper needs stderr text.
+
+Switch to `Command::...output()` and fold stderr into the error
+payload:
+
+```rust
+let output = Command::new(runtime())
+    .arg("compose").arg("-p").arg(project).arg("up").arg("-d")
+    .env("RIMAP_DOVECOT_HOST_PORT", host_port.to_string())
+    .env("RIMAP_DOVECOT_HOST_PORT_STARTTLS", host_starttls_port.to_string())
+    .current_dir(compose_dir)
+    .output()
+    .map_err(|e| HarnessError::DockerCommandFailed(e.to_string()))?;
+if !output.status.success() {
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    return Err(HarnessError::DockerCommandFailed(
+        format!("compose up exit {}: {stderr}", output.status),
+    ));
+}
+```
+
+This is an unconditional improvement to diagnostics independent of the
+race fix.
+
+### ComposeRunner trait
+
+```rust
+trait ComposeRunner {
+    fn up(
+        &self,
+        project: &str,
+        compose_dir: &Path,
+        tls_port: u16,
+        starttls_port: u16,
+    ) -> Result<(), HarnessError>;
+}
+
+struct DockerComposeRunner;
+
+impl ComposeRunner for DockerComposeRunner {
+    fn up(&self, project: &str, compose_dir: &Path, tls: u16, starttls: u16)
+        -> Result<(), HarnessError>
+    {
+        // Body is the current compose_up function logic, with the
+        // stderr-capturing change from above.
+        ...
+    }
+}
+```
+
+`try_start` instantiates `DockerComposeRunner` and passes it to
+`compose_up_with_retry`. The trait exists solely so unit tests can
+substitute a flaky double.
+
+### Port-collision classifier
+
+```rust
+fn is_port_collision(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("port is already allocated")
+        || s.contains("address already in use")
+        || s.contains("bind for")
+}
+```
+
+The three substrings cover the docker engine error (the one observed
+in CI), the standard libc EADDRINUSE message, and podman's variant.
+
+## Data flow
+
+```
+ReservedPort::acquire (TLS)
+ReservedPort::acquire (STARTTLS)
+              │
+              ▼
+   compose_up_with_retry(runner, project, dir, &mut tls, &mut starttls)
+   ┌───────────────────────────────┐
+   │ loop:                         │
+   │   tls.release();              │
+   │   starttls.release();         │
+   │   runner.up(...)              │
+   │   ┌── Ok → return Ok          │
+   │   ├── Err(collision)          │
+   │   │   ├── compose_down        │
+   │   │   ├── sleep(backoff)      │
+   │   │   └── reacquire ports     │
+   │   └── Err(other) → return Err │
+   └───────────────────────────────┘
+              │
+              ▼
+   wait_for_ready → returns harness
+```
+
+## Error handling
+
+| Path                                        | Outcome                                |
+|---------------------------------------------|----------------------------------------|
+| First `compose up` succeeds                 | Return Ok; reservations dropped        |
+| 1st attempt fails (port collision)          | Tear down, sleep 50 ms, retry          |
+| 2nd attempt fails (port collision)          | Tear down, sleep 250 ms, retry         |
+| 3rd attempt fails (port collision)          | Return "exhausted attempts" + last stderr |
+| Any attempt fails (non-collision error)     | Return immediately, original payload   |
+| `ReservedPort::acquire` fails inside retry  | Propagate as `PortReadFailed`          |
+
+`compose_down` between retries uses the existing helper, which is
+already best-effort silent.
+
+## Testing strategy
+
+Three unit tests in `crates/rimap-imap/tests/integration/support/container.rs`
+(behind `#[cfg(test)]`), driven by a `FlakyComposeRunner` double.
+
+1. **Retry-then-succeed.** Runner fails the first two attempts with a
+   collision message, succeeds on the third. Assert: result is `Ok`;
+   runner saw three distinct attempts; each attempt used a fresh
+   `(tls_port, starttls_port)` pair (proves the reacquire path).
+
+2. **Give up after max attempts.** Runner always fails with a
+   collision message. Assert: result is `Err(DockerCommandFailed)`
+   whose message contains both "exhausted" and the underlying stderr
+   substring; runner saw exactly three attempts.
+
+3. **Non-collision errors don't retry.** Runner fails with a generic
+   "unrelated docker error" message. Assert: result is `Err`; runner
+   saw exactly one attempt.
+
+The tests live in the same `support/container.rs` module so they
+run under `cargo test -p rimap-imap` without requiring docker.
+`FlakyComposeRunner` records every observed call in a
+`Mutex<Vec<(u16, u16)>>` for assertion.
+
+`#[expect(clippy::expect_used, reason = "tests")]` /
+`#[expect(clippy::unwrap_used, reason = "tests")]` at module scope
+already cover the test-time `.expect()` / `.unwrap()` calls these
+tests will use.
+
+## Migration / rollout
+
+Single PR. The change is local to one file (`support/container.rs`).
+The dovecot integration suite continues to skip silently on hosts
+without docker (`HarnessError::DockerUnavailable`) — that path is
+untouched.
+
+Order within the PR (informs the implementation plan):
+
+1. Switch `compose_up` to `Command::...output()` and fold stderr into
+   the error payload.
+2. Add `is_port_collision`.
+3. Introduce `ReservedPort` with `release()`; migrate `try_start` to
+   hold listeners across `compose_up`.
+4. Extract the compose-up logic into a `ComposeRunner` trait with
+   `DockerComposeRunner` production impl.
+5. Implement `compose_up_with_retry`; wire it into `try_start`.
+6. Add `FlakyComposeRunner` and the three unit tests.
+7. Run `just ci` locally; push; verify the MSRV lane goes green over
+   multiple consecutive runs.
+
+Each step is independently committable.
+
+## Open questions
+
+None at design time. The implementation plan will address the exact
+placement of the `ComposeRunner` trait (whether it sits next to
+`DovecotHarness` or in a small sub-module), and the wording of the
+final "exhausted retries" error message.

--- a/docs/superpowers/specs/2026-05-11-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-05-11-release-versioning-design.md
@@ -120,10 +120,16 @@ instead of `env!("CARGO_PKG_VERSION")` at the three call sites listed below.
 
 Three sites switch from `CARGO_PKG_VERSION` to `rimap_core::version()`:
 
-1. `crates/rimap-server/src/cli/mod.rs:24` — clap's `#[command(version = ...)]`.
-   Short `--version` prints `rusty-imap-mcp <version>`. Long `--version`
-   (clap's `long_version`) adds the commit short SHA, target triple, and
-   `release`/`dev` indicator for support diagnostics.
+1. `crates/rimap-server/src/cli/mod.rs:24` — the `#[command(version)]`
+   attribute is removed from the derive, and `crates/rimap-server/src/main.rs`
+   switches to clap's `CommandFactory` builder pattern
+   (`Cli::command().version(rimap_core::version::version()).get_matches()`).
+   Short `--version` prints `rusty-imap-mcp <version>`. The richer
+   `long_version` (commit + target triple + release flag) is deferred
+   until a real user asks for it — wiring it through the builder also
+   requires a `String`-with-`'static`-lifetime workaround that adds
+   little for support diagnostics, since the audit log already carries
+   the commit.
 2. `crates/rimap-server/src/mcp/server.rs:228` — `server_info.version`
    announced to MCP clients during the initialize handshake.
 3. `crates/rimap-server/src/boot/audit_init.rs:66` — the `version` field

--- a/docs/superpowers/specs/2026-05-11-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-05-11-release-versioning-design.md
@@ -1,0 +1,299 @@
+# Release Versioning Design
+
+Date: 2026-05-11
+Status: Approved (pending implementation plan)
+
+## Summary
+
+Establish a semver-compliant release workflow for `rusty-imap-mcp`. Builds
+produced from a `vX.Y.Z` git tag identify as the bare semver `X.Y.Z`. All
+other builds — local development, pull-request CI, branch builds — identify
+as `X.Y.Z-dev+g<short-sha>` (with `.dirty` appended when the worktree has
+uncommitted changes). The workspace version drops from the current
+aspirational `1.0.0` to `0.1.0`, reflecting the project's pre-release reality.
+
+The version string is computed once at compile time by a build script in
+`rimap-core` and consumed via a `rimap_core::version()` helper. It flows to
+every runtime surface that previously read `CARGO_PKG_VERSION`: the clap CLI
+`--version`, the MCP `server_info.version` field, and the audit-record
+`version` field.
+
+The release workflow gains a tag-vs-Cargo guard that hard-fails before any
+build job runs if the pushed tag does not match the workspace version.
+
+## Goals
+
+- Make every build identify itself unambiguously: a release build prints a
+  clean semver; a dev build prints the commit it was built from.
+- Keep `Cargo.toml` as the single source of truth for the base version.
+  Cutting a release is "tag and push" — no manifest edit required at the
+  moment of release.
+- Catch tag/manifest drift in CI before any artifact is built, so the
+  published version always matches what was tagged.
+- Add no new runtime dependencies and no new heavyweight build-time
+  dependencies. Use only `git` (already required for the repo).
+
+## Non-goals
+
+- Pre-release identifiers beyond `-dev` (no `-rc.N`, `-beta.N`, `-alpha`).
+- Conventional-commits-driven CHANGELOG generation.
+- Automatic version bumping (no `cargo-release` / `cargo-edit` integration).
+- Reproducible builds beyond honoring `SOURCE_DATE_EPOCH` as a rerun trigger.
+- Publishing to crates.io. The project ships binaries via GitHub Releases.
+- Changing the existing tag format. `v` prefix stays.
+
+## Architecture
+
+### Version composition
+
+The workspace `Cargo.toml` carries the canonical base version with no
+suffix. At build time, `rimap-core/build.rs` decides whether the build is a
+release or a dev build and emits the appropriate version string as a
+`cargo:rustc-env` variable:
+
+```
+RIMAP_VERSION = "X.Y.Z"                          (release: HEAD is tag vX.Y.Z)
+RIMAP_VERSION = "X.Y.Z-dev+g<sha>"               (dev: clean worktree)
+RIMAP_VERSION = "X.Y.Z-dev+g<sha>.dirty"         (dev: uncommitted changes)
+RIMAP_VERSION = "X.Y.Z-dev+gunknown"             (no .git present)
+```
+
+The format follows semver 2.0:
+
+- `-dev` is the pre-release identifier (everything after `-`, before `+`).
+- `+g<sha>` is build metadata. The `g` prefix follows the `git describe`
+  convention. Semver tools ignore build metadata for ordering, which is
+  the correct behavior: two dev builds at different commits are not
+  comparable.
+
+The base version (`X.Y.Z`) is parsed from `Cargo.toml`'s workspace
+`[workspace.package].version`. On initial implementation it is `0.1.0`.
+
+### Build script
+
+`crates/rimap-core/build.rs` runs three `git` subprocesses via
+`std::process::Command`:
+
+1. `git describe --tags --exact-match HEAD` — succeeds only when HEAD is
+   an annotated tag. If the tag matches `v<workspace-version>`, the build is
+   a release. Any other outcome (no tag, mismatched tag, error) falls through
+   to the dev path.
+2. `git rev-parse --short=7 HEAD` — short commit SHA (7 hex chars).
+3. `git status --porcelain` — non-empty output flips the `.dirty` flag.
+
+Outputs emitted to cargo:
+
+```
+cargo:rustc-env=RIMAP_VERSION=<computed>
+cargo:rustc-env=RIMAP_COMMIT=<sha-or-"unknown">
+cargo:rustc-env=RIMAP_RELEASE=<"true"|"false">
+cargo:rerun-if-changed=.git/HEAD
+cargo:rerun-if-changed=.git/refs/tags
+cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
+```
+
+Failure handling: the build script never errors out of cargo. Every `git`
+failure path produces the `gunknown` fallback. This keeps `cargo build` in
+a vendored source tarball, a Docker layer without `.git`, or a future
+crates.io publish working without surprise breakage.
+
+The script shells out via `Command::new("git")` directly — no `sh -c`, no
+shell interpolation of any variable. Worst-case behavior on a malicious
+`git` binary on `$PATH` is identical to the rest of `cargo build`. A
+one-line acknowledgment is added to the supply-chain audit (SC-PROC-01)
+since this is a new build script in the workspace.
+
+### Public API
+
+`rimap-core` exposes:
+
+```rust
+pub fn version() -> &'static str { env!("RIMAP_VERSION") }
+pub fn commit() -> &'static str  { env!("RIMAP_COMMIT") }
+pub fn is_release() -> bool      { env!("RIMAP_RELEASE") == "true" }
+```
+
+No other public surface change. Downstream crates use these helpers
+instead of `env!("CARGO_PKG_VERSION")` at the three call sites listed below.
+
+### Runtime surfaces
+
+Three sites switch from `CARGO_PKG_VERSION` to `rimap_core::version()`:
+
+1. `crates/rimap-server/src/cli/mod.rs:24` — clap's `#[command(version = ...)]`.
+   Short `--version` prints `rusty-imap-mcp <version>`. Long `--version`
+   (clap's `long_version`) adds the commit short SHA, target triple, and
+   `release`/`dev` indicator for support diagnostics.
+2. `crates/rimap-server/src/mcp/server.rs:228` — `server_info.version`
+   announced to MCP clients during the initialize handshake.
+3. `crates/rimap-server/src/boot/audit_init.rs:66` — the `version` field
+   stamped into every audit record at startup.
+
+The single source of truth means a captured audit log, an MCP client
+session record, and an operator's `--version` output all reference the
+same commit hash for a given build.
+
+Other uses of `env!("CARGO_PKG_VERSION")` in the tree (test fixtures,
+manifest-dir resolution) are unrelated and stay as-is.
+
+### Cargo.toml changes
+
+```toml
+[workspace.package]
+version = "0.1.0"   # was "1.0.0"
+```
+
+Twelve `version = "1.0.0"` literals on path-dependency entries across the
+seven dependent member crates (`rimap-imap`, `rimap-content`, `rimap-config`,
+`rimap-audit`, `rimap-smtp`, `rimap-authz`, `rimap-server`) update to
+`"0.1.0"`. The existing comment in `crates/rimap-imap/Cargo.toml`
+(`# Internal — direct path + explicit version to satisfy cargo-deny's
+wildcard ban.`) records that explicit version literals are required by
+`cargo-deny`'s `wildcards = "deny"` rule, so the version cannot simply be
+inherited from the workspace at these sites. The duplication is accepted
+and updated by a single `sed`-style pass; the `verify-tag` guard
+(below) and pre-merge CI prevent drift from the workspace value.
+
+### Release workflow guard
+
+`.github/workflows/release.yml` gains a new first job, `verify-tag`, that
+the existing five build jobs depend on via `needs:`. The job:
+
+1. Checks out the source with `persist-credentials: false`.
+2. Parses the workspace version out of `Cargo.toml` (a small awk or
+   grep-cut one-liner — no new tool dependency).
+3. Strips the leading `v` from `${{ github.ref_name }}`.
+4. Hard-fails if any of:
+   - The pushed tag and the Cargo version disagree.
+   - The Cargo version contains a `-` (catches a stray `0.1.0-dev` in the
+     manifest).
+   - The tag does not match `^v[0-9]+\.[0-9]+\.[0-9]+$` exactly. Pre-release
+     tag formats are deferred to a future design.
+5. Echoes the verified version into `$GITHUB_OUTPUT` for downstream use.
+
+The existing per-tag CHANGELOG extraction step runs unchanged after the
+guard.
+
+A `workflow_dispatch` trigger is added with a `dry_run` boolean input. When
+`dry_run` is true, the verify job runs but the build and release jobs skip,
+allowing the guard logic to be exercised without cutting a real tag.
+
+### Local mirror script
+
+`scripts/check-release-version.sh` runs the same comparison locally:
+
+```
+just release-check v0.1.0
+```
+
+Pure bash, `set -euo pipefail`, shellcheck-clean, no new dependencies. The
+`justfile` gets a `release-check` recipe that invokes it. A `prek` hook
+on the script itself keeps it clean.
+
+### CHANGELOG migration
+
+The current `CHANGELOG.md` has both an `[Unreleased]` section and an
+aspirational `[1.0.0] - 2026-04-13` section, plus a duplicate `[Unreleased]`
+heading at the bottom that looks like a copy-paste artifact. There is no
+`v1.0.0` git tag and no published release.
+
+The migration:
+
+1. Remove the duplicate trailing `[Unreleased]` heading.
+2. Rename `## [1.0.0] - 2026-04-13` → `## [0.1.0] - Unreleased`.
+3. Fold the existing top `[Unreleased]` content (multi-account credential-
+   namespacing entries) into the `[0.1.0]` section — they ship together as
+   the first real release.
+4. Leave an empty `## [Unreleased]` heading at the top for post-0.1.0 work.
+5. Update or add the reference-link footer:
+   `[0.1.0]: https://github.com/randomparity/rusty-imap-mcp/releases/tag/v0.1.0`.
+
+Keep-a-Changelog formatting is preserved throughout.
+
+## Data flow
+
+```
+                  Cargo.toml workspace version "X.Y.Z"
+                            │
+              ┌─────────────┴─────────────┐
+              ▼                           ▼
+   rimap-core/build.rs           release.yml verify-tag
+   ├ git describe ...HEAD        ├ parse Cargo.toml version
+   ├ git rev-parse --short HEAD  ├ strip "v" from github.ref_name
+   └ git status --porcelain      ├ regex check ^v\d+\.\d+\.\d+$
+              │                  └ hard-fail on any mismatch
+              ▼
+   cargo:rustc-env=RIMAP_VERSION, RIMAP_COMMIT, RIMAP_RELEASE
+              │
+              ▼
+   rimap_core::version() / commit() / is_release()
+              │
+   ┌──────────┼──────────┐
+   ▼          ▼          ▼
+  CLI        MCP        Audit
+ --version   server_info version field
+```
+
+The build-script branch (left) decides the runtime version on every
+`cargo build`. The workflow-guard branch (right) is independent — it
+runs only on tag pushes and gates the release build jobs from starting.
+Both read the same `Cargo.toml` workspace version as input.
+
+## Error handling
+
+| Path                                | Outcome                              |
+|-------------------------------------|--------------------------------------|
+| `git` not installed                 | `RIMAP_VERSION = X.Y.Z-dev+gunknown` |
+| No `.git` directory                 | `RIMAP_VERSION = X.Y.Z-dev+gunknown` |
+| `git describe` returns no match     | Dev path with real SHA               |
+| `git describe` matches mismatched tag (e.g. tag is `v0.0.9` but Cargo is `0.1.0`) | Dev path with real SHA |
+| Worktree dirty                      | `.dirty` suffix appended             |
+| Tag pushed but Cargo.toml not bumped | `verify-tag` job hard-fails CI      |
+| Cargo.toml contains `-dev` literal   | `verify-tag` job hard-fails CI      |
+| Tag is `v0.1` or `v0.1.0-rc1`        | `verify-tag` job hard-fails CI      |
+
+## Testing strategy
+
+- **`rimap-core` unit tests**: `version()` returns a non-empty string;
+  `commit()` matches `unknown|[0-9a-f]{7}(-dirty)?`; `is_release()` is
+  boolean and consistent with whether `version()` contains `-dev`.
+- **CLI smoke**: `assert_cmd` test that `rusty-imap-mcp --version` prints
+  a string starting with `rusty-imap-mcp ` followed by a non-empty version
+  token.
+- **Workflow dry-run**: `workflow_dispatch` invocation of `release.yml`
+  with `dry_run: true` exercises the verify job against the current
+  `Cargo.toml` and a synthetic tag name.
+- **Local check**: `just release-check v0.1.0` exits 0 when in sync,
+  non-zero otherwise. A negative test (`just release-check v9.9.9`) is
+  documented in the script's help text.
+- **Mutation coverage**: not in scope for this change; the new logic is
+  small and exercised by the smoke tests above.
+
+## Migration / rollout
+
+This is a single coordinated change because the Cargo version bump, the
+crate path-dep update, and the build-script wiring must land together to
+keep the workspace compiling. No staged rollout. Order of operations
+within the PR:
+
+1. Drop the workspace version to `0.1.0`; update the seven path-dep
+   pins; verify `cargo check --workspace` succeeds.
+2. Add `rimap-core/build.rs` plus the public `version()` / `commit()` /
+   `is_release()` helpers.
+3. Switch the three runtime call sites to the helpers.
+4. Add the `verify-tag` job and `workflow_dispatch` trigger to
+   `release.yml`. Add `scripts/check-release-version.sh` and the
+   `justfile` recipe.
+5. Migrate `CHANGELOG.md` as described above.
+6. Update `SC-PROC-01` audit comment in `Cargo.toml` (or the relevant
+   tracking doc) to acknowledge the new `rimap-core/build.rs`.
+
+Each step is independently committable; the PR can be reviewed as a single
+unit or split into commits in the order above.
+
+## Open questions
+
+None at design time. The implementation plan will address ordering of
+commits within the PR and any edge cases discovered during build-script
+testing on each release target (linux-x86_64, linux-aarch64, macos-arm64,
+linux-ppc64le, linux-s390x).

--- a/docs/superpowers/specs/2026-05-11-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-05-11-release-versioning-design.md
@@ -143,8 +143,9 @@ manifest-dir resolution) are unrelated and stay as-is.
 version = "0.1.0"   # was "1.0.0"
 ```
 
-Twelve `version = "1.0.0"` literals on path-dependency entries across the
-seven dependent member crates (`rimap-imap`, `rimap-content`, `rimap-config`,
+22 `version = "1.0.0"` literals on path-dependency entries (including
+dev-deps and the self-referencing test-support entries in `rimap-server`)
+across the seven dependent member crates (`rimap-imap`, `rimap-content`, `rimap-config`,
 `rimap-audit`, `rimap-smtp`, `rimap-authz`, `rimap-server`) update to
 `"0.1.0"`. The existing comment in `crates/rimap-imap/Cargo.toml`
 (`# Internal — direct path + explicit version to satisfy cargo-deny's

--- a/justfile
+++ b/justfile
@@ -232,3 +232,9 @@ ci: fmt-check lint test test-msrv deny
 hooks:
     prek install
     prek run --all-files
+
+# Verify a candidate tag against the Cargo.toml workspace version.
+# Run this before pushing a `vX.Y.Z` tag.
+#   just release-check v0.1.0
+release-check TAG:
+    ./scripts/check-release-version.sh {{TAG}}

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Compare a tag-style argument against the workspace version in Cargo.toml.
+#
+# Usage:
+#   scripts/check-release-version.sh v0.1.0
+#
+# Exits 0 when the tag matches the workspace version, non-zero otherwise.
+# Mirrors the verify-tag job in .github/workflows/release.yml so contributors
+# can sanity-check before pushing a tag.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $(basename "$0") <vX.Y.Z>" >&2
+    exit 64
+fi
+
+tag="$1"
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: tag must match ^v[0-9]+\.[0-9]+\.[0-9]+\$ (got '$tag')" >&2
+    exit 65
+fi
+
+# Strip the leading 'v'.
+tag_version="${tag#v}"
+
+# Parse workspace version. Match `version = "X.Y.Z"` only under [workspace.package].
+# awk pattern: enter range on [workspace.package], exit on next section header.
+workspace_version=$(
+    awk '
+        /^\[workspace\.package\]/ {in_section=1; next}
+        in_section && /^\[/ {in_section=0}
+        in_section && /^version = / {
+            sub(/^version = "/, "")
+            sub(/"$/, "")
+            print
+            exit
+        }
+    ' Cargo.toml
+)
+
+if [ -z "$workspace_version" ]; then
+    echo "error: could not parse [workspace.package].version from Cargo.toml" >&2
+    exit 66
+fi
+
+if [[ "$workspace_version" == *-* ]]; then
+    echo "error: Cargo.toml workspace version contains '-' (got '$workspace_version'); release tags must point at a clean semver" >&2
+    exit 67
+fi
+
+if [ "$tag_version" != "$workspace_version" ]; then
+    echo "error: tag '$tag' does not match Cargo.toml workspace version '$workspace_version'" >&2
+    exit 68
+fi
+
+echo "ok: tag '$tag' matches Cargo.toml workspace version '$workspace_version'"

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -25,6 +25,11 @@ fi
 # Strip the leading 'v'.
 tag_version="${tag#v}"
 
+if [ ! -f Cargo.toml ]; then
+    echo "error: Cargo.toml not found (run from the repo root)" >&2
+    exit 66
+fi
+
 # Parse workspace version. Match `version = "X.Y.Z"` only under [workspace.package].
 # awk pattern: enter range on [workspace.package], exit on next section header.
 workspace_version=$(


### PR DESCRIPTION
## Summary

- Workspace version drops from the aspirational `1.0.0` to `0.1.0`. Every
  `version = "1.0.0"` literal on the 22 cross-crate path-deps follows.
- New `rimap-core/build.rs` shells out to `git describe --tags
  --exact-match HEAD`, `rev-parse --short=7`, and `status --porcelain` to
  compute a semver-compliant version string at compile time:
  `X.Y.Z` for tag-exact builds, `X.Y.Z-dev+g<sha>[.dirty]` otherwise.
- The CLI `--version`, MCP `server_info.version`, and audit-log
  `process_start.version` / `.git_commit` fields all consume the new
  `rimap_core::version` helpers, so a captured audit log identifies the
  exact commit a dev build came from.
- `.github/workflows/release.yml` gains a `verify-tag` job that
  hard-fails before any build job runs if the pushed tag does not match
  the workspace version, and a `workflow_dispatch` trigger with
  `dry_run: true` that exercises the guard without cutting a real tag.
- `scripts/check-release-version.sh` mirrors the CI guard locally via
  `just release-check vX.Y.Z`.
- `CHANGELOG.md` relabels `[1.0.0]` → `[0.1.0]`, folds the in-flight
  `[Unreleased]` entries into it, and adds reference-link footers.
- One follow-up bug fix in `release.yml` corrects the per-tag CHANGELOG
  awk extraction so the GitHub release body contains the section
  body (not just the heading).

Spec: `docs/superpowers/specs/2026-05-11-release-versioning-design.md`.
Plan: `docs/superpowers/plans/2026-05-11-release-versioning.md`.

## Test plan

- [x] `just ci` passes locally (fmt, lint, test, test-msrv, deny, typos)
- [x] `just hooks` passes across the whole tree
- [x] `cargo test -p rimap-core --test version` passes
- [x] `cargo test -p rimap-server --test cli_smoke` passes
- [x] `rusty-imap-mcp --version` prints `rusty-imap-mcp 0.1.0-dev+g<sha>`
- [x] `./scripts/check-release-version.sh v0.1.0` exits 0
- [x] `./scripts/check-release-version.sh v9.9.9` exits 68
- [x] `./scripts/check-release-version.sh v0.1.0-rc1` exits 65
- [x] `gh workflow run release.yml -f tag=v0.1.0 -f dry_run=true` → verify-tag passes (verified post-push in this task)
- [x] `gh workflow run release.yml -f tag=v9.9.9 -f dry_run=true` → verify-tag fails (verified post-push in this task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)