### PR TITLE
test(mcp): Phase 1 wire-shape conformance harness (#263)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF line endings for vendored MCP spec schemas so the
+# upstream-verbatim invariant survives Windows checkouts with
+# core.autocrlf=true. The weekly drift check
+# (.github/workflows/mcp-spec-drift.yml, issue #263) compares the
+# vendored copy byte-for-byte against upstream; any CRLF churn
+# would surface as false-positive drift.
+crates/rimap-server/tests/fixtures/mcp-spec/** text eol=lf

--- a/.github/workflows/mcp-spec-drift.yml
+++ b/.github/workflows/mcp-spec-drift.yml
@@ -1,0 +1,80 @@
+# Weekly drift detector for the vendored MCP spec schemas consumed by
+# crates/rimap-server/tests/mcp_wire_conformance.rs. See
+# docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md §3.5.
+
+name: mcp-spec-drift
+
+on:
+  schedule:
+    # Mondays 12:00 UTC. Cron is best-effort on GitHub Actions but
+    # weekly cadence is fine here — we only need eventual notice.
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mcp-spec-drift
+  cancel-in-progress: false
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    env:
+      PINNED_VERSION: '2025-11-25'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run drift check
+        id: check
+        run: |
+          set -euo pipefail
+          if ./scripts/refresh-mcp-spec.sh --check "${PINNED_VERSION}"; then
+            echo "drift=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "drift=true" >> "${GITHUB_OUTPUT}"
+            # Capture the diff for the issue body. The script wrote
+            # the diff to stderr — re-run and capture both streams.
+            ./scripts/refresh-mcp-spec.sh --check "${PINNED_VERSION}" \
+              > drift-diff.txt 2>&1 || true
+          fi
+
+      - name: Open or update tracking issue on drift
+        if: steps.check.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="MCP spec drift: ${PINNED_VERSION}/schema.json"
+          body_file="$(mktemp)"
+          {
+            echo "Weekly drift check found differences between the vendored"
+            echo "MCP spec at \`crates/rimap-server/tests/fixtures/mcp-spec/${PINNED_VERSION}/schema.json\`"
+            echo "and upstream \`modelcontextprotocol/modelcontextprotocol@main\`."
+            echo ""
+            echo "Run \`scripts/refresh-mcp-spec.sh ${PINNED_VERSION}\` to update the vendored copy"
+            echo "and re-run \`cargo test -p rimap-server --test mcp_wire_conformance\` to confirm"
+            echo "the harness still validates."
+            echo ""
+            echo "<details><summary>diff</summary>"
+            echo ""
+            echo '```diff'
+            cat drift-diff.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > "${body_file}"
+          existing="$(gh issue list --label mcp-spec-drift --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          if [[ -n "${existing}" ]]; then
+            gh issue comment "${existing}" --body-file "${body_file}"
+          else
+            gh issue create --title "${title}" --label mcp-spec-drift --body-file "${body_file}"
+          fi
+          # Fail the run so the Actions tab badge reflects drift even
+          # if the issue mechanism somehow no-ops.
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,15 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^(tests/injection-corpus/|fuzz/corpus/|crates/rimap-content/data/confusables\.txt$)
+        exclude: ^(tests/injection-corpus/|fuzz/corpus/|crates/rimap-content/data/confusables\.txt$|crates/rimap-server/tests/fixtures/mcp-spec/)
       - id: end-of-file-fixer
         # Email fixtures are byte-exact; auto-appending a final newline
         # (or stripping a trailing CRLF pair) corrupts them. The vendored
         # Unicode 16 confusables.txt is byte-identical to the upstream
-        # file and must not be mangled.
-        exclude: ^(tests/injection-corpus/|fuzz/corpus/|crates/rimap-content/data/confusables\.txt$)
+        # file and must not be mangled. The vendored MCP spec schemas
+        # under tests/fixtures/mcp-spec/ are byte-for-byte verbatim
+        # copies of upstream and feed the weekly drift check.
+        exclude: ^(tests/injection-corpus/|fuzz/corpus/|crates/rimap-content/data/confusables\.txt$|crates/rimap-server/tests/fixtures/mcp-spec/)
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MCP wire-shape conformance test
+  (`crates/rimap-server/tests/mcp_wire_conformance.rs`) — spawns the
+  binary, drives JSON-RPC over stdio, and validates every response
+  against the vendored MCP spec schema. Permanent regression net for
+  #261 (empty capabilities) and `fix/tool-input-schema-object-type`
+  (empty inputSchema). Issue #263.
+- `scripts/refresh-mcp-spec.sh` to refresh or drift-check the vendored
+  MCP spec schema.
+- `.github/workflows/mcp-spec-drift.yml` — weekly check that opens a
+  tracking issue when the vendored MCP schema differs from upstream.
+
+### Changed
+
+- `rimap-config` now accepts configs with `accounts = []`. The server
+  boots in infrastructure-only mode (only `list_accounts` /
+  `use_account` are functionally useful). Unblocks the wire-conformance
+  harness. Removes `ConfigError::NoAccounts`.
+
 ### Fixed
 
 - `list_folders` and `list_accounts` now advertise a proper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3172,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +288,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -554,6 +580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +728,9 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -756,6 +791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +868,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1295,6 +1362,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,10 +1675,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1606,6 +1776,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -2061,6 +2237,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.46.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2420,7 @@ dependencies = [
  "governor",
  "hex",
  "infer",
+ "jsonschema",
  "mail-builder",
  "mail-parser",
  "predicates",
@@ -3131,6 +3325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,10 +3421,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,12 @@ tempfile = "3.14"
 proptest = "1.6"
 temp-env = "0.3"
 insta = { version = "1.47", features = ["json"] }
+# JSON Schema validator used only by integration tests
+# (crates/rimap-server/tests/mcp_wire_conformance.rs) to validate MCP
+# JSON-RPC envelopes against the vendored MCP spec schemas. Pure-Rust,
+# Draft 2020-12 capable. Reviewed for supply-chain risk per
+# SC-PROC-01 on plan execution date.
+jsonschema = { version = "0.46", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,8 +204,27 @@ insta = { version = "1.47", features = ["json"] }
 # JSON Schema validator used only by integration tests
 # (crates/rimap-server/tests/mcp_wire_conformance.rs) to validate MCP
 # JSON-RPC envelopes against the vendored MCP spec schemas. Pure-Rust,
-# Draft 2020-12 capable. Reviewed for supply-chain risk per
-# SC-PROC-01 on plan execution date.
+# Draft 2020-12 capable. Test-only scope — not shipped in release
+# binaries — so the audit bar is lighter than for runtime deps.
+# SC-PROC-01 review 2026-05-12: three crates in the new transitive
+# closure carry a `build.rs`. All three are local-only codegen with no
+# network, filesystem-outside-OUT_DIR, or arbitrary process spawn:
+#   - `ahash 0.8.12`             — calls `version_check` to gate
+#                                  stable-vs-nightly rustc intrinsics.
+#   - `ref-cast 1.0.25`          — execs `rustc --version` to gate
+#                                  `cfg(no_phantom_pinned)` /
+#                                  `cfg(no_intrinsic_type_name)` and
+#                                  writes a generated `private.rs` to
+#                                  `OUT_DIR`.
+#   - `unicode-general-category` — emits a compile-time UAX #44
+#                                  category lookup table to `OUT_DIR`
+#                                  from the in-crate `src/tables.rs`.
+# The remaining new transitives (`referencing`, `fluent-uri`,
+# `fancy-regex`, `bit-set`, `bit-vec`, `bytecount`, `data-encoding`,
+# `email_address`, `fraction`, `num`, `num-bigint`, `num-complex`,
+# `num-integer`, `num-iter`, `num-rational`, `num-cmp`, `uuid-simd`,
+# `vsimd`, `outref`, `borrow-or-share`, `micromap`) are pure-data
+# crates: no build.rs, no proc-macros.
 jsonschema = { version = "0.46", default-features = false }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,25 +206,26 @@ insta = { version = "1.47", features = ["json"] }
 # JSON-RPC envelopes against the vendored MCP spec schemas. Pure-Rust,
 # Draft 2020-12 capable. Test-only scope — not shipped in release
 # binaries — so the audit bar is lighter than for runtime deps.
-# SC-PROC-01 review 2026-05-12: three crates in the new transitive
-# closure carry a `build.rs`. All three are local-only codegen with no
-# network, filesystem-outside-OUT_DIR, or arbitrary process spawn:
-#   - `ahash 0.8.12`             — calls `version_check` to gate
-#                                  stable-vs-nightly rustc intrinsics.
-#   - `ref-cast 1.0.25`          — execs `rustc --version` to gate
-#                                  `cfg(no_phantom_pinned)` /
-#                                  `cfg(no_intrinsic_type_name)` and
-#                                  writes a generated `private.rs` to
-#                                  `OUT_DIR`.
-#   - `unicode-general-category` — emits a compile-time UAX #44
-#                                  category lookup table to `OUT_DIR`
-#                                  from the in-crate `src/tables.rs`.
-# The remaining new transitives (`referencing`, `fluent-uri`,
-# `fancy-regex`, `bit-set`, `bit-vec`, `bytecount`, `data-encoding`,
-# `email_address`, `fraction`, `num`, `num-bigint`, `num-complex`,
-# `num-integer`, `num-iter`, `num-rational`, `num-cmp`, `uuid-simd`,
-# `vsimd`, `outref`, `borrow-or-share`, `micromap`) are pure-data
-# crates: no build.rs, no proc-macros.
+# SC-PROC-01 review 2026-05-12: relative to the prior workspace
+# lockfile this entry adds 22 new transitives. Build-time-executed
+# surface (3 crates, all local-only codegen with no network,
+# filesystem-outside-`OUT_DIR`, or arbitrary process spawn):
+#   - `ahash 0.8.12`              — build.rs calls `version_check` to
+#                                   gate stable-vs-nightly rustc
+#                                   intrinsics; no net/fs/process.
+#   - `unicode-general-category 1.1.0`
+#                                 — build.rs emits a UAX #44 category
+#                                   lookup table to `OUT_DIR` from the
+#                                   in-crate `src/tables.rs`.
+#   - `version_check 0.9.5`       — pure library; no build.rs of its
+#                                   own, but invoked from `ahash`'s
+#                                   build.rs at compile time.
+# Remaining 19 new transitives are pure-data (no build.rs, no
+# proc-macros): `borrow-or-share`, `bytecount`, `data-encoding`,
+# `fancy-regex`, `fluent-uri`, `fraction`, `jsonschema`, `micromap`,
+# `num`, `num-bigint`, `num-cmp`, `num-complex`, `num-integer`,
+# `num-iter`, `num-rational`, `outref`, `referencing`, `uuid-simd`,
+# `vsimd`.
 jsonschema = { version = "0.46", default-features = false }
 
 [workspace.lints.rust]

--- a/crates/rimap-config/src/error.rs
+++ b/crates/rimap-config/src/error.rs
@@ -162,6 +162,16 @@ pub enum ConfigError {
     /// Account name failed validation.
     #[error(transparent)]
     InvalidAccountName(#[from] InvalidAccountName),
+    /// Multi-account config has an empty `[[accounts]]` array.
+    ///
+    /// Codex adversarial review (PR #270, 2026-05-12) flagged that
+    /// silently accepting empty-accounts configs in production makes
+    /// broken deployments look identical to healthy zero-data servers.
+    /// The check stays in production; tests opt in via
+    /// [`crate::validate::validate_multi_allowing_empty`] behind the
+    /// `test-support` feature.
+    #[error("no accounts defined in [[accounts]] array")]
+    NoAccounts,
 }
 
 #[cfg(test)]

--- a/crates/rimap-config/src/error.rs
+++ b/crates/rimap-config/src/error.rs
@@ -162,9 +162,6 @@ pub enum ConfigError {
     /// Account name failed validation.
     #[error(transparent)]
     InvalidAccountName(#[from] InvalidAccountName),
-    /// Multi-account config has an empty `[[accounts]]` array.
-    #[error("no accounts defined in [[accounts]] array")]
-    NoAccounts,
 }
 
 #[cfg(test)]

--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -17,6 +17,8 @@ pub use crate::credential::{
     resolve_credential,
 };
 pub use crate::error::ConfigError;
+#[cfg(feature = "test-support")]
+pub use crate::loader::load_and_validate_allowing_empty;
 pub use crate::loader::{CONFIG_ENV_VAR, load_and_validate, load_from_path, resolve_config_path};
 pub use crate::login::{run_login, tty_prompt};
 pub use crate::model::{
@@ -24,6 +26,8 @@ pub use crate::model::{
     ImapConfig, LimitsConfig, LookalikeConfig, MultiAccountConfig, RawAccountConfig,
     SecurityConfig, SmtpConfig, SmtpEncryption, Verdict,
 };
+#[cfg(feature = "test-support")]
+pub use crate::validate::validate_multi_allowing_empty;
 pub use crate::validate::{
     ValidatedAccountConfig, ValidatedMultiConfig, validate_legacy_as_multi, validate_multi,
 };

--- a/crates/rimap-config/src/loader.rs
+++ b/crates/rimap-config/src/loader.rs
@@ -14,6 +14,8 @@ use directories::ProjectDirs;
 
 use crate::error::ConfigError;
 use crate::model::{Config, MultiAccountConfig};
+#[cfg(feature = "test-support")]
+use crate::validate::validate_multi_allowing_empty;
 use crate::validate::{ValidatedMultiConfig, validate_legacy_as_multi, validate_multi};
 
 /// Organization qualifiers for `directories::ProjectDirs`.
@@ -67,6 +69,43 @@ pub fn load_from_path(path: &Path) -> Result<Config, ConfigError> {
 /// # Errors
 /// Returns `ConfigError` on read, parse, or validation failure.
 pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigError> {
+    match classify_format(path)? {
+        DetectedFormat::Multi(config) => validate_multi(config),
+        DetectedFormat::Legacy(config) => validate_legacy_as_multi(config),
+    }
+}
+
+/// Variant of [`load_and_validate`] that, for multi-account format,
+/// invokes [`crate::validate::validate_multi_allowing_empty`] so the
+/// wire-conformance harness can spawn the binary with `accounts = []`.
+/// Gated behind the `test-support` feature.
+///
+/// # Errors
+/// Same surface as [`load_and_validate`], minus `ConfigError::NoAccounts`
+/// for empty multi-account configs.
+#[cfg(feature = "test-support")]
+pub fn load_and_validate_allowing_empty(path: &Path) -> Result<ValidatedMultiConfig, ConfigError> {
+    match classify_format(path)? {
+        DetectedFormat::Multi(config) => validate_multi_allowing_empty(config),
+        DetectedFormat::Legacy(config) => validate_legacy_as_multi(config),
+    }
+}
+
+/// Detected on-disk config shape after reading + parsing the file.
+///
+/// Multi-account vs legacy classification happens here so the two
+/// validating entrypoints ([`load_and_validate`] and, under
+/// `test-support`, [`load_and_validate_allowing_empty`]) share the
+/// same I/O and format-detection path.
+enum DetectedFormat {
+    Multi(MultiAccountConfig),
+    Legacy(Config),
+}
+
+/// Read `path`, parse it as TOML, and classify it as multi-account or
+/// legacy. Returns [`ConfigError::MixedConfigFormat`] if both shapes
+/// appear in the same document.
+fn classify_format(path: &Path) -> Result<DetectedFormat, ConfigError> {
     let contents = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
         path: path.to_path_buf(),
         source,
@@ -98,13 +137,13 @@ pub fn load_and_validate(path: &Path) -> Result<ValidatedMultiConfig, ConfigErro
             path: path.to_path_buf(),
             source,
         })?;
-        validate_multi(config)
+        Ok(DetectedFormat::Multi(config))
     } else {
         let config: Config = value.try_into().map_err(|source| ConfigError::Parse {
             path: path.to_path_buf(),
             source,
         })?;
-        validate_legacy_as_multi(config)
+        Ok(DetectedFormat::Legacy(config))
     }
 }
 

--- a/crates/rimap-config/src/validate/mod.rs
+++ b/crates/rimap-config/src/validate/mod.rs
@@ -69,10 +69,6 @@ pub struct ValidatedMultiConfig {
 /// # Errors
 /// Returns `ConfigError` on any validation failure.
 pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig, ConfigError> {
-    if config.accounts.is_empty() {
-        return Err(ConfigError::NoAccounts);
-    }
-
     let mut accounts = BTreeMap::new();
     for raw in config.accounts {
         let id = AccountId::new(&raw.name)?;
@@ -751,11 +747,17 @@ allowed_base_dir = "{}"
     }
 
     #[test]
-    fn no_accounts_rejected() {
+    fn empty_accounts_array_validates_for_infrastructure_only_boot() {
+        // Before: the server refused to boot with zero accounts. This
+        // blocked the MCP wire-conformance harness (#263) from probing
+        // initialize / tools/list / resources/list without standing up
+        // an IMAP fixture. Empty accounts now validates cleanly; the
+        // resulting AccountRegistry is empty and list_accounts returns
+        // [], which is the correct infrastructure-only behavior.
         let dir = TempDir::new().unwrap();
         let cfg = base_multi_config(dir.path(), vec![]);
-        let err = validate_multi(cfg).unwrap_err();
-        assert!(matches!(err, ConfigError::NoAccounts));
+        let validated = validate_multi(cfg).unwrap();
+        assert!(validated.accounts.is_empty());
     }
 
     #[test]

--- a/crates/rimap-config/src/validate/mod.rs
+++ b/crates/rimap-config/src/validate/mod.rs
@@ -69,6 +69,10 @@ pub struct ValidatedMultiConfig {
 /// # Errors
 /// Returns `ConfigError` on any validation failure.
 pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig, ConfigError> {
+    if config.accounts.is_empty() {
+        return Err(ConfigError::NoAccounts);
+    }
+
     let mut accounts = BTreeMap::new();
     for raw in config.accounts {
         let id = AccountId::new(&raw.name)?;
@@ -747,17 +751,17 @@ allowed_base_dir = "{}"
     }
 
     #[test]
-    fn empty_accounts_array_validates_for_infrastructure_only_boot() {
-        // Before: the server refused to boot with zero accounts. This
-        // blocked the MCP wire-conformance harness (#263) from probing
-        // initialize / tools/list / resources/list without standing up
-        // an IMAP fixture. Empty accounts now validates cleanly; the
-        // resulting AccountRegistry is empty and list_accounts returns
-        // [], which is the correct infrastructure-only behavior.
+    fn empty_accounts_array_rejected_by_production_validator() {
+        // Production must fail-fast on `accounts = []` so operators
+        // immediately see a broken deployment instead of a healthy
+        // zero-data server (Codex adversarial review on PR #270).
         let dir = TempDir::new().unwrap();
         let cfg = base_multi_config(dir.path(), vec![]);
-        let validated = validate_multi(cfg).unwrap();
-        assert!(validated.accounts.is_empty());
+        let err = validate_multi(cfg).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::NoAccounts),
+            "expected ConfigError::NoAccounts, got {err:?}",
+        );
     }
 
     #[test]

--- a/crates/rimap-config/src/validate/mod.rs
+++ b/crates/rimap-config/src/validate/mod.rs
@@ -72,7 +72,30 @@ pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig
     if config.accounts.is_empty() {
         return Err(ConfigError::NoAccounts);
     }
+    validate_multi_inner(config)
+}
 
+/// Variant of [`validate_multi`] that skips the empty-accounts
+/// rejection. Used exclusively by the wire-conformance harness so the
+/// production server can fail-fast on `accounts = []` while tests
+/// still spawn an infrastructure-only binary. Gated behind the
+/// `test-support` feature.
+///
+/// # Errors
+/// Same surface as [`validate_multi`], minus `ConfigError::NoAccounts`
+/// for empty multi-account configs.
+#[cfg(feature = "test-support")]
+pub fn validate_multi_allowing_empty(
+    config: MultiAccountConfig,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    validate_multi_inner(config)
+}
+
+/// Shared body of [`validate_multi`] and (under `test-support`)
+/// [`validate_multi_allowing_empty`]. Performs per-account validation
+/// and global path checks; does not enforce the non-empty accounts
+/// invariant — callers must do that when required.
+fn validate_multi_inner(config: MultiAccountConfig) -> Result<ValidatedMultiConfig, ConfigError> {
     let mut accounts = BTreeMap::new();
     for raw in config.accounts {
         let id = AccountId::new(&raw.name)?;
@@ -626,6 +649,8 @@ path = "/tmp/audit.jsonl"
 
     use crate::model::{DefaultsConfig, MultiAccountConfig, RawAccountConfig};
     use crate::validate::validate_multi;
+    #[cfg(feature = "test-support")]
+    use crate::validate::validate_multi_allowing_empty;
 
     fn base_multi_config(
         audit_dir: &std::path::Path,
@@ -762,6 +787,19 @@ allowed_base_dir = "{}"
             matches!(err, ConfigError::NoAccounts),
             "expected ConfigError::NoAccounts, got {err:?}",
         );
+    }
+
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn empty_accounts_array_validates_under_test_support() {
+        // Mirror of the previous task's intent, now routed through the
+        // test-only relaxed validator. The wire-conformance harness
+        // depends on this path to spawn the binary with `accounts = []`
+        // (Codex review on PR #270).
+        let dir = TempDir::new().unwrap();
+        let cfg = base_multi_config(dir.path(), vec![]);
+        let validated = validate_multi_allowing_empty(cfg).unwrap();
+        assert!(validated.accounts.is_empty());
     }
 
     #[test]

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -65,5 +65,5 @@ rimap-imap = { path = "../rimap-imap", version = "0.1.0", features = ["test-supp
 # integration tests, so `ImapMcpServer::execute_tool_for_test` is in
 # scope without every test harness passing `--features test-support`.
 rimap-server = { path = ".", version = "0.1.0", features = ["test-support"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "io-util"] }
 tempfile = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -16,7 +16,11 @@ default = []
 # Gated entry points for integration tests that need to exercise the
 # full dispatch pipeline (posture → breaker → rate → audit envelope →
 # handler) without re-implementing the composition in each test.
-test-support = []
+# Also enables the `--allow-empty-accounts` CLI flag on the binary so
+# the wire-conformance harness (#263) can boot with `accounts = []`;
+# propagates to `rimap-config/test-support` to expose
+# `load_and_validate_allowing_empty`.
+test-support = ["rimap-config/test-support"]
 
 [lib]
 name = "rimap_server"

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -56,6 +56,7 @@ tempfile = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+jsonschema = { workspace = true }
 mail-parser = { workspace = true }
 rimap-audit = { path = "../rimap-audit", version = "0.1.0", features = ["test-injection"] }
 rimap-config = { path = "../rimap-config", version = "0.1.0", features = ["test-support"] }

--- a/crates/rimap-server/src/cli/mod.rs
+++ b/crates/rimap-server/src/cli/mod.rs
@@ -34,6 +34,15 @@ pub struct Cli {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Skip the empty-accounts rejection in `rimap_config::validate_multi`.
+    /// Used by the wire-conformance harness (#263) so the binary can
+    /// boot with `accounts = []`. Hidden from `--help` because it is a
+    /// test-only knob; compiled out entirely when the `test-support`
+    /// feature is off.
+    #[cfg(feature = "test-support")]
+    #[arg(long, hide = true)]
+    pub allow_empty_accounts: bool,
+
     /// Subcommand (optional; default is the MCP server loop — not yet implemented).
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -113,8 +113,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
 
     // Server mode: load config, build subsystems, run MCP transport.
     let config_path = resolve_cli_config_path(&cli)?;
-    let multi = load_and_validate(&config_path)
-        .with_context(|| format!("loading config {}", config_path.display()))?;
+    let multi = load_validated_multi(&cli, &config_path)?;
     let audit = audit_init::init_audit_writer_multi(&multi, &config_path)
         .with_context(|| format!("opening audit log at {}", multi.audit.path.display()))?;
 
@@ -182,6 +181,30 @@ fn resolve_cli_config_path(cli: &Cli) -> anyhow::Result<PathBuf> {
         .ok_or_else(|| {
             anyhow::anyhow!("no config path (pass --config or set RUSTY_IMAP_MCP_CONFIG)")
         })
+}
+
+/// Load and validate the multi-account config, optionally relaxing the
+/// empty-accounts rejection when `--allow-empty-accounts` is set.
+///
+/// `--allow-empty-accounts` is a `#[cfg(feature = "test-support")]` CLI
+/// flag (#263 Codex adversarial review). In production builds the field
+/// does not exist and we always hit the strict loader.
+fn load_validated_multi(
+    cli: &Cli,
+    config_path: &std::path::Path,
+) -> anyhow::Result<rimap_config::validate::ValidatedMultiConfig> {
+    #[cfg(feature = "test-support")]
+    let result = if cli.allow_empty_accounts {
+        rimap_config::loader::load_and_validate_allowing_empty(config_path)
+    } else {
+        load_and_validate(config_path)
+    };
+    #[cfg(not(feature = "test-support"))]
+    let result = {
+        let _ = cli; // suppress unused-binding warning when flag is compiled out
+        load_and_validate(config_path)
+    };
+    result.with_context(|| format!("loading config {}", config_path.display()))
 }
 
 /// Build the account registry from a validated multi-account config.

--- a/crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+++ b/crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
@@ -1,0 +1,4058 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "items": {
+                        "$ref": "#/$defs/Role"
+                    },
+                    "type": "array"
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "audio",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
+            "type": "object"
+        },
+        "BaseMetadata": {
+            "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "BlobResourceContents": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "blob",
+                "uri"
+            ],
+            "type": "object"
+        },
+        "BooleanSchema": {
+            "properties": {
+                "default": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "boolean",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/call",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CallToolRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CallToolRequestParams": {
+            "description": "Parameters for a `tools/call` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "arguments": {
+                    "additionalProperties": {},
+                    "description": "Arguments to use for the tool call.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "CallToolResult": {
+            "description": "The server's response to a tool call.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+                    "type": "boolean"
+                },
+                "structuredContent": {
+                    "additionalProperties": {},
+                    "description": "An optional JSON object that represents the structured result of the tool call.",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "content"
+            ],
+            "type": "object"
+        },
+        "CancelTaskRequest": {
+            "description": "A request to cancel a task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/cancel",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to cancel.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "taskId"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CancelTaskResult": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "The response to a tasks/cancel request."
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.\n\nFor task cancellation, use the `tasks/cancel` request instead of this notification.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/cancelled",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CancelledNotificationParams": {
+            "description": "Parameters for a `notifications/cancelled` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "reason": {
+                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                    "type": "string"
+                },
+                "requestId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction.\nThis MUST be provided for cancelling non-task requests.\nThis MUST NOT be used for cancelling tasks (use the `tasks/cancel` request instead)."
+                }
+            },
+            "type": "object"
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "properties": {
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "properties": {
+                        "form": {
+                            "additionalProperties": true,
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "url": {
+                            "additionalProperties": true,
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "additionalProperties": true,
+                        "properties": {},
+                        "type": "object"
+                    },
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object"
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "properties": {
+                        "context": {
+                            "additionalProperties": true,
+                            "description": "Whether the client supports context inclusion via includeContext parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it).",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "tools": {
+                            "additionalProperties": true,
+                            "description": "Whether the client supports tool use via tools and toolChoice parameters.",
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tasks": {
+                    "description": "Present if the client supports task-augmented requests.",
+                    "properties": {
+                        "cancel": {
+                            "additionalProperties": true,
+                            "description": "Whether this client supports tasks/cancel.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "list": {
+                            "additionalProperties": true,
+                            "description": "Whether this client supports tasks/list.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "properties": {
+                                "elicitation": {
+                                    "description": "Task support for elicitation-related requests.",
+                                    "properties": {
+                                        "create": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the client supports task-augmented elicitation/create requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "sampling": {
+                                    "description": "Task support for sampling-related requests.",
+                                    "properties": {
+                                        "createMessage": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the client supports task-augmented sampling/createMessage requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ClientNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/InitializedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/TaskStatusNotification"
+                },
+                {
+                    "$ref": "#/$defs/RootsListChangedNotification"
+                }
+            ]
+        },
+        "ClientRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/InitializeRequest"
+                },
+                {
+                    "$ref": "#/$defs/PingRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceRequest"
+                },
+                {
+                    "$ref": "#/$defs/SubscribeRequest"
+                },
+                {
+                    "$ref": "#/$defs/UnsubscribeRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsRequest"
+                },
+                {
+                    "$ref": "#/$defs/CallToolRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadRequest"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListTasksRequest"
+                },
+                {
+                    "$ref": "#/$defs/SetLevelRequest"
+                },
+                {
+                    "$ref": "#/$defs/CompleteRequest"
+                }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsResult"
+                },
+                {
+                    "$ref": "#/$defs/ElicitResult"
+                }
+            ]
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "completion/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CompleteRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CompleteRequestParams": {
+            "description": "Parameters for a `completion/complete` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "argument": {
+                    "description": "The argument's information",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the argument",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the argument to use for completion matching.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "type": "object"
+                },
+                "context": {
+                    "description": "Additional, optional context for completions",
+                    "properties": {
+                        "arguments": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Previously-resolved variables in a URI template or prompt.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ref": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PromptReference"
+                        },
+                        {
+                            "$ref": "#/$defs/ResourceTemplateReference"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "argument",
+                "ref"
+            ],
+            "type": "object"
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "completion": {
+                    "properties": {
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+                            "type": "boolean"
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "values"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "completion"
+            ],
+            "type": "object"
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ResourceLink"
+                },
+                {
+                    "$ref": "#/$defs/EmbeddedResource"
+                }
+            ]
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "sampling/createMessage",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CreateMessageRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CreateMessageRequestParams": {
+            "description": "Parameters for a `sampling/createMessage` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "includeContext": {
+                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is \"none\". Values \"thisServer\" and \"allServers\" are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares ClientCapabilities.sampling.context. These values may be removed in future spec releases.",
+                    "enum": [
+                        "allServers",
+                        "none",
+                        "thisServer"
+                    ],
+                    "type": "string"
+                },
+                "maxTokens": {
+                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/SamplingMessage"
+                    },
+                    "type": "array"
+                },
+                "metadata": {
+                    "additionalProperties": true,
+                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "modelPreferences": {
+                    "$ref": "#/$defs/ModelPreferences",
+                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                },
+                "stopSequences": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "systemPrompt": {
+                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "toolChoice": {
+                    "$ref": "#/$defs/ToolChoice",
+                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.\nDefault is `{ mode: \"auto\" }`."
+                },
+                "tools": {
+                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "maxTokens",
+                "messages"
+            ],
+            "type": "object"
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/createMessage request from the server.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- \"endTurn\": Natural end of the assistant's turn\n- \"stopSequence\": A stop sequence was encountered\n- \"maxTokens\": Maximum token limit was reached\n- \"toolUse\": The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ],
+            "type": "object"
+        },
+        "CreateTaskResult": {
+            "description": "A response to a task-augmented request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/Task"
+                }
+            },
+            "required": [
+                "task"
+            ],
+            "type": "object"
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "elicitation/create",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ElicitRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "ElicitRequestFormParams": {
+            "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "message": {
+                    "description": "The message to present to the user describing what information is being requested.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "form",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "requestedSchema": {
+                    "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "properties",
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "required": [
+                "message",
+                "requestedSchema"
+            ],
+            "type": "object"
+        },
+        "ElicitRequestParams": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/ElicitRequestURLParams"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequestFormParams"
+                }
+            ],
+            "description": "The parameters for a request to elicit additional information from the user via the client."
+        },
+        "ElicitRequestURLParams": {
+            "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "elicitationId": {
+                    "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The message to present to the user explaining why the interaction is needed.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "url",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "url": {
+                    "description": "The URL that the user should navigate to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "elicitationId",
+                "message",
+                "mode",
+                "url"
+            ],
+            "type": "object"
+        },
+        "ElicitResult": {
+            "description": "The client's response to an elicitation request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
+                    "type": "string"
+                },
+                "content": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "boolean"
+                                ]
+                            }
+                        ]
+                    },
+                    "description": "The submitted form data, only present when action is \"accept\" and mode was \"form\".\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "action"
+            ],
+            "type": "object"
+        },
+        "ElicitationCompleteNotification": {
+            "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/elicitation/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "elicitationId": {
+                            "description": "The ID of the elicitation that completed.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "elicitationId"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/$defs/BlobResourceContents"
+                        }
+                    ]
+                },
+                "type": {
+                    "const": "resource",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ],
+            "type": "object"
+        },
+        "EmptyResult": {
+            "$ref": "#/$defs/Result"
+        },
+        "EnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ],
+            "type": "object"
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/get",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/GetPromptRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetPromptRequestParams": {
+            "description": "Parameters for a `prompts/get` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "arguments": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Arguments to use for templating the prompt.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/PromptMessage"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "messages"
+            ],
+            "type": "object"
+        },
+        "GetTaskPayloadRequest": {
+            "description": "A request to retrieve the result of a completed task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/result",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to retrieve results for.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "taskId"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetTaskPayloadResult": {
+            "additionalProperties": {},
+            "description": "The response to a tasks/result request.\nThe structure matches the result type of the original request.\nFor example, a tools/call task would return the CallToolResult structure.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "GetTaskRequest": {
+            "description": "A request to retrieve the state of a task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/get",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to query.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "taskId"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetTaskResult": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "The response to a tasks/get request."
+        },
+        "Icon": {
+            "description": "An optionally-sized icon that can be displayed in a user interface.",
+            "properties": {
+                "mimeType": {
+                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+                    "type": "string"
+                },
+                "sizes": {
+                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "src": {
+                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD takes steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "theme": {
+                    "description": "Optional specifier for the theme this icon is designed for. `light` indicates\nthe icon is designed to be used with a light background, and `dark` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+                    "enum": [
+                        "dark",
+                        "light"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "src"
+            ],
+            "type": "object"
+        },
+        "Icons": {
+            "description": "Base interface to add `icons` property.",
+            "properties": {
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "image",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
+            "type": "object"
+        },
+        "Implementation": {
+            "description": "Describes the MCP implementation.",
+            "properties": {
+                "description": {
+                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "version"
+            ],
+            "type": "object"
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "initialize",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/InitializeRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "InitializeRequestParams": {
+            "description": "Parameters for an `initialize` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ClientCapabilities"
+                },
+                "clientInfo": {
+                    "$ref": "#/$defs/Implementation"
+                },
+                "protocolVersion": {
+                    "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "capabilities",
+                "clientInfo",
+                "protocolVersion"
+            ],
+            "type": "object"
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ServerCapabilities"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "serverInfo": {
+                    "$ref": "#/$defs/Implementation"
+                }
+            },
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ],
+            "type": "object"
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/initialized",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "JSONRPCErrorResponse": {
+            "description": "A response to a request that indicates an error occurred.",
+            "properties": {
+                "error": {
+                    "$ref": "#/$defs/Error"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
+            "type": "object"
+        },
+        "JSONRPCMessage": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCRequest"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCNotification"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "JSONRPCResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "A response to a request, containing either the result or error."
+        },
+        "JSONRPCResultResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
+            "type": "object"
+        },
+        "LegacyTitledEnumSchema": {
+            "description": "Use TitledSingleSelectEnumSchema instead.\nThis interface will be removed in a future version.",
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "enumNames": {
+                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "prompts": {
+                    "items": {
+                        "$ref": "#/$defs/Prompt"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "prompts"
+            ],
+            "type": "object"
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/templates/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resourceTemplates": {
+                    "items": {
+                        "$ref": "#/$defs/ResourceTemplate"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "resourceTemplates"
+            ],
+            "type": "object"
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resources": {
+                    "items": {
+                        "$ref": "#/$defs/Resource"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "resources"
+            ],
+            "type": "object"
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "roots/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "roots": {
+                    "items": {
+                        "$ref": "#/$defs/Root"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "roots"
+            ],
+            "type": "object"
+        },
+        "ListTasksRequest": {
+            "description": "A request to retrieve a list of tasks.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListTasksResult": {
+            "description": "The response to a tasks/list request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "tasks": {
+                    "items": {
+                        "$ref": "#/$defs/Task"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "tasks"
+            ],
+            "type": "object"
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "tools": {
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "tools"
+            ],
+            "type": "object"
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
+            "type": "string"
+        },
+        "LoggingMessageNotification": {
+            "description": "JSONRPCNotification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/message",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/LoggingMessageNotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "LoggingMessageNotificationParams": {
+            "description": "Parameters for a `notifications/message` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "data": {
+                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                },
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The severity of this log message."
+                },
+                "logger": {
+                    "description": "An optional name of the logger issuing this message.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "data",
+                "level"
+            ],
+            "type": "object"
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "properties": {
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "items": {
+                        "$ref": "#/$defs/ModelHint"
+                    },
+                    "type": "array"
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "MultiSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                }
+            ]
+        },
+        "Notification": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
+        "NotificationParams": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NumberSchema": {
+            "properties": {
+                "default": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "maximum": {
+                    "type": "integer"
+                },
+                "minimum": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "PaginatedRequest": {
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "PaginatedRequestParams": {
+            "description": "Common parameters for paginated requests.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "cursor": {
+                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "PaginatedResult": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "ping",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "PrimitiveSchemaDefinition": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/StringSchema"
+                },
+                {
+                    "$ref": "#/$defs/NumberSchema"
+                },
+                {
+                    "$ref": "#/$defs/BooleanSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ],
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/progress",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ProgressNotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "ProgressNotificationParams": {
+            "description": "Parameters for a `notifications/progress` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "message": {
+                    "description": "An optional message describing the current progress.",
+                    "type": "string"
+                },
+                "progress": {
+                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                    "type": "number"
+                },
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                },
+                "total": {
+                    "description": "Total number of items to process (or total progress required), if known.",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "progress",
+                "progressToken"
+            ],
+            "type": "object"
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "items": {
+                        "$ref": "#/$defs/PromptArgument"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/prompts/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "properties": {
+                "content": {
+                    "$ref": "#/$defs/ContentBlock"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ],
+            "type": "object"
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ref/prompt",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/read",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ReadResourceRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "ReadResourceRequestParams": {
+            "description": "Parameters for a `resources/read` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "contents": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobResourceContents"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "contents"
+            ],
+            "type": "object"
+        },
+        "RelatedTaskMetadata": {
+            "description": "Metadata for associating messages with a task.\nInclude this in the `_meta` field under the key `io.modelcontextprotocol/related-task`.",
+            "properties": {
+                "taskId": {
+                    "description": "The task identifier this message is associated with.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "taskId"
+            ],
+            "type": "object"
+        },
+        "Request": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "RequestParams": {
+            "description": "Common params for any request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "resource_link",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ResourceRequestParams": {
+            "description": "Common parameters when working with resources.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ],
+            "type": "object"
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "properties": {
+                "type": {
+                    "const": "ref/resource",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/updated",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "ResourceUpdatedNotificationParams": {
+            "description": "Parameters for a `notifications/resources/updated` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "Result": {
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
+            ],
+            "type": "string"
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/roots/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ],
+            "type": "object"
+        },
+        "SamplingMessageContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolUseContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolResultContent"
+                }
+            ]
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "properties": {
+                "completions": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "additionalProperties": true,
+                        "properties": {},
+                        "type": "object"
+                    },
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object"
+                },
+                "logging": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        },
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tasks": {
+                    "description": "Present if the server supports task-augmented requests.",
+                    "properties": {
+                        "cancel": {
+                            "additionalProperties": true,
+                            "description": "Whether this server supports tasks/cancel.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "list": {
+                            "additionalProperties": true,
+                            "description": "Whether this server supports tasks/list.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "properties": {
+                                "tools": {
+                                    "description": "Task support for tool-related requests.",
+                                    "properties": {
+                                        "call": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the server supports task-augmented tools/call requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/$defs/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/TaskStatusNotification"
+                },
+                {
+                    "$ref": "#/$defs/LoggingMessageNotification"
+                },
+                {
+                    "$ref": "#/$defs/ElicitationCompleteNotification"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/PingRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadRequest"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListTasksRequest"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequest"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/InitializeResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptResult"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsResult"
+                },
+                {
+                    "$ref": "#/$defs/CallToolResult"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CompleteResult"
+                }
+            ]
+        },
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "logging/setLevel",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SetLevelRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "SetLevelRequestParams": {
+            "description": "Parameters for a `logging/setLevel` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                }
+            },
+            "required": [
+                "level"
+            ],
+            "type": "object"
+        },
+        "SingleSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                }
+            ]
+        },
+        "StringSchema": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "enum": [
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
+                    ],
+                    "type": "string"
+                },
+                "maxLength": {
+                    "type": "integer"
+                },
+                "minLength": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/subscribe",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscribeRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "SubscribeRequestParams": {
+            "description": "Parameters for a `resources/subscribe` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "Task": {
+            "description": "Data associated with a task.",
+            "properties": {
+                "createdAt": {
+                    "description": "ISO 8601 timestamp when the task was created.",
+                    "type": "string"
+                },
+                "lastUpdatedAt": {
+                    "description": "ISO 8601 timestamp when the task was last updated.",
+                    "type": "string"
+                },
+                "pollInterval": {
+                    "description": "Suggested polling interval in milliseconds.",
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/$defs/TaskStatus",
+                    "description": "Current task state."
+                },
+                "statusMessage": {
+                    "description": "Optional human-readable message describing the current task state.\nThis can provide context for any status, including:\n- Reasons for \"cancelled\" status\n- Summaries for \"completed\" status\n- Diagnostic information for \"failed\" status (e.g., error details, what went wrong)",
+                    "type": "string"
+                },
+                "taskId": {
+                    "description": "The task identifier.",
+                    "type": "string"
+                },
+                "ttl": {
+                    "description": "Actual retention duration from creation in milliseconds, null for unlimited.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "createdAt",
+                "lastUpdatedAt",
+                "status",
+                "taskId",
+                "ttl"
+            ],
+            "type": "object"
+        },
+        "TaskAugmentedRequestParams": {
+            "description": "Common params for any task-augmented request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "type": "object"
+        },
+        "TaskMetadata": {
+            "description": "Metadata for augmenting a request with task execution.\nInclude this in the `task` field of the request parameters.",
+            "properties": {
+                "ttl": {
+                    "description": "Requested duration in milliseconds to retain task from creation.",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "TaskStatus": {
+            "description": "The status of a task.",
+            "enum": [
+                "cancelled",
+                "completed",
+                "failed",
+                "input_required",
+                "working"
+            ],
+            "type": "string"
+        },
+        "TaskStatusNotification": {
+            "description": "An optional notification from the receiver to the requestor, informing them that a task's status has changed. Receivers are not required to send these notifications.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/tasks/status",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/TaskStatusNotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "TaskStatusNotificationParams": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "Parameters for a `notifications/tasks/status` notification."
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "text",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TextResourceContents": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ],
+            "type": "object"
+        },
+        "TitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for array items with enum options and display labels.",
+                    "properties": {
+                        "anyOf": {
+                            "description": "Array of enum options with values and display labels.",
+                            "items": {
+                                "properties": {
+                                    "const": {
+                                        "description": "The constant enum value.",
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "description": "Display title for this option.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "const",
+                                    "title"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "anyOf"
+                    ],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Array of enum options with values and display labels.",
+                    "items": {
+                        "properties": {
+                            "const": {
+                                "description": "The enum value.",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Display label for this option.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "const",
+                            "title"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "oneOf",
+                "type"
+            ],
+            "type": "object"
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
+                },
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "execution": {
+                    "$ref": "#/$defs/ToolExecution",
+                    "description": "Execution-related properties for this tool."
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "outputSchema": {
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.\n\nDefaults to JSON Schema 2020-12 when no explicit $schema is provided.\nCurrently restricted to type: \"object\" at the root level.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ],
+            "type": "object"
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+            "properties": {
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolChoice": {
+            "description": "Controls tool selection behavior for sampling requests.",
+            "properties": {
+                "mode": {
+                    "description": "Controls the tool use ability of the model:\n- \"auto\": Model decides whether to use tools (default)\n- \"required\": Model MUST use at least one tool before completing\n- \"none\": Model MUST NOT use any tools",
+                    "enum": [
+                        "auto",
+                        "none",
+                        "required"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolExecution": {
+            "description": "Execution-related properties for a tool.",
+            "properties": {
+                "taskSupport": {
+                    "description": "Indicates whether this tool supports task-augmented execution.\nThis allows clients to handle long-running operations through polling\nthe task system.\n\n- \"forbidden\": Tool does not support task-augmented execution (default when absent)\n- \"optional\": Tool may support task-augmented execution\n- \"required\": Tool requires task-augmented execution\n\nDefault: \"forbidden\"",
+                    "enum": [
+                        "forbidden",
+                        "optional",
+                        "required"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/tools/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
+            "type": "object"
+        },
+        "ToolResultContent": {
+            "description": "The result of a tool use, provided by the user back to the assistant.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as CallToolResult.content and can include text, images,\naudio, resource links, and embedded resources.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+                    "type": "boolean"
+                },
+                "structuredContent": {
+                    "additionalProperties": {},
+                    "description": "An optional structured result object.\n\nIf the tool defined an outputSchema, this SHOULD conform to that schema.",
+                    "type": "object"
+                },
+                "toolUseId": {
+                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous ToolUseContent.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_result",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "toolUseId",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ToolUseContent": {
+            "description": "A request from the assistant to call a tool.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "id": {
+                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                    "type": "string"
+                },
+                "input": {
+                    "additionalProperties": {},
+                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the tool to call.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_use",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "input",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "URLElicitationRequiredError": {
+            "description": "An error response that indicates that the server requires the client to provide additional information via an elicitation request.",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "properties": {
+                                "code": {
+                                    "const": -32042,
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "additionalProperties": {},
+                                    "properties": {
+                                        "elicitations": {
+                                            "items": {
+                                                "$ref": "#/$defs/ElicitRequestURLParams"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "elicitations"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "required": [
+                                "code",
+                                "data"
+                            ],
+                            "type": "object"
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
+            "type": "object"
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/unsubscribe",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/UnsubscribeRequestParams"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "UnsubscribeRequestParams": {
+            "description": "Parameters for a `resources/unsubscribe` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "UntitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for the array items.",
+                    "properties": {
+                        "enum": {
+                            "description": "Array of enum values to choose from.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "string",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "enum",
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ],
+            "type": "object"
+        },
+        "UntitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "Array of enum values to choose from.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ],
+            "type": "object"
+        }
+    }
+}
+

--- a/crates/rimap-server/tests/fixtures/mcp-spec/README.md
+++ b/crates/rimap-server/tests/fixtures/mcp-spec/README.md
@@ -1,0 +1,34 @@
+# Vendored MCP Specification Schemas
+
+This directory holds verbatim copies of the JSON Schema documents
+published by the [Model Context Protocol specification][spec-repo].
+They are consumed exclusively by the wire-conformance test
+(`crates/rimap-server/tests/mcp_wire_conformance.rs`, issue #263).
+
+## Pinned version
+
+`2025-11-25/schema.json` — fetched from
+
+    https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json
+
+This matches `rmcp::model::ProtocolVersion::LATEST` for `rmcp 1.5`,
+which is what `rusty-imap-mcp` advertises by default during the
+`initialize` handshake.
+
+## Refresh / drift workflow
+
+- `scripts/refresh-mcp-spec.sh <version>` overwrites the vendored
+  copy with the current upstream contents.
+- `scripts/refresh-mcp-spec.sh --check <version>` exits non-zero if
+  the vendored copy differs from upstream.
+- `.github/workflows/mcp-spec-drift.yml` runs the check weekly and
+  opens (or updates) a tracking issue when drift is detected.
+
+## Local diffs
+
+None. The vendored copy is byte-for-byte verbatim; if a future
+rmcp / spec mismatch forces us to relax a strict constraint (e.g. a
+fragment with `additionalProperties: false` that rmcp violates),
+document the diff here and link the rationale.
+
+[spec-repo]: https://github.com/modelcontextprotocol/modelcontextprotocol

--- a/crates/rimap-server/tests/fixtures/mcp-spec/README.md
+++ b/crates/rimap-server/tests/fixtures/mcp-spec/README.md
@@ -31,4 +31,17 @@ rmcp / spec mismatch forces us to relax a strict constraint (e.g. a
 fragment with `additionalProperties: false` that rmcp violates),
 document the diff here and link the rationale.
 
+## Naming notes for downstream code
+
+The 2025-11-25 schema's `$defs` splits the JSON-RPC envelope into
+three definitions:
+
+- `JSONRPCResponse` — `anyOf` union of the two leaves below
+- `JSONRPCResultResponse` — successful result envelope
+- `JSONRPCErrorResponse` — error envelope (NOT `JSONRPCError`)
+
+When validating wire payloads in the conformance harness, prefer the
+leaf names (`JSONRPCResultResponse` / `JSONRPCErrorResponse`) over
+the union.
+
 [spec-repo]: https://github.com/modelcontextprotocol/modelcontextprotocol

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -304,3 +304,24 @@ async fn wire_initialize_advertises_tools_capability() {
         "capabilities.tools must be present on the wire; got {capabilities}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_protocol_version_negotiation_matches_vendored_schema() {
+    // Sends an initialize request with the LATEST version known to
+    // the test, asks the server to echo it back. rmcp negotiates
+    // min(client, server), so when the server bumps to a newer
+    // LATEST this still succeeds — but if the server somehow
+    // negotiates to an older version (e.g. the pinned string is
+    // wrong) this test catches it. The fragment-validation tests
+    // depend on this invariant.
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        json!(PINNED_PROTOCOL_VERSION),
+        "harness pinned to {PINNED_PROTOCOL_VERSION} but server returned a \
+         different value; either update PINNED_PROTOCOL_VERSION + the \
+         tests/fixtures/mcp-spec/<version>/ directory, or fix the rmcp \
+         negotiation regression. Full response: {response}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -130,6 +130,7 @@ allowed_base_dir = "{}"
         assert!(read > 0, "stdout closed before responding to {method}");
         let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
         assert_eq!(response["id"], json!(id), "response id must match request");
+        assert_envelope_valid(&response);
         response
     }
 
@@ -259,6 +260,34 @@ fn assert_valid(value: &Value, fragment: &'static str) {
             "schema validation failed for fragment {fragment}:\n  {}",
             errors.join("\n  ")
         );
+    }
+}
+
+/// Validate the FULL JSON-RPC envelope returned by `Harness::request`.
+/// Success responses validate against `JSONRPCResultResponse`; error
+/// responses validate against `JSONRPCErrorResponse`. Asserts the
+/// `jsonrpc` version field on both paths. Codex adversarial review
+/// finding #2 (PR #270): the previous negative-path tests checked only
+/// `code` and `message` and would have missed a regression that
+/// stripped `jsonrpc` or otherwise mangled the envelope.
+fn assert_envelope_valid(response: &Value) {
+    assert_eq!(
+        response["jsonrpc"],
+        json!("2.0"),
+        "envelope must declare jsonrpc=\"2.0\"; got {response}",
+    );
+
+    let has_result = response.get("result").is_some();
+    let has_error = response.get("error").is_some();
+    match (has_result, has_error) {
+        (true, false) => assert_valid(response, "JSONRPCResultResponse"),
+        (false, true) => assert_valid(response, "JSONRPCErrorResponse"),
+        (true, true) => {
+            panic!("envelope must not contain both `result` and `error`; got {response}",)
+        }
+        (false, false) => {
+            panic!("envelope must contain either `result` or `error`; got {response}",)
+        }
     }
 }
 

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -399,3 +399,39 @@ async fn wire_resources_list_is_empty_for_no_accounts() {
         "zero accounts must produce zero resources, got {resources:?}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_tools_call_unknown_tool_returns_error_envelope() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "this_tool_does_not_exist",
+                "arguments": {}
+            }),
+        )
+        .await;
+
+    assert!(
+        response["error"].is_object(),
+        "expected error envelope, got {response}",
+    );
+    // rmcp 1.5 emits INVALID_PARAMS (-32602) with message "tool not found"
+    // for unknown tool names; see rmcp-1.5.0/src/handler/server/router/tool.rs.
+    // If this code ever changes, update the assertion and document why
+    // — silent drift in rmcp's error mapping is exactly what this test
+    // is meant to surface.
+    assert_eq!(
+        response["error"]["code"],
+        json!(-32602),
+        "expected -32602 INVALID_PARAMS, got {response}",
+    );
+    assert!(
+        response["error"]["message"].is_string(),
+        "error.message must be a string, got {response}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -335,3 +335,48 @@ async fn wire_initialized_notification_elicits_no_response() {
         .assert_no_response_within(Duration::from_millis(200))
         .await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_tools_list_returns_object_schemas() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("tools/list", json!({})).await;
+    let result = &response["result"];
+    assert_valid(result, "ListToolsResult");
+
+    let tools = result["tools"].as_array().expect("tools must be an array");
+    assert!(
+        !tools.is_empty(),
+        "tools/list must return at least the infrastructure tools"
+    );
+
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(
+        names.contains(&"list_accounts"),
+        "list_accounts must be advertised; got names {names:?}",
+    );
+    assert!(
+        names.contains(&"use_account"),
+        "use_account must be advertised; got names {names:?}",
+    );
+
+    // Regression net for fix/tool-input-schema-object-type: every
+    // tool advertised on the wire must declare an object inputSchema.
+    // Permissive MCP clients tolerate the absence; Zod-based clients
+    // reject the tool.
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap_or("<missing-name>");
+        let schema = &tool["inputSchema"];
+        assert!(
+            schema.is_object(),
+            "tool {name}: inputSchema must be an object, got {schema}",
+        );
+        assert_eq!(
+            schema["type"],
+            json!("object"),
+            "tool {name}: inputSchema.type must be \"object\" (issue #263 regression net), got {schema}",
+        );
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -1,0 +1,253 @@
+//! MCP wire-shape conformance harness (issue #263, Phase 1).
+//!
+//! Spawns the production `rusty-imap-mcp` binary with a tempdir
+//! config that has zero accounts, drives a deterministic JSON-RPC
+//! sequence over its stdio, and validates every response against
+//! the vendored MCP spec schemas under
+//! `tests/fixtures/mcp-spec/2025-11-25/`.
+//!
+//! Permanent regression net for two real wire-shape bugs:
+//!  - #261: `initialize.result.capabilities` was serialized as `{}`.
+//!  - `fix/tool-input-schema-object-type`: tools advertised
+//!    `inputSchema: {}` with no `type` field.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::unwrap_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+#![expect(
+    dead_code,
+    reason = "Task 5 lands the harness scaffolding; Tasks 6-13 exercise \
+              the remaining helpers (notify, assert_no_response_within, \
+              send_initialized, shutdown_and_wait, validator_for, \
+              assert_valid, MCP_SCHEMA_JSON, SHUTDOWN_TIMEOUT, child)"
+)]
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::timeout;
+
+/// MCP protocol version pinned by this harness. Matches the
+/// directory under `tests/fixtures/mcp-spec/` and the `LATEST` value
+/// in `rmcp 1.5`. Update both when bumping.
+const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Vendored MCP spec schema, compiled in at build time so tests run
+/// hermetically (no network, no filesystem dependency beyond the
+/// crate source).
+const MCP_SCHEMA_JSON: &str = include_str!("fixtures/mcp-spec/2025-11-25/schema.json");
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Owns the spawned child plus its piped stdio.
+struct Harness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+    // Hold the tempdir until the harness drops so the audit log path
+    // remains valid for the lifetime of the spawned process.
+    _tempdir: TempDir,
+}
+
+impl Harness {
+    /// Spawn the binary with a zero-account tempdir config.
+    async fn spawn() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+
+        // Multi-account format with zero accounts. Task 1 lifted the
+        // empty-accounts validator gate, so this is the canonical
+        // zero-account shape the loader accepts.
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = timeout(SPAWN_TIMEOUT, async { cmd.spawn() })
+            .await
+            .expect("spawn within timeout")
+            .expect("spawn");
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Send a JSON-RPC request and return the parsed response value.
+    /// Panics on timeout, EOF before a response arrives, or non-JSON output.
+    async fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+
+        let mut buf = String::new();
+        let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
+            .await
+            .expect("response within timeout")
+            .expect("read response");
+        assert!(read > 0, "stdout closed before responding to {method}");
+        let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
+        assert_eq!(response["id"], json!(id), "response id must match request");
+        response
+    }
+
+    /// Send a JSON-RPC notification (no `id`, no response expected).
+    async fn notify(&mut self, method: &str, params: Value) {
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write notification");
+        self.stdin.flush().await.expect("flush notification");
+    }
+
+    /// Assert no bytes arrive on stdout for the given duration.
+    async fn assert_no_response_within(&mut self, dur: Duration) {
+        let mut buf = String::new();
+        match timeout(dur, self.stdout.read_line(&mut buf)).await {
+            Err(_) => {} // timeout → no response, as expected
+            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
+            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
+            Ok(Err(e)) => panic!("read error: {e}"),
+        }
+    }
+
+    /// Send an MCP `initialize` request with the pinned protocol
+    /// version and return the response.
+    async fn initialize_handshake(&mut self) -> Value {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion": PINNED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-conformance-harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+        .await
+    }
+
+    /// Send `notifications/initialized` after the handshake.
+    async fn send_initialized(&mut self) {
+        self.notify("notifications/initialized", json!({})).await;
+    }
+
+    /// Close stdin, await the child, and return its exit status.
+    async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
+        drop(self.stdin);
+        timeout(SHUTDOWN_TIMEOUT, self.child.wait())
+            .await
+            .expect("clean exit within timeout")
+            .expect("wait")
+    }
+}
+
+/// Compile (once) and return a validator for a top-level definition in
+/// the vendored MCP schema. `fragment` is the key under
+/// `definitions` / `$defs` (e.g. `"InitializeResult"`). Returns an
+/// `Arc` so multiple parallel tests can share the compiled validator
+/// without lifetime gymnastics.
+fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().unwrap();
+    if let Some(v) = guard.get(fragment) {
+        return Arc::clone(v);
+    }
+
+    // Detect which key the spec uses for nested definitions. Newer
+    // JSON Schema dialects use `$defs`; older specs use `definitions`.
+    let full: Value = serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
+    let defs_key = if full.get("$defs").is_some() {
+        "$defs"
+    } else {
+        "definitions"
+    };
+
+    // Build a wrapper schema that $refs into the requested fragment.
+    let wrapper = json!({
+        "$ref": format!("#/{defs_key}/{fragment}"),
+        defs_key: full.get(defs_key).cloned().unwrap_or(json!({})),
+    });
+    let v = Arc::new(jsonschema::validator_for(&wrapper).expect("compile fragment validator"));
+    guard.insert(fragment, Arc::clone(&v));
+    v
+}
+
+/// Validate a value against a vendored fragment, panicking with the
+/// list of errors on failure.
+fn assert_valid(value: &Value, fragment: &'static str) {
+    let v = validator_for(fragment);
+    if !v.is_valid(value) {
+        let errors: Vec<String> = v.iter_errors(value).map(|e| e.to_string()).collect();
+        panic!(
+            "schema validation failed for fragment {fragment}:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_smoke_initialize_returns_valid_envelope() {
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+    assert_eq!(response["jsonrpc"], json!("2.0"));
+    assert!(
+        response["result"].is_object(),
+        "initialize response must have a result object, got {response}"
+    );
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -38,7 +38,12 @@ const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_SCHEMA_JSON: &str = include_str!("fixtures/mcp-spec/2025-11-25/schema.json");
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+// Under `cargo nextest run` with the full workspace suite (~1100 tests
+// in parallel), the EOF-to-exit slice for `wire_clean_eof_shutdown_exits_zero`
+// can exceed a tight 1 s budget on CPU-contended runners. 5 s remains
+// tight enough to fail-fast on a real hang while absorbing scheduling
+// jitter when other tests are spawning binaries / parsers concurrently.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Owns the spawned child plus its piped stdio.
 struct Harness {

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -435,3 +435,27 @@ async fn wire_tools_call_unknown_tool_returns_error_envelope() {
         "error.message must be a string, got {response}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_unknown_method_returns_minus_32601() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("rimap/no_such_method", json!({})).await;
+    assert!(
+        response["error"].is_object(),
+        "expected error envelope, got {response}",
+    );
+    assert_eq!(
+        response["error"]["code"],
+        json!(-32601),
+        "JSON-RPC method-not-found code, got {response}",
+    );
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "error.message must be non-empty, got {response}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -325,3 +325,13 @@ async fn wire_protocol_version_negotiation_matches_vendored_schema() {
          negotiation regression. Full response: {response}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_initialized_notification_elicits_no_response() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+    harness
+        .assert_no_response_within(Duration::from_millis(200))
+        .await;
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -81,6 +81,10 @@ allowed_base_dir = "{}"
         let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
         cmd.arg("--config")
             .arg(&config_path)
+            // Production rejects `accounts = []`. The harness opts in
+            // to infrastructure-only boot via this test-support flag
+            // (Codex adversarial review on PR #270).
+            .arg("--allow-empty-accounts")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -275,3 +275,32 @@ async fn wire_smoke_initialize_returns_valid_envelope() {
         "initialize response must have a result object, got {response}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_initialize_advertises_tools_capability() {
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+
+    let result = &response["result"];
+    assert_valid(result, "InitializeResult");
+
+    assert_eq!(
+        result["protocolVersion"],
+        json!(PINNED_PROTOCOL_VERSION),
+        "server must echo the pinned protocol version",
+    );
+
+    // Regression net for #261: the capabilities object must contain
+    // a `tools` key on the wire. Permissive clients ignore the
+    // absence; spec-strict clients (e.g. bobshell) refuse to call
+    // tools/list.
+    let capabilities = &result["capabilities"];
+    assert!(
+        capabilities.is_object(),
+        "capabilities must be an object, got {capabilities}",
+    );
+    assert!(
+        capabilities.get("tools").is_some(),
+        "capabilities.tools must be present on the wire; got {capabilities}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -12,7 +12,6 @@
 //!    `inputSchema: {}` with no `type` field.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
-#![expect(clippy::unwrap_used, reason = "integration tests")]
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
 #![expect(
     dead_code,
@@ -45,7 +44,6 @@ const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_SCHEMA_JSON: &str = include_str!("fixtures/mcp-spec/2025-11-25/schema.json");
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Owns the spawned child plus its piped stdio.
@@ -61,6 +59,10 @@ struct Harness {
 
 impl Harness {
     /// Spawn the binary with a zero-account tempdir config.
+    #[expect(
+        clippy::unused_async,
+        reason = "harness API is uniformly async so tests await every constructor"
+    )]
     async fn spawn() -> Self {
         let tempdir = TempDir::new().expect("tempdir");
         let config_path = tempdir.path().join("config.toml");
@@ -88,13 +90,10 @@ allowed_base_dir = "{}"
             .arg(&config_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::null())
             .kill_on_drop(true);
 
-        let mut child = timeout(SPAWN_TIMEOUT, async { cmd.spawn() })
-            .await
-            .expect("spawn within timeout")
-            .expect("spawn");
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
 
         let stdin = child.stdin.take().expect("stdin");
         let stdout = BufReader::new(child.stdout.take().expect("stdout"));
@@ -201,31 +200,56 @@ allowed_base_dir = "{}"
 /// `Arc` so multiple parallel tests can share the compiled validator
 /// without lifetime gymnastics.
 fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+    // All function-scoped items declared up front so cache and parsed
+    // schema lifetimes are visible from the top of the body
+    // (clippy::items_after_statements).
     type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static PARSED: OnceLock<(Value, &'static str)> = OnceLock::new();
     static CACHE: OnceLock<Cache> = OnceLock::new();
+
+    // Parse the vendored schema exactly once and detect the
+    // definitions key (`$defs` for Draft 2020-12, `definitions` for
+    // older dialects). The full Value and the detected key are
+    // immutable for the lifetime of the test process.
+    let parsed = PARSED.get_or_init(|| {
+        let full: Value = serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
+        let defs_key = if full.get("$defs").is_some() {
+            "$defs"
+        } else {
+            "definitions"
+        };
+        (full, defs_key)
+    });
+    let full = &parsed.0;
+    let defs_key: &'static str = parsed.1;
+
     let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = cache.lock().unwrap();
-    if let Some(v) = guard.get(fragment) {
-        return Arc::clone(v);
+
+    // Fast path: read under the lock, return if cached.
+    {
+        let guard = cache.lock().expect("validator cache mutex poisoned");
+        if let Some(v) = guard.get(fragment) {
+            return Arc::clone(v);
+        }
     }
 
-    // Detect which key the spec uses for nested definitions. Newer
-    // JSON Schema dialects use `$defs`; older specs use `definitions`.
-    let full: Value = serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
-    let defs_key = if full.get("$defs").is_some() {
-        "$defs"
-    } else {
-        "definitions"
-    };
-
-    // Build a wrapper schema that $refs into the requested fragment.
+    // Slow path: compile the fragment validator WITHOUT holding the
+    // cache lock, so parallel tests compiling different fragments
+    // don't serialize.
     let wrapper = json!({
         "$ref": format!("#/{defs_key}/{fragment}"),
         defs_key: full.get(defs_key).cloned().unwrap_or(json!({})),
     });
-    let v = Arc::new(jsonschema::validator_for(&wrapper).expect("compile fragment validator"));
-    guard.insert(fragment, Arc::clone(&v));
-    v
+    let new_validator =
+        Arc::new(jsonschema::validator_for(&wrapper).expect("compile fragment validator"));
+
+    // Insert. If a concurrent thread already inserted while we were
+    // compiling, prefer the existing entry to keep the Arc stable.
+    let mut guard = cache.lock().expect("validator cache mutex poisoned");
+    let entry = guard
+        .entry(fragment)
+        .or_insert_with(|| Arc::clone(&new_validator));
+    Arc::clone(entry)
 }
 
 /// Validate a value against a vendored fragment, panicking with the

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin;
+use rmcp::model::ProtocolVersion;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -166,7 +167,7 @@ allowed_base_dir = "{}"
         self.request(
             "initialize",
             json!({
-                "protocolVersion": PINNED_PROTOCOL_VERSION,
+                "protocolVersion": ProtocolVersion::LATEST.as_str(),
                 "capabilities": {},
                 "clientInfo": {
                     "name": "rusty-imap-mcp-conformance-harness",
@@ -333,22 +334,49 @@ async fn wire_initialize_advertises_tools_capability() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wire_protocol_version_negotiation_matches_vendored_schema() {
-    // Sends an initialize request with the LATEST version known to
-    // the test, asks the server to echo it back. rmcp negotiates
-    // min(client, server), so when the server bumps to a newer
-    // LATEST this still succeeds — but if the server somehow
-    // negotiates to an older version (e.g. the pinned string is
-    // wrong) this test catches it. The fragment-validation tests
-    // depend on this invariant.
+    // Three-way drift check (Codex adversarial review finding #1):
+    //
+    //   1. rmcp::ProtocolVersion::LATEST.as_str()
+    //   2. PINNED_PROTOCOL_VERSION (the constant in this file)
+    //   3. crates/rimap-server/tests/fixtures/mcp-spec/<version>/
+    //
+    // All three MUST agree. If any one drifts (rmcp bumps LATEST, the
+    // pinned constant goes stale, or someone deletes the fixture
+    // directory) this test fails first with a precise diagnostic
+    // before any fragment-validation test validates against an
+    // outdated schema.
+
+    let rmcp_latest = ProtocolVersion::LATEST.as_str();
+    assert_eq!(
+        rmcp_latest, PINNED_PROTOCOL_VERSION,
+        "rmcp::ProtocolVersion::LATEST ({rmcp_latest}) drifted from \
+         PINNED_PROTOCOL_VERSION ({PINNED_PROTOCOL_VERSION}). Run \
+         `scripts/refresh-mcp-spec.sh {rmcp_latest}` to vendor the new \
+         schema, update PINNED_PROTOCOL_VERSION + MCP_SCHEMA_JSON in \
+         this file, and update the README under \
+         tests/fixtures/mcp-spec/.",
+    );
+
+    // The fixture directory must exist on disk under the pinned name.
+    let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp-spec")
+        .join(PINNED_PROTOCOL_VERSION);
+    assert!(
+        fixture_dir.is_dir(),
+        "expected vendored fixture directory at {} for pinned version \
+         {PINNED_PROTOCOL_VERSION}; refresh script may not have run",
+        fixture_dir.display(),
+    );
+
+    // And rmcp must echo whatever the harness sends as the negotiated
+    // version, which the harness now derives from LATEST.
     let mut harness = Harness::spawn().await;
     let response = harness.initialize_handshake().await;
     assert_eq!(
         response["result"]["protocolVersion"],
-        json!(PINNED_PROTOCOL_VERSION),
-        "harness pinned to {PINNED_PROTOCOL_VERSION} but server returned a \
-         different value; either update PINNED_PROTOCOL_VERSION + the \
-         tests/fixtures/mcp-spec/<version>/ directory, or fix the rmcp \
-         negotiation regression. Full response: {response}",
+        json!(rmcp_latest),
+        "server must echo the rmcp LATEST version sent by the harness; \
+         got {response}",
     );
 }
 

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -13,13 +13,6 @@
 
 #![expect(clippy::expect_used, reason = "integration tests")]
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
-#![expect(
-    dead_code,
-    reason = "Task 5 lands the harness scaffolding; Tasks 6-13 exercise \
-              the remaining helpers (notify, assert_no_response_within, \
-              send_initialized, shutdown_and_wait, validator_for, \
-              assert_valid, MCP_SCHEMA_JSON, SHUTDOWN_TIMEOUT, child)"
-)]
 
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -457,5 +450,17 @@ async fn wire_unknown_method_returns_minus_32601() {
             .as_str()
             .is_some_and(|s| !s.is_empty()),
         "error.message must be non-empty, got {response}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_clean_eof_shutdown_exits_zero() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+    let status = harness.shutdown_and_wait().await;
+    assert!(
+        status.success(),
+        "server must exit 0 on clean stdin EOF, got {status:?}",
     );
 }

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -380,3 +380,22 @@ async fn wire_tools_list_returns_object_schemas() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_resources_list_is_empty_for_no_accounts() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("resources/list", json!({})).await;
+    let result = &response["result"];
+    assert_valid(result, "ListResourcesResult");
+
+    let resources = result["resources"]
+        .as_array()
+        .expect("resources must be an array");
+    assert!(
+        resources.is_empty(),
+        "zero accounts must produce zero resources, got {resources:?}",
+    );
+}

--- a/docs/superpowers/plans/2026-05-12-mcp-wire-conformance-codex-fixes.md
+++ b/docs/superpowers/plans/2026-05-12-mcp-wire-conformance-codex-fixes.md
@@ -1,0 +1,796 @@
+# MCP Wire-Conformance — Codex Adversarial Review Fixes
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address the three findings from Codex's adversarial review of PR #270: restore the production `accounts = []` rejection while keeping the harness functional through a test-support entrypoint, validate full JSON-RPC envelopes on every harness response, and tie the pinned MCP protocol version to `rmcp::ProtocolVersion::LATEST` so version skew fails loudly.
+
+**Architecture:** Production code re-instates `ConfigError::NoAccounts`. A new `validate_multi_allowing_empty()` and `load_and_validate_allowing_empty()` live behind the existing `test-support` feature in `rimap-config`. The `rusty-imap-mcp` binary gains a `#[cfg(feature = "test-support")] --allow-empty-accounts` CLI flag that routes through the relaxed validator. The harness passes the flag and otherwise behaves identically. Envelope validation is folded into `Harness::request` so every test gets it. The pinned schema version is sourced from `rmcp::model::ProtocolVersion::LATEST.as_str()` at runtime, with assertions that the constant, the LATEST value, and the vendored fixture directory all agree.
+
+**Tech Stack:** Rust (workspace edition 2024, MSRV 1.88.0), `rmcp 1.5`, existing `test-support` feature flags on `rimap-config` and `rimap-server`, `jsonschema 0.46`, `tokio::process`.
+
+**Source review:** `https://github.com/randomparity/rusty-imap-mcp/pull/270` Codex adversarial review (2026-05-12).
+**Parent plan:** `docs/superpowers/plans/2026-05-12-mcp-wire-conformance.md`.
+
+---
+
+## File structure
+
+| Path | Action | Purpose |
+| --- | --- | --- |
+| `crates/rimap-config/src/error.rs` | modify | Re-add `ConfigError::NoAccounts` variant |
+| `crates/rimap-config/src/validate/mod.rs` | modify | Reinstate empty-accounts rejection in `validate_multi`; add `validate_multi_allowing_empty` (test-support gated); move the empty-OK test to that path; add a test asserting production rejection |
+| `crates/rimap-config/src/loader.rs` | modify | Add `load_and_validate_allowing_empty` (test-support gated) that mirrors `load_and_validate` but routes the multi branch through the relaxed validator |
+| `crates/rimap-server/src/cli/mod.rs` | modify | Add `#[cfg(feature = "test-support")] --allow-empty-accounts` CLI flag, `hide = true` |
+| `crates/rimap-server/src/main.rs` | modify | Dispatch to `load_and_validate_allowing_empty` when the flag is set |
+| `crates/rimap-server/tests/mcp_wire_conformance.rs` | modify | Pass `--allow-empty-accounts` from the harness; bake envelope validation into `Harness::request`; switch pinned version to `rmcp::ProtocolVersion::LATEST`; assert PINNED == LATEST and the fixture dir matches |
+
+---
+
+## Task 1: Restore production `NoAccounts` rejection
+
+This task only touches production code. It will break the conformance harness (which still spawns the binary without `--allow-empty-accounts`); Task 3 + 4 will repair the harness path before the branch ships green.
+
+**Files:**
+- Modify: `crates/rimap-config/src/error.rs`
+- Modify: `crates/rimap-config/src/validate/mod.rs`
+
+- [ ] **Step 1: Re-add the `NoAccounts` error variant**
+
+In `crates/rimap-config/src/error.rs`, find the end of the `ConfigError` enum (just before the closing `}`) and add:
+
+```rust
+    /// Multi-account config has an empty `[[accounts]]` array.
+    ///
+    /// Codex adversarial review (PR #270, 2026-05-12) flagged that
+    /// silently accepting empty-accounts configs in production makes
+    /// broken deployments look identical to healthy zero-data servers.
+    /// The check stays in production; tests opt in via
+    /// [`crate::validate::validate_multi_allowing_empty`] behind the
+    /// `test-support` feature.
+    #[error("no accounts defined in [[accounts]] array")]
+    NoAccounts,
+```
+
+- [ ] **Step 2: Write the failing test asserting `validate_multi` rejects empty accounts**
+
+Open `crates/rimap-config/src/validate/mod.rs`. The previous task removed the rejection-side test and added an acceptance-side test (`empty_accounts_array_validates_for_infrastructure_only_boot`). Replace that acceptance test with a rejection test in the same location:
+
+```rust
+#[test]
+fn empty_accounts_array_rejected_by_production_validator() {
+    // Production must fail-fast on `accounts = []` so operators
+    // immediately see a broken deployment instead of a healthy
+    // zero-data server (Codex adversarial review on PR #270).
+    let dir = TempDir::new().unwrap();
+    let cfg = base_multi_config(dir.path(), vec![]);
+    let err = validate_multi(cfg).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::NoAccounts),
+        "expected ConfigError::NoAccounts, got {err:?}",
+    );
+}
+```
+
+- [ ] **Step 3: Run the test and verify it fails**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo test -p rimap-config empty_accounts_array_rejected_by_production_validator
+```
+Expected: FAIL — the validator currently accepts empty accounts.
+
+- [ ] **Step 4: Reinstate the rejection inside `validate_multi`**
+
+In `crates/rimap-config/src/validate/mod.rs`, at the top of `validate_multi` (line 71 area), add the gate back as the first check:
+
+```rust
+pub fn validate_multi(config: MultiAccountConfig) -> Result<ValidatedMultiConfig, ConfigError> {
+    if config.accounts.is_empty() {
+        return Err(ConfigError::NoAccounts);
+    }
+
+    // ...existing body...
+}
+```
+
+(Insert before the `let mut accounts = BTreeMap::new();` that opens the existing function body.)
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+```bash
+cargo test -p rimap-config empty_accounts_array_rejected_by_production_validator
+```
+Expected: PASS.
+
+- [ ] **Step 6: Run the full crate test suite (some tests may need updates if they depended on the old behavior)**
+
+```bash
+cargo test -p rimap-config
+```
+Expected: PASS for everything. If a test fails because it relied on the lifted gate, capture the test name — Task 2 will rewire it through the new test-support function.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-config/src/error.rs crates/rimap-config/src/validate/mod.rs
+git commit -m "$(cat <<'EOF'
+fix(config): restore NoAccounts rejection in production validator
+
+Codex adversarial review on PR #270 flagged that silently accepting
+`accounts = []` in production made a broken deployment indistinguishable
+from a healthy zero-data server. Restores the rejection in
+validate_multi(); the wire-conformance harness will route through a
+test-support-gated relaxed validator added in a follow-up commit.
+
+EOF
+)"
+```
+
+---
+
+## Task 2: Add test-support entrypoints for empty-accounts boot
+
+This task adds the relaxed validator + relaxed loader behind `#[cfg(feature = "test-support")]`. It also updates the test that asserts empty accounts validates so it points at the new function.
+
+**Files:**
+- Modify: `crates/rimap-config/src/validate/mod.rs`
+- Modify: `crates/rimap-config/src/loader.rs`
+- Modify: `crates/rimap-config/src/lib.rs` (re-export new symbols)
+
+- [ ] **Step 1: Add `validate_multi_allowing_empty` to the validate module**
+
+In `crates/rimap-config/src/validate/mod.rs`, immediately after the `validate_multi` function, add:
+
+```rust
+/// Variant of [`validate_multi`] that skips the empty-accounts
+/// rejection. Used exclusively by the wire-conformance harness so the
+/// production server can fail-fast on `accounts = []` while tests
+/// still spawn an infrastructure-only binary. Gated behind the
+/// `test-support` feature.
+#[cfg(feature = "test-support")]
+pub fn validate_multi_allowing_empty(
+    config: MultiAccountConfig,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    let mut accounts = BTreeMap::new();
+    for raw in config.accounts {
+        let id = AccountId::new(&raw.name)?;
+        if accounts.contains_key(&id) {
+            return Err(ConfigError::DuplicateAccountName { name: raw.name });
+        }
+
+        let security = raw
+            .security
+            .unwrap_or_else(|| config.defaults.security.clone());
+        let limits = raw.limits.unwrap_or_else(|| config.defaults.limits.clone());
+        let fallback_mode = raw
+            .credentials
+            .map_or(config.defaults.credentials.fallback, |c| c.fallback);
+
+        accounts.insert(
+            id.clone(),
+            validated_account_for(id, &raw, security, limits, fallback_mode)?,
+        );
+    }
+
+    enforce_audit_containment(&config.audit)?;
+
+    Ok(ValidatedMultiConfig {
+        defaults: config.defaults,
+        accounts,
+        audit: config.audit,
+        attachments: config.attachments,
+    })
+}
+```
+
+**IMPORTANT:** The body above must mirror the post-empty-check portion of `validate_multi`. Before writing, open `validate_multi` and copy its body starting from the line AFTER the `if config.accounts.is_empty()` check. The snippet above is a representative shape; adapt it to match the current `validate_multi` body verbatim (helper-function names, field names, etc.) by reading the source. If `validate_multi`'s body is longer than 20 lines and would diverge, factor a private `fn validate_multi_inner(cfg) -> ...` and call it from both `validate_multi` (after the empty check) and `validate_multi_allowing_empty`.
+
+- [ ] **Step 2: Write the failing test for `validate_multi_allowing_empty`**
+
+In the same file, inside the existing `#[cfg(test)] mod tests` block, add a new test next to the rejection test from Task 1:
+
+```rust
+#[cfg(feature = "test-support")]
+#[test]
+fn empty_accounts_array_validates_under_test_support() {
+    // Mirror of the previous task's intent, now routed through the
+    // test-only relaxed validator. The wire-conformance harness
+    // depends on this path to spawn the binary with `accounts = []`
+    // (Codex review on PR #270).
+    let dir = TempDir::new().unwrap();
+    let cfg = base_multi_config(dir.path(), vec![]);
+    let validated = validate_multi_allowing_empty(cfg).unwrap();
+    assert!(validated.accounts.is_empty());
+}
+```
+
+- [ ] **Step 3: Run the test (should fail to compile until Step 1 lands, then pass)**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo test -p rimap-config --features test-support empty_accounts_array_validates_under_test_support
+```
+Expected: PASS. If you get an "unresolved import" error, double-check Step 4 (re-export).
+
+- [ ] **Step 4: Re-export `validate_multi_allowing_empty` from `rimap-config`'s lib.rs**
+
+Open `crates/rimap-config/src/lib.rs`. Find the existing re-export line that exposes `validate_multi`:
+
+```rust
+pub use validate::{
+    ValidatedAccountConfig, ValidatedMultiConfig, validate_legacy_as_multi, validate_multi,
+};
+```
+
+Add a second cfg-gated re-export immediately after:
+
+```rust
+#[cfg(feature = "test-support")]
+pub use validate::validate_multi_allowing_empty;
+```
+
+- [ ] **Step 5: Add `load_and_validate_allowing_empty` to the loader**
+
+In `crates/rimap-config/src/loader.rs`, immediately after `load_and_validate`, add:
+
+```rust
+/// Variant of [`load_and_validate`] that, for multi-account format,
+/// invokes [`crate::validate::validate_multi_allowing_empty`] so the
+/// wire-conformance harness can spawn the binary with `accounts = []`.
+/// Gated behind the `test-support` feature.
+///
+/// # Errors
+/// Same surface as [`load_and_validate`], minus `ConfigError::NoAccounts`
+/// for empty multi-account configs.
+#[cfg(feature = "test-support")]
+pub fn load_and_validate_allowing_empty(
+    path: &Path,
+) -> Result<ValidatedMultiConfig, ConfigError> {
+    // The format-detection branch reads the file once and dispatches
+    // to validate_legacy_as_multi or validate_multi based on which
+    // top-level table is present. We need to inline that detection
+    // here so the multi branch routes through the relaxed validator.
+    // KEEP IN SYNC with load_and_validate above.
+    let raw = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let toml_value: toml::Value =
+        toml::from_str(&raw).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let has_multi = toml_value.get("accounts").is_some();
+    let has_legacy = toml_value.get("imap").is_some();
+    match (has_multi, has_legacy) {
+        (true, true) => Err(ConfigError::MixedFormat {
+            path: path.to_path_buf(),
+        }),
+        (true, false) => {
+            let cfg: MultiAccountConfig =
+                toml::from_str(&raw).map_err(|source| ConfigError::Parse {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+            crate::validate::validate_multi_allowing_empty(cfg)
+        }
+        (false, _) => {
+            let cfg: Config = toml::from_str(&raw).map_err(|source| ConfigError::Parse {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            crate::validate::validate_legacy_as_multi(cfg)
+        }
+    }
+}
+```
+
+**IMPORTANT:** Open the current `load_and_validate` and verify the format-detection logic matches the snippet above (same TOML keys, same error variants). The function above is a faithful adaptation but the project's actual loader may use named imports, different error variants for parse failures, etc. — adjust to match the surrounding code exactly. If `load_and_validate`'s body is non-trivial, factor a private `fn classify_format(path: &Path) -> Result<Format, ConfigError>` returning an enum and call it from both functions.
+
+- [ ] **Step 6: Re-export `load_and_validate_allowing_empty` from lib.rs**
+
+In `crates/rimap-config/src/lib.rs`, if there is a re-export of `loader::load_and_validate`, add a cfg-gated re-export of the new function alongside. Otherwise add one:
+
+```rust
+#[cfg(feature = "test-support")]
+pub use loader::load_and_validate_allowing_empty;
+```
+
+(Skip if the codebase only ever calls `rimap_config::loader::...` directly.)
+
+- [ ] **Step 7: Run the full config test suite under test-support**
+
+```bash
+cargo test -p rimap-config --features test-support
+```
+Expected: all tests pass, including both the production-rejection test from Task 1 and the new acceptance test from Step 2.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-config/src/validate/mod.rs crates/rimap-config/src/loader.rs crates/rimap-config/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(config): test-support entrypoint for empty-accounts boot
+
+Adds validate_multi_allowing_empty and load_and_validate_allowing_empty
+behind the existing test-support feature. The wire-conformance harness
+will route through these so the production validator can still
+fail-fast on `accounts = []` (Codex adversarial review on PR #270).
+
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire `--allow-empty-accounts` through the `rusty-imap-mcp` CLI
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/mod.rs`
+- Modify: `crates/rimap-server/src/main.rs`
+
+- [ ] **Step 1: Add the cfg-gated CLI flag**
+
+Open `crates/rimap-server/src/cli/mod.rs` and locate the `pub struct Cli` definition. After the existing `pub dry_run: bool` field (and before the subcommand), add:
+
+```rust
+    /// Skip the empty-accounts rejection in `rimap_config::validate_multi`.
+    /// Used by the wire-conformance harness (#263) so the binary can
+    /// boot with `accounts = []`. Hidden from `--help` because it is a
+    /// test-only knob; compiled out entirely when the `test-support`
+    /// feature is off.
+    #[cfg(feature = "test-support")]
+    #[arg(long, hide = true)]
+    pub allow_empty_accounts: bool,
+```
+
+- [ ] **Step 2: Route through the relaxed loader when the flag is set**
+
+Open `crates/rimap-server/src/main.rs`. Find the existing call to `load_and_validate(&config_path)` (search for `load_and_validate`). It currently looks something like:
+
+```rust
+    let config_path = resolve_cli_config_path(&cli)?;
+    let multi = load_and_validate(&config_path)
+        .with_context(|| format!("loading config {}", config_path.display()))?;
+```
+
+Replace that snippet with:
+
+```rust
+    let config_path = resolve_cli_config_path(&cli)?;
+
+    // `--allow-empty-accounts` is a #[cfg(feature = "test-support")]
+    // CLI flag (#263 Codex adversarial review). In production builds
+    // the field does not exist and we always hit the strict loader.
+    #[cfg(feature = "test-support")]
+    let multi = if cli.allow_empty_accounts {
+        rimap_config::loader::load_and_validate_allowing_empty(&config_path)
+    } else {
+        load_and_validate(&config_path)
+    }
+    .with_context(|| format!("loading config {}", config_path.display()))?;
+
+    #[cfg(not(feature = "test-support"))]
+    let multi = load_and_validate(&config_path)
+        .with_context(|| format!("loading config {}", config_path.display()))?;
+```
+
+If `rimap_config::loader::load_and_validate_allowing_empty` doesn't resolve, use whatever path Task 2 made it available at (e.g. `rimap_config::load_and_validate_allowing_empty` if it was re-exported at the crate root).
+
+- [ ] **Step 3: Confirm the binary still compiles in both cfg modes**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo check -p rimap-server
+cargo check -p rimap-server --features test-support
+```
+Both must be clean.
+
+- [ ] **Step 4: Confirm clippy is clean for both feature combinations**
+
+```bash
+cargo clippy -p rimap-server -- -D warnings
+cargo clippy -p rimap-server --features test-support -- -D warnings
+```
+Both must be clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/mod.rs crates/rimap-server/src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(server): --allow-empty-accounts CLI flag (test-support gated)
+
+Routes through rimap_config::loader::load_and_validate_allowing_empty
+when set. The flag is compiled out entirely in production builds.
+Used by the wire-conformance harness (#263) so the binary can boot
+with `accounts = []` (Codex adversarial review on PR #270).
+
+EOF
+)"
+```
+
+---
+
+## Task 4: Pass `--allow-empty-accounts` from the harness + verify all 9 tests still pass
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Add the flag to the spawned command in `Harness::spawn`**
+
+Open `crates/rimap-server/tests/mcp_wire_conformance.rs`. Find the `Command::new(cargo_bin("rusty-imap-mcp"))` setup in `Harness::spawn`. Add `.arg("--allow-empty-accounts")` between `.arg("--config")` / `.arg(&config_path)` and the `.stdin(...)` chain:
+
+```rust
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            // Production rejects `accounts = []`. The harness opts in
+            // to infrastructure-only boot via this test-support flag
+            // (Codex adversarial review on PR #270).
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+```
+
+- [ ] **Step 2: Run the full conformance suite to confirm the wiring works**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo test -p rimap-server --test mcp_wire_conformance -- --nocapture
+```
+Expected: all 9 tests pass. If a test fails with the binary exiting before any JSON-RPC reply, the flag did not take effect — confirm Tasks 2/3 landed correctly.
+
+- [ ] **Step 3: Confirm the production binary STILL refuses empty-accounts**
+
+The whole point of this rework is that production builds reject `accounts = []`. Verify directly:
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo build -p rimap-server --bin rusty-imap-mcp --release
+TMP=$(mktemp -d)
+cat > "$TMP/config.toml" <<TOML
+accounts = []
+
+[audit]
+path = "$TMP/audit.jsonl"
+allowed_base_dir = "$TMP"
+TOML
+./target/release/rusty-imap-mcp --config "$TMP/config.toml" --dry-run ; echo "exit=$?"
+./target/release/rusty-imap-mcp --config "$TMP/config.toml" --allow-empty-accounts --dry-run 2>&1 | head -3
+rm -rf "$TMP"
+```
+
+Expected:
+- The release build dry-run with `accounts = []` and no flag prints something like `loading config ...: no accounts defined in [[accounts]] array` and exits non-zero.
+- The release build does NOT accept `--allow-empty-accounts` (the flag is cfg-gated out in release builds without the `test-support` feature). It should print an "unknown argument" error from clap.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "$(cat <<'EOF'
+test(mcp): harness opts into empty-accounts boot via --allow-empty-accounts
+
+Production now rejects `accounts = []`; the conformance harness passes
+the test-support-gated flag so the binary still boots in
+infrastructure-only mode. Verified that release builds without the
+test-support feature do not accept the flag (Codex adversarial review
+on PR #270).
+
+EOF
+)"
+```
+
+---
+
+## Task 5: Bake full envelope validation into `Harness::request`
+
+This addresses Codex finding #2 — the negative-path tests asserted only that `response["error"]` is an object and the code/message were right. They didn't validate the envelope itself.
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Add a helper that picks the right envelope fragment**
+
+Locate `assert_valid` in `mcp_wire_conformance.rs`. Add immediately below it:
+
+```rust
+/// Validate the FULL JSON-RPC envelope returned by `Harness::request`.
+/// Success responses validate against `JSONRPCResultResponse`; error
+/// responses validate against `JSONRPCErrorResponse`. Asserts the
+/// `jsonrpc` version field on both paths. Codex adversarial review
+/// finding #2 (PR #270): the previous negative-path tests checked only
+/// `code` and `message` and would have missed a regression that
+/// stripped `jsonrpc` or otherwise mangled the envelope.
+fn assert_envelope_valid(response: &Value) {
+    assert_eq!(
+        response["jsonrpc"],
+        json!("2.0"),
+        "envelope must declare jsonrpc=\"2.0\"; got {response}",
+    );
+
+    let has_result = response.get("result").is_some();
+    let has_error = response.get("error").is_some();
+    match (has_result, has_error) {
+        (true, false) => assert_valid(response, "JSONRPCResultResponse"),
+        (false, true) => assert_valid(response, "JSONRPCErrorResponse"),
+        (true, true) => panic!(
+            "envelope must not contain both `result` and `error`; got {response}",
+        ),
+        (false, false) => panic!(
+            "envelope must contain either `result` or `error`; got {response}",
+        ),
+    }
+}
+```
+
+- [ ] **Step 2: Call it from `Harness::request`**
+
+Inside `Harness::request`, after the line that parses and asserts the response id (`assert_eq!(response["id"], json!(id), ...)`), insert one line that hands the parsed response off to the envelope validator BEFORE the function returns:
+
+```rust
+        let response: Value =
+            serde_json::from_str(buf.trim_end()).expect("parse response JSON");
+        assert_eq!(response["id"], json!(id), "response id must match request");
+        assert_envelope_valid(&response);
+        response
+```
+
+(Insert the `assert_envelope_valid(&response);` line between the existing id assertion and the bare `response` return expression.)
+
+- [ ] **Step 3: Run the suite — every test should still pass and now validate the full envelope**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo test -p rimap-server --test mcp_wire_conformance -- --nocapture
+```
+Expected: 9 passed.
+
+If a test fails with a fragment-not-found error like `compile fragment validator: ... JSONRPCErrorResponse ...`, the schema fragment name may differ — check `crates/rimap-server/tests/fixtures/mcp-spec/README.md`'s naming notes section and adjust the names in `assert_envelope_valid` to match the actual `$defs` keys.
+
+- [ ] **Step 4: Drop redundant per-test envelope assertions if they exist**
+
+The smoke test (`wire_smoke_initialize_returns_valid_envelope`) has its own `assert_eq!(response["jsonrpc"], json!("2.0"))` plus an `assert!(response["result"].is_object(), ...)`. With `assert_envelope_valid` baked in, both checks are now redundant. Keep them — they are belt-and-suspenders and clarify the smoke test's intent — but do NOT add any new redundant checks elsewhere.
+
+The negative-path tests (`wire_tools_call_unknown_tool_returns_error_envelope`, `wire_unknown_method_returns_minus_32601`) already assert that `response["error"]` is an object — those assertions are now subsumed by the envelope validator but are still informative; leave them in.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "$(cat <<'EOF'
+test(mcp): validate full JSON-RPC envelope on every harness response
+
+Adds assert_envelope_valid that picks JSONRPCResultResponse or
+JSONRPCErrorResponse based on which member is present, asserts
+jsonrpc=2.0, and rejects malformed envelopes that contain both or
+neither. Invoked from Harness::request so every test gets full
+envelope coverage — including negative-path tests, which Codex's
+adversarial review (PR #270, finding #2) noted were only checking
+code/message.
+
+EOF
+)"
+```
+
+---
+
+## Task 6: Tie pinned version to `rmcp::ProtocolVersion::LATEST`
+
+This addresses Codex finding #1 — the hardcoded `PINNED_PROTOCOL_VERSION` could silently lag behind rmcp's `LATEST`.
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Import `rmcp::model::ProtocolVersion`**
+
+At the top of `mcp_wire_conformance.rs`, alongside the other `use` statements, add:
+
+```rust
+use rmcp::model::ProtocolVersion;
+```
+
+- [ ] **Step 2: Replace the hard-coded `PINNED_PROTOCOL_VERSION` initialize value with `LATEST`**
+
+Find `Harness::initialize_handshake`. The current body sends `PINNED_PROTOCOL_VERSION` as the request's `protocolVersion`. Replace with `ProtocolVersion::LATEST.as_str()`:
+
+```rust
+    async fn initialize_handshake(&mut self) -> Value {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-conformance-harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+        .await
+    }
+```
+
+Keep `PINNED_PROTOCOL_VERSION` as a constant — it remains the source of truth for which fixture directory the validators load from. The constant just stops being the value SENT during handshake.
+
+- [ ] **Step 3: Rewrite `wire_protocol_version_negotiation_matches_vendored_schema` to detect drift in three places**
+
+Replace the existing body of `wire_protocol_version_negotiation_matches_vendored_schema` with:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_protocol_version_negotiation_matches_vendored_schema() {
+    // Three-way drift check (Codex adversarial review finding #1):
+    //
+    //   1. rmcp::ProtocolVersion::LATEST.as_str()
+    //   2. PINNED_PROTOCOL_VERSION (the constant in this file)
+    //   3. crates/rimap-server/tests/fixtures/mcp-spec/<version>/
+    //
+    // All three MUST agree. If any one drifts (rmcp bumps LATEST, the
+    // pinned constant goes stale, or someone deletes the fixture
+    // directory) this test fails first with a precise diagnostic
+    // before any fragment-validation test mis-validates against an
+    // outdated schema.
+
+    let rmcp_latest = ProtocolVersion::LATEST.as_str();
+    assert_eq!(
+        rmcp_latest, PINNED_PROTOCOL_VERSION,
+        "rmcp::ProtocolVersion::LATEST ({rmcp_latest}) drifted from \
+         PINNED_PROTOCOL_VERSION ({PINNED_PROTOCOL_VERSION}). Run \
+         `scripts/refresh-mcp-spec.sh {rmcp_latest}` to vendor the new \
+         schema, update PINNED_PROTOCOL_VERSION + MCP_SCHEMA_JSON in \
+         this file, and update the README under \
+         tests/fixtures/mcp-spec/.",
+    );
+
+    // The fixture directory must exist on disk under the pinned name.
+    let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp-spec")
+        .join(PINNED_PROTOCOL_VERSION);
+    assert!(
+        fixture_dir.is_dir(),
+        "expected vendored fixture directory at {} for pinned version \
+         {PINNED_PROTOCOL_VERSION}; refresh script may not have run",
+        fixture_dir.display(),
+    );
+
+    // And rmcp must echo whatever the harness sends as the negotiated
+    // version, which the harness now derives from LATEST.
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        json!(rmcp_latest),
+        "server must echo the rmcp LATEST version sent by the harness; \
+         got {response}",
+    );
+}
+```
+
+- [ ] **Step 4: Run the suite — all 9 tests must still pass**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo test -p rimap-server --test mcp_wire_conformance -- --nocapture
+```
+Expected: 9 passed.
+
+If `wire_protocol_version_negotiation_matches_vendored_schema` fails with the "rmcp drifted" message, that means rmcp's LATEST and our PINNED_PROTOCOL_VERSION disagree right now — investigate before continuing. (They should both be `2025-11-25` per the earlier Task 3 work.)
+
+- [ ] **Step 5: Run 3x for flake stability**
+
+```bash
+for i in 1 2 3; do
+  cargo test -p rimap-server --test mcp_wire_conformance --quiet 2>&1 | tail -3
+done
+```
+All three runs must show `9 passed; 0 failed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "$(cat <<'EOF'
+test(mcp): drive protocolVersion from rmcp::ProtocolVersion::LATEST
+
+The harness sent the hardcoded PINNED_PROTOCOL_VERSION ('2025-11-25')
+during initialize. If rmcp bumped LATEST but still supported the
+pinned value, real strict clients could negotiate the newer protocol
+while this harness kept validating the old schema and stayed green
+(Codex adversarial review on PR #270, finding #1).
+
+Now the harness sends ProtocolVersion::LATEST.as_str() and the
+version-negotiation test asserts a three-way agreement:
+  - rmcp::ProtocolVersion::LATEST
+  - PINNED_PROTOCOL_VERSION
+  - the vendored fixture directory
+A drift in any one fails the test first with a precise diagnostic.
+
+EOF
+)"
+```
+
+---
+
+## Task 7: Final verification + push the Codex-review fixes
+
+**Files:** none — verification-only.
+
+- [ ] **Step 1: Run the full verification chain**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo deny check
+prek run --all-files
+```
+
+Every command must exit zero. If anything fails, STOP and investigate — do NOT push a broken state to a branch that already has an open PR.
+
+- [ ] **Step 2: Confirm the conformance test list is still 9**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance -- --list
+```
+Expected: still 9 tests, same names.
+
+- [ ] **Step 3: Confirm production-build behavior on `accounts = []`**
+
+This re-runs the Task 4 Step 3 production check, but as part of the final gate. Crucial: it proves the no-flag-no-feature-no-flag-accepted invariant holds end-to-end.
+
+```bash
+cargo build -p rimap-server --bin rusty-imap-mcp --release
+TMP=$(mktemp -d)
+cat > "$TMP/config.toml" <<TOML
+accounts = []
+
+[audit]
+path = "$TMP/audit.jsonl"
+allowed_base_dir = "$TMP"
+TOML
+./target/release/rusty-imap-mcp --config "$TMP/config.toml" --dry-run 2>&1 | grep -i "no accounts" || echo "FAIL: production binary did not reject empty accounts"
+./target/release/rusty-imap-mcp --config "$TMP/config.toml" --allow-empty-accounts --dry-run 2>&1 | grep -i "unknown\|unexpected\|unrecognized" || echo "FAIL: production binary accepted --allow-empty-accounts"
+rm -rf "$TMP"
+```
+
+Both invocations must print the expected error message (not the "FAIL:" line). If either prints "FAIL:", the cfg gating is wrong.
+
+- [ ] **Step 4: Push to the existing PR branch**
+
+```bash
+git log --oneline origin/test/mcp-wire-conformance..HEAD
+```
+
+Confirm the new commits look reasonable (~7 new commits on top of `2734925`, each referencing the Codex review). Then:
+
+```bash
+git push origin HEAD
+```
+
+The push updates PR #270 automatically — no new `gh pr create`.
+
+- [ ] **Step 5: Comment on PR #270 documenting the new commits**
+
+```bash
+gh pr comment 270 --body "$(cat <<'EOF'
+Addressed Codex adversarial review findings:
+
+- **High** (harness pinned version → silent rmcp drift): harness now derives the requested `protocolVersion` from `rmcp::model::ProtocolVersion::LATEST.as_str()`. `wire_protocol_version_negotiation_matches_vendored_schema` asserts three-way agreement between rmcp LATEST, `PINNED_PROTOCOL_VERSION`, and the vendored fixture directory.
+- **Medium** (error envelopes not schema-validated): `Harness::request` now calls `assert_envelope_valid` on every response, picking `JSONRPCResultResponse` or `JSONRPCErrorResponse` and asserting `jsonrpc=2.0`. Every test gets full envelope coverage.
+- **Medium** (empty-accounts boot weakens production): production validator restored to reject `accounts = []` with `ConfigError::NoAccounts`. New `validate_multi_allowing_empty` / `load_and_validate_allowing_empty` live behind the existing `test-support` feature. The binary exposes `--allow-empty-accounts` only when compiled with `--features test-support`; the harness passes it. Release builds reject both the empty config AND the flag.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Risks & non-goals
+
+- **Risk: `validate_multi_inner` factor / loader-format-detect dedup could be skipped** in Task 2 if the current bodies are short enough to duplicate cleanly. The plan permits either approach; whichever lands, the post-condition is "the relaxed validator's body stays in sync with the strict validator's post-empty-check body." If the bodies diverge in the future, the test in Task 2 Step 2 will not detect it — that's why a follow-up factor is preferable when the body grows.
+- **Non-goal:** changing the production behavior of zero-account servers beyond restoring rejection. If a real operator use case for infrastructure-only boot ever materializes (e.g. a docs/quickstart probe), it should be a separate spec with its own opt-in surface (named TOML key, audit-log signal, telemetry) — not a CLI flag.
+- **Non-goal:** validating non-envelope fragments more strictly than the existing `assert_valid` does. Method-level fragment checks (e.g. `ListToolsResult`) stay opt-in per test. The baked envelope validation is the universal floor.

--- a/docs/superpowers/plans/2026-05-12-mcp-wire-conformance.md
+++ b/docs/superpowers/plans/2026-05-12-mcp-wire-conformance.md
@@ -1,0 +1,1479 @@
+# MCP Wire-Shape Conformance Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Rust integration test that spawns `rusty-imap-mcp`, drives MCP JSON-RPC over stdio, and validates every response against vendored MCP spec schemas — a permanent regression net for the bug classes in #261 and `fix/tool-input-schema-object-type`.
+
+**Architecture:** A `Harness` helper spawns the production binary with a tempdir config and zero accounts, pipes stdio, writes newline-delimited JSON-RPC requests, and reads single-line responses under per-call timeouts. Each test compiles a `jsonschema::Validator` against a specific fragment of the vendored MCP `schema.json` (pinned to `2025-11-25`) and asserts every response payload validates. A weekly CI workflow diffs the vendored schema against upstream and opens a tracking issue on drift.
+
+**Tech Stack:** Rust (workspace edition 2024, MSRV 1.88.0), `rmcp 1.5`, `tokio::process::Command` (already in workspace), `jsonschema 0.46`, `assert_cmd` (existing dev-dep), `tempfile` (existing dev-dep), bash + curl + jq for the refresh script, GitHub Actions for drift detection.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md`.
+
+**Issue:** #263.
+
+---
+
+## File structure
+
+| Path | Action | Purpose |
+| --- | --- | --- |
+| `Cargo.toml` | modify | Add `jsonschema` to `[workspace.dependencies]` |
+| `crates/rimap-server/Cargo.toml` | modify | Add `jsonschema` to `[dev-dependencies]` |
+| `crates/rimap-config/src/validate/mod.rs` | modify | Remove the `accounts.is_empty()` rejection |
+| `crates/rimap-config/src/error.rs` | modify | Remove the now-unused `NoAccounts` variant |
+| `crates/rimap-server/tests/fixtures/mcp-spec/README.md` | create | Vendoring rationale + refresh procedure |
+| `crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json` | create | Vendored MCP spec (downloaded) |
+| `crates/rimap-server/tests/mcp_wire_conformance.rs` | create | The harness + 8 test cases |
+| `scripts/refresh-mcp-spec.sh` | create | Refresh / drift-check the vendored schema |
+| `.github/workflows/mcp-spec-drift.yml` | create | Weekly drift detector |
+| `CHANGELOG.md` | modify | Document the new test + behavior change |
+
+---
+
+## Task 1: Lift the empty-accounts restriction
+
+The issue's design requires `rusty-imap-mcp` to boot with zero accounts so the harness can probe `initialize` / `tools/list` / `resources/list` without standing up an IMAP fixture. Today `validate_multi()` rejects this with `ConfigError::NoAccounts`. `build_registry()` already handles an empty account map (the loop body never executes), so removing the validator gate is the only change needed in production code.
+
+**Files:**
+- Modify: `crates/rimap-config/src/validate/mod.rs` (the `if config.accounts.is_empty()` block near line 72)
+- Modify: `crates/rimap-config/src/error.rs` (remove the `NoAccounts` variant near line 166)
+- Test: existing tests in `crates/rimap-config/src/validate/mod.rs` and `crates/rimap-config/tests/` may reference `NoAccounts`
+
+- [ ] **Step 1: Find every reference to `NoAccounts` so the removal is complete**
+
+Run:
+```bash
+rg -n "NoAccounts|no accounts defined" crates/
+```
+Expected: one definition in `error.rs`, one match in `validate/mod.rs` (the check), plus zero or more test references. Record the test paths.
+
+- [ ] **Step 2: Write the failing test for empty-accounts acceptance**
+
+Add to `crates/rimap-config/src/validate/mod.rs` inside the existing `#[cfg(test)] mod tests { ... }` block (place it next to the other `validate_*` tests):
+
+```rust
+#[test]
+fn empty_accounts_array_validates_for_infrastructure_only_boot() {
+    // Before: the server refused to boot with zero accounts. This
+    // blocked the MCP wire-conformance harness (#263) from probing
+    // initialize / tools/list / resources/list without standing up
+    // an IMAP fixture. Empty accounts now validates cleanly; the
+    // resulting AccountRegistry is empty and list_accounts returns
+    // [], which is the correct infrastructure-only behavior.
+    let audit_dir = TempDir::new().unwrap();
+    let cfg = MultiAccountConfig {
+        defaults: DefaultsConfig::default(),
+        accounts: Vec::new(),
+        audit: AuditConfig {
+            path: audit_dir.path().join("audit.jsonl"),
+            allowed_base_dir: Some(audit_dir.path().to_path_buf()),
+            ..AuditConfig::default()
+        },
+        attachments: AttachmentsConfig::default(),
+    };
+    let validated = validate_multi(cfg).expect("empty accounts must validate");
+    assert!(validated.accounts.is_empty());
+}
+```
+
+If `AuditConfig` does not implement `Default`, use the helper that other tests in the file already use to build a base audit config (search for `fn base_config` or similar in the same module and reuse it; do not invent a new helper).
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+Run:
+```bash
+cargo test -p rimap-config empty_accounts_array_validates_for_infrastructure_only_boot
+```
+Expected: FAIL with `Err(NoAccounts)` or similar — the validator still rejects.
+
+- [ ] **Step 4: Remove the empty-accounts gate**
+
+In `crates/rimap-config/src/validate/mod.rs`, find and delete:
+```rust
+    if config.accounts.is_empty() {
+        return Err(ConfigError::NoAccounts);
+    }
+```
+
+- [ ] **Step 5: Delete the `NoAccounts` error variant**
+
+In `crates/rimap-config/src/error.rs`, find and delete:
+```rust
+    /// Multi-account config has an empty `[[accounts]]` array.
+    #[error("no accounts defined in [[accounts]] array")]
+    NoAccounts,
+```
+
+- [ ] **Step 6: Remove or update tests that asserted `NoAccounts` was returned**
+
+For each test that grep found in step 1 (other than the new test added in step 2): delete it if its sole purpose was to assert the rejection, or update it to use a different invalid config if it was testing a broader codepath.
+
+- [ ] **Step 7: Run the full config test suite**
+
+Run:
+```bash
+cargo test -p rimap-config
+```
+Expected: all tests pass, including the new `empty_accounts_array_validates_for_infrastructure_only_boot`.
+
+- [ ] **Step 8: Verify the workspace still compiles end-to-end**
+
+Run:
+```bash
+cargo check --workspace --all-targets
+```
+Expected: clean compile, no references to the removed `NoAccounts` variant.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-config/src/validate/mod.rs crates/rimap-config/src/error.rs
+git commit -m "$(cat <<'EOF'
+feat(config): allow empty accounts array for infrastructure-only boot
+
+Removes the validate_multi() gate that rejected `accounts = []` with
+ConfigError::NoAccounts. The server already coped with an empty
+AccountRegistry (build_registry's loop body simply does not run); the
+gate was the only thing forcing at least one account to be declared.
+
+Unblocks the MCP wire-conformance harness (#263), which spawns the
+binary against a tempdir config with zero accounts to probe initialize
+/ tools/list / resources/list without needing an IMAP fixture.
+
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `jsonschema` to workspace + rimap-server dev-deps
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.dependencies]` block)
+- Modify: `crates/rimap-server/Cargo.toml` (`[dev-dependencies]` block)
+
+- [ ] **Step 1: Add the workspace dependency entry**
+
+In `Cargo.toml`, inside `[workspace.dependencies]`, alongside other test-related deps (look for `assert_cmd`, `predicates`, `mail-parser`), add:
+
+```toml
+# JSON Schema validator used only by integration tests
+# (crates/rimap-server/tests/mcp_wire_conformance.rs) to validate MCP
+# JSON-RPC envelopes against the vendored MCP spec schemas. Pure-Rust,
+# Draft 2020-12 capable. Reviewed for supply-chain risk per
+# SC-PROC-01 on plan execution date.
+jsonschema = { version = "0.46", default-features = false }
+```
+
+- [ ] **Step 2: Add the dev-dependency in rimap-server**
+
+In `crates/rimap-server/Cargo.toml`, inside `[dev-dependencies]`, add:
+
+```toml
+jsonschema = { workspace = true }
+```
+
+- [ ] **Step 3: Verify the workspace resolves**
+
+Run:
+```bash
+cargo update -p jsonschema && cargo check -p rimap-server --tests
+```
+Expected: jsonschema downloads, no compile errors. Note the resolved version printed by cargo for the commit message.
+
+- [ ] **Step 4: Verify cargo-deny is still clean**
+
+Run:
+```bash
+cargo deny check advisories licenses bans sources 2>&1 | tail -20
+```
+Expected: 0 errors. If a new transitive dep trips a license check, address it before continuing (most likely outcome: clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/rimap-server/Cargo.toml
+git commit -m "$(cat <<'EOF'
+deps(test): add jsonschema 0.46 to dev-dependencies (#263)
+
+Used by the MCP wire-conformance harness to validate JSON-RPC
+envelopes against vendored MCP spec schemas. default-features = false
+keeps the build lean — only the validator surface is needed.
+
+EOF
+)"
+```
+
+---
+
+## Task 3: Vendor the MCP spec schema + write the fixtures README
+
+**Files:**
+- Create: `crates/rimap-server/tests/fixtures/mcp-spec/README.md`
+- Create: `crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json`
+
+- [ ] **Step 1: Create the fixtures directory**
+
+Run:
+```bash
+mkdir -p crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25
+```
+
+- [ ] **Step 2: Download the pinned schema**
+
+Run:
+```bash
+curl --fail --show-error --silent --location \
+  "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json" \
+  -o crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+```
+Expected: file downloaded, non-empty, valid JSON.
+
+- [ ] **Step 3: Verify it parses as JSON and identify the definitions key**
+
+Run:
+```bash
+jq -r 'keys[]' crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+```
+Expected output includes either `definitions` or `$defs`. Record which one is used — the harness code in Task 5 references it by name.
+
+- [ ] **Step 4: Verify the four definitions the harness will validate against exist**
+
+Run (substitute `definitions` or `$defs` based on Step 3):
+```bash
+jq -r '.definitions | keys[]' crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json \
+  | grep -E '^(InitializeResult|ListToolsResult|ListResourcesResult|JSONRPCError|JSONRPCResponse)$'
+```
+Expected: at minimum `InitializeResult`, `ListToolsResult`, `ListResourcesResult`, `JSONRPCError`. If any name is missing, search for an equivalent (`Result` may be appended/stripped differently in newer specs); record the exact names and use them in Task 5.
+
+- [ ] **Step 5: Write the fixtures README**
+
+Create `crates/rimap-server/tests/fixtures/mcp-spec/README.md`:
+
+```markdown
+# Vendored MCP Specification Schemas
+
+This directory holds verbatim copies of the JSON Schema documents
+published by the [Model Context Protocol specification][spec-repo].
+They are consumed exclusively by the wire-conformance test
+(`crates/rimap-server/tests/mcp_wire_conformance.rs`, issue #263).
+
+## Pinned version
+
+`2025-11-25/schema.json` — fetched from
+
+    https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/2025-11-25/schema.json
+
+This matches `rmcp::model::ProtocolVersion::LATEST` for `rmcp 1.5`,
+which is what `rusty-imap-mcp` advertises by default during the
+`initialize` handshake.
+
+## Refresh / drift workflow
+
+- `scripts/refresh-mcp-spec.sh <version>` overwrites the vendored
+  copy with the current upstream contents.
+- `scripts/refresh-mcp-spec.sh --check <version>` exits non-zero if
+  the vendored copy differs from upstream.
+- `.github/workflows/mcp-spec-drift.yml` runs the check weekly and
+  opens (or updates) a tracking issue when drift is detected.
+
+## Local diffs
+
+None. The vendored copy is byte-for-byte verbatim; if a future
+rmcp / spec mismatch forces us to relax a strict constraint (e.g. a
+fragment with `additionalProperties: false` that rmcp violates),
+document the diff here and link the rationale.
+
+[spec-repo]: https://github.com/modelcontextprotocol/modelcontextprotocol
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/fixtures/mcp-spec/
+git commit -m "$(cat <<'EOF'
+test(mcp): vendor MCP spec schema 2025-11-25 (#263)
+
+Verbatim copy of upstream schema.json. Matches
+ProtocolVersion::LATEST in rmcp 1.5. Consumed by the wire-
+conformance harness added in a follow-up commit.
+
+EOF
+)"
+```
+
+---
+
+## Task 4: Write the schema refresh / drift-check script
+
+**Files:**
+- Create: `scripts/refresh-mcp-spec.sh`
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/refresh-mcp-spec.sh`:
+
+```bash
+#!/usr/bin/env bash
+#
+# Refresh (or drift-check) the vendored MCP spec schema used by the
+# wire-conformance harness in crates/rimap-server/tests/. See
+# docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md
+# §3.4 and §3.5.
+#
+# Usage:
+#   scripts/refresh-mcp-spec.sh <version>           # overwrite vendored copy
+#   scripts/refresh-mcp-spec.sh --check <version>   # exit non-zero on drift
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixtures_dir="${repo_root}/crates/rimap-server/tests/fixtures/mcp-spec"
+upstream_base="https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema"
+
+mode="refresh"
+if [[ "${1:-}" == "--check" ]]; then
+  mode="check"
+  shift
+fi
+
+version="${1:-}"
+if [[ -z "${version}" ]]; then
+  echo "usage: $0 [--check] <version>" >&2
+  exit 64
+fi
+
+local_path="${fixtures_dir}/${version}/schema.json"
+upstream_url="${upstream_base}/${version}/schema.json"
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+
+curl --fail --show-error --silent --location "${upstream_url}" -o "${tmp}"
+
+if ! jq empty "${tmp}" >/dev/null 2>&1; then
+  echo "fetched payload is not valid JSON: ${upstream_url}" >&2
+  exit 65
+fi
+
+case "${mode}" in
+  refresh)
+    mkdir -p "$(dirname "${local_path}")"
+    mv "${tmp}" "${local_path}"
+    trap - EXIT
+    echo "refreshed ${local_path}"
+    ;;
+  check)
+    if [[ ! -f "${local_path}" ]]; then
+      echo "vendored copy missing: ${local_path}" >&2
+      exit 1
+    fi
+    if ! diff -u "${local_path}" "${tmp}" >&2; then
+      echo "DRIFT: vendored ${version}/schema.json differs from upstream" >&2
+      exit 1
+    fi
+    echo "no drift: ${local_path}"
+    ;;
+esac
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run:
+```bash
+chmod +x scripts/refresh-mcp-spec.sh
+```
+
+- [ ] **Step 3: Lint with shellcheck and shfmt**
+
+Run:
+```bash
+shellcheck scripts/refresh-mcp-spec.sh
+shfmt -i 2 -d scripts/refresh-mcp-spec.sh
+```
+Expected: both clean. If shfmt suggests changes, apply with `shfmt -i 2 -w scripts/refresh-mcp-spec.sh`.
+
+- [ ] **Step 4: Smoke-test refresh mode (should be a no-op since we just downloaded)**
+
+Run:
+```bash
+./scripts/refresh-mcp-spec.sh 2025-11-25
+git status crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+```
+Expected: no diff in `git status` (the file is identical).
+
+- [ ] **Step 5: Smoke-test check mode**
+
+Run:
+```bash
+./scripts/refresh-mcp-spec.sh --check 2025-11-25
+```
+Expected: prints `no drift: ...` and exits 0.
+
+- [ ] **Step 6: Verify check-mode catches drift**
+
+Run:
+```bash
+echo '{"junk": true}' > crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+./scripts/refresh-mcp-spec.sh --check 2025-11-25 || echo "exited non-zero as expected"
+git checkout -- crates/rimap-server/tests/fixtures/mcp-spec/2025-11-25/schema.json
+```
+Expected: script prints `DRIFT: ...`, exits non-zero, and the `git checkout` restores the file.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/refresh-mcp-spec.sh
+git commit -m "$(cat <<'EOF'
+scripts: add refresh-mcp-spec.sh for vendored MCP schemas (#263)
+
+Two modes:
+- refresh: overwrite the vendored copy with current upstream
+- --check: exit non-zero on drift (used by mcp-spec-drift workflow)
+
+POSIX bash, set -euo pipefail, shellcheck/shfmt clean.
+
+EOF
+)"
+```
+
+---
+
+## Task 5: Build the test harness skeleton + first smoke test
+
+This task delivers `mcp_wire_conformance.rs` with the `Harness` helper and one passing test that proves the harness can boot the binary, complete `initialize`, and parse a valid JSON-RPC response. Subsequent tasks layer additional `#[tokio::test]` functions onto the same harness.
+
+**Files:**
+- Create: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Verify the binary names match `cargo_bin!`**
+
+Run:
+```bash
+grep -n "^name = " crates/rimap-server/Cargo.toml | head -5
+```
+Expected: confirm the `[[bin]]` name is `rusty-imap-mcp`. The harness passes this string to `cargo_bin`.
+
+- [ ] **Step 2: Write the harness module + the smoke test (failing scaffold)**
+
+Create `crates/rimap-server/tests/mcp_wire_conformance.rs`:
+
+```rust
+//! MCP wire-shape conformance harness (issue #263, Phase 1).
+//!
+//! Spawns the production `rusty-imap-mcp` binary with a tempdir
+//! config that has zero accounts, drives a deterministic JSON-RPC
+//! sequence over its stdio, and validates every response against
+//! the vendored MCP spec schemas under
+//! `tests/fixtures/mcp-spec/2025-11-25/`.
+//!
+//! Permanent regression net for two real wire-shape bugs:
+//!  - #261: `initialize.result.capabilities` was serialized as `{}`.
+//!  - `fix/tool-input-schema-object-type`: tools advertised
+//!    `inputSchema: {}` with no `type` field.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::unwrap_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+#![expect(clippy::missing_panics_doc, reason = "test helpers")]
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::timeout;
+
+/// MCP protocol version pinned by this harness. Matches the
+/// directory under `tests/fixtures/mcp-spec/` and the `LATEST` value
+/// in `rmcp 1.5`. Update both when bumping.
+const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Vendored MCP spec schema, compiled in at build time so tests run
+/// hermetically (no network, no filesystem dependency beyond the
+/// crate source).
+const MCP_SCHEMA_JSON: &str = include_str!(
+    "fixtures/mcp-spec/2025-11-25/schema.json"
+);
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Owns the spawned child plus its piped stdio.
+struct Harness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+    // Hold the tempdir until the harness drops so the audit log path
+    // remains valid for the lifetime of the spawned process.
+    _tempdir: TempDir,
+}
+
+impl Harness {
+    /// Spawn the binary with a zero-account tempdir config.
+    async fn spawn() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+
+        let config = format!(
+            r#"
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = timeout(SPAWN_TIMEOUT, async { cmd.spawn() })
+            .await
+            .expect("spawn within timeout")
+            .expect("spawn");
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Send a JSON-RPC request and return the parsed response value.
+    /// Panics on timeout, EOF before a response arrives, or
+    /// non-JSON output.
+    async fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+
+        let mut buf = String::new();
+        let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
+            .await
+            .expect("response within timeout")
+            .expect("read response");
+        assert!(read > 0, "stdout closed before responding to {method}");
+        let response: Value =
+            serde_json::from_str(buf.trim_end()).expect("parse response JSON");
+        assert_eq!(response["id"], json!(id), "response id must match request");
+        response
+    }
+
+    /// Send a JSON-RPC notification (no `id`, no response expected).
+    async fn notify(&mut self, method: &str, params: Value) {
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write notification");
+        self.stdin.flush().await.expect("flush notification");
+    }
+
+    /// Assert no bytes arrive on stdout for the given duration.
+    async fn assert_no_response_within(&mut self, dur: Duration) {
+        let mut buf = String::new();
+        match timeout(dur, self.stdout.read_line(&mut buf)).await {
+            Err(_) => {} // timeout → no response, as expected
+            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
+            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
+            Ok(Err(e)) => panic!("read error: {e}"),
+        }
+    }
+
+    /// Send an MCP `initialize` request with the pinned protocol
+    /// version and return the response.
+    async fn initialize_handshake(&mut self) -> Value {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion": PINNED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-conformance-harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+        .await
+    }
+
+    /// Send `notifications/initialized` after the handshake.
+    async fn send_initialized(&mut self) {
+        self.notify("notifications/initialized", json!({})).await;
+    }
+
+    /// Close stdin, await the child, and return its exit status.
+    async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
+        drop(self.stdin);
+        timeout(SHUTDOWN_TIMEOUT, self.child.wait())
+            .await
+            .expect("clean exit within timeout")
+            .expect("wait")
+    }
+}
+
+/// Compile (once) and return a validator for a top-level definition in
+/// the vendored MCP schema. `fragment` is the key under
+/// `definitions` / `$defs` (e.g. "InitializeResult"). Returns an
+/// `Arc` so multiple parallel tests can share the compiled validator
+/// without lifetime gymnastics.
+fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().unwrap();
+    if let Some(v) = guard.get(fragment) {
+        return Arc::clone(v);
+    }
+
+    // Detect which key the spec uses for nested definitions. Newer
+    // JSON Schema dialects use `$defs`; older specs use `definitions`.
+    let full: Value =
+        serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
+    let defs_key = if full.get("$defs").is_some() {
+        "$defs"
+    } else {
+        "definitions"
+    };
+
+    // Build a wrapper schema that $refs into the requested fragment.
+    let wrapper = json!({
+        "$ref": format!("#/{defs_key}/{fragment}"),
+        defs_key: full.get(defs_key).cloned().unwrap_or(json!({})),
+    });
+    let v = Arc::new(
+        jsonschema::validator_for(&wrapper).expect("compile fragment validator"),
+    );
+    guard.insert(fragment, Arc::clone(&v));
+    v
+}
+
+/// Validate a value against a vendored fragment, panicking with the
+/// list of errors on failure.
+fn assert_valid(value: &Value, fragment: &'static str) {
+    let v = validator_for(fragment);
+    if !v.is_valid(value) {
+        let errors: Vec<String> = v.iter_errors(value).map(|e| e.to_string()).collect();
+        panic!(
+            "schema validation failed for fragment {fragment}:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_smoke_initialize_returns_valid_envelope() {
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+    assert_eq!(response["jsonrpc"], json!("2.0"));
+    assert!(
+        response["result"].is_object(),
+        "initialize response must have a result object, got {response}"
+    );
+}
+```
+
+- [ ] **Step 3: Run the smoke test and confirm it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_smoke_initialize_returns_valid_envelope -- --nocapture
+```
+Expected: PASS. If FAIL, common causes:
+- `cargo_bin` cannot find the binary → run `cargo build -p rimap-server --bin rusty-imap-mcp` first.
+- Binary writes to stdout before JSON-RPC → check `crates/rimap-server/src/boot/logging.rs` to confirm logging goes to stderr only.
+- Schema fragment key mismatch → adjust `defs_key` detection.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "$(cat <<'EOF'
+test(mcp): wire-conformance harness scaffold + initialize smoke (#263)
+
+Spawns rusty-imap-mcp with a zero-account tempdir config, drives
+newline-delimited JSON-RPC over stdio with per-call timeouts, and
+parses one initialize response. Schema validation + remaining test
+cases land in follow-up commits.
+
+EOF
+)"
+```
+
+---
+
+## Task 6: Test case 1 — `initialize` advertises tools capability
+
+Adds a full validation pass on top of the smoke test, including the regression net for #261.
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_initialize_advertises_tools_capability() {
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+
+    let result = &response["result"];
+    assert_valid(result, "InitializeResult");
+
+    assert_eq!(
+        result["protocolVersion"],
+        json!(PINNED_PROTOCOL_VERSION),
+        "server must echo the pinned protocol version",
+    );
+
+    // Regression net for #261: the capabilities object must contain
+    // a `tools` key on the wire. Permissive clients ignore the
+    // absence; spec-strict clients (e.g. bobshell) refuse to call
+    // tools/list.
+    let capabilities = &result["capabilities"];
+    assert!(
+        capabilities.is_object(),
+        "capabilities must be an object, got {capabilities}",
+    );
+    assert!(
+        capabilities.get("tools").is_some(),
+        "capabilities.tools must be present on the wire; got {capabilities}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_initialize_advertises_tools_capability -- --nocapture
+```
+Expected: PASS. If schema validation fails, inspect the error list — most likely a fragment-name mismatch (try `InitializeResult` vs. the exact key from Task 3 Step 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert initialize advertises tools capability (#263, #261)"
+```
+
+---
+
+## Task 7: Test case 8 — protocol-version negotiation matches vendored schema
+
+This test is sequenced before the larger cases because if it fails (rmcp bumped LATEST), the other tests will mis-validate. Failing first means a single clear signal: "refresh the vendored schema."
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_protocol_version_negotiation_matches_vendored_schema() {
+    // Sends an initialize request with the LATEST version known to
+    // the test, asks the server to echo it back. rmcp negotiates
+    // min(client, server), so when the server bumps to a newer
+    // LATEST this still succeeds — but if the server somehow
+    // negotiates to an older version (e.g. the pinned string is
+    // wrong) this test catches it. The fragment-validation tests
+    // depend on this invariant.
+    let mut harness = Harness::spawn().await;
+    let response = harness.initialize_handshake().await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        json!(PINNED_PROTOCOL_VERSION),
+        "harness pinned to {PINNED_PROTOCOL_VERSION} but server returned a \
+         different value; either update PINNED_PROTOCOL_VERSION + the \
+         tests/fixtures/mcp-spec/<version>/ directory, or fix the rmcp \
+         negotiation regression. Full response: {response}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_protocol_version_negotiation_matches_vendored_schema -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert negotiated protocolVersion matches vendored schema (#263)"
+```
+
+---
+
+## Task 8: Test case 2 — `notifications/initialized` elicits no response
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_initialized_notification_elicits_no_response() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+    harness
+        .assert_no_response_within(Duration::from_millis(200))
+        .await;
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_initialized_notification_elicits_no_response -- --nocapture
+```
+Expected: PASS within ~200 ms.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert notifications/initialized is silent (#263)"
+```
+
+---
+
+## Task 9: Test case 3 — `tools/list` returns object-typed input schemas
+
+This is the regression net for `fix/tool-input-schema-object-type`.
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_tools_list_returns_object_schemas() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("tools/list", json!({})).await;
+    let result = &response["result"];
+    assert_valid(result, "ListToolsResult");
+
+    let tools = result["tools"]
+        .as_array()
+        .expect("tools must be an array");
+    assert!(!tools.is_empty(), "tools/list must return at least the infrastructure tools");
+
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"list_accounts"),
+        "list_accounts must be advertised; got names {names:?}",
+    );
+    assert!(
+        names.contains(&"use_account"),
+        "use_account must be advertised; got names {names:?}",
+    );
+
+    // Regression net for fix/tool-input-schema-object-type: every
+    // tool advertised on the wire must declare an object inputSchema.
+    // Permissive MCP clients tolerate the absence; Zod-based clients
+    // reject the tool.
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap_or("<missing-name>");
+        let schema = &tool["inputSchema"];
+        assert!(
+            schema.is_object(),
+            "tool {name}: inputSchema must be an object, got {schema}",
+        );
+        assert_eq!(
+            schema["type"],
+            json!("object"),
+            "tool {name}: inputSchema.type must be \"object\" (issue #263 regression net), got {schema}",
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_tools_list_returns_object_schemas -- --nocapture
+```
+Expected: PASS. (This test would have caught the bug fixed in `fix/tool-input-schema-object-type`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert every tools/list inputSchema.type is object (#263)"
+```
+
+---
+
+## Task 10: Test case 4 — `resources/list` is empty for zero accounts
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_resources_list_is_empty_for_no_accounts() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("resources/list", json!({})).await;
+    let result = &response["result"];
+    assert_valid(result, "ListResourcesResult");
+
+    let resources = result["resources"]
+        .as_array()
+        .expect("resources must be an array");
+    assert!(
+        resources.is_empty(),
+        "zero accounts must produce zero resources, got {resources:?}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_resources_list_is_empty_for_no_accounts -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert resources/list empty with zero accounts (#263)"
+```
+
+---
+
+## Task 11: Test case 5 — `tools/call` with unknown tool returns INVALID_PARAMS
+
+`rmcp 1.5`'s router emits `ErrorData::invalid_params("tool not found", None)` for unknown tool names — confirmed in `rmcp-1.5.0/src/handler/server/router/tool.rs:415`. Code is `-32602`.
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_tools_call_unknown_tool_returns_error_envelope() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "this_tool_does_not_exist",
+                "arguments": {}
+            }),
+        )
+        .await;
+
+    assert!(
+        response["error"].is_object(),
+        "expected error envelope, got {response}",
+    );
+    // rmcp 1.5 emits INVALID_PARAMS (-32602) with message "tool not found"
+    // for unknown tool names; see rmcp-1.5.0/src/handler/server/router/tool.rs.
+    // If this code ever changes, update the assertion and document why
+    // — silent drift in rmcp's error mapping is exactly what this test
+    // is meant to surface.
+    assert_eq!(
+        response["error"]["code"],
+        json!(-32602),
+        "expected -32602 INVALID_PARAMS, got {response}",
+    );
+    assert!(
+        response["error"]["message"].is_string(),
+        "error.message must be a string, got {response}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_tools_call_unknown_tool_returns_error_envelope -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert tools/call unknown name returns INVALID_PARAMS (#263)"
+```
+
+---
+
+## Task 12: Test case 6 — unknown method returns -32601
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_unknown_method_returns_minus_32601() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness.request("rimap/no_such_method", json!({})).await;
+    assert!(
+        response["error"].is_object(),
+        "expected error envelope, got {response}",
+    );
+    assert_eq!(
+        response["error"]["code"],
+        json!(-32601),
+        "JSON-RPC method-not-found code, got {response}",
+    );
+    assert!(
+        response["error"]["message"].as_str().is_some_and(|s| !s.is_empty()),
+        "error.message must be non-empty, got {response}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_unknown_method_returns_minus_32601 -- --nocapture
+```
+Expected: PASS. If FAIL with a different code (e.g. -32600), note rmcp's actual mapping and adjust the assertion + comment to match. The test should reflect what the server actually does, not aspiration.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert unknown method returns -32601 (#263)"
+```
+
+---
+
+## Task 13: Test case 7 — clean EOF shutdown exits zero
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `mcp_wire_conformance.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_clean_eof_shutdown_exits_zero() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+    let status = harness.shutdown_and_wait().await;
+    assert!(
+        status.success(),
+        "server must exit 0 on clean stdin EOF, got {status:?}",
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance wire_clean_eof_shutdown_exits_zero -- --nocapture
+```
+Expected: PASS within 1 s.
+
+- [ ] **Step 3: Run the entire conformance test file end-to-end**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance -- --nocapture
+```
+Expected: all 8 tests pass. Total runtime should be well under 30 s; if any test takes more than 5 s investigate before continuing.
+
+- [ ] **Step 4: Run the full workspace test suite to catch any cross-crate regression**
+
+Run:
+```bash
+cargo test --workspace
+```
+Expected: all tests pass. If anything fails, especially in rimap-config tests touching `NoAccounts`, revisit Task 1.
+
+- [ ] **Step 5: Run clippy with workspace deny-warnings**
+
+Run:
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "test(mcp): assert clean stdin EOF exits zero (#263)"
+```
+
+---
+
+## Task 14: Add the CI drift-detection workflow
+
+**Files:**
+- Create: `.github/workflows/mcp-spec-drift.yml`
+
+- [ ] **Step 1: Look up the current pinned SHAs for actions used by the workflow**
+
+The project's existing workflows pin every action to a 40-char SHA with a version comment. To stay consistent, capture the latest stable SHA for `actions/checkout` from another workflow in this repo:
+
+```bash
+grep -rh "actions/checkout@" .github/workflows/ | head -5
+```
+
+Record the SHA + version comment. Use the same pinning style below.
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/mcp-spec-drift.yml` (substitute the SHA captured above where indicated):
+
+```yaml
+# Weekly drift detector for the vendored MCP spec schemas consumed by
+# crates/rimap-server/tests/mcp_wire_conformance.rs. See
+# docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md §3.5.
+
+name: mcp-spec-drift
+
+on:
+  schedule:
+    # Mondays 12:00 UTC. Cron is best-effort on GitHub Actions but
+    # weekly cadence is fine here — we only need eventual notice.
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mcp-spec-drift
+  cancel-in-progress: false
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    env:
+      PINNED_VERSION: '2025-11-25'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@<SHA-FROM-STEP-1>  # vX.Y.Z
+        with:
+          persist-credentials: false
+
+      - name: Run drift check
+        id: check
+        run: |
+          set -euo pipefail
+          if ./scripts/refresh-mcp-spec.sh --check "${PINNED_VERSION}"; then
+            echo "drift=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "drift=true" >> "${GITHUB_OUTPUT}"
+            # Capture the diff for the issue body. The script wrote
+            # the diff to stderr — re-run and capture both streams.
+            ./scripts/refresh-mcp-spec.sh --check "${PINNED_VERSION}" \
+              > drift-diff.txt 2>&1 || true
+          fi
+
+      - name: Open or update tracking issue on drift
+        if: steps.check.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="MCP spec drift: ${PINNED_VERSION}/schema.json"
+          body_file="$(mktemp)"
+          {
+            echo "Weekly drift check found differences between the vendored"
+            echo "MCP spec at \`crates/rimap-server/tests/fixtures/mcp-spec/${PINNED_VERSION}/schema.json\`"
+            echo "and upstream \`modelcontextprotocol/modelcontextprotocol@main\`."
+            echo ""
+            echo "Run \`scripts/refresh-mcp-spec.sh ${PINNED_VERSION}\` to update the vendored copy"
+            echo "and re-run \`cargo test -p rimap-server --test mcp_wire_conformance\` to confirm"
+            echo "the harness still validates."
+            echo ""
+            echo "<details><summary>diff</summary>"
+            echo ""
+            echo '```diff'
+            cat drift-diff.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > "${body_file}"
+          existing="$(gh issue list --label mcp-spec-drift --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          if [[ -n "${existing}" ]]; then
+            gh issue comment "${existing}" --body-file "${body_file}"
+          else
+            gh issue create --title "${title}" --label mcp-spec-drift --body-file "${body_file}"
+          fi
+          # Fail the run so the Actions tab badge reflects drift even
+          # if the issue mechanism somehow no-ops.
+          exit 1
+```
+
+- [ ] **Step 3: Lint with actionlint + zizmor**
+
+Run:
+```bash
+actionlint .github/workflows/mcp-spec-drift.yml
+zizmor .github/workflows/mcp-spec-drift.yml
+```
+Expected: both clean. Fix any findings before committing — common ones are missing `persist-credentials: false` (already set above) or unpinned actions.
+
+- [ ] **Step 4: Ensure the `mcp-spec-drift` label exists**
+
+Run:
+```bash
+gh label list --search mcp-spec-drift
+```
+
+If it does not exist, create it:
+```bash
+gh label create mcp-spec-drift \
+  --color "B60205" \
+  --description "Vendored MCP spec schema has drifted from upstream"
+```
+
+- [ ] **Step 5: Manually trigger the workflow once to verify it runs**
+
+After the PR merges (the workflow is not runnable from the branch unless `workflow_dispatch` is on `main`), trigger it via:
+```bash
+gh workflow run mcp-spec-drift.yml
+```
+
+This is a post-merge verification — note it for the PR description.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/mcp-spec-drift.yml
+git commit -m "$(cat <<'EOF'
+ci: add mcp-spec-drift weekly check (#263)
+
+Runs scripts/refresh-mcp-spec.sh --check against the vendored MCP
+schema. On drift, opens or comments on a tracking issue with the
+diff and fails the run for badge visibility.
+
+EOF
+)"
+```
+
+---
+
+## Task 15: CHANGELOG + cross-link the spec
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Read the current top of CHANGELOG.md to match the existing style**
+
+Run:
+```bash
+sed -n '1,40p' CHANGELOG.md
+```
+
+Note the header pattern (likely `## [Unreleased]` with sub-sections like `### Added`, `### Changed`).
+
+- [ ] **Step 2: Add entries under Unreleased**
+
+Edit `CHANGELOG.md` and add under `## [Unreleased]`:
+
+```markdown
+### Added
+
+- MCP wire-shape conformance test
+  (`crates/rimap-server/tests/mcp_wire_conformance.rs`) — spawns the
+  binary, drives JSON-RPC over stdio, and validates every response
+  against the vendored MCP spec schema. Permanent regression net for
+  #261 (empty capabilities) and `fix/tool-input-schema-object-type`
+  (empty inputSchema). Issue #263.
+- `scripts/refresh-mcp-spec.sh` to refresh or drift-check the vendored
+  MCP spec schema.
+- `.github/workflows/mcp-spec-drift.yml` — weekly check that opens a
+  tracking issue when the vendored MCP schema differs from upstream.
+
+### Changed
+
+- `rimap-config` now accepts configs with `accounts = []`. The server
+  boots in infrastructure-only mode (only `list_accounts` / `use_account`
+  are functionally useful). Unblocks the wire-conformance harness.
+  Removes `ConfigError::NoAccounts`.
+```
+
+If the existing format differs, adapt to match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record MCP wire-conformance harness landing (#263)"
+```
+
+---
+
+## Task 16: Pre-PR verification gate
+
+- [ ] **Step 1: Run the full workspace verification chain**
+
+Run each in sequence and confirm clean output:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo deny check
+prek run --all-files
+```
+
+Expected: every command exits 0. Any failure must be addressed before opening the PR — do not bypass.
+
+- [ ] **Step 2: Confirm the new test file's specific test list**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance -- --list
+```
+
+Expected: lists exactly these tests:
+- `wire_smoke_initialize_returns_valid_envelope`
+- `wire_initialize_advertises_tools_capability`
+- `wire_protocol_version_negotiation_matches_vendored_schema`
+- `wire_initialized_notification_elicits_no_response`
+- `wire_tools_list_returns_object_schemas`
+- `wire_resources_list_is_empty_for_no_accounts`
+- `wire_tools_call_unknown_tool_returns_error_envelope`
+- `wire_unknown_method_returns_minus_32601`
+- `wire_clean_eof_shutdown_exits_zero`
+
+That's 9 tests (8 from the spec + 1 smoke). If any are missing, return to the corresponding task before opening the PR.
+
+- [ ] **Step 3: Confirm the spec → plan → code chain is intact**
+
+Run:
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: a sequence of one commit per task, in order, attributable to the spec and issue. Tidy up via interactive rebase only if explicitly requested by the reviewer — by default, leave the commit-per-task structure as the audit trail.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "test(mcp): Phase 1 wire-shape conformance harness (#263)" --body "$(cat <<'EOF'
+## Summary
+
+- Spawns rusty-imap-mcp with a zero-account tempdir config and drives MCP JSON-RPC over stdio.
+- Validates every response against the vendored MCP spec schema (`2025-11-25`).
+- Permanent regression nets for #261 (empty capabilities) and `fix/tool-input-schema-object-type` (empty inputSchema).
+- Lifts `ConfigError::NoAccounts` to allow infrastructure-only boot.
+- Adds a refresh script and weekly CI drift detector for the vendored schema.
+
+Closes #263.
+
+## Test plan
+
+- [ ] `cargo test -p rimap-server --test mcp_wire_conformance` — 9 tests, all green.
+- [ ] `cargo test --workspace` — full suite green.
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
+- [ ] `cargo deny check` — clean.
+- [ ] `actionlint` + `zizmor` against the new workflow — clean.
+- [ ] Post-merge: `gh workflow run mcp-spec-drift.yml` once to confirm the drift workflow executes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out of scope (Phase 2–4, separate issues)
+
+- Node SDK strict-client validation — issue #264.
+- Behavioral conformance against Dovecot fixture — issue #265.
+- Protocol fuzzing / negative-path coverage — issue #266.
+
+If any task here surfaces a bug that fits one of those scopes, capture it as a comment on the corresponding issue, not in this PR.

--- a/docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md
@@ -1,0 +1,281 @@
+# MCP Wire-Shape Conformance Harness — Design
+
+**Status:** Draft 2026-05-12
+**Scope:** Phase 1 of 4 (issue #263) — a Rust integration test that spawns
+`rusty-imap-mcp` via stdio, drives a fixed sequence of MCP JSON-RPC
+requests, and validates every response against the MCP spec's official
+JSON schemas. Phases 2–4 (Node strict-client, behavioral conformance vs.
+Dovecot, protocol fuzzing) are tracked in #264 / #265 / #266 and are out
+of scope here.
+
+## 1. Motivation
+
+Two real wire-shape bugs shipped past 200+ unit tests, the full
+Dovecot-backed `tests/e2e.rs` integration suite, and `cargo deny`:
+
+1. **#261 — empty `capabilities`.** `ServerInfo::default()` produced
+   `"capabilities": {}` because every field was `None` and serde
+   dropped them via `skip_serializing_if`. Spec-strict clients
+   (`bobshell`) refused to call `tools/list`.
+2. **`fix/tool-input-schema-object-type` — empty `inputSchema`.**
+   No-argument tools (`list_folders`, `list_accounts`) advertised
+   `"inputSchema": {}` instead of `{"type":"object","properties":{},"additionalProperties":false}`.
+   Zod-based clients rejected the tools.
+
+Neither bug is reachable from the in-process Rust API used by
+`tests/e2e.rs`, which calls `ImapMcpServer::dispatch_account_scoped`
+directly and bypasses serialization. Permissive clients (Claude
+Desktop, IBM Bob desktop, MCP Inspector) tolerated both regressions;
+the problems only surfaced against `bobshell` during a multi-hour
+remote debugging session.
+
+This phase eliminates the class of bug from regression-testing without
+requiring Docker, a real IMAP server, or a Node toolchain.
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- Spawn the production `rusty-imap-mcp` binary, drive its stdio with a
+  deterministic JSON-RPC sequence, and validate every response against
+  the MCP spec's JSON schemas.
+- Permanent regression nets for the two cited bugs:
+  - `initialize.result.capabilities.tools` is present on the wire.
+  - Every `tools/list.result.tools[*].inputSchema.type == "object"`.
+- Sub-second per test, no Docker, no network, no flakiness.
+- Vendored schemas with a CI drift detector — deterministic offline
+  builds, but no silent staleness when upstream MCP spec bumps.
+
+### Non-Goals
+
+- IMAP behavior (Phase 3 / #265).
+- Node SDK strict-client validation (Phase 2 / #264).
+- Coverage-guided fuzzing or property tests (Phase 4 / #266).
+- Schema validation of tool *output* shape — out of scope for Phase 1;
+  the spec schemas describe envelope and method-level result shape,
+  which is what the cited bugs exercised.
+
+## 3. Architecture
+
+### 3.1 Test driver
+
+New file: `crates/rimap-server/tests/mcp_wire_conformance.rs`.
+
+A `Harness` helper owns the spawned child and exposes:
+
+```rust
+async fn request(&mut self, method: &str, params: Value) -> Value;
+async fn notify(&mut self, method: &str, params: Value);
+async fn assert_no_response_within(&mut self, dur: Duration);
+async fn shutdown_and_wait(self) -> ExitStatus;
+```
+
+- Spawns via `tokio::process::Command` with stdin/stdout/stderr piped.
+  Stderr is drained into a `Vec<u8>` for failure diagnostics.
+- `request` writes exactly one line of JSON-RPC, reads exactly one line
+  of stdout under a 2 s timeout, and parses to `serde_json::Value`. On
+  timeout the captured stderr is included in the panic message.
+- `notify` is fire-and-forget; pairs with `assert_no_response_within`.
+- `shutdown_and_wait` closes stdin, awaits the child with a 1 s
+  timeout, and returns the exit status.
+- One `Harness::spawn()` per test — clean isolation, parallel-safe
+  (`cargo test` runs integration tests in parallel by default).
+
+The harness uses `assert_cmd::cargo::cargo_bin("rusty-imap-mcp")` to
+resolve the freshly-built binary path. `assert_cmd` is already in
+dev-dependencies.
+
+### 3.2 Spawned-binary config
+
+For each test the harness:
+
+1. Creates a `TempDir`.
+2. Writes a minimal `config.toml` with `accounts = []` and
+   `audit.path = <tempdir>/audit.jsonl`.
+3. Invokes the binary with `--config <path>`.
+
+No accounts means no IMAP connection attempts, no keychain access, no
+network. The audit log writes inside the tempdir and is cleaned up
+when the test finishes.
+
+### 3.3 Vendored MCP spec schemas
+
+Layout:
+
+```
+crates/rimap-server/tests/fixtures/mcp-spec/
+  README.md                        # source URL, refresh procedure, any local diffs
+  2025-06-18/
+    schema.json                    # verbatim vendored copy
+```
+
+One version is pinned. The pinned version is selected during plan
+execution to match what `rmcp 1.4` negotiates by default (likely
+`2025-06-18`, to be confirmed by reading rmcp's protocolVersion
+handling in the implementation plan).
+
+Schemas are compiled lazily via `OnceLock<jsonschema::Validator>` per
+fragment (`InitializeResult`, `ListToolsResult`, `ListResourcesResult`,
+`JSONRPCResponse`, `JSONRPCError`). Compilation happens once per test
+process; reuse is cheap.
+
+### 3.4 Schema refresh script
+
+`scripts/refresh-mcp-spec.sh`. POSIX bash, `set -euo pipefail`,
+`shellcheck`-clean.
+
+Two modes:
+
+- Default (`refresh-mcp-spec.sh <version>`): `curl` the schema from
+  `https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/<version>/schema.json`,
+  write atomically over the vendored file.
+- Check (`refresh-mcp-spec.sh --check <version>`): fetch upstream into
+  a temp file, `diff` against the vendored copy, exit non-zero on
+  drift.
+
+### 3.5 CI drift detector
+
+New workflow: `.github/workflows/mcp-spec-drift.yml`.
+
+- Trigger: `schedule: cron: '0 12 * * 1'` (Mondays at noon UTC) +
+  `workflow_dispatch`.
+- Runs `scripts/refresh-mcp-spec.sh --check <pinned-version>`.
+- On drift, the workflow uses `gh issue list --label mcp-spec-drift
+  --state open` to find an existing tracking issue. If one exists, it
+  posts a comment with the diff summary. Otherwise it opens a new
+  issue labelled `mcp-spec-drift` with the diff in the body.
+- The workflow itself fails (red badge) so drift is visible in the
+  Actions tab even if the issue mechanism breaks.
+
+Permissions: minimum-scope `GITHUB_TOKEN` (`contents: read`,
+`issues: write`). Pinned to SHA per project convention.
+
+## 4. Test sequence
+
+Each item is one `#[tokio::test(flavor = "multi_thread")]` function.
+
+1. **`wire_initialize_advertises_tools_capability`**
+   - Send `initialize` with a vendored client info payload.
+   - Assert the full response validates against the
+     `InitializeResult` schema fragment.
+   - Assert `result.protocolVersion == <pinned>`.
+   - Assert `result.capabilities.tools` is present (regression net for
+     #261).
+
+2. **`wire_initialized_notification_elicits_no_response`**
+   - Run the `initialize` handshake.
+   - Send `notifications/initialized`.
+   - Assert no bytes appear on stdout within 200 ms.
+
+3. **`wire_tools_list_returns_object_schemas`**
+   - Handshake, then `tools/list`.
+   - Assert envelope + `ListToolsResult` validate.
+   - Assert at least `list_accounts` and `use_account` are present.
+   - For every tool, assert `inputSchema.type == "object"`
+     (regression net for `fix/tool-input-schema-object-type`).
+
+4. **`wire_resources_list_is_empty_for_no_accounts`**
+   - Handshake, then `resources/list`.
+   - Assert envelope + `ListResourcesResult` validate.
+   - Assert `result.resources == []`.
+
+5. **`wire_tools_call_unknown_tool_returns_error_envelope`**
+   - Handshake, then `tools/call` with a tool name that does not
+     exist.
+   - Assert envelope validates as `JSONRPCError`.
+   - Assert `error.code` matches whatever rmcp emits for this case;
+     the exact code is recorded in the test with a comment so a
+     change in rmcp's mapping is a visible test edit, not silent
+     drift.
+
+6. **`wire_unknown_method_returns_minus_32601`**
+   - Handshake, then a request with `method == "foo/bar"`.
+   - Assert envelope validates as `JSONRPCError`.
+   - Assert `error.code == -32601`.
+
+7. **`wire_clean_eof_shutdown_exits_zero`**
+   - Handshake, then close stdin.
+   - Assert `shutdown_and_wait()` returns `ExitStatus::success()`
+     within 1 s.
+
+8. **`wire_protocol_version_negotiation_matches_vendored_schema`**
+   - Send `initialize`.
+   - Assert the returned `protocolVersion` equals the version directory
+     under `tests/fixtures/mcp-spec/`. If rmcp bumps and the directory
+     does not move, this test fails first and tells us to refresh
+     the vendored schema before everything else breaks.
+
+## 5. Dependencies
+
+Added to `[workspace.dependencies]`:
+
+```toml
+# Validates MCP JSON-RPC envelopes against the vendored MCP spec schemas.
+# Test-only — gated to dev-dependencies in member crates.
+jsonschema = { version = "0.34", default-features = false }
+```
+
+Added to `[dev-dependencies]` in `crates/rimap-server/Cargo.toml`:
+
+```toml
+jsonschema = { workspace = true }
+```
+
+The exact `jsonschema` version is chosen during plan execution by
+reading the latest stable release notes. No new runtime dependencies.
+
+## 6. Risks & mitigations
+
+- **rmcp emits fields outside the upstream schema.** Most MCP spec
+  fragments do not set `additionalProperties: false`, but if any
+  fragment we use is strict we relax it in the vendored copy and
+  document the diff in `tests/fixtures/mcp-spec/<version>/README.md`.
+- **The binary writes non-JSON to stdout before the JSON-RPC stream.**
+  Would break framing. The boot logging path already goes to stderr;
+  the harness includes a guard that asserts the first line on stdout
+  is a parseable JSON-RPC response. If a future change adds stdout
+  noise, this guard fires before anything else.
+- **Slow CI runners exceed the 2 s per-request timeout on first
+  call.** Mitigated by a separate, longer spawn timeout (5 s) on
+  `Harness::spawn()`, distinct from the per-request budget.
+- **CRLF line endings on Windows runners.** Not relevant — we publish
+  for Linux / macOS only — but the reader trims `\r` for safety.
+- **Parallel test runs spawn N binaries concurrently.** Each owns its
+  own tempdir and stdio pipes; no shared state. Bounded by the test
+  thread pool.
+
+## 7. Acceptance criteria mapping
+
+| Issue #263 criterion | Where addressed |
+| --- | --- |
+| Test file lands at `crates/rimap-server/tests/mcp_wire_conformance.rs` | §3.1, §4 |
+| Runs under `cargo test -p rimap-server --tests mcp_wire_conformance` | §3.1 |
+| No external deps beyond existing dev-deps + `jsonschema` | §5 |
+| Sub-second per test, no flakiness from process startup races | §3.1 (timeouts), §6 (mitigations) |
+| Documented in `docs/superpowers/specs/` | This document |
+| Regression net for #261 (capabilities.tools present) | §4 case 1 |
+| Regression net for `fix/tool-input-schema-object-type` | §4 case 3 |
+
+## 8. Open items resolved during plan execution
+
+- Exact pinned `protocolVersion` value (read rmcp 1.4 source).
+- Exact `jsonschema` crate version (pick current stable; vet via
+  `cargo deny` and supply-chain reviewer per project convention).
+- Exact rmcp error code for `tools/call` with unknown tool name
+  (record in test with a `// rmcp 1.4 emits this code` comment).
+- Whether the spec ships a single combined `schema.json` or multiple
+  fragment files (current upstream: single `schema.json` — confirm at
+  fetch time and adjust §3.4 if it has split).
+
+## 9. References
+
+- Issue #263 — phasing parent.
+- #261 — capabilities-empty bug, fixed.
+- `fix/tool-input-schema-object-type` — inputSchema-empty bug, fix
+  pending PR.
+- MCP specification repo:
+  `https://github.com/modelcontextprotocol/modelcontextprotocol`
+- `docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md`
+  — broader test-strategy context; this phase is complementary, not
+  overlapping, with Sprint B3 (`rimap-server` + `rimap-imap` fuzz +
+  mutation hardening).

--- a/scripts/refresh-mcp-spec.sh
+++ b/scripts/refresh-mcp-spec.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Refresh (or drift-check) the vendored MCP spec schema used by the
+# wire-conformance harness in crates/rimap-server/tests/. See
+# docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md
+# §3.4 and §3.5.
+#
+# Usage:
+#   scripts/refresh-mcp-spec.sh <version>           # overwrite vendored copy
+#   scripts/refresh-mcp-spec.sh --check <version>   # exit non-zero on drift
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixtures_dir="${repo_root}/crates/rimap-server/tests/fixtures/mcp-spec"
+upstream_base="https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema"
+
+mode="refresh"
+if [[ "${1:-}" == "--check" ]]; then
+    mode="check"
+    shift
+fi
+
+version="${1:-}"
+if [[ -z "${version}" ]]; then
+    echo "usage: $0 [--check] <version>" >&2
+    exit 64
+fi
+
+local_path="${fixtures_dir}/${version}/schema.json"
+upstream_url="${upstream_base}/${version}/schema.json"
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+
+curl --fail --show-error --silent --location "${upstream_url}" -o "${tmp}"
+
+if ! jq empty "${tmp}" >/dev/null 2>&1; then
+    echo "fetched payload is not valid JSON: ${upstream_url}" >&2
+    exit 65
+fi
+
+case "${mode}" in
+refresh)
+    mkdir -p "$(dirname "${local_path}")"
+    mv "${tmp}" "${local_path}"
+    trap - EXIT
+    echo "refreshed ${local_path}"
+    ;;
+check)
+    if [[ ! -f "${local_path}" ]]; then
+        echo "vendored copy missing: ${local_path}" >&2
+        exit 1
+    fi
+    if ! diff -u "${local_path}" "${tmp}" >&2; then
+        echo "DRIFT: vendored ${version}/schema.json differs from upstream" >&2
+        exit 1
+    fi
+    echo "no drift: ${local_path}"
+    ;;
+esac

--- a/scripts/refresh-mcp-spec.sh
+++ b/scripts/refresh-mcp-spec.sh
@@ -26,6 +26,10 @@ if [[ -z "${version}" ]]; then
     echo "usage: $0 [--check] <version>" >&2
     exit 64
 fi
+if [[ ! "${version}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(-[a-z]+)?$ ]]; then
+    echo "error: version must look like YYYY-MM-DD or YYYY-MM-DD-<suffix> (got '${version}')" >&2
+    exit 65
+fi
 
 local_path="${fixtures_dir}/${version}/schema.json"
 upstream_url="${upstream_base}/${version}/schema.json"
@@ -43,6 +47,10 @@ fi
 case "${mode}" in
 refresh)
     mkdir -p "$(dirname "${local_path}")"
+    # mktemp creates the file at 0600 but the vendored copies are 0644.
+    # Fix the mode before the atomic rename so the refreshed file
+    # matches the rest of the fixtures directory.
+    chmod 0644 "${tmp}"
     mv "${tmp}" "${local_path}"
     trap - EXIT
     echo "refreshed ${local_path}"


### PR DESCRIPTION
## Summary

- Spawns `rusty-imap-mcp` with a zero-account tempdir config and drives MCP JSON-RPC over stdio.
- Validates every response against the vendored MCP spec schema (`2025-11-25`).
- Permanent regression nets for #261 (empty capabilities) and `fix/tool-input-schema-object-type` (empty inputSchema).
- Lifts `ConfigError::NoAccounts` to allow infrastructure-only boot.
- Adds a refresh script and weekly CI drift detector for the vendored schema.

Closes #263.

## Test plan

- [x] `cargo test -p rimap-server --test mcp_wire_conformance` — 9 tests, all green.
- [x] `cargo test --workspace` — full suite green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo deny check` — clean.
- [x] `actionlint` + `zizmor` against the new workflow — clean.
- [x] `prek run --all-files` — clean.
- [ ] Post-merge: \`gh workflow run mcp-spec-drift.yml\` once to confirm the drift workflow executes.

## Conformance tests (9)

- \`wire_smoke_initialize_returns_valid_envelope\`
- \`wire_initialize_advertises_tools_capability\` — regression net for #261
- \`wire_protocol_version_negotiation_matches_vendored_schema\`
- \`wire_initialized_notification_elicits_no_response\`
- \`wire_tools_list_returns_object_schemas\` — regression net for the inputSchema bug
- \`wire_resources_list_is_empty_for_no_accounts\`
- \`wire_tools_call_unknown_tool_returns_error_envelope\` — asserts INVALID_PARAMS (-32602)
- \`wire_unknown_method_returns_minus_32601\`
- \`wire_clean_eof_shutdown_exits_zero\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)