### PR TITLE
docs(quickstart): correct setup steps for Gmail and Proton Bridge

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -170,11 +170,12 @@ command = "/usr/local/bin/rusty-imap-mcp"
 args = ["--config", "/home/dave/.config/rusty-imap-mcp/codex.toml"]
 ```
 
-`~/.config/rusty-imap-mcp/claude.toml`:
+`~/.config/rusty-imap-mcp/claude.toml` (Linux example — the TOML
+parser does not expand `~`, so `audit.path` must be absolute):
 
 ```toml
 [audit]
-path = "~/.local/state/rusty-imap-mcp/audit-claude.jsonl"
+path = "/home/dave/.local/share/rusty-imap-mcp/audit-claude.jsonl"
 # ... rest of config identical between the two
 ```
 
@@ -182,9 +183,15 @@ path = "~/.local/state/rusty-imap-mcp/audit-claude.jsonl"
 
 ```toml
 [audit]
-path = "~/.local/state/rusty-imap-mcp/audit-codex.jsonl"
+path = "/home/dave/.local/share/rusty-imap-mcp/audit-codex.jsonl"
 # ...
 ```
+
+Both parent directories must already exist before startup — create
+them with `mkdir -p /home/dave/.local/share/rusty-imap-mcp` (Linux)
+or the equivalent under `~/Library/Application Support/rusty-imap-mcp/`
+on macOS. The audit path must also live under the platform-default
+`allowed_base_dir` (or set `audit.allowed_base_dir` explicitly).
 
 #### Cross-project: per-project `.mcp.json`
 
@@ -292,9 +299,13 @@ warning and are skipped.
 rusty-imap-mcp audit merge \
   --since 2026-04-07T00:00:00Z \
   --tool fetch_message \
-  ~/.local/state/rusty-imap-mcp/audit.jsonl \
+  ~/.local/share/rusty-imap-mcp/audit.jsonl \
   | jq '.result_summary'
 ```
+
+(The CLI path here is a shell argument, so `~` is expanded by the
+shell — only `audit.path` inside the TOML config file is taken
+literally.)
 
 ### File permissions for merged output
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ posture = "draft-safe"
 commands_per_second = 10
 
 [audit]
-path = "/home/alice/.local/state/rusty-imap-mcp/audit.jsonl"
+path = "/home/alice/.local/share/rusty-imap-mcp/audit.jsonl"
 
 [attachments]
 download_dir = ""
@@ -85,7 +85,7 @@ username = "me@fastmail.com"
 posture = "readonly"
 
 [audit]
-path = "/home/user/.local/state/rusty-imap-mcp/audit.jsonl"
+path = "/home/user/.local/share/rusty-imap-mcp/audit.jsonl"
 ```
 
 See [multi-account.md](multi-account.md) for account discovery and
@@ -220,13 +220,13 @@ accounts in multi-account configs).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | string | (required) | Path to the audit log file (JSONL) |
+| `path` | string | (required) | Path to the audit log file (JSONL). Must be an absolute path — the TOML parser does not expand `~`. The parent directory must exist before startup. |
 | `rotate_bytes` | u64 | 10,485,760 (10 MiB) | Rotate when the file reaches this size. `0` disables rotation. |
 | `rotate_keep` | u32 | 5 | Number of rotated files to keep after rotation |
 | `retention_seconds` | u64 | (none) | Time-based retention for rotated files. Omit to disable. |
 | `provenance_window_seconds` | u32 | 60 | Provenance ring buffer window |
 | `fail_open` | bool | false | If true, continue on audit write failure (insecure). Default: audit write failure fails the tool call. |
-| `allowed_base_dir` | string | (platform default) | Containment base for `audit.path`. Defaults to `$XDG_STATE_HOME/rusty-imap-mcp/`. Set to `"/"` to disable (not recommended). |
+| `allowed_base_dir` | string | (platform default) | Containment base for `audit.path`. Default is `directories::ProjectDirs::data_local_dir()` — `~/Library/Application Support/rusty-imap-mcp/` on macOS, `$XDG_DATA_HOME/rusty-imap-mcp/` (typically `~/.local/share/rusty-imap-mcp/`) on Linux. Set to `"/"` to disable (not recommended). |
 
 See [audit-log.md](audit-log.md) for the log format and record types.
 
@@ -262,12 +262,17 @@ in the per-account section inherit from defaults.
 Passwords are never stored in the config file. Resolution order:
 
 1. **OS keychain** -- service `rusty-imap-mcp`, account
-   `<username>@<host>`. Store credentials with:
+   `<account-id>/<username>@<host>` (the legacy `<username>@<host>` form
+   is still read for back-compat). Store credentials with:
    ```
-   rusty-imap-mcp login
+   rusty-imap-mcp login --host <host> --username <username>
    ```
+   Add `--account <name>` to target a non-default account. The command
+   prompts on `/dev/tty`; the password is never read from stdin or the
+   environment.
 2. **Environment variable** `RUSTY_IMAP_MCP_PASSWORD` -- fallback for
-   headless, container, or CI environments.
+   headless, container, or CI environments. Read by the server at
+   credential-resolution time, not by `login`.
 3. **Error** -- if neither source has a value, the server exits with a
    message directing the user to run `rusty-imap-mcp login` or set the
    environment variable.

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -10,26 +10,53 @@ Set up rusty-imap-mcp with a Gmail account in about 10 minutes.
 ## Step 1: Install
 
 Download a pre-built binary from the
-[releases page](https://github.com/randomparity/rusty-imap-mcp/releases),
-or build from source:
+[releases page](https://github.com/randomparity/rusty-imap-mcp/releases)
+and put it on your `$PATH`, or build from source and install:
 
 ```bash
 git clone https://github.com/randomparity/rusty-imap-mcp.git
 cd rusty-imap-mcp
-cargo build --release
-# Binary at target/release/rusty-imap-mcp
+cargo install --path crates/rimap-server   # installs into ~/.cargo/bin
 ```
 
-Verify the binary works:
+If `~/.cargo/bin` isn't already on your `$PATH`, add it (e.g.
+`export PATH="$HOME/.cargo/bin:$PATH"` in `~/.zshrc` or `~/.bashrc`),
+then verify:
 
 ```bash
 rusty-imap-mcp --version
 ```
 
-## Step 2: Create the config file
+All subsequent commands assume `rusty-imap-mcp` resolves on `$PATH`.
 
-Create `~/.config/rusty-imap-mcp/config.toml` (Linux) or
-`~/Library/Application Support/rusty-imap-mcp/config.toml` (macOS):
+## Step 2: Create the config and audit directories
+
+The config file lives at:
+
+- **Linux:** `~/.config/rusty-imap-mcp/config.toml`
+- **macOS:** `~/Library/Application Support/rusty-imap-mcp/config.toml`
+
+The audit log directory must exist before startup; `rusty-imap-mcp`
+never creates it for you. The audit path must also live under the
+platform-default `allowed_base_dir`
+(`~/Library/Application Support/rusty-imap-mcp/` on macOS,
+`~/.local/share/rusty-imap-mcp/` on Linux) unless you set
+`audit.allowed_base_dir` explicitly.
+
+Create both directories:
+
+```bash
+# macOS
+mkdir -p ~/Library/Application\ Support/rusty-imap-mcp
+
+# Linux
+mkdir -p ~/.config/rusty-imap-mcp ~/.local/share/rusty-imap-mcp
+```
+
+Then write the config file. **The TOML parser does not expand `~`** —
+`audit.path` must be an absolute path. Pick the block for your platform:
+
+**macOS** (`~/Library/Application Support/rusty-imap-mcp/config.toml`):
 
 ```toml
 [imap]
@@ -37,15 +64,32 @@ host = "imap.gmail.com"
 port = 993
 username = "you@gmail.com"
 
-[smtp]
-host = "smtp.gmail.com"
-port = 465
-encryption = "tls"
+[audit]
+path = "/Users/you/Library/Application Support/rusty-imap-mcp/audit.jsonl"
+```
+
+**Linux** (`~/.config/rusty-imap-mcp/config.toml`):
+
+```toml
+[imap]
+host = "imap.gmail.com"
+port = 993
 username = "you@gmail.com"
 
 [audit]
-path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
+path = "/home/you/.local/share/rusty-imap-mcp/audit.jsonl"
 ```
+
+Replace `you@gmail.com` with your Gmail address and `/Users/you` or
+`/home/you` with your actual home directory (run `echo $HOME` if
+unsure).
+
+> **No `[smtp]` yet.** The default posture (`draft-safe`) does not
+> permit `send_email`, so SMTP is not needed for this quickstart.
+> Adding an `[smtp]` block while the credential is missing causes the
+> server to fail at startup. To enable sending later, switch posture to
+> `full` and follow [Optional: enable sending](#optional-enable-sending)
+> below.
 
 If you plan to run multiple MCP clients against this account (e.g.
 two Claude Code windows on different projects, or Claude Code
@@ -53,19 +97,19 @@ alongside Codex), see
 [Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
 for the per-client configuration pattern.
 
-Replace `you@gmail.com` with your Gmail address.
-
 ## Step 3: Store your credentials
 
-Store the App Password in your OS keychain:
+Store the App Password in your OS keychain. The `login` subcommand
+prompts on `/dev/tty`; `--host` and `--username` are required:
 
 ```bash
-rusty-imap-mcp login
+rusty-imap-mcp login --host imap.gmail.com --username you@gmail.com
 ```
 
 When prompted, paste your 16-character App Password (not your Google
-account password). The password is stored in the OS keychain under
-service `rusty-imap-mcp`, account `you@gmail.com@imap.gmail.com`.
+account password). Spaces in the displayed App Password don't matter.
+The password is stored in the OS keychain under service
+`rusty-imap-mcp`, account `default/you@gmail.com@imap.gmail.com`.
 
 ## Step 4: Test the connection
 
@@ -84,6 +128,8 @@ exits. It does not authenticate.
 
 | Error | Cause | Fix |
 |-------|-------|-----|
+| `path ... is not writable: directory does not exist` | Audit log parent directory missing | Create it (see Step 2). Confirm `audit.path` is an absolute path, not `~/...` — the TOML parser does not expand `~`. |
+| `audit path ... is not contained in allowed base ...` | `audit.path` is outside the platform-default base | Move the audit file under the platform-default base (Step 2) or set `audit.allowed_base_dir` explicitly in the `[audit]` block. |
 | `ERR_TLS` | TLS handshake failure | Verify your network allows connections to imap.gmail.com:993 |
 | `Capabilities ...: unavailable (...)` | Preflight could not complete | Inspect the parenthesised cause — typically connectivity, DNS, or TLS. `--dry-run` does not authenticate, so an auth error cannot surface here |
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
@@ -136,6 +182,38 @@ email content), and `security_warnings` (any detected issues).
 > "Search for emails from nonexistent-sender-abc123@example.com."
 
 Expected: an empty result set, not an error.
+
+## Optional: enable sending
+
+The default `draft-safe` posture cannot send mail. To enable
+`send_email`, you need both the SMTP block in the config and a separate
+keyring entry for the SMTP host (Gmail uses different hosts for IMAP
+and SMTP, so the IMAP keyring entry does not cover SMTP):
+
+1. Add an `[smtp]` block and switch posture:
+
+   ```toml
+   [smtp]
+   host = "smtp.gmail.com"
+   port = 465
+   encryption = "tls"
+   username = "you@gmail.com"
+
+   [security]
+   posture = "full"
+   ```
+
+2. Store the App Password under the SMTP host as well:
+
+   ```bash
+   rusty-imap-mcp login --host smtp.gmail.com --username you@gmail.com
+   ```
+
+   Reuse the same 16-character App Password — Gmail accepts it for both
+   IMAP and SMTP.
+
+3. Re-run `rusty-imap-mcp --dry-run` to confirm the matrix now shows
+   `send_email` as `[ok ]`.
 
 ## What's next
 

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -13,35 +13,121 @@ Set up rusty-imap-mcp with Proton Mail via Proton Bridge in about
 ## Step 1: Install
 
 Download a pre-built binary from the
-[releases page](https://github.com/randomparity/rusty-imap-mcp/releases),
-or build from source:
+[releases page](https://github.com/randomparity/rusty-imap-mcp/releases)
+and put it on your `$PATH`, or build from source and install:
 
 ```bash
 git clone https://github.com/randomparity/rusty-imap-mcp.git
 cd rusty-imap-mcp
-cargo build --release
-# Binary at target/release/rusty-imap-mcp
+cargo install --path crates/rimap-server   # installs into ~/.cargo/bin
 ```
 
-Verify the binary works:
+If `~/.cargo/bin` isn't already on your `$PATH`, add it (e.g.
+`export PATH="$HOME/.cargo/bin:$PATH"` in `~/.zshrc` or `~/.bashrc`),
+then verify:
 
 ```bash
 rusty-imap-mcp --version
 ```
 
-## Step 2: Capture the TLS fingerprint
+All subsequent commands assume `rusty-imap-mcp` resolves on `$PATH`.
+
+## Step 2: Create the config and audit directories
+
+The config file lives at:
+
+- **Linux:** `~/.config/rusty-imap-mcp/config.toml`
+- **macOS:** `~/Library/Application Support/rusty-imap-mcp/config.toml`
+
+The audit log directory must exist before startup; `rusty-imap-mcp`
+never creates it for you. The audit path must also live under the
+platform-default `allowed_base_dir`
+(`~/Library/Application Support/rusty-imap-mcp/` on macOS,
+`~/.local/share/rusty-imap-mcp/` on Linux) unless you set
+`audit.allowed_base_dir` explicitly.
+
+Create both directories:
+
+```bash
+# macOS
+mkdir -p ~/Library/Application\ Support/rusty-imap-mcp
+
+# Linux
+mkdir -p ~/.config/rusty-imap-mcp ~/.local/share/rusty-imap-mcp
+```
+
+Then write the initial config. Proton Bridge's default IMAP mode is
+STARTTLS on port 1143; the implicit-TLS alternative (port 1993)
+requires enabling "SSL" in Bridge's Advanced Settings. This config
+uses the default.
+
+**The TOML parser does not expand `~`** — `audit.path` must be an
+absolute path. Leave `tls_fingerprint_sha256` empty for now; you fill
+it in after Step 3:
+
+**macOS** (`~/Library/Application Support/rusty-imap-mcp/config.toml`):
+
+```toml
+[imap]
+host = "127.0.0.1"
+port = 1143
+encryption = "starttls"
+username = "you@proton.me"
+# tls_fingerprint_sha256 = "fill-in-after-step-3"
+
+[security]
+posture = "draft-safe"
+
+[audit]
+path = "/Users/you/Library/Application Support/rusty-imap-mcp/audit.jsonl"
+```
+
+**Linux** (`~/.config/rusty-imap-mcp/config.toml`):
+
+```toml
+[imap]
+host = "127.0.0.1"
+port = 1143
+encryption = "starttls"
+username = "you@proton.me"
+# tls_fingerprint_sha256 = "fill-in-after-step-3"
+
+[security]
+posture = "draft-safe"
+
+[audit]
+path = "/home/you/.local/share/rusty-imap-mcp/audit.jsonl"
+```
+
+Replace `you@proton.me` with your Proton email address and `/Users/you`
+or `/home/you` with your actual home directory (run `echo $HOME` if
+unsure).
+
+> **No `[smtp]` yet.** The default posture (`draft-safe`) does not
+> permit `send_email`, so SMTP is not needed for this quickstart.
+> Adding an `[smtp]` block before storing the credential causes the
+> server to fail at startup. To enable sending later, see
+> [Optional: enable sending](#optional-enable-sending) below.
+
+If you plan to run multiple MCP clients against this account (e.g.
+two Claude Code windows on different projects, or Claude Code
+alongside Codex), see
+[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
+for the per-client configuration pattern.
+
+## Step 3: Capture and pin the TLS fingerprint
 
 Proton Bridge uses a self-signed TLS certificate that is not in your
 system trust store. Pin the certificate fingerprint so the server can
 verify it.
 
-### Get the TLS fingerprint (recommended path)
+### Recommended: capture via `--dry-run`
 
-After saving an initial `config.toml` with `host`, `port`, and `username`,
+With the config from Step 2 saved (and the audit directory created),
 run:
 
 ```bash
-rusty-imap-mcp --config config.toml --dry-run
+rusty-imap-mcp --dry-run
 ```
 
 The output includes a `TLS fingerprint (sha256):` line followed by the
@@ -53,8 +139,9 @@ TLS fingerprint (sha256):
   (add `tls_fingerprint_sha256 = "ab:cd:ef:...:ef"` under [imap] in config.toml to pin)
 ```
 
-Copy the hex value into `tls_fingerprint_sha256` under `[imap]` and re-run
-`--dry-run`; the fingerprint section now reads `(matches configured pin)`.
+Uncomment `tls_fingerprint_sha256` in `[imap]` and paste the hex value,
+then re-run `--dry-run`; the fingerprint section now reads
+`(matches configured pin)`.
 
 > **Trust note**: `--dry-run` records whatever cert the network presents.
 > Run it from a network you trust at the time of fingerprint extraction —
@@ -62,7 +149,8 @@ Copy the hex value into `tls_fingerprint_sha256` under `[imap]` and re-run
 
 ### Alternative: extract the fingerprint with openssl
 
-If you prefer not to run a partial config first, the fingerprint can also be extracted directly:
+If you prefer to extract the fingerprint without invoking
+`rusty-imap-mcp` at all:
 
 ```bash
 openssl s_client -connect 127.0.0.1:1143 -starttls imap < /dev/null 2>/dev/null \
@@ -71,7 +159,8 @@ openssl s_client -connect 127.0.0.1:1143 -starttls imap < /dev/null 2>/dev/null 
   | awk '{print $2}'
 ```
 
-This prints a 64-character hex string. Copy it for the next step.
+This prints a 64-character hex string. Paste it as the value of
+`tls_fingerprint_sha256` in `[imap]`.
 
 Bridge's IMAP port uses STARTTLS rather than implicit TLS, so `-starttls imap`
 is required — without it, `openssl` returns no certificate and the pipeline
@@ -81,66 +170,25 @@ If you see that value, you forgot the flag.
 
 The fingerprint changes when Proton Bridge regenerates its certificate
 (after a Bridge update or reinstall). If the server later fails with
-`ERR_TLS`, re-run this command and update the config.
-
-## Step 3: Create the config file
-
-Create `~/.config/rusty-imap-mcp/config.toml` (Linux) or
-`~/Library/Application Support/rusty-imap-mcp/config.toml` (macOS):
-
-Proton Bridge's default IMAP mode is STARTTLS on port 1143. The implicit-TLS
-alternative (port 1993) requires enabling "SSL" in Bridge's Advanced Settings.
-This config uses the default.
-
-```toml
-[imap]
-host = "127.0.0.1"
-port = 1143
-encryption = "starttls"
-username = "you@proton.me"
-tls_fingerprint_sha256 = "paste-your-64-char-fingerprint-here"
-
-[smtp]
-host = "127.0.0.1"
-port = 1025
-encryption = "starttls"
-username = "you@proton.me"
-
-[security]
-posture = "draft-safe"
-
-[audit]
-path = "~/.local/state/rusty-imap-mcp/audit.jsonl"
-```
-
-If you plan to run multiple MCP clients against this account (e.g.
-two Claude Code windows on different projects, or Claude Code
-alongside Codex), see
-[Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
-for the per-client configuration pattern.
-
-Replace `you@proton.me` with your Proton email address and
-`tls_fingerprint_sha256` with the output from Step 2.
+`ERR_TLS`, re-run this step and update the config.
 
 ## Step 4: Store your credentials
 
-Store the Bridge password in your OS keychain:
+Store the Bridge password in your OS keychain. The `login` subcommand
+prompts on `/dev/tty`; `--host` and `--username` are required:
 
 ```bash
-rusty-imap-mcp login
+rusty-imap-mcp login --host 127.0.0.1 --username you@proton.me
 ```
 
 When prompted, paste the bridge password from Proton Bridge settings
 (not your Proton account password). The password is stored in the OS
 keychain under service `rusty-imap-mcp`, account
-`you@proton.me@127.0.0.1`.
+`default/you@proton.me@127.0.0.1`.
 
-For SMTP (if using `send_email` in `full` posture), the same bridge
-password is used. Store it for the SMTP host:
-
-```bash
-RUSTY_IMAP_MCP_PASSWORD=<bridge-password> rusty-imap-mcp login
-```
+Because Proton Bridge serves IMAP and SMTP on the same host
+(`127.0.0.1`), this single keyring entry covers both protocols — no
+separate SMTP login is needed when you later enable sending.
 
 ## Step 5: Test the connection
 
@@ -159,7 +207,9 @@ exits. It does not authenticate.
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `ERR_TLS` | Fingerprint mismatch or Bridge not running | Verify Bridge is running, then re-capture the fingerprint (Step 2) |
+| `path ... is not writable: directory does not exist` | Audit log parent directory missing | Create it (see Step 2). Confirm `audit.path` is an absolute path, not `~/...` — the TOML parser does not expand `~`. |
+| `audit path ... is not contained in allowed base ...` | `audit.path` is outside the platform-default base | Move the audit file under the platform-default base (Step 2) or set `audit.allowed_base_dir` explicitly in the `[audit]` block. |
+| `ERR_TLS` | Fingerprint mismatch or Bridge not running | Verify Bridge is running, then re-capture the fingerprint (Step 3) |
 | `Capabilities ...: unavailable (...)` | Preflight could not complete | Inspect the parenthesised cause — typically connectivity or TLS. `--dry-run` does not authenticate, so an auth error cannot surface here |
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
 | Connection refused | Bridge not running or wrong port | Start Proton Bridge and verify the IMAP port in Bridge settings |
@@ -212,6 +262,32 @@ email content), and `security_warnings` (any detected issues).
 
 Expected: an empty result set, not an error.
 
+## Optional: enable sending
+
+The default `draft-safe` posture cannot send mail. To enable
+`send_email`, add an `[smtp]` block and switch posture to `full`:
+
+```toml
+[smtp]
+host = "127.0.0.1"
+port = 1025
+encryption = "starttls"
+username = "you@proton.me"
+
+[security]
+posture = "full"
+```
+
+The keyring entry stored in Step 4 already covers SMTP — Bridge uses
+the same host (`127.0.0.1`) and the same bridge password for both
+protocols, so no second `login` invocation is needed.
+
+The SMTP port shown above (1025) is the Proton Bridge default; the
+exact port appears in Bridge settings.
+
+Re-run `rusty-imap-mcp --dry-run` to confirm the matrix now shows
+`send_email` as `[ok ]`.
+
 ## Known quirks
 
 ### Bridge password vs. account password
@@ -256,7 +332,7 @@ Bridge is slow to start or your mailbox is large, increase
 
 The fingerprint changes when Bridge regenerates its certificate (after
 updates or reinstalls). If you get `ERR_TLS` after a Bridge update,
-re-run the openssl command from Step 2 and update the config.
+re-run the fingerprint capture from Step 3 and update the config.
 
 ### Running headless or over SSH
 
@@ -304,6 +380,6 @@ then store the Bridge password for `rusty-imap-mcp` the usual way
 Bridge does.
 
 **C. Capture the fingerprint from a TTY.** The `openssl` pipeline in
-Step 2 works over SSH as long as you can reach `127.0.0.1:1143` from
+Step 3 works over SSH as long as you can reach `127.0.0.1:1143` from
 the shell where Bridge is running. The `-starttls imap` flag is
 required regardless of session type.


### PR DESCRIPTION
## Summary

The Gmail and Proton Bridge quickstarts shipped configurations that fail at startup. Followed verbatim, `rusty-imap-mcp --dry-run` exits with errors like:

```
path \`~/.local/state/rusty-imap-mcp\` is not writable: directory does not exist
```

This PR fixes the user-visible setup flow and a few cascading inaccuracies in `configuration.md` and `audit-log.md`.

### What was broken (all verified against code, not memory)

- **`audit.path` does not expand `~`.** `crates/rimap-config/src/model.rs:320` parses to a plain `PathBuf` and no expansion code exists; the validator (`crates/rimap-config/src/validate/paths.rs:115`) then rejects the non-existent literal directory.
- **macOS containment.** The default `allowed_base_dir` is `directories::ProjectDirs::data_local_dir()` — `~/Library/Application Support/rusty-imap-mcp/` on macOS, `~/.local/share/rusty-imap-mcp/` on Linux. The previous `~/.local/state/...` examples fail `AuditPathOutsideBase` on macOS and don't match the actual Linux default either.
- **`rusty-imap-mcp login` requires `--host` and `--username`** (`crates/rimap-server/src/cli/mod.rs:46-57`). The bare invocation in both quickstarts fails clap parsing.
- **Gmail's `[smtp]` block was a startup landmine.** `build_smtp_client` (`crates/rimap-server/src/main.rs:247-266`) resolves the SMTP credential eagerly whenever `[smtp]` is present, even under `draft-safe` which denies `send_email`. Gmail's SMTP host differs from its IMAP host, so the IMAP keyring entry can't cover SMTP and startup fails with `NoCredential`.
- **Proton's SMTP-login snippet (`RUSTY_IMAP_MCP_PASSWORD=... rusty-imap-mcp login`) didn't do what it implied.** `login` is `rpassword`-interactive; the env var is a server-side resolution fallback. Bridge serves IMAP and SMTP from `127.0.0.1`, so a single keyring entry already covers both.
- **The binary wasn't on `\$PATH`** after `cargo build --release`, but the next line ran `rusty-imap-mcp --version`.

### What changed

- `docs/quickstart-gmail.md` and `docs/quickstart-proton-bridge.md`:
  - Added a `cargo install --path crates/rimap-server` step and a `$PATH` note.
  - Added explicit `mkdir -p` for the audit log directory.
  - Switched the example `audit.path` values to absolute paths under each platform's default `allowed_base_dir`.
  - Fixed every `rusty-imap-mcp login` invocation to pass `--host` and `--username`.
  - Moved SMTP setup into an "Optional: enable sending" section (Gmail walks through the second `login --host smtp.gmail.com`; Proton notes the shared host).
  - Renumbered Proton steps so the audit dir exists before the recommended `--dry-run` fingerprint capture, and updated cross-references in the "Known quirks" section.
  - Expanded the `--dry-run` error table to cover the audit-path failure modes users will now hit if they misconfigure.
- `docs/configuration.md`: keyring key format updated to the post-#77 `<account-id>/<username>@<host>` form; `login` syntax corrected; `[audit].path` and `allowed_base_dir` row descriptions made accurate.
- `docs/audit-log.md`: multi-client example switched to absolute Linux paths with a `mkdir -p` reminder.

Internal design docs under `docs/superpowers/{specs,plans}/` contain similar stale snippets but were left untouched — they're historical design records, not user-facing setup instructions.

## Test plan

- [ ] Walk a fresh macOS shell through the Gmail quickstart end-to-end (cargo install, mkdir, config write, `login`, `--dry-run`). Confirm no `path ... is not writable` or `AuditPathOutsideBase` errors.
- [ ] Same walk-through on Linux with the Linux config block.
- [ ] Walk through the Proton Bridge quickstart end-to-end against a running Bridge instance: directory creation, `--dry-run` fingerprint capture, pinning, `login`, second `--dry-run` showing `(matches configured pin)`.
- [ ] Verify the "Optional: enable sending" anchor link resolves on the rendered docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)