### PR TITLE
fix(mcp): declare tools capability + docs walkthrough fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `initialize` response now advertises the `tools` and `resources`
+  capabilities. Previously `get_info()` returned
+  `ServerCapabilities::default()` (all-`None` fields), so the wire
+  payload was `"capabilities": {}` and spec-strict MCP clients (e.g.
+  `bobshell`) refused to call `tools/list` with "No prompts or tools
+  found on the server." Permissive clients (Claude Desktop, IBM Bob
+  desktop) called `tools/list` anyway and were unaffected.
+
 ## [0.1.0] - Unreleased
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -159,10 +159,16 @@ Binaries are published for five targets on each
 - [Security model and posture matrix](docs/security-model.md)
 - [Multi-account support](docs/multi-account.md)
 - [Audit log format](docs/audit-log.md)
+- [Troubleshooting](docs/troubleshooting.md)
 - [Full documentation index](docs/INDEX.md)
 
 ## Troubleshooting
 
+- **MCP client reports `Connection closed` / `MCP error -32000` at
+  startup** — the server exited before completing the handshake; the
+  real error went to stderr. See
+  [docs/troubleshooting.md](docs/troubleshooting.md) for the
+  `--dry-run` and stderr-capture workflow.
 - **`rusty-imap-mcp` exits at startup with `audit file ... is already locked`** —
   another `rusty-imap-mcp` process holds the audit lock. Each MCP
   client must use a distinct `[audit].path`; see

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -19,7 +19,8 @@ use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ErrorCode as McpCode, ErrorData, Implementation,
     ListResourcesResult, ListToolsResult, PaginatedRequestParams, RawResource,
-    ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ServerInfo, Tool,
+    ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 
@@ -223,7 +224,20 @@ fn error_data_to_rimap_error(err: &ErrorData) -> rimap_core::RimapError {
 
 impl ServerHandler for ImapMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::default().with_server_info(Implementation::new(
+        // Spec-strict MCP clients refuse to call `tools/list` unless the
+        // server's `initialize` response advertises a `tools` capability.
+        // `ServerCapabilities::default()` is all-`None`, so without this
+        // declaration the wire payload is `"capabilities": {}` and such
+        // clients report "no tools found." `tool_list_changed` matches the
+        // existing `notifications/tools/list_changed` emission after
+        // `use_account` (see `call_tool` below). `resources` advertises the
+        // `list_resources`/`read_resource` surface implemented in this file.
+        let capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_tool_list_changed()
+            .enable_resources()
+            .build();
+        ServerInfo::new(capabilities).with_server_info(Implementation::new(
             "rusty-imap-mcp",
             rimap_core::version::version(),
         ))

--- a/crates/rimap-server/tests/server_capabilities.rs
+++ b/crates/rimap-server/tests/server_capabilities.rs
@@ -1,0 +1,98 @@
+//! Regression test: `get_info()` must advertise the `tools` and
+//! `resources` capabilities. Without them, spec-strict MCP clients
+//! (e.g. `bobshell`) refuse to call `tools/list` and report "No
+//! prompts or tools found on the server."
+
+#![expect(clippy::expect_used, reason = "tests")]
+
+use std::collections::BTreeMap;
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_server::boot::registry::AccountRegistry;
+use rimap_server::mcp::server::ImapMcpServer;
+use rmcp::handler::server::ServerHandler;
+use tempfile::TempDir;
+
+fn build_test_server() -> (ImapMcpServer, TempDir) {
+    let audit_dir = TempDir::new().expect("audit tempdir");
+    let audit_path = audit_dir.path().join("audit.jsonl");
+    let audit = AuditWriter::open(&AuditOptions {
+        path: audit_path,
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let registry = AccountRegistry::new(BTreeMap::new());
+    let (cancellation_sender, _cancellation_rx) = rimap_audit::cancellation_channel();
+    let server = ImapMcpServer::new(registry, audit, cancellation_sender);
+    (server, audit_dir)
+}
+
+#[test]
+fn get_info_declares_tools_capability() {
+    let (server, _audit_dir) = build_test_server();
+    let info = server.get_info();
+
+    let tools = info
+        .capabilities
+        .tools
+        .as_ref()
+        .expect("tools capability must be declared so spec-strict clients call tools/list");
+    assert_eq!(
+        tools.list_changed,
+        Some(true),
+        "tools.list_changed must be true to match the notifications/tools/list_changed \
+         emission after use_account",
+    );
+}
+
+#[test]
+fn get_info_declares_resources_capability() {
+    let (server, _audit_dir) = build_test_server();
+    let info = server.get_info();
+
+    assert!(
+        info.capabilities.resources.is_some(),
+        "resources capability must be declared because list_resources/read_resource are \
+         implemented in ImapMcpServer",
+    );
+}
+
+#[test]
+fn get_info_omits_prompts_capability() {
+    let (server, _audit_dir) = build_test_server();
+    let info = server.get_info();
+
+    assert!(
+        info.capabilities.prompts.is_none(),
+        "prompts capability must NOT be declared because no prompts surface is implemented",
+    );
+}
+
+#[test]
+fn get_info_serializes_tools_in_capabilities_payload() {
+    // Spec-strict clients inspect the JSON shape of `capabilities`. This
+    // test guards against a future field-rename or
+    // `skip_serializing_if = "Option::is_none"` regression that would
+    // emit `"capabilities": {}` on the wire.
+    let (server, _audit_dir) = build_test_server();
+    let info = server.get_info();
+    let json = serde_json::to_value(&info.capabilities).expect("serialize capabilities");
+
+    assert!(
+        json.get("tools").is_some(),
+        "capabilities JSON must contain a `tools` key on the wire; got {json}",
+    );
+    assert!(
+        json.get("resources").is_some(),
+        "capabilities JSON must contain a `resources` key on the wire; got {json}",
+    );
+    assert!(
+        json.get("prompts").is_none(),
+        "capabilities JSON must omit `prompts` (not implemented); got {json}",
+    );
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,7 @@
 | [Security postures](postures.md) | 4-tier tool matrix, per-tool overrides, folder safety |
 | [Multi-account support](multi-account.md) | Account discovery, selection, per-account isolation |
 | [Audit log](audit-log.md) | JSONL format, rotation, merge subcommand, tamper detection |
+| [Troubleshooting](troubleshooting.md) | Diagnosing startup failures, where logs go, capturing stderr from GUI MCP clients |
 
 ## Security
 

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -173,6 +173,53 @@ it happens), re-run `--dry-run` and update the pinned value.
 > **Trust note:** the pin records whatever cert the network presents
 > the first time. Capture it from a network you trust.
 
+### Optional: verify the credential authenticates
+
+`--dry-run` deliberately stops before `LOGIN`, so it cannot tell you
+whether your stored password is accepted. The first auth attempt
+happens inside the MCP client at server startup, which is the worst
+place to discover a wrong password. To verify the credential before
+integration, speak IMAP to Gmail directly:
+
+```bash
+openssl s_client -connect imap.gmail.com:993 -crlf -quiet
+```
+
+After the `* OK ...` greeting, type these (the `a1`/`a2` tags are
+arbitrary identifiers you make up):
+
+```
+a1 LOGIN you@gmail.com YourAppPasswordHere
+a2 LOGOUT
+```
+
+Interpreting the response:
+
+| Response to `a1` | Meaning | Next step |
+|------------------|---------|-----------|
+| `a1 OK ...` | Credential accepted | Continue to Step 5 |
+| `a1 NO ...` | Server rejected the credential | Re-check the App Password (16 chars, spaces optional); regenerate if needed and re-run `rusty-imap-mcp login` |
+| `a1 BAD ...` | Server rejected the `LOGIN` command itself | Server may require `AUTHENTICATE` with a specific SASL mechanism; send `a3 CAPABILITY` and look at what's advertised |
+
+> **Shell-history caveat.** The command line above places your App
+> Password in your shell history. Prefix the entire shell command
+> with a space (most shells with `HISTCONTROL=ignorespace` skip it),
+> or run `LOGIN you@gmail.com "PaSt3 H3rE"` after the connection
+> opens so the password only lives in the openssl session.
+
+Confirm the stored password matches what just worked:
+
+```bash
+security find-generic-password \
+  -s rusty-imap-mcp \
+  -a "default/you@gmail.com@imap.gmail.com" -w
+```
+
+The printed value should match byte-for-byte what you typed at the
+`LOGIN` prompt. If they differ, re-run `rusty-imap-mcp login`. For
+Linux equivalents and broader credential management, see
+[docs/troubleshooting.md](troubleshooting.md#verifying-and-managing-stored-credentials).
+
 ## Step 5: Add to your MCP client
 
 ### Claude Desktop

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -135,6 +135,44 @@ exits. It does not authenticate.
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
 | Config not found | Wrong file location | Verify the path matches your platform (see Step 2) or use `--config <path>` |
 
+### Optional: pin the TLS certificate
+
+The dry-run output ends with the observed certificate's SHA-256
+fingerprint and a copy-pasteable line:
+
+```
+TLS fingerprint (sha256):
+  ab:cd:ef:...:ef
+  (add `tls_fingerprint_sha256 = "ab:cd:ef:...:ef"` under [imap] in config.toml to pin)
+```
+
+Gmail's certificate chains to a public root, so pinning is **not
+required** for a successful connection. Pin anyway if you want
+defense-in-depth against:
+
+- Corporate TLS-inspection proxies presenting an internal CA
+- Local MITM (compromised network, malicious profile)
+- Any environment where the cert chain `rusty-imap-mcp` sees should
+  match what you observed at setup time
+
+Paste the printed line into your `[imap]` block:
+
+```toml
+[imap]
+host = "imap.gmail.com"
+port = 993
+username = "you@gmail.com"
+tls_fingerprint_sha256 = "ab:cd:ef:...:ef"
+```
+
+Re-run `rusty-imap-mcp --dry-run`; the fingerprint section now reads
+`(matches configured pin)`. From this point, a fingerprint mismatch
+aborts the connection — when Gmail rotates its certificate (rare, but
+it happens), re-run `--dry-run` and update the pinned value.
+
+> **Trust note:** the pin records whatever cert the network presents
+> the first time. Capture it from a network you trust.
+
 ## Step 5: Add to your MCP client
 
 ### Claude Desktop

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -297,7 +297,33 @@ and SMTP, so the IMAP keyring entry does not cover SMTP):
    Reuse the same 16-character App Password — Gmail accepts it for both
    IMAP and SMTP.
 
-3. Re-run `rusty-imap-mcp --dry-run` to confirm the matrix now shows
+3. (Optional) Verify the SMTP credential authenticates. `--dry-run`
+   exercises IMAP only, so a wrong SMTP password surfaces inside the
+   MCP client at first `send_email` attempt. Test it ahead of time
+   with [`swaks`](https://github.com/jetmore/swaks)
+   (`brew install swaks` on macOS, `apt install swaks` /
+   `dnf install swaks` on Linux):
+
+   ```bash
+   swaks --server smtp.gmail.com:465 --tls-on-connect \
+         --auth LOGIN \
+         --auth-user you@gmail.com \
+         --auth-password 'YOUR-APP-PASSWORD' \
+         --quit-after AUTH
+   ```
+
+   `--quit-after AUTH` sends `EHLO` → AUTH negotiation → `QUIT`. No
+   message is transacted. Look for `235 2.7.0 Accepted` on the AUTH
+   response — that's the credential confirmed. `535 5.7.8 ...` means
+   the App Password was rejected; regenerate it and re-run
+   `rusty-imap-mcp login --host smtp.gmail.com --username you@gmail.com`.
+
+   > **Shell-history caveat.** The command above places your App
+   > Password on the command line. Prefix the entire command with a
+   > space if your shell has `HISTCONTROL=ignorespace`, or omit
+   > `--auth-password` and let swaks prompt for it on stderr.
+
+4. Re-run `rusty-imap-mcp --dry-run` to confirm the matrix now shows
    `send_email` as `[ok ]`.
 
 ## What's next

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -214,6 +214,54 @@ exits. It does not authenticate.
 | `ERR_CONFIG` | Config parse error | Check TOML syntax and field names against the [configuration reference](configuration.md) |
 | Connection refused | Bridge not running or wrong port | Start Proton Bridge and verify the IMAP port in Bridge settings |
 
+### Optional: verify the credential authenticates
+
+`--dry-run` deliberately stops before `LOGIN`, so it cannot tell you
+whether your stored password is accepted. The first auth attempt
+happens inside the MCP client at server startup, which is the worst
+place to discover a wrong password. To verify the credential before
+integration, speak IMAP to Bridge directly (note `-starttls imap` —
+Bridge uses STARTTLS on port 1143, not implicit TLS):
+
+```bash
+openssl s_client -connect 127.0.0.1:1143 -starttls imap -crlf -quiet
+```
+
+After the `* OK ...` greeting, type these (the `a1`/`a2` tags are
+arbitrary identifiers you make up):
+
+```
+a1 LOGIN you@proton.me YourBridgePasswordHere
+a2 LOGOUT
+```
+
+Interpreting the response:
+
+| Response to `a1` | Meaning | Next step |
+|------------------|---------|-----------|
+| `a1 OK ...` | Credential accepted | Continue to Step 6 |
+| `a1 NO ...` | Server rejected the credential | Re-copy the bridge password from Proton Bridge settings (not your Proton account password); re-run `rusty-imap-mcp login` if you mistyped it earlier |
+| `a1 BAD ...` | Server rejected the `LOGIN` command itself | Unexpected against Bridge; send `a3 CAPABILITY` and inspect what's advertised |
+
+> **Shell-history caveat.** The command line above places your bridge
+> password in your shell history. Prefix the entire shell command
+> with a space (most shells with `HISTCONTROL=ignorespace` skip it),
+> or run `LOGIN you@proton.me "PaSt3 H3rE"` after the connection
+> opens so the password only lives in the openssl session.
+
+Confirm the stored password matches what just worked:
+
+```bash
+security find-generic-password \
+  -s rusty-imap-mcp \
+  -a "default/you@proton.me@127.0.0.1" -w
+```
+
+The printed value should match byte-for-byte what you typed at the
+`LOGIN` prompt. If they differ, re-run `rusty-imap-mcp login`. For
+Linux equivalents and broader credential management, see
+[docs/troubleshooting.md](troubleshooting.md#verifying-and-managing-stored-credentials).
+
 ## Step 6: Add to your MCP client
 
 ### Claude Desktop

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -333,6 +333,36 @@ protocols, so no second `login` invocation is needed.
 The SMTP port shown above (1025) is the Proton Bridge default; the
 exact port appears in Bridge settings.
 
+### Optional: verify the SMTP credential authenticates
+
+`--dry-run` exercises IMAP only, so a wrong SMTP password surfaces
+inside the MCP client at first `send_email` attempt. Test it ahead of
+time with [`swaks`](https://github.com/jetmore/swaks)
+(`brew install swaks` on macOS, `apt install swaks` /
+`dnf install swaks` on Linux):
+
+```bash
+swaks --server 127.0.0.1:1025 --tls \
+      --auth LOGIN \
+      --auth-user you@proton.me \
+      --auth-password 'YOUR-BRIDGE-PASSWORD' \
+      --quit-after AUTH
+```
+
+`--quit-after AUTH` sends `EHLO` → STARTTLS → AUTH negotiation →
+`QUIT`. No message is transacted. Look for `235 ... Authentication
+succeeded` on the AUTH response — that's the credential confirmed.
+`535 ...` means Bridge rejected the password; re-copy it from
+Bridge settings (it's the bridge-specific password, not your Proton
+account password) and re-run `rusty-imap-mcp login`.
+
+> **Shell-history caveat.** The command above places your bridge
+> password on the command line. Prefix the entire command with a
+> space if your shell has `HISTCONTROL=ignorespace`, or omit
+> `--auth-password` and let swaks prompt for it on stderr.
+
+### Confirm the posture matrix
+
 Re-run `rusty-imap-mcp --dry-run` to confirm the matrix now shows
 `send_email` as `[ok ]`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -185,6 +185,47 @@ shell history. Use this only for diagnosis or in environments where
 the OS keyring genuinely isn't available. Move back to the keyring as
 soon as the underlying problem is fixed.
 
+**The env-var fallback is single-valued.** `RUSTY_IMAP_MCP_PASSWORD`
+is the only password env var; it serves IMAP and SMTP lookups
+indistinguishably (see `crates/rimap-config/src/credential.rs` —
+`resolve_credential` is called from both protocol paths with the
+same env var name). If your IMAP and SMTP passwords are identical
+(Gmail App Passwords, Proton Bridge passwords), this is fine. If
+they differ, the env-var fallback can silently feed the wrong
+password to one of the two protocols.
+
+For split-credential setups, use the keyring (each protocol uses its
+own key — `<account>/<imap_username>@<imap_host>` vs
+`<account>/<smtp_username>@<smtp_host>`) and switch the credential
+policy to keyring-only so a keyring miss fails loud instead of
+falling through to the wrong env var:
+
+```toml
+[defaults.credentials]
+fallback = "keyring-only"
+```
+
+The `fallback` field lives under `[defaults.credentials]` (applies
+to all accounts) or per-account under `[accounts.credentials]`. It
+is **not available in legacy single-account configs** (flat `[imap]`
+with no `[[accounts]]`) — `deny_unknown_fields` rejects a
+`[credentials]` block at the top level. To use keyring-only with a
+single account, migrate to the multi-account form:
+
+```toml
+[defaults.credentials]
+fallback = "keyring-only"
+
+[[accounts]]
+name = "default"
+imap = { host = "imap.example.com", port = 993, username = "you@example.com" }
+```
+
+See `crates/rimap-config/src/model.rs` (`FallbackMode` doc-comment)
+for the design rationale: the same hazard motivated the keyring-only
+mode for multi-account deployments and applies here within a single
+account.
+
 ### `--dry-run` does not verify credentials
 
 A successful `--dry-run` proves your config parses, your network

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,33 @@
 
 Diagnosing startup failures and runtime issues with `rusty-imap-mcp`.
 
+## "No prompts or tools found" / `tools/list` returns nothing
+
+If an MCP client reports that the server is reachable but exposes
+no tools, drive the stdio transport directly to see what the server
+actually returns:
+
+```bash
+./scripts/mcp-probe-tools.sh
+```
+
+The script auto-generates `/tmp/rimap-probe.toml` from your main
+config (rewriting `[audit].path` to a distinct file so it doesn't
+fight a running MCP client's audit lock), sends `initialize` +
+`notifications/initialized` + `tools/list`, and reports the tool
+count and names plus full stderr.
+
+- **Tool count matches the posture matrix (16 on draft-safe)** —
+  the gap is client-side. Capture the client's `initialize` request
+  via the stderr-capture shim below and inspect its
+  `clientCapabilities` plus the actual `tools/list` response in the
+  client's own logs. Spec-strict clients (e.g. `bobshell`) verify
+  the server's advertised capabilities first; the server must
+  declare `tools` in its `initialize` response or these clients
+  refuse to call `tools/list` at all.
+- **Tool count is 0 or the probe shows a server error** — the gap
+  is server-side; check the stderr output the script printed.
+
 ## "Connection closed" / "MCP error -32000" from your MCP client
 
 A generic transport error from the client (Claude Desktop, Claude Code,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,244 @@
+# Troubleshooting
+
+Diagnosing startup failures and runtime issues with `rusty-imap-mcp`.
+
+## "Connection closed" / "MCP error -32000" from your MCP client
+
+A generic transport error from the client (Claude Desktop, Claude Code,
+IBM Bob, Cursor, etc.) almost always means the server **exited before
+completing the MCP handshake**. The real error went to stderr. See
+[Where logs go](#where-logs-go) below.
+
+### First move: run the server from a terminal
+
+Reproduce the failure outside the MCP client with stderr visible:
+
+```bash
+RIMAP_LOG=debug rusty-imap-mcp --dry-run
+```
+
+`--dry-run` loads and validates the config, resolves credentials from
+the OS keychain, opens an IMAP/TLS connection, prints the posture
+matrix and capability list, and exits. It does **not** start the MCP
+transport, so any startup-stage failure surfaces as a normal stderr
+error instead of being hidden behind "connection closed."
+
+If `--dry-run` succeeds but the MCP client still fails, run the server
+without `--dry-run` and redirect stderr to a file:
+
+```bash
+RIMAP_LOG=debug rusty-imap-mcp 2>/tmp/rimap.log
+# press Ctrl-D to send EOF, then inspect the log
+```
+
+### Common root causes
+
+| Symptom in stderr | Cause | Fix |
+|-------------------|-------|-----|
+| `no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)` | Server could not locate a config file | Set `RUSTY_IMAP_MCP_CONFIG` in the client's MCP `env` block, pass `--config <path>`, or place the file at the platform default (see [configuration.md](configuration.md)) |
+| `audit file ... is already locked` | Another `rusty-imap-mcp` process holds the audit lock | Each MCP client must use a distinct `[audit].path`; see [Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients) |
+| `path ... is not writable: directory does not exist` | Audit log parent directory missing | Create it; `audit.path` must be absolute (no `~` — the TOML parser does not expand `~`) |
+| `audit path ... is not contained in allowed base ...` | `audit.path` is outside the platform-default base | Move the audit file under the default base, or set `audit.allowed_base_dir` explicitly |
+| `ERR_TLS` | TLS handshake failure | Verify network reachability to the IMAP host on port 993 |
+| `ERR_TLS: ... UnknownIssuer` | Server cert chains to a CA not in the compiled `webpki-roots` bundle (corporate internal CA, self-signed cert, or a TLS-inspection proxy presenting an internal CA) | Pin the leaf cert: capture via `--dry-run` and add `tls_fingerprint_sha256` to `[imap]`. See [Optional: pin the TLS certificate](quickstart-gmail.md#optional-pin-the-tls-certificate) for the procedure; pinning skips chain validation entirely |
+| `Capabilities ...: unavailable (...)` | Preflight could not complete | Inspect the parenthesised cause — typically DNS, connectivity, or TLS |
+| `ERR_CONFIG` | TOML parse or validation error | Check syntax and field names against [configuration.md](configuration.md) |
+| No credential found in keyring | `rusty-imap-mcp login` was never run for this account | Run `rusty-imap-mcp login --host <h> --username <u>` |
+
+### GUI MCP clients and PATH
+
+GUI applications launched from the macOS Dock or Spotlight (and the
+Linux equivalents) do **not** inherit your shell environment. `$PATH`
+is usually limited to `/usr/bin:/bin:/usr/sbin:/sbin`, and any env vars
+exported from `~/.zshrc` or `~/.bashrc` are invisible.
+
+For GUI MCP clients, use the absolute path to the binary and set
+`RUSTY_IMAP_MCP_CONFIG` explicitly in the client's MCP `env` block:
+
+```jsonc
+{
+  "mcpServers": {
+    "email": {
+      "command": "/Users/you/.cargo/bin/rusty-imap-mcp",
+      "env": {
+        "RUSTY_IMAP_MCP_CONFIG": "/Users/you/Library/Application Support/rusty-imap-mcp/config.toml"
+      }
+    }
+  }
+}
+```
+
+## Verifying and managing stored credentials
+
+`rusty-imap-mcp login` stores the IMAP/SMTP password in the OS-native
+secret store: macOS Keychain via the Security framework, Linux Secret
+Service (libsecret) via D-Bus. The MCP server never reads passwords
+from `config.toml`. If startup fails with `ERR_AUTH: credential
+unavailable`, the credential is either not stored, stored under a
+different key (typo in `--host` or `--username`), or stored but
+inaccessible from the launching process's context.
+
+The expected key is `<account>/<username>@<host>`, where `<account>`
+is `default` for a legacy single-account config (no `[[accounts]]`
+block) and the account ID otherwise. Service is always
+`rusty-imap-mcp`.
+
+### macOS
+
+The CLI is `security` (built in, no install). Keychain Access.app is
+the GUI equivalent.
+
+```bash
+# Existence check (no password retrieval)
+security find-generic-password \
+  -s rusty-imap-mcp \
+  -a "default/you@example.com@imap.example.com"
+# Exit 0 = found; exit 44 = not found.
+
+# Retrieve the password (exercises ACL — same path the server walks)
+security find-generic-password \
+  -s rusty-imap-mcp \
+  -a "default/you@example.com@imap.example.com" -w
+
+# List everything stored under the service (useful when the username
+# or host is uncertain or has a typo)
+security dump-keychain | rg -A 2 '"svce".*"rusty-imap-mcp"'
+
+# Delete a wrong entry
+security delete-generic-password \
+  -s rusty-imap-mcp \
+  -a "default/wrong-username@imap.example.com"
+```
+
+GUI: open **Keychain Access.app** → login keychain → search
+`rusty-imap-mcp`. Double-click an item → **Access Control** tab to
+view or widen the allow-list. Most GUI MCP clients launch the same
+binary path that `login` used, so the existing ACL applies — but
+macOS may prompt "Always Allow / Allow Once / Deny" on first
+GUI-context access. Pick **Always Allow** or you'll have to revisit
+the ACL panel each time.
+
+### Linux
+
+The CLI is `secret-tool` from the `libsecret-tools` package
+(`apt install libsecret-tools` on Debian/Ubuntu, `dnf install
+libsecret` on Fedora). The keyring crate stores items with these
+attributes:
+
+| Attribute | Value |
+|-----------|-------|
+| `service` | `rusty-imap-mcp` |
+| `username` | `<account>/<username>@<host>` |
+| `target` | `default` |
+| `application` | `rust-keyring` |
+
+```bash
+# Discover everything this binary has stored (shows all attributes,
+# useful when key strings are uncertain)
+secret-tool search service rusty-imap-mcp
+
+# Retrieve a specific password (prints it to stdout)
+secret-tool lookup \
+  service rusty-imap-mcp \
+  username "default/you@example.com@imap.example.com"
+
+# Delete an entry by matching attributes
+secret-tool clear \
+  service rusty-imap-mcp \
+  username "default/wrong-username@imap.example.com"
+```
+
+GUI: **Seahorse** ("Passwords and Keys") on GNOME, **KWalletManager**
+on KDE. Look under "Login" or the equivalent default keyring.
+
+The Secret Service requires a running `dbus-daemon` and a Secret
+Service provider (`gnome-keyring-daemon`, `kwallet`, or a headless
+alternative like `pass-secret-service`). On headless servers without
+a desktop session, neither `secret-tool` nor `rusty-imap-mcp login`
+will work — fall back to the `RUSTY_IMAP_MCP_PASSWORD` environment
+variable (see [Fallback: environment variable](#fallback-environment-variable)
+below).
+
+### Windows
+
+Pre-built binaries are not currently published for Windows targets
+(see [README.md](../README.md#pre-built-binaries) for the release
+matrix). Windows support would use Credential Manager via the same
+keyring crate, but is untested and unsupported. Build from source at
+your own risk.
+
+### Fallback: environment variable
+
+If the keyring path is blocked (headless host, no Secret Service
+provider, ACL denied, debugging) the server reads
+`RUSTY_IMAP_MCP_PASSWORD` from the environment as a last resort:
+
+```jsonc
+"env": {
+  "RUSTY_IMAP_MCP_PASSWORD": "...",
+  "RUSTY_IMAP_MCP_CONFIG": "..."
+}
+```
+
+Environment variables leak through process listings, crash dumps, and
+shell history. Use this only for diagnosis or in environments where
+the OS keyring genuinely isn't available. Move back to the keyring as
+soon as the underlying problem is fixed.
+
+### `--dry-run` does not verify credentials
+
+A successful `--dry-run` proves your config parses, your network
+reaches the IMAP server, and your TLS configuration is correct. It
+does **not** prove your credential is stored — the preflight probe
+deliberately stops before `LOGIN` (see
+`crates/rimap-imap/src/preflight.rs`). If `--dry-run` succeeds but
+your MCP client fails on auth, run the verification commands above
+before assuming the credential is fine.
+
+## Where logs go
+
+`rusty-imap-mcp` writes diagnostic logs (from the `tracing` framework)
+to **stderr only**. There is no log file, no rotation, no
+`RIMAP_LOG_FILE` setting.
+
+This is by design: stdout is reserved for the MCP JSON-RPC transport,
+so the server can never write logs there. The project does not own a
+debug log file — routing stderr is the operator's choice.
+
+The separate `[audit]` block in `config.toml` controls the **audit
+event log** (structured JSONL: tool calls, auth events, process
+lifecycle). It is not a debug log and contains nothing from before
+audit initialization.
+
+### Log level
+
+The level filter is read from the `RIMAP_LOG` env var first, then
+`RUST_LOG`, then defaults to `info`. Both use the standard
+`tracing-subscriber` `EnvFilter` syntax:
+
+```bash
+RIMAP_LOG=debug rusty-imap-mcp
+RIMAP_LOG=rimap_imap=trace,info rusty-imap-mcp   # per-module override
+```
+
+### Capturing stderr from GUI MCP clients
+
+GUI MCP clients typically launch the server with stdin/stdout wired to
+the protocol and stderr inherited or discarded. To capture stderr,
+wrap the binary in a shim script:
+
+```sh
+#!/bin/sh
+# ~/bin/rusty-imap-mcp-debug
+exec /Users/you/.cargo/bin/rusty-imap-mcp "$@" 2>>/tmp/rusty-imap-mcp.stderr.log
+```
+
+```bash
+chmod +x ~/bin/rusty-imap-mcp-debug
+```
+
+Point the MCP client's `command` at the shim instead of the binary,
+add `RIMAP_LOG=debug` to its `env` block, and tail
+`/tmp/rusty-imap-mcp.stderr.log` while the client reconnects. Remove
+the shim once the cause is identified — appending to a long-lived log
+file leaks diagnostic data over time.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -189,11 +189,25 @@ soon as the underlying problem is fixed.
 
 A successful `--dry-run` proves your config parses, your network
 reaches the IMAP server, and your TLS configuration is correct. It
-does **not** prove your credential is stored — the preflight probe
-deliberately stops before `LOGIN` (see
-`crates/rimap-imap/src/preflight.rs`). If `--dry-run` succeeds but
-your MCP client fails on auth, run the verification commands above
-before assuming the credential is fine.
+does **not** prove your credentials authenticate — the preflight
+probe deliberately stops before `LOGIN` (see
+`crates/rimap-imap/src/preflight.rs`), and SMTP isn't touched at all.
+
+The verify-the-credential-stored commands above prove the keyring
+entry exists, but not that the stored password is accepted by the
+server. To exercise authentication directly:
+
+- **IMAP:** see "Optional: verify the credential authenticates" in
+  [quickstart-gmail.md](quickstart-gmail.md#optional-verify-the-credential-authenticates)
+  or [quickstart-proton-bridge.md](quickstart-proton-bridge.md#optional-verify-the-credential-authenticates)
+  — uses `openssl s_client` to send `LOGIN` / `LOGOUT` directly.
+- **SMTP:** see the "Verify the SMTP credential" step in the
+  "Optional: enable sending" section of either quickstart — uses
+  `swaks --quit-after AUTH` to exercise AUTH without transacting a
+  message.
+
+Built-in support for both is tracked in
+[issue #259](https://github.com/randomparity/rusty-imap-mcp/issues/259).
 
 ## Where logs go
 

--- a/scripts/mcp-probe-tools.sh
+++ b/scripts/mcp-probe-tools.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Speak MCP directly to rusty-imap-mcp's stdio transport and report what
+# `tools/list` returns. Use when an MCP client (Claude Desktop, Claude Code,
+# IBM Bob, etc.) reports "no tools exposed" — this isolates whether the gap is
+# server-side (server returns 0 tools) or client-side (server returns tools,
+# client doesn't display them).
+#
+# Usage: scripts/mcp-probe-tools.sh [path/to/config.toml]
+#
+# With no argument the script uses /tmp/rimap-probe.toml — and auto-generates
+# it from your main config (RUSTY_IMAP_MCP_CONFIG or the platform default) if
+# it doesn't exist. The probe config gets a different [audit].path so it
+# doesn't fight a running MCP client's audit lock.
+set -euo pipefail
+
+CONFIG="${1:-}"
+BIN="$(command -v rusty-imap-mcp || true)"
+
+if [ -z "$BIN" ]; then
+    echo "rusty-imap-mcp not on PATH" >&2
+    echo "install with: cargo install --path crates/rimap-server --locked" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null; then
+    echo "jq is required" >&2
+    exit 1
+fi
+
+# Resolve probe config. Priority:
+#   1. Explicit argument
+#   2. Existing /tmp/rimap-probe.toml
+#   3. Auto-generate /tmp/rimap-probe.toml from the main config
+if [ -z "$CONFIG" ] && [ -f "/tmp/rimap-probe.toml" ]; then
+    CONFIG="/tmp/rimap-probe.toml"
+fi
+if [ -z "$CONFIG" ]; then
+    # Locate the main config to derive from.
+    MAIN_CONFIG="${RUSTY_IMAP_MCP_CONFIG:-}"
+    if [ -z "$MAIN_CONFIG" ]; then
+        for candidate in \
+            "$HOME/Library/Application Support/rusty-imap-mcp/config.toml" \
+            "$HOME/.config/rusty-imap-mcp/config.toml"; do
+            if [ -f "$candidate" ]; then
+                MAIN_CONFIG="$candidate"
+                break
+            fi
+        done
+    fi
+    if [ -z "$MAIN_CONFIG" ] || [ ! -f "$MAIN_CONFIG" ]; then
+        echo "no main config found (set RUSTY_IMAP_MCP_CONFIG or place a config" >&2
+        echo "at the platform default), and no probe config path was provided." >&2
+        exit 1
+    fi
+
+    # Extract the main audit.path so the probe audit can live next to it
+    # (under the same allowed_base_dir) with a distinct filename.
+    MAIN_AUDIT="$(awk '
+		BEGIN { in_audit = 0 }
+		/^\[audit\]/ { in_audit = 1; next }
+		/^\[/ && in_audit { exit }
+		in_audit && /^[[:space:]]*path[[:space:]]*=/ {
+			match($0, /"[^"]*"/)
+			if (RSTART > 0) {
+				print substr($0, RSTART + 1, RLENGTH - 2)
+				exit
+			}
+		}
+	' "$MAIN_CONFIG")"
+    if [ -z "$MAIN_AUDIT" ]; then
+        echo "could not extract [audit].path from $MAIN_CONFIG" >&2
+        exit 1
+    fi
+    PROBE_AUDIT="$(dirname "$MAIN_AUDIT")/audit-probe.jsonl"
+    CONFIG="/tmp/rimap-probe.toml"
+
+    awk -v new_path="$PROBE_AUDIT" '
+		BEGIN { in_audit = 0 }
+		/^\[audit\]/ { in_audit = 1; print; next }
+		/^\[/ && in_audit { in_audit = 0 }
+		in_audit && /^[[:space:]]*path[[:space:]]*=/ {
+			print "path = \"" new_path "\""
+			next
+		}
+		{ print }
+	' "$MAIN_CONFIG" >"$CONFIG"
+
+    echo "generated probe config: $CONFIG"
+    echo "  - source:      $MAIN_CONFIG"
+    echo "  - audit.path:  $PROBE_AUDIT"
+    echo
+fi
+
+if [ ! -f "$CONFIG" ]; then
+    echo "config not found: $CONFIG" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t rimap-probe.XXXXXX)"
+ENVELOPE="$WORKDIR/probe.jsonl"
+STDOUT_LOG="$WORKDIR/stdout.log"
+STDERR_LOG="$WORKDIR/stderr.log"
+
+# Build the JSON-RPC envelopes via jq -nc. Each call emits one compact line, so
+# there's no risk of terminal width wrapping a JSON object across two lines.
+{
+    jq -nc '{jsonrpc:"2.0",id:1,method:"initialize",params:{protocolVersion:"2025-06-18",capabilities:{},clientInfo:{name:"probe",version:"1.0"}}}'
+    jq -nc '{jsonrpc:"2.0",method:"notifications/initialized"}'
+    jq -nc '{jsonrpc:"2.0",id:2,method:"tools/list",params:{}}'
+} >"$ENVELOPE"
+
+printf 'config:   %s\n' "$CONFIG"
+printf 'binary:   %s\n' "$BIN"
+printf 'workdir:  %s\n' "$WORKDIR"
+echo
+
+set +e
+RUSTY_IMAP_MCP_CONFIG="$CONFIG" "$BIN" <"$ENVELOPE" >"$STDOUT_LOG" 2>"$STDERR_LOG"
+EXIT_CODE=$?
+set -e
+
+echo "=== stdout (JSON-RPC responses) ==="
+if [ -s "$STDOUT_LOG" ]; then
+    jq -c '.' <"$STDOUT_LOG" 2>/dev/null || cat "$STDOUT_LOG"
+else
+    echo "(empty — server wrote nothing to stdout before exiting)"
+fi
+echo
+
+echo "=== tools/list summary ==="
+TOOL_COUNT="$(jq -s '[.[] | select(.id == 2) | .result.tools] | first | length // 0' "$STDOUT_LOG" 2>/dev/null || echo "?")"
+echo "tool count: $TOOL_COUNT"
+if [ "$TOOL_COUNT" != "0" ] && [ "$TOOL_COUNT" != "?" ]; then
+    echo "tool names:"
+    jq -r -s '.[] | select(.id == 2) | .result.tools[].name' "$STDOUT_LOG" 2>/dev/null | sed 's/^/  /'
+fi
+echo
+
+echo "=== stderr (server logs) ==="
+if [ -s "$STDERR_LOG" ]; then
+    cat "$STDERR_LOG"
+else
+    echo "(empty)"
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+    echo
+    echo "server exited with code $EXIT_CODE"
+fi


### PR DESCRIPTION
## Summary

Surfaced during onboarding to IBM Bob and `bobshell` against an IBM internal IMAP server. Two threads, kept on one branch because the docs work directly preceded and led to the bug fix.

**One server-side bug fix** (`fix(mcp)`):

- `initialize` response now advertises the `tools` and `resources` capabilities. `ServerCapabilities::default()` produced all-`None` fields, which combined with `skip_serializing_if = "Option::is_none"` made the wire payload `"capabilities": {}`. Per the MCP spec, servers MUST declare a capability for each feature they support; spec-strict clients (`bobshell`) refuse to call `tools/list` and report "No prompts or tools found on the server." Permissive clients (Claude Desktop, IBM Bob desktop 3.26.6) call `tools/list` anyway and never surface the bug.

**Docs walkthrough fixes** uncovered while debugging IBM Bob onboarding end-to-end. Each piece closes a real gap that bit during the session:

- **TLS cert pinning in Gmail quickstart** — the dry-run already prints a paste-ready `tls_fingerprint_sha256 = "..."` line, but no step in the quickstart said "now do that paste." Frames pinning as optional defense-in-depth, with corporate TLS-inspection proxies and local MITM called out as the scenarios where it matters (the IBM scenario hit here).
- **`docs/troubleshooting.md`** — new doc covering "Connection closed" / `MCP error -32000`, where logs actually go (stderr only, by design — stdout is the JSON-RPC transport), the GUI-client PATH/env-inheritance pitfalls, and the stderr-capture shim pattern.
- **Per-OS credential management** — macOS `security` CLI, Linux `secret-tool` with the exact attribute schema sourced from the pinned `keyring-3.6.3` release, Windows explicitly called out as unsupported. `RUSTY_IMAP_MCP_PASSWORD` env-var fallback documented with leak caveats and the single-credential limitation (`fallback = "keyring-only"` pointer for split-credential setups).
- **Credential verification step** in both quickstarts — `--dry-run` deliberately stops before `LOGIN`, so a wrong stored password surfaces inside the MCP client's stderr. New "Optional: verify the credential authenticates" subsection uses `openssl s_client` for IMAP and `swaks --quit-after AUTH` for SMTP. Both protocols covered.
- **`scripts/mcp-probe-tools.sh`** — diagnostic that drives the stdio MCP transport directly and reports the `tools/list` response. Auto-generates a probe config from the main config (rewriting `[audit].path` so it doesn't fight a running MCP client's lock). This is the script that found the capability-declaration bug.

**Filed during this work** (tracked separately, not in this PR):

- #259 — `feat(cli): credential verification mode for preflight` (IMAP + SMTP)
- #260 — `feat(config): per-protocol password env vars`

## Commits

```
b5086b8 docs(scripts): add mcp-probe-tools.sh diagnostic + cross-link
5102c0a fix(mcp): advertise tools and resources capabilities in get_info()
372d829 docs(troubleshooting): document single-valued env-var fallback
60c2d8b docs: add SMTP credential verification step and cross-links
d056b2d docs(quickstart): add optional credential verification step
b227d75 docs(troubleshooting): add guide for startup, logs, credentials
64d3123 docs(quickstart-gmail): add optional TLS fingerprint pinning step
```

## Test plan

- [x] `crates/rimap-server/tests/server_capabilities.rs` — 4 regression tests covering the typed `ServerCapabilities` and the on-the-wire JSON shape (guards against future field-rename or `skip_serializing_if` regression that would re-emit `"capabilities": {}`).
- [x] `cargo test -p rimap-server --tests` — full integration suite passes (201 lib tests + cli_smoke, dispatch_ticket, e2e, dry_run_cli, audit_merge, audit_fail_open, server_capabilities).
- [x] `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings` — clean.
- [x] Pre-push hooks ran `just test` (cargo nextest) + `cargo deny check` — clean.
- [x] `scripts/mcp-probe-tools.sh` — shellcheck + shfmt clean (4-space indent per project config).
- [ ] Manual verification needed: rebuild the binary in your environment (`cargo install --path crates/rimap-server --locked --force`), restart `bobshell` / Bob, run `/mcp list` and confirm 16 tools appear under the `email` server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)