### PR TITLE
fix(mcp): use proper object schema for no-arg tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `list_folders` and `list_accounts` now advertise a proper
+  `"type": "object"` `inputSchema` instead of a bare `{}`. Spec-strict
+  MCP clients (e.g. `bobshell`'s Zod validator) reject any tool whose
+  `inputSchema.type` is not the string `"object"` and surface
+  `invalid_value` errors at tool-discovery time. `{}` is a valid JSON
+  Schema (matches anything) but the wrong shape for MCP. New
+  `every_tool_input_schema_declares_object_type` regression test
+  guards every entry in `TOOL_DEFS`.
 - `initialize` response now advertises the `tools` and `resources`
   capabilities. Previously `get_info()` returned
   `ServerCapabilities::default()` (all-`None` fields), so the wire

--- a/crates/rimap-server/src/mcp/tool_catalog.rs
+++ b/crates/rimap-server/src/mcp/tool_catalog.rs
@@ -63,6 +63,24 @@ fn schema_map<T: schemars::JsonSchema>() -> serde_json::Map<String, serde_json::
     }
 }
 
+/// JSON Schema for a tool that takes no arguments. The MCP spec models
+/// `inputSchema` as an object schema (`"type": "object"`) — a bare `{}` is
+/// technically a permissive JSON Schema but spec-strict clients (e.g.
+/// `bobshell`'s Zod validator) reject any tool whose `inputSchema.type`
+/// is not the string `"object"`.
+fn no_args_schema() -> serde_json::Map<String, serde_json::Value> {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "type".to_string(),
+        serde_json::Value::String("object".into()),
+    );
+    map.insert(
+        "properties".to_string(),
+        serde_json::Value::Object(serde_json::Map::new()),
+    );
+    map
+}
+
 /// Return (description, schema) for the given `ToolName`, or `None`
 /// for sub-capabilities that share an MCP tool name with a parent
 /// (e.g. `SearchAdvanced`, `FetchMessageHtml`).
@@ -83,7 +101,7 @@ fn tool_spec(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::retrieval::list_attachments::ListAttachmentsInput;
     use crate::tools::retrieval::search::SearchInput;
     let tuple = match name {
-        ToolName::ListFolders => ("List all IMAP folders", serde_json::Map::new()),
+        ToolName::ListFolders => ("List all IMAP folders", no_args_schema()),
         ToolName::Search => (
             "Search messages with structured query",
             schema_map::<SearchInput>(),
@@ -152,7 +170,7 @@ fn tool_spec(name: ToolName) -> Option<ToolSpec> {
             "Set the active account for subsequent tool calls",
             schema_map::<UseAccountInput>(),
         ),
-        ToolName::ListAccounts => ("List all configured email accounts", serde_json::Map::new()),
+        ToolName::ListAccounts => ("List all configured email accounts", no_args_schema()),
         // Sub-capabilities that share an MCP tool name with a parent
         // (e.g. `SearchAdvanced` shares `search`; `FetchMessageHtml`
         // shares `fetch_message`) are advertised under the parent entry,
@@ -222,15 +240,29 @@ mod tests {
             .into_iter()
             .filter_map(|tn| TOOL_DEFS.get(&tn))
         {
-            // list_folders and list_accounts have no input — empty
-            // schema is expected.
-            if def.name == "list_folders" || def.name == "list_accounts" {
-                continue;
-            }
             let schema = &def.input_schema;
             assert!(
                 !schema.is_empty(),
                 "tool {} has empty input schema",
+                def.name,
+            );
+        }
+    }
+
+    #[test]
+    fn every_tool_input_schema_declares_object_type() {
+        // Spec-strict MCP clients (e.g. bobshell's Zod validator) reject
+        // any tool whose inputSchema.type is not the string "object". A
+        // bare `{}` is a valid JSON Schema but the wrong shape for MCP.
+        for def in ToolName::all()
+            .into_iter()
+            .filter_map(|tn| TOOL_DEFS.get(&tn))
+        {
+            let type_field = def.input_schema.get("type");
+            assert_eq!(
+                type_field.and_then(serde_json::Value::as_str),
+                Some("object"),
+                "tool {} input_schema.type must be the string \"object\"; got {type_field:?}",
                 def.name,
             );
         }


### PR DESCRIPTION
## Summary

`list_folders` and `list_accounts` take no arguments, and their `inputSchema` was emitted as `serde_json::Map::new()` — a bare `{}` on the wire. That is a valid JSON Schema (matches anything) but the wrong shape for MCP: spec-strict clients (e.g. `bobshell`'s Zod validator) reject any tool whose `inputSchema.type` is not the string `"object"` and report errors at tool discovery:

```
Invalid input: expected "object"
path: ["tools", 1, "inputSchema", "type"]
path: ["tools", 2, "inputSchema", "type"]
```

(Indices 1 and 2 are `list_accounts` and `list_folders` respectively.)

Adds a `no_args_schema()` helper returning `{"type": "object", "properties": {}}` and switches both no-arg tools to use it. The change is one-line per tool plus an 8-line helper with a doc comment explaining why a bare `{}` is the wrong shape.

The pre-existing `tool_definitions_have_non_empty_schemas` test special-cased `list_folders` / `list_accounts` because the old design assumed empty schemas were fine. That exception is removed and a new strict invariant lands as `every_tool_input_schema_declares_object_type`: every entry in `TOOL_DEFS` must have `input_schema.type == "object"`. Any future no-arg tool added with the wrong shape will fail this test.

## Why this slipped past #261

Permissive MCP clients (Claude Desktop, IBM Bob desktop, the probe in `scripts/mcp-probe-tools.sh`) accept a bare `{}` and treat it as "any input is valid." The bug only surfaces against spec-strict clients. The capability-declaration fix in #261 unblocked discovery for `bobshell`, which then immediately hit this second issue at the schema-validation stage.

Both this bug and the #261 bug are wire-shape issues that are invisible from the Rust API surface — `crates/rimap-server/tests/e2e.rs` calls `ImapMcpServer::dispatch_account_scoped` directly and never traverses serialization. A four-phase test harness to permanently close that gap is now tracked as:

- #263 — Phase 1: Rust wire-shape conformance (zero-account, jsonschema crate, every PR)
- #264 — Phase 2: Node strict-client conformance via official SDK (Zod-validated)
- #265 — Phase 3: Behavioral conformance via stdio against Dovecot fixture
- #266 — Phase 4: Protocol fuzzing + negative-path coverage

## Test plan

- [x] `cargo test -p rimap-server --lib mcp::tool_catalog` — 6/6 pass including the new `every_tool_input_schema_declares_object_type` regression
- [x] `cargo test -p rimap-server --tests` — full integration suite passes (no regressions in dispatch_ticket, e2e, server_capabilities, etc.)
- [x] `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings` — clean
- [x] Pre-push hooks ran `just test` (cargo nextest) + `cargo deny check advisories bans` — clean
- [ ] Manual verification needed: rebuild the binary in your environment (`cargo install --path crates/rimap-server --locked --force`), restart `bobshell`, and confirm tool discovery no longer reports the Zod `invalid_value` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)