### PR TITLE
test(mcp): Phase 3 — behavioral conformance via stdio against Dovecot fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
         with:
           tool: cargo-nextest
       - run: cargo nextest run --workspace --locked --no-tests=pass
+      - name: Phase 3 wire e2e — fail if zero tests selected
+        run: |
+          cargo nextest run -p rimap-server --test e2e_wire \
+            --locked --no-tests=fail \
+            --no-capture
+        env:
+          RIMAP_REQUIRE_DOCKER: "1"
 
   msrv:
     name: test (MSRV 1.88.0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,35 @@ jobs:
           tool: cargo-nextest
       - run: cargo nextest run --workspace --locked --no-tests=pass
 
+  tool-schema-drift:
+    name: tool-schema drift
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: 1.94.0) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          key: tool-schema-drift
+      - uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37  # v2.75.25
+        with:
+          tool: just
+      - name: Regenerate tool schemas
+        run: just regen-tool-schemas
+      - name: Verify no schema drift
+        run: |
+          if ! git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/; then
+            git diff --stat crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+            echo "::error::Tool schemas are out of sync — run 'just regen-tool-schemas' and commit the updated fixture files"
+            exit 1
+          fi
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,12 @@ audit-log pairing + namespace attribution.
   on macOS arm64 without Docker); with Docker on linux/x86_64 expected
   ~10–25s on a warm machine (Dovecot bring-up dominates). Recorded in
   CI logs.
-- Gating: silent-skip when no container runtime is present;
-  `RIMAP_REQUIRE_DOCKER=1` flips to loud failure. Same convention
-  as the legacy in-process `e2e_full_session`.
+- Gating: silent-skip ONLY when no container runtime is genuinely
+  unavailable (missing docker/podman or non-x86_64 host).
+  `RIMAP_REQUIRE_DOCKER=1` flips every other failure mode
+  (compose-up, readiness timeout, port reservation, fingerprint read)
+  to a panic with diagnostic context. Same convention as the legacy
+  in-process `e2e_full_session`.
 - Schema regen: when changing any `<Tool>Meta` or `<Tool>Untrusted`
   struct in `crates/rimap-server/src/tools/`, run
   `just regen-tool-schemas` and commit the diff. CI fails on a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,20 @@ to force a specific one. Set `RIMAP_REQUIRE_DOCKER=1` to fail loudly
 instead of silently skipping when no runtime is installed (the env var
 name is historical — it gates both docker and podman).
 
+**Apple Silicon (arm64 macOS):** Docker Desktop *can* run x86_64 images via
+Rosetta emulation in general, **but the pinned `dovecot/dovecot:2.3.21`
+image fails under Rosetta** — the container starts and the IMAPS port
+binds, but dovecot's child processes (`anvil`, `log`, `auth`) die with
+`rosetta error: unable to mmap ExecutableHeap: 12` (ENOMEM emulating an
+executable heap) and `userdb lookup ... Disconnected unexpectedly`. The
+`dovecot/dovecot:2.4.x` line is multi-arch but has breaking config-format
+changes deferred out of scope (see commit `ae1bf8b` and
+`crates/rimap-imap/tests/integration/dovecot/docker-compose.yml`). For
+that reason the harness `std::env::consts::ARCH != "x86_64"` check in
+`crates/rimap-server/tests/support/dovecot/harness.rs` silently skips on
+arm64 hosts — the gate exists for this specific fixture incompatibility,
+not as a blanket assumption about Docker emulation.
+
 ### Wire-driven Dovecot e2e (Phase 3, #265)
 
 `crates/rimap-server/tests/e2e_wire.rs` drives the production binary
@@ -88,9 +102,10 @@ audit-log pairing + namespace attribution.
   on macOS arm64 without Docker); with Docker on linux/x86_64 expected
   ~10–25s on a warm machine (Dovecot bring-up dominates). Recorded in
   CI logs.
-- Gating: silent-skip ONLY when no container runtime is genuinely
-  unavailable (missing docker/podman or non-x86_64 host).
-  `RIMAP_REQUIRE_DOCKER=1` flips every other failure mode
+- Gating: silent-skip ONLY when the host genuinely cannot run the
+  fixture — missing docker/podman, or an arm64 host where dovecot
+  2.3.21 amd64 crashes under Rosetta (see the Apple Silicon note
+  above). `RIMAP_REQUIRE_DOCKER=1` flips every other failure mode
   (compose-up, readiness timeout, port reservation, fingerprint read)
   to a panic with diagnostic context. Same convention as the legacy
   in-process `e2e_full_session`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ strict-client conformance spec (`2026-05-12-mcp-conformance-node-design.md`)
 extends the Phase 1 wire-conformance work
 (`2026-05-12-mcp-wire-conformance-design.md`) with a Node + TypeScript harness
 that drives `rusty-imap-mcp` through the official `@modelcontextprotocol/sdk`.
+The Phase 3 behavioral-conformance spec
+(`docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md`) covers
+the wire-driven Dovecot e2e harness for tool dispatch + audit-log attribution.
 
 ## Repository status
 
@@ -70,6 +73,29 @@ runtimes work on macOS, Ubuntu CI, and Fedora. Override with
 to force a specific one. Set `RIMAP_REQUIRE_DOCKER=1` to fail loudly
 instead of silently skipping when no runtime is installed (the env var
 name is historical — it gates both docker and podman).
+
+### Wire-driven Dovecot e2e (Phase 3, #265)
+
+`crates/rimap-server/tests/e2e_wire.rs` drives the production binary
+over its stdio JSON-RPC wire against the same Dovecot fixture
+`e2e_full_session` uses. It exercises every draft-safe and read-only
+posture tool, validates every response against the vendored MCP spec
+schemas + per-tool schemas under
+`crates/rimap-server/tests/fixtures/rimap-tool-schemas/`, and asserts
+audit-log pairing + namespace attribution.
+
+- Wall time: silent-skip path is sub-second (measured locally at ~0.019s
+  on macOS arm64 without Docker); with Docker on linux/x86_64 expected
+  ~10–25s on a warm machine (Dovecot bring-up dominates). Recorded in
+  CI logs.
+- Gating: silent-skip when no container runtime is present;
+  `RIMAP_REQUIRE_DOCKER=1` flips to loud failure. Same convention
+  as the legacy in-process `e2e_full_session`.
+- Schema regen: when changing any `<Tool>Meta` or `<Tool>Untrusted`
+  struct in `crates/rimap-server/src/tools/`, run
+  `just regen-tool-schemas` and commit the diff. CI fails on a
+  non-empty diff under `tests/fixtures/rimap-tool-schemas/`.
+- Specs: see `docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md`.
 
 ## Toolchain and MSRV
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "assert_cmd",
+ "base64 0.22.1",
  "clap",
  "governor",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,7 @@ dependencies = [
  "proptest",
  "rimap-content",
  "rimap-core",
+ "schemars",
  "scraper",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,10 @@ schemars = "1.0"
 infer = "0.19"
 
 # Dev dependencies shared across crates
+# base64 0.22 — deterministic base64 encoding for MIME test fixtures.
+# No build.rs, no proc-macros, pure-Rust. Apache-2.0 OR MIT.
+# Re-audit on minor bump. (SC-DEP-11)
+base64 = "0.22.1"
 assert_cmd = "2.0"
 predicates = "3.1"
 tempfile = "3.14"

--- a/crates/rimap-config/src/credential.rs
+++ b/crates/rimap-config/src/credential.rs
@@ -109,34 +109,66 @@ pub fn resolve_credential(
     use rimap_core::CredentialSource;
 
     let new_key = account_key(account_id, username, host);
-    if let Some(p) = store.get_password(&new_key)?
-        && !p.expose_secret().is_empty()
-    {
-        return Ok((p, CredentialSource::Keyring));
+    let legacy_key = legacy_account_key(username, host);
+
+    // Probe the keyring without surfacing transport errors yet. In
+    // `KeyringThenEnv` mode a hard keyring failure (e.g. no D-Bus session
+    // in CI/Docker) must not short-circuit the documented env-var fallback;
+    // in `KeyringOnly` mode it still propagates because the operator opted
+    // out of env. See model.rs `FallbackMode` docs and #265.
+    let mut keyring_error: Option<ConfigError> = None;
+    match store.get_password(&new_key) {
+        Ok(Some(p)) if !p.expose_secret().is_empty() => {
+            return Ok((p, CredentialSource::Keyring));
+        }
+        Ok(_) => {}
+        Err(e) => keyring_error = Some(e),
     }
 
     // Back-compat: before #77 the keyring key was <username>@<host>, with no
-    // account-id prefix. If the new key lookup missed, try the legacy key and
-    // warn the operator to run `rusty-imap-mcp migrate-keyring`.
-    let legacy_key = legacy_account_key(username, host);
-    if let Some(p) = store.get_password(&legacy_key)?
-        && !p.expose_secret().is_empty()
-    {
-        tracing::warn!(
-            account_id = %account_id.as_str(),
-            host = %host,
-            "credential resolved via legacy keyring key format; \
-             run `rusty-imap-mcp migrate-keyring --account {}` to migrate",
-            account_id.as_str(),
-        );
-        return Ok((p, CredentialSource::LegacyKeyring));
+    // account-id prefix. If the new key lookup missed and the keyring is
+    // otherwise reachable, try the legacy key and warn the operator to run
+    // `rusty-imap-mcp migrate-keyring`. Skip when the new-key probe already
+    // failed — the keyring transport is broken either way.
+    if keyring_error.is_none() {
+        match store.get_password(&legacy_key) {
+            Ok(Some(p)) if !p.expose_secret().is_empty() => {
+                tracing::warn!(
+                    account_id = %account_id.as_str(),
+                    host = %host,
+                    "credential resolved via legacy keyring key format; \
+                     run `rusty-imap-mcp migrate-keyring --account {}` to migrate",
+                    account_id.as_str(),
+                );
+                return Ok((p, CredentialSource::LegacyKeyring));
+            }
+            Ok(_) => {}
+            Err(e) => keyring_error = Some(e),
+        }
     }
 
     if fallback_mode == crate::model::FallbackMode::KeyringThenEnv
         && let Ok(env) = std::env::var(PASSWORD_ENV_VAR)
         && !env.is_empty()
     {
+        if let Some(e) = &keyring_error {
+            tracing::warn!(
+                account_id = %account_id.as_str(),
+                host = %host,
+                error = %e,
+                "keyring lookup failed; using `RUSTY_IMAP_MCP_PASSWORD` fallback",
+            );
+        }
         return Ok((SecretString::from(env), CredentialSource::EnvVar));
+    }
+
+    // No env fallback available (env unset/empty, or `KeyringOnly` mode).
+    // If the keyring transport itself errored, surface that diagnostic
+    // instead of the generic "no credential" message — it tells the
+    // operator the difference between a misconfigured keyring and a
+    // missing entry.
+    if let Some(e) = keyring_error {
+        return Err(e);
     }
 
     Err(ConfigError::NoCredential {
@@ -423,10 +455,57 @@ mod tests {
     }
 
     #[test]
-    fn keychain_error_propagates() {
+    fn keychain_error_propagates_in_keyring_only_mode() {
+        // `KeyringOnly` is the strict mode: the operator opted out of
+        // the env-var fallback, so a hard keyring failure must surface
+        // (not silently mask the misconfigured keyring).
         let store = MockStore::failing();
         let default_id = AccountId::default_account();
         temp_env::with_var(PASSWORD_ENV_VAR, Some("unused"), || {
+            let err = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringOnly,
+            )
+            .unwrap_err();
+            assert!(matches!(err, ConfigError::Keychain { .. }));
+        });
+    }
+
+    #[test]
+    fn keychain_error_falls_back_to_env_in_keyring_then_env_mode() {
+        // Documented behavior (model.rs `FallbackMode::KeyringThenEnv`):
+        // "Suitable for CI/test and single-account deployments." In
+        // environments without a working keyring (CI runners, Docker
+        // containers, headless servers) the env var must take over —
+        // otherwise the documented mode is unusable in its primary
+        // use case. Surfaced by the Phase 3 wire e2e tests (#265).
+        let store = MockStore::failing();
+        let default_id = AccountId::default_account();
+        temp_env::with_var(PASSWORD_ENV_VAR, Some("from_env"), || {
+            let (got, src) = resolve_credential(
+                &store,
+                &default_id,
+                "alice",
+                "host",
+                FallbackMode::KeyringThenEnv,
+            )
+            .unwrap();
+            assert_eq!(got.expose_secret(), "from_env");
+            assert_eq!(src, rimap_core::CredentialSource::EnvVar);
+        });
+    }
+
+    #[test]
+    fn keychain_error_propagates_when_no_env_in_keyring_then_env_mode() {
+        // With no env-var set, the keyring error is the most useful
+        // diagnostic: it tells the operator the difference between a
+        // missing keyring entry and a broken keyring transport.
+        let store = MockStore::failing();
+        let default_id = AccountId::default_account();
+        temp_env::with_var(PASSWORD_ENV_VAR, None::<&str>, || {
             let err = resolve_credential(
                 &store,
                 &default_id,

--- a/crates/rimap-config/src/model.rs
+++ b/crates/rimap-config/src/model.rs
@@ -68,12 +68,19 @@ fn default_connect_timeout() -> u32 {
 
 /// How credential resolution falls back when the keyring has no entry.
 ///
-/// - `KeyringThenEnv` (default) — try the keyring, then
-///   `RUSTY_IMAP_MCP_PASSWORD`, then fail. Suitable for CI/test and
-///   single-account deployments.
-/// - `KeyringOnly` — keyring only; a miss returns `NoCredential` without
-///   consulting the env var. Recommended for multi-account deployments
-///   where a shared env-var fallback would silently send one account's
+/// - `KeyringThenEnv` (default) — try the keyring; on either a miss or
+///   a hard keyring failure (e.g. no D-Bus session available, as in CI
+///   runners and Docker containers), fall back to
+///   `RUSTY_IMAP_MCP_PASSWORD`; if that is unset, fail. Suitable for
+///   CI/test and single-account deployments, including headless
+///   environments without a running secret-service. When the env-var
+///   fallback fires because of a keyring transport error rather than a
+///   plain miss, the resolver emits a `tracing::warn!` so the
+///   misconfiguration is still visible to operators.
+/// - `KeyringOnly` — keyring only; a miss returns `NoCredential` and a
+///   transport error propagates as `Keychain`. The env var is never
+///   consulted. Recommended for multi-account deployments where a
+///   shared env-var fallback would silently send one account's
 ///   password to another account's server (see #78).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/rimap-content/Cargo.toml
+++ b/crates/rimap-content/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 rimap-core = { path = "../rimap-core", version = "0.1.0" }
+schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -44,6 +45,12 @@ phf_codegen = { workspace = true }
 # for the epvme_runner binary and when depending on this crate from
 # integration tests.
 test-util = []
+# Optional JsonSchema derives on the wire-facing public types
+# (SecurityWarning, WarningCode, AttachmentMeta). Enabled transitively
+# by rimap-server's test-support feature so Phase 3's wire-conformance
+# harness can generate schemas for the full response envelope. Off in
+# production — schemars stays out of the runtime dep graph.
+test-support = ["dep:schemars"]
 
 [[bin]]
 name = "epvme_runner"

--- a/crates/rimap-content/src/output.rs
+++ b/crates/rimap-content/src/output.rs
@@ -80,6 +80,7 @@ pub struct MailingListInfo {
 /// Metadata for a single attachment part. Body bytes are not retained.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct AttachmentMeta {
     /// Decoded filename if available (from `Content-Disposition` or
     /// `Content-Type` name parameter), sanitized.
@@ -116,6 +117,7 @@ pub struct Untrusted {
 /// A single warning emitted by the content pipeline.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct SecurityWarning {
     /// Classification of the warning.
     pub code: WarningCode,

--- a/crates/rimap-core/src/warning.rs
+++ b/crates/rimap-core/src/warning.rs
@@ -6,13 +6,14 @@
 //! so both crates can reference the typed enum without a
 //! `rimap-content -> rimap-audit` dependency inversion.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Classification of pipeline warnings. New variants will be added as
 /// new detectors land — the enum is `#[non_exhaustive]` so matches
 /// outside this crate must include a wildcard arm.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WarningCode {
     /// Zero-width codepoints were present in input text and stripped.
@@ -116,7 +117,7 @@ pub enum WarningCode {
 /// adversarial signals without each caller maintaining its own
 /// classification table.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WarningSeverity {
     /// Emitted for normal-operation events (e.g. a legitimate

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -30,7 +30,7 @@ default = []
 # binary's wire shape rather than the production binary's, silently
 # voiding its regression nets. See:
 #   docs/superpowers/specs/2026-05-12-mcp-conformance-node-design.md §4.7
-test-support = ["rimap-config/test-support"]
+test-support = ["rimap-config/test-support", "rimap-content/test-support"]
 
 [lib]
 name = "rimap_server"

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -81,3 +81,4 @@ rimap-imap = { path = "../rimap-imap", version = "0.1.0", features = ["test-supp
 rimap-server = { path = ".", version = "0.1.0", features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "io-util"] }
 tempfile = { workspace = true }
+base64 = { workspace = true }

--- a/crates/rimap-server/src/cli/dump_tool_schemas.rs
+++ b/crates/rimap-server/src/cli/dump_tool_schemas.rs
@@ -87,44 +87,125 @@ fn build_schemas() -> BTreeMap<&'static str, Value> {
 // security_warnings are skip-serialize-if-empty/None, so the schema
 // makes them optional, not required.
 
-fn warnings_schema() -> Value {
-    let schema = schemars::schema_for!(rimap_content::SecurityWarning);
+/// Strip the `$defs` block from `value` and return the extracted defs.
+/// `value` is mutated in place: after the call it no longer carries a
+/// `$defs` key at its top level. Returns an empty `Map` if there were
+/// no defs to hoist.
+fn extract_defs(value: &mut Value) -> serde_json::Map<String, Value> {
+    let Some(obj) = value.as_object_mut() else {
+        return serde_json::Map::new();
+    };
+    match obj.remove("$defs") {
+        Some(Value::Object(defs)) => defs,
+        _ => serde_json::Map::new(),
+    }
+}
+
+/// Merge `from` into `into`. Panics if any key in `from` already
+/// exists in `into` with a different value — that would be a real
+/// name collision and we want to surface it loudly rather than
+/// silently keep one side. For Phase 3's struct set this should
+/// never trigger; schemars uses the Rust type's identifier as the
+/// def key and the four root types we compose don't share inner
+/// types with different shapes.
+#[expect(
+    clippy::panic,
+    reason = "programmer error: schemars $defs key collision"
+)]
+fn merge_defs(into: &mut serde_json::Map<String, Value>, from: serde_json::Map<String, Value>) {
+    for (key, value) in from {
+        match into.get(&key) {
+            None => {
+                into.insert(key, value);
+            }
+            Some(existing) if existing == &value => { /* identical, skip */ }
+            Some(existing) => {
+                panic!(
+                    "duplicate $defs key {key:?} with conflicting shapes:\n\
+                     existing: {existing}\nincoming: {value}"
+                );
+            }
+        }
+    }
+}
+
+/// `Vec<rimap_content::SecurityWarning>` schema, with its nested $defs
+/// hoisted into the caller's accumulator.
+#[expect(
+    clippy::expect_used,
+    reason = "schemars always produces serializable output; failure is a bug"
+)]
+fn warnings_schema(defs: &mut serde_json::Map<String, Value>) -> Value {
+    let mut schema = serde_json::to_value(schemars::schema_for!(rimap_content::SecurityWarning))
+        .expect("SecurityWarning schema serializes");
+    merge_defs(defs, extract_defs(&mut schema));
     serde_json::json!({
         "type": "array",
         "items": schema,
     })
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "schemars always produces serializable output; failure is a bug"
+)]
 fn meta_only<M: schemars::JsonSchema>() -> Value {
-    let schema = schemars::schema_for!(M);
-    serde_json::json!({
+    let mut meta = serde_json::to_value(schemars::schema_for!(M)).expect("meta schema serializes");
+    let mut defs = extract_defs(&mut meta);
+    let warnings = warnings_schema(&mut defs);
+
+    let mut envelope = serde_json::json!({
         "type": "object",
         "properties": {
-            "meta": schema,
-            "security_warnings": warnings_schema(),
+            "meta": meta,
+            "security_warnings": warnings,
         },
         "required": ["meta"],
         "additionalProperties": false,
-    })
+    });
+    if !defs.is_empty() {
+        envelope
+            .as_object_mut()
+            .expect("envelope is object")
+            .insert("$defs".to_string(), Value::Object(defs));
+    }
+    envelope
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "schemars always produces serializable output; failure is a bug"
+)]
 fn meta_and_untrusted<M: schemars::JsonSchema, U: schemars::JsonSchema>() -> Value {
-    let m = schemars::schema_for!(M);
-    let u = schemars::schema_for!(U);
-    serde_json::json!({
+    let mut meta = serde_json::to_value(schemars::schema_for!(M)).expect("meta schema serializes");
+    let mut untrusted =
+        serde_json::to_value(schemars::schema_for!(U)).expect("untrusted schema serializes");
+    let mut defs = extract_defs(&mut meta);
+    merge_defs(&mut defs, extract_defs(&mut untrusted));
+    let warnings = warnings_schema(&mut defs);
+
+    let mut envelope = serde_json::json!({
         "type": "object",
         "properties": {
-            "meta": m,
-            "untrusted": u,
-            "security_warnings": warnings_schema(),
+            "meta": meta,
+            "untrusted": untrusted,
+            "security_warnings": warnings,
         },
         "required": ["meta", "untrusted"],
         "additionalProperties": false,
-    })
+    });
+    if !defs.is_empty() {
+        envelope
+            .as_object_mut()
+            .expect("envelope is object")
+            .insert("$defs".to_string(), Value::Object(defs));
+    }
+    envelope
 }
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::expect_used, reason = "tests")]
 mod tests {
     use super::*;
 
@@ -176,6 +257,33 @@ mod tests {
             assert!(
                 parsed[name]["properties"]["untrusted"].is_object(),
                 "{name} must declare an untrusted schema"
+            );
+        }
+    }
+
+    #[test]
+    fn search_schema_hoists_defs_to_envelope_root() {
+        let mut buf = Vec::new();
+        dump_tool_schemas(&mut buf).unwrap();
+        let parsed: serde_json::Map<String, Value> = serde_json::from_slice(&buf).unwrap();
+
+        let search = &parsed["search"];
+        assert!(
+            search.get("$defs").is_some(),
+            "search schema must hoist nested $defs to envelope root: {search}"
+        );
+        let defs = search["$defs"].as_object().expect("$defs is an object");
+        assert!(
+            defs.contains_key("SearchResultEntry"),
+            "envelope $defs must include SearchResultEntry: {defs:?}"
+        );
+
+        // No nested $defs anywhere under properties.
+        let props = search["properties"].as_object().expect("properties");
+        for (name, sub) in props {
+            assert!(
+                sub.get("$defs").is_none(),
+                "tool subschema {name} must not carry its own $defs after hoist: {sub}"
             );
         }
     }

--- a/crates/rimap-server/src/cli/dump_tool_schemas.rs
+++ b/crates/rimap-server/src/cli/dump_tool_schemas.rs
@@ -1,0 +1,182 @@
+//! `dump-tool-schemas` test-support CLI subcommand. Emits one JSON
+//! Schema per in-scope tool, composing `<Tool>Meta` and (where
+//! present) `<Tool>Untrusted` into a single `{meta, untrusted}`
+//! envelope schema. Used by the Phase 3 wire-conformance harness
+//! (issue #265) to validate every wire response against a per-tool
+//! schema regenerated from the Rust output structs.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use serde_json::Value;
+
+/// Emit `{ "<tool>": <schema>, ... }` as pretty-printed JSON to the
+/// given writer. Iteration order is deterministic (`BTreeMap`).
+///
+/// # Errors
+///
+/// Returns the I/O error if the writer fails or the serializer cannot
+/// encode an entry. Schemars produces valid JSON for every derive-using
+/// struct in scope; failure indicates a bug, not user input.
+pub fn dump_tool_schemas<W: Write>(writer: &mut W) -> std::io::Result<()> {
+    let schemas = build_schemas();
+    serde_json::to_writer_pretty(&mut *writer, &schemas)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+fn build_schemas() -> BTreeMap<&'static str, Value> {
+    use rimap_server::tools::{
+        admin::{
+            accounts::{ListAccountsMeta, UseAccountMeta},
+            list_folders::ListFoldersMeta,
+        },
+        compose::create_draft::CreateDraftMeta,
+        mailbox::{
+            flags::FlagsMeta,
+            labels::{LabelsMeta, ListLabelsMeta},
+            move_message::MoveMessageMeta,
+        },
+        retrieval::{
+            download_attachment::{DownloadAttachmentMeta, DownloadAttachmentUntrusted},
+            fetch_message::{FetchMessageMeta, FetchMessageUntrusted},
+            list_attachments::{ListAttachmentsMeta, ListAttachmentsUntrusted},
+            search::{SearchMeta, SearchUntrusted},
+        },
+    };
+
+    let mut out = BTreeMap::<&'static str, Value>::new();
+
+    // meta-only tools (no untrusted payload on the wire)
+    out.insert("list_folders", meta_only::<ListFoldersMeta>());
+    out.insert("list_accounts", meta_only::<ListAccountsMeta>());
+    out.insert("list_labels", meta_only::<ListLabelsMeta>());
+    out.insert("mark_read", meta_only::<FlagsMeta>());
+    out.insert("mark_unread", meta_only::<FlagsMeta>());
+    out.insert("flag", meta_only::<FlagsMeta>());
+    out.insert("unflag", meta_only::<FlagsMeta>());
+    out.insert("add_label", meta_only::<LabelsMeta>());
+    out.insert("remove_label", meta_only::<LabelsMeta>());
+    out.insert("move_message", meta_only::<MoveMessageMeta>());
+    out.insert("create_draft", meta_only::<CreateDraftMeta>());
+    out.insert("use_account", meta_only::<UseAccountMeta>());
+
+    // meta + untrusted tools
+    out.insert(
+        "search",
+        meta_and_untrusted::<SearchMeta, SearchUntrusted>(),
+    );
+    out.insert(
+        "fetch_message",
+        meta_and_untrusted::<FetchMessageMeta, FetchMessageUntrusted>(),
+    );
+    out.insert(
+        "list_attachments",
+        meta_and_untrusted::<ListAttachmentsMeta, ListAttachmentsUntrusted>(),
+    );
+    out.insert(
+        "download_attachment",
+        meta_and_untrusted::<DownloadAttachmentMeta, DownloadAttachmentUntrusted>(),
+    );
+
+    out
+}
+
+// Top-level wire envelope is `{meta, untrusted?, security_warnings?}`
+// per crates/rimap-server/src/mcp/response.rs:14-25. untrusted and
+// security_warnings are skip-serialize-if-empty/None, so the schema
+// makes them optional, not required.
+
+fn warnings_schema() -> Value {
+    let schema = schemars::schema_for!(rimap_content::SecurityWarning);
+    serde_json::json!({
+        "type": "array",
+        "items": schema,
+    })
+}
+
+fn meta_only<M: schemars::JsonSchema>() -> Value {
+    let schema = schemars::schema_for!(M);
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "meta": schema,
+            "security_warnings": warnings_schema(),
+        },
+        "required": ["meta"],
+        "additionalProperties": false,
+    })
+}
+
+fn meta_and_untrusted<M: schemars::JsonSchema, U: schemars::JsonSchema>() -> Value {
+    let m = schemars::schema_for!(M);
+    let u = schemars::schema_for!(U);
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "meta": m,
+            "untrusted": u,
+            "security_warnings": warnings_schema(),
+        },
+        "required": ["meta", "untrusted"],
+        "additionalProperties": false,
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dump_emits_one_key_per_in_scope_tool() {
+        let mut buf = Vec::new();
+        dump_tool_schemas(&mut buf).unwrap();
+        let parsed: serde_json::Map<String, Value> = serde_json::from_slice(&buf).unwrap();
+
+        for name in [
+            "list_folders",
+            "list_accounts",
+            "list_labels",
+            "list_attachments",
+            "download_attachment",
+            "search",
+            "fetch_message",
+            "mark_read",
+            "mark_unread",
+            "flag",
+            "unflag",
+            "add_label",
+            "remove_label",
+            "move_message",
+            "create_draft",
+            "use_account",
+        ] {
+            assert!(parsed.contains_key(name), "missing schema for {name}");
+            let entry = &parsed[name];
+            assert_eq!(entry["type"], "object");
+            assert!(
+                entry["properties"]["meta"].is_object(),
+                "{name}.meta must be a JSON Schema object"
+            );
+        }
+    }
+
+    #[test]
+    fn meta_and_untrusted_tools_include_untrusted_key() {
+        let mut buf = Vec::new();
+        dump_tool_schemas(&mut buf).unwrap();
+        let parsed: serde_json::Map<String, Value> = serde_json::from_slice(&buf).unwrap();
+        for name in [
+            "search",
+            "fetch_message",
+            "list_attachments",
+            "download_attachment",
+        ] {
+            assert!(
+                parsed[name]["properties"]["untrusted"].is_object(),
+                "{name} must declare an untrusted schema"
+            );
+        }
+    }
+}

--- a/crates/rimap-server/src/cli/mod.rs
+++ b/crates/rimap-server/src/cli/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod audit_merge;
 pub(crate) mod dry_run;
 #[cfg(feature = "test-support")]
 pub(crate) mod dump_tool_catalog;
+#[cfg(feature = "test-support")]
+pub(crate) mod dump_tool_schemas;
 pub(crate) mod migrate_keyring;
 
 use std::path::PathBuf;
@@ -97,6 +99,15 @@ pub enum Command {
     #[cfg(feature = "test-support")]
     #[command(name = "dump-tool-catalog", hide = true)]
     DumpToolCatalog,
+    /// Emit per-tool JSON Schemas (one entry per in-scope tool,
+    /// composing `<Tool>Meta` and `<Tool>Untrusted` into a single
+    /// `{meta, untrusted}` envelope) as pretty JSON on stdout. Used
+    /// by the Phase 3 wire-conformance harness (#265) and the
+    /// `just regen-tool-schemas` recipe. Hidden from `--help` because
+    /// it is a test-only utility.
+    #[cfg(feature = "test-support")]
+    #[command(name = "dump-tool-schemas", hide = true)]
+    DumpToolSchemas,
 }
 
 /// Actions under `rusty-imap-mcp audit <action>`.

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -360,13 +360,23 @@ fn resolve_download_dir_multi(
 /// code path and the `run` body stays under the workspace 100-line cap.
 #[cfg(feature = "test-support")]
 fn run_test_support_subcommands(cli: &Cli) -> Option<anyhow::Result<()>> {
-    if matches!(cli.command, Some(Command::DumpToolCatalog)) {
-        let mut stdout = std::io::stdout().lock();
-        return Some(
-            cli::dump_tool_catalog::dump_tool_catalog(&mut stdout).context("dumping tool catalog"),
-        );
+    match cli.command {
+        Some(Command::DumpToolCatalog) => {
+            let mut stdout = std::io::stdout().lock();
+            Some(
+                cli::dump_tool_catalog::dump_tool_catalog(&mut stdout)
+                    .context("dumping tool catalog"),
+            )
+        }
+        Some(Command::DumpToolSchemas) => {
+            let mut stdout = std::io::stdout().lock();
+            Some(
+                cli::dump_tool_schemas::dump_tool_schemas(&mut stdout)
+                    .context("dumping tool schemas"),
+            )
+        }
+        _ => None,
     }
-    None
 }
 
 /// Handle the `migrate-keyring` subcommand.

--- a/crates/rimap-server/src/mcp/response.rs
+++ b/crates/rimap-server/src/mcp/response.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 /// untrusted body should return `ToolResponse<M, ()>` with
 /// `untrusted: None`.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ToolResponse<M: Serialize = serde_json::Value, U: Serialize = serde_json::Value> {
     /// Server-controlled metadata. Trusted.
     pub meta: M,

--- a/crates/rimap-server/src/tools/admin/accounts.rs
+++ b/crates/rimap-server/src/tools/admin/accounts.rs
@@ -14,6 +14,7 @@ pub struct UseAccountInput {
 
 /// Trusted metadata for a `use_account` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct UseAccountMeta {
     /// The account that is now active.
     pub account: String,
@@ -23,6 +24,7 @@ pub struct UseAccountMeta {
 
 /// A single account entry in a `list_accounts` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct AccountEntry {
     /// Account name.
     pub name: String,
@@ -32,6 +34,7 @@ pub struct AccountEntry {
 
 /// Trusted metadata for a `list_accounts` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ListAccountsMeta {
     /// All configured accounts.
     pub accounts: Vec<AccountEntry>,

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -80,6 +80,7 @@ fn sanitize_folder_entry(
 
 /// A single folder entry in a `list_folders` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct FolderEntry {
     /// Sanitized, display-safe folder name. Bidi / zero-width / Unicode
@@ -106,6 +107,7 @@ pub struct FolderEntry {
 
 /// Trusted metadata for a `list_folders` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ListFoldersMeta {
     /// All folders returned by the server.
     pub folders: Vec<FolderEntry>,

--- a/crates/rimap-server/src/tools/compose/create_draft.rs
+++ b/crates/rimap-server/src/tools/compose/create_draft.rs
@@ -12,6 +12,7 @@ pub type CreateDraftInput = ComposeInput;
 
 /// Trusted metadata for a `create_draft` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct CreateDraftMeta {
     /// Folder the draft was appended to.
     pub folder: String,

--- a/crates/rimap-server/src/tools/mailbox/flags.rs
+++ b/crates/rimap-server/src/tools/mailbox/flags.rs
@@ -45,6 +45,7 @@ pub struct FlagInput {
 
 /// Trusted metadata for a flag mutation response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct FlagsMeta {
     /// Folder the flags were updated in.
     pub folder: String,

--- a/crates/rimap-server/src/tools/mailbox/labels.rs
+++ b/crates/rimap-server/src/tools/mailbox/labels.rs
@@ -109,6 +109,7 @@ pub struct ListLabelsInput {
 
 /// Trusted metadata for `add_label` and `remove_label` responses.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct LabelsMeta {
     /// Folder the label was applied to.
     pub folder: String,
@@ -124,6 +125,7 @@ pub struct LabelsMeta {
 
 /// Trusted metadata for a `list_labels` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ListLabelsMeta {
     /// Folder the labels were fetched from.
     pub folder: String,

--- a/crates/rimap-server/src/tools/mailbox/move_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/move_message.rs
@@ -38,6 +38,7 @@ pub struct MoveMessageInput {
 
 /// Per-UID move result entry.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct MoveEntry {
     /// Source UID that was moved.
     pub old_uid: u32,
@@ -47,6 +48,7 @@ pub struct MoveEntry {
 
 /// Trusted metadata for a `move_message` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct MoveMessageMeta {
     /// Source folder.
     pub folder: String,

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -7,9 +7,9 @@
 //! Callers must reference the subdir path (`crate::tools::retrieval::fetch_message`);
 //! no wildcard facade is provided so the partition stays meaningful.
 
-pub(crate) mod admin;
-pub(crate) mod compose;
+pub mod admin;
+pub mod compose;
 pub(crate) mod fetch_by_uid;
-pub(crate) mod mailbox;
-pub(crate) mod retrieval;
+pub mod mailbox;
+pub mod retrieval;
 pub(crate) mod validation;

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -37,6 +37,7 @@ pub struct DownloadAttachmentInput {
 
 /// Trusted metadata for a `download_attachment` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct DownloadAttachmentMeta {
     /// IMAP folder the message was fetched from.
     pub folder: String,
@@ -58,6 +59,7 @@ pub struct DownloadAttachmentMeta {
 
 /// Untrusted payload for a `download_attachment` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct DownloadAttachmentUntrusted {
     /// Original filename from `Content-Disposition` / `Content-Type`
     /// name parameter (sanitized).

--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -33,6 +33,7 @@ pub struct FetchMessageInput {
 
 /// Trusted metadata for a `fetch_message` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct FetchMessageMeta {
     /// IMAP folder the message was fetched from.
     pub folder: String,
@@ -48,6 +49,7 @@ pub struct FetchMessageMeta {
 
 /// Sanitized untrusted payload for a `fetch_message` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct FetchMessageUntrusted {
     /// Plain-text body (sanitized).
     pub body_text: String,
@@ -64,7 +66,18 @@ pub struct FetchMessageUntrusted {
     pub cc: Vec<String>,
     /// `Reply-To` header.
     pub reply_to: Option<String>,
-    /// `Date` header.
+    /// `Date` header. Serialized as a 9-element integer tuple:
+    /// `[year, ordinal, hour, minute, second, nanosecond,
+    ///   offset_whole_hours, offset_minutes_past_hour,
+    ///   offset_seconds_past_minute]`.
+    ///
+    /// Note: the `time` crate does not enable `serde-human-readable` in
+    /// this workspace, so `OffsetDateTime` always serializes as a tuple
+    /// regardless of the serializer's `is_human_readable()` flag.
+    #[cfg_attr(
+        feature = "test-support",
+        schemars(schema_with = "offset_date_time_tuple_schema")
+    )]
     pub date: Option<time::OffsetDateTime>,
     /// MIME attachment parts found in the message.
     pub attachments: Vec<rimap_content::AttachmentMeta>,
@@ -144,4 +157,43 @@ pub async fn handle(
         attachments: content.meta.attachments,
     })
     .with_warnings(content.security_warnings))
+}
+
+/// JSON Schema for `time::OffsetDateTime` as serialized by the `time` crate
+/// without the `serde-human-readable` feature.
+///
+/// The `time` crate serializes `OffsetDateTime` as a 9-element integer tuple:
+/// `[year, day_of_year, hour, minute, second, nanosecond,
+///   offset_whole_hours, offset_minutes_past_hour, offset_seconds_past_minute]`.
+/// This matches the actual wire bytes produced by `serde_json::to_string` when
+/// the workspace does not enable `serde-human-readable` on the `time` crate.
+///
+/// Used via `#[schemars(schema_with = "offset_date_time_tuple_schema")]` on
+/// `FetchMessageUntrusted::date`.
+#[cfg(feature = "test-support")]
+fn offset_date_time_tuple_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    use schemars::json_schema;
+    json_schema!({
+        "type": ["array", "null"],
+        "description": concat!(
+            "time::OffsetDateTime as a 9-element integer tuple: ",
+            "[year, day_of_year, hour, minute, second, nanosecond, ",
+            "offset_whole_hours, offset_minutes_past_hour, ",
+            "offset_seconds_past_minute]. Null when the header is absent."
+        ),
+        "prefixItems": [
+            { "type": "integer", "description": "year" },
+            { "type": "integer", "description": "day_of_year (ordinal 1–366)" },
+            { "type": "integer", "description": "hour (0–23)" },
+            { "type": "integer", "description": "minute (0–59)" },
+            { "type": "integer", "description": "second (0–60)" },
+            { "type": "integer", "description": "nanosecond (0–999999999)" },
+            { "type": "integer", "description": "UTC offset: whole hours (-23–23)" },
+            { "type": "integer", "description": "UTC offset: minutes past hour (-59–59)" },
+            { "type": "integer", "description": "UTC offset: seconds past minute (-59–59)" }
+        ],
+        "minItems": 9,
+        "maxItems": 9,
+        "items": false
+    })
 }

--- a/crates/rimap-server/src/tools/retrieval/list_attachments.rs
+++ b/crates/rimap-server/src/tools/retrieval/list_attachments.rs
@@ -29,6 +29,7 @@ pub struct ListAttachmentsInput {
 
 /// Metadata for a single attachment discovered in the MIME tree.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct AttachmentInfo {
     /// IMAP part identifier (e.g. `"2"`, `"1.2"`).
     pub part_id: String,
@@ -42,6 +43,7 @@ pub struct AttachmentInfo {
 
 /// Trusted metadata for a `list_attachments` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ListAttachmentsMeta {
     /// IMAP folder the message was fetched from.
     pub folder: String,
@@ -53,6 +55,7 @@ pub struct ListAttachmentsMeta {
 
 /// Untrusted payload for a `list_attachments` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct ListAttachmentsUntrusted {
     /// Attachment parts found in the MIME tree.
     pub attachments: Vec<AttachmentInfo>,

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -52,6 +52,7 @@ pub struct SearchInput {
 
 /// A single message entry in a `search` untrusted payload.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct SearchResultEntry {
     /// UID of the message.
     pub uid: u32,
@@ -80,6 +81,7 @@ pub struct SearchResultEntry {
 
 /// Trusted metadata for a `search` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct SearchMeta {
     /// Folder that was searched.
     pub folder: String,
@@ -93,6 +95,7 @@ pub struct SearchMeta {
 
 /// Untrusted payload for a `search` response.
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 pub struct SearchUntrusted {
     /// Matching messages with sanitized header fields.
     pub messages: Vec<SearchResultEntry>,

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -69,10 +69,10 @@ pub struct SearchResultEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<String>,
     /// From addresses, sanitized. Omitted when empty.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub from: Vec<String>,
     /// To addresses, sanitized. Omitted when empty.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub to: Vec<String>,
     /// RFC 2822 `Message-ID`, sanitized.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -23,6 +23,7 @@
 
 #![expect(clippy::unwrap_used, reason = "tests")]
 #![expect(clippy::expect_used, reason = "tests")]
+#![expect(clippy::panic, reason = "test diagnostics")]
 
 // Import dovecot directly (not via support/mod.rs) so this binary
 // doesn't compile the wire driver it doesn't use.
@@ -46,7 +47,7 @@ use rimap_core::posture::Posture;
 use rimap_imap::{Connection, ConnectionConfig};
 use tempfile::TempDir;
 
-use dovecot::DovecotHarness;
+use dovecot::{DovecotHarness, HarnessError};
 use rimap_server::mcp::server::ImapMcpServer;
 
 struct StaticCreds(String);
@@ -225,8 +226,10 @@ fn test_message() -> Vec<u8> {
 
 #[tokio::test]
 async fn e2e_full_session() {
-    let Some(harness) = DovecotHarness::try_start() else {
-        return; // silent skip
+    let harness = match DovecotHarness::try_start() {
+        Ok(h) => h,
+        Err(HarnessError::DockerUnavailable) => return,
+        Err(e) => panic!("Dovecot harness failed: {e}"),
     };
 
     harness.create_mailbox("Drafts");

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -24,11 +24,14 @@
 #![expect(clippy::unwrap_used, reason = "tests")]
 #![expect(clippy::expect_used, reason = "tests")]
 
+// Import dovecot directly (not via support/mod.rs) so this binary
+// doesn't compile the wire driver it doesn't use.
+#[path = "support/dovecot/mod.rs"]
+mod dovecot;
+
 use std::collections::BTreeMap;
-use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use rimap_audit::{AuditOptions, AuditWriter, Seq};
 use rimap_authz::DispatchGuard;
@@ -38,240 +41,13 @@ use rimap_authz::rate_limit::Governor;
 use rimap_config::credential::CredentialStore;
 use rimap_config::model::{ImapConfig, ImapEncryption, LimitsConfig, SecurityConfig};
 use rimap_config::validate::ValidatedAccountConfig;
-use rimap_core::TlsFingerprint;
 use rimap_core::account::AccountId;
 use rimap_core::posture::Posture;
 use rimap_imap::{Connection, ConnectionConfig};
 use tempfile::TempDir;
 
+use dovecot::DovecotHarness;
 use rimap_server::mcp::server::ImapMcpServer;
-
-// ── Container harness (adapted from rimap-imap) ─────────────────────
-
-fn runtime() -> &'static str {
-    static TOOL: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
-    TOOL.get_or_init(|| {
-        match std::env::var("RIMAP_CONTAINER_TOOL").as_deref() {
-            Ok("docker") => return "docker",
-            Ok("podman") => return "podman",
-            _ => {}
-        }
-        if binary_present("docker") {
-            "docker"
-        } else if binary_present("podman") {
-            "podman"
-        } else {
-            "docker"
-        }
-    })
-}
-
-fn binary_present(bin: &str) -> bool {
-    Command::new(bin)
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn runtime_available() -> bool {
-    binary_present("docker") || binary_present("podman")
-}
-
-fn container_name(project: &str) -> String {
-    format!("{project}-dovecot")
-}
-
-struct DovecotHarness {
-    project: String,
-    compose_dir: PathBuf,
-    fingerprint: TlsFingerprint,
-    port: u16,
-}
-
-impl DovecotHarness {
-    fn try_start() -> Option<Self> {
-        const BACKOFF_MS: [u64; 2] = [50, 250];
-        const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
-
-        if std::env::consts::ARCH != "x86_64" {
-            return None;
-        }
-        if !runtime_available() {
-            return None;
-        }
-
-        let compose_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("rimap-imap")
-            .join("tests")
-            .join("integration")
-            .join("dovecot");
-
-        let project = format!(
-            "rimap-e2e-{:x}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        );
-
-        let mut host_port = ReservedPort::acquire()?;
-
-        // Attempt 0 is the initial try (no prior sleep). Attempts 1 and 2
-        // are retries preceded by teardown + backoff sleep + fresh port.
-        for attempt in 0..MAX_ATTEMPTS {
-            if attempt > 0 {
-                compose_down(&project, &compose_dir);
-                std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS[attempt - 1]));
-                host_port = ReservedPort::acquire()?;
-            }
-            host_port.release();
-
-            let output = Command::new(runtime())
-                .arg("compose")
-                .arg("-p")
-                .arg(&project)
-                .arg("up")
-                .arg("-d")
-                .env("RIMAP_DOVECOT_HOST_PORT", host_port.port().to_string())
-                .current_dir(&compose_dir)
-                .output()
-                .ok()?;
-
-            if output.status.success() {
-                return wait_for_ready(&project, host_port.port(), &compose_dir);
-            }
-
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !is_port_collision(&stderr) {
-                // Non-collision failure: stop retrying.
-                return None;
-            }
-        }
-
-        // All attempts hit port collisions.
-        None
-    }
-
-    /// Create a mailbox via `doveadm` inside the container.
-    fn create_mailbox(&self, name: &str) {
-        let status = Command::new(runtime())
-            .arg("exec")
-            .arg(container_name(&self.project))
-            .arg("doveadm")
-            .arg("mailbox")
-            .arg("create")
-            .arg("-u")
-            .arg("rimap-test")
-            .arg(name)
-            .status()
-            .expect("doveadm exec failed");
-        assert!(status.success(), "doveadm mailbox create {name} failed",);
-    }
-}
-
-fn wait_for_ready(
-    project: &str,
-    host_port: u16,
-    compose_dir: &std::path::Path,
-) -> Option<DovecotHarness> {
-    let started = Instant::now();
-    let timeout = Duration::from_secs(60);
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
-    loop {
-        if started.elapsed() > timeout {
-            compose_down(project, compose_dir);
-            return None;
-        }
-        let Ok(fp) = read_fingerprint(project) else {
-            std::thread::sleep(Duration::from_millis(500));
-            continue;
-        };
-        if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
-            return Some(DovecotHarness {
-                project: project.to_string(),
-                compose_dir: compose_dir.to_path_buf(),
-                fingerprint: fp,
-                port: host_port,
-            });
-        }
-        std::thread::sleep(Duration::from_millis(500));
-    }
-}
-
-impl Drop for DovecotHarness {
-    fn drop(&mut self) {
-        compose_down(&self.project, &self.compose_dir);
-    }
-}
-
-fn compose_down(project: &str, compose_dir: &std::path::Path) {
-    let _ = Command::new(runtime())
-        .arg("compose")
-        .arg("-p")
-        .arg(project)
-        .arg("down")
-        .arg("-v")
-        .arg("--remove-orphans")
-        .current_dir(compose_dir)
-        .status();
-}
-
-fn read_fingerprint(project: &str) -> Result<TlsFingerprint, String> {
-    let out = Command::new(runtime())
-        .arg("exec")
-        .arg(container_name(project))
-        .arg("cat")
-        .arg("/shared/fingerprint.hex")
-        .output()
-        .map_err(|e| e.to_string())?;
-    if !out.status.success() {
-        return Err("not ready".into());
-    }
-    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    TlsFingerprint::from_hex(&s).map_err(|e| e.to_string())
-}
-
-/// Host port reserved by binding `127.0.0.1:0` and reading the
-/// kernel-assigned number. The `TcpListener` is kept open until
-/// `release()` is called, holding the kernel-level lease so docker
-/// (or any other process) cannot bind the same port in the meantime.
-struct ReservedPort {
-    port: u16,
-    listener: Option<std::net::TcpListener>,
-}
-
-impl ReservedPort {
-    fn acquire() -> Option<Self> {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
-        let port = listener.local_addr().ok()?.port();
-        Some(Self {
-            port,
-            listener: Some(listener),
-        })
-    }
-
-    fn port(&self) -> u16 {
-        self.port
-    }
-
-    /// Drop the underlying `TcpListener`, releasing the kernel-level
-    /// port lease. Idempotent.
-    fn release(&mut self) {
-        self.listener.take();
-    }
-}
-
-/// Classify a stderr blob from a failed `compose up`: `true` when the
-/// failure looks like a host-port bind collision.
-fn is_port_collision(stderr: &str) -> bool {
-    let s = stderr.to_lowercase();
-    s.contains("port is already allocated")
-        || s.contains("address already in use")
-        || s.contains("bind for 127.0.0.1")
-}
 
 struct StaticCreds(String);
 
@@ -353,7 +129,7 @@ fn test_account_config(harness: &DovecotHarness) -> ValidatedAccountConfig {
         id: AccountId::default_account(),
         imap: ImapConfig {
             host: "127.0.0.1".into(),
-            port: harness.port,
+            port: harness.port(),
             username: "rimap-test".into(),
             encryption: ImapEncryption::Tls,
             tls_fingerprint_sha256: None,
@@ -367,7 +143,7 @@ fn test_account_config(harness: &DovecotHarness) -> ValidatedAccountConfig {
         },
         limits: LimitsConfig::default(),
         tool_overrides: BTreeMap::new(),
-        tls_fingerprint: Some(harness.fingerprint),
+        tls_fingerprint: Some(*harness.fingerprint()),
         fallback_mode: rimap_config::model::FallbackMode::default(),
     }
 }
@@ -377,10 +153,10 @@ fn test_connection(harness: &DovecotHarness, audit: &AuditWriter) -> Connection 
         account: None,
         account_id: rimap_core::account::AccountId::default_account(),
         host: "127.0.0.1".into(),
-        port: harness.port,
+        port: harness.port(),
         encryption: rimap_imap::ImapEncryption::Tls,
         username: "rimap-test".into(),
-        pinned_fingerprint: Some(harness.fingerprint),
+        pinned_fingerprint: Some(*harness.fingerprint()),
         connect_timeout: Duration::from_secs(10),
         command_timeout: Duration::from_secs(30),
         max_fetch_body_bytes: 5_242_880,

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -1,0 +1,568 @@
+//! Phase 3 wire-driven Dovecot e2e (#265). Drives `rusty-imap-mcp`
+//! over its stdio JSON-RPC wire against the existing Dovecot
+//! container fixture, exercising every draft-safe + read-only
+//! posture tool category and validating each response against
+//! Phase 1's vendored MCP spec schemas + per-tool response schemas
+//! under `tests/fixtures/rimap-tool-schemas/`.
+//!
+//! Silent-skip when no container runtime is available or the host
+//! arch is not `x86_64`; `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test diagnostics")]
+
+// Each integration-test binary imports only its needed support
+// submodules directly to avoid cross-binary dead-code warnings.
+#[path = "support/dovecot/mod.rs"]
+mod dovecot;
+#[path = "support/wire/mod.rs"]
+mod wire;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_config::credential::{CredentialStore, KeyringCredentialResolver, PASSWORD_ENV_VAR};
+use rimap_config::model::FallbackMode;
+use rimap_imap::{Connection, ConnectionConfig, ImapEncryption};
+use secrecy::SecretString;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use dovecot::{DovecotHarness, fixtures};
+// `Harness`, `PINNED_PROTOCOL_VERSION`, and `assert_valid` go through
+// `wire::*` (the same re-exports `mcp_wire_conformance.rs` uses) so
+// the re-exports in `support/wire/mod.rs` register as "used" in both
+// binaries. `e2e_wire`-only items live one level deeper in the
+// sub-modules to avoid creating re-exports that appear dead from the
+// Phase 1 binary's perspective.
+use wire::config::build_dovecot_config;
+use wire::schema::validator_for_tool_response;
+use wire::{Harness, PINNED_PROTOCOL_VERSION, assert_valid};
+
+// Per-binary dead-code cross-talk: each integration-test file is its
+// own compilation unit, but every binary that pulls in
+// `support/wire/harness.rs` compiles every method on `Harness`. Items
+// used only by `mcp_wire_conformance.rs` (`Harness::spawn`,
+// `Harness::assert_no_response_within`) appear dead here. Workspace
+// lint `clippy::allow_attributes = "deny"` forbids `#[allow]`, so we
+// reference the cross-binary items in a never-called function — the
+// reference itself counts as "use" for the dead-code analysis. The
+// function name omits the leading `_` so the function itself is
+// flagged dead and the `#[expect(dead_code)]` is fulfilled.
+#[expect(
+    dead_code,
+    reason = "type-link to items used only by mcp_wire_conformance"
+)]
+fn force_use_for_dead_code_link() {
+    let _: &str = PINNED_PROTOCOL_VERSION;
+    let _: Duration = wire::harness::REQUEST_TIMEOUT;
+    let _: Duration = wire::harness::SHUTDOWN_TIMEOUT;
+    let _ = Harness::spawn;
+    let _ = Harness::assert_no_response_within;
+}
+
+/// Dovecot's seeded test password. Matches the value injected via the
+/// docker-compose fixture; see `e2e.rs` `StaticCreds` for the in-process
+/// equivalent.
+const DOVECOT_PASSWORD: &str = "testpass";
+
+/// In-process credential store for the seed connection. Returns
+/// `DOVECOT_PASSWORD` unconditionally.
+struct StaticCreds;
+
+impl CredentialStore for StaticCreds {
+    fn get_password(
+        &self,
+        _account: &str,
+    ) -> Result<Option<SecretString>, rimap_config::ConfigError> {
+        Ok(Some(SecretString::from(DOVECOT_PASSWORD.to_string())))
+    }
+
+    #[expect(clippy::panic_in_result_fn, reason = "seed never writes")]
+    fn set_password(
+        &self,
+        _account: &str,
+        _password: &str,
+    ) -> Result<(), rimap_config::ConfigError> {
+        panic!("seed never writes credentials")
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wire_e2e_full_session_draft_safe() {
+    let Some(dovecot) = DovecotHarness::try_start() else {
+        return; // silent skip — matches e2e_full_session
+    };
+    dovecot.create_mailbox("Drafts");
+    dovecot.create_mailbox("Trash");
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path().to_path_buf();
+    let download_dir = tempdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("mkdir download_dir");
+
+    seed_multipart_message(&dovecot).await;
+
+    let config_path = tempdir.path().join("config.toml");
+    // build_dovecot_config has a decoupled signature: pass fingerprint+port
+    // directly so the wire support module does not depend on DovecotHarness.
+    let fingerprint_hex = dovecot.fingerprint().to_hex();
+    let config = build_dovecot_config(
+        &fingerprint_hex,
+        dovecot.port(),
+        &audit_path,
+        &allowed_base,
+        &download_dir,
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let envs = [(PASSWORD_ENV_VAR, DOVECOT_PASSWORD)];
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &envs).await;
+
+    let init = harness.initialize_handshake().await;
+    let init_result = &init["result"];
+    assert_valid(init_result, "InitializeResult");
+    assert!(init_result["capabilities"]["tools"].is_object());
+    harness.send_initialized().await;
+
+    assert_tools_list(&mut harness).await;
+    let uid = drive_account_scoped_tools(&mut harness).await;
+    assert_move_message(&mut harness, uid).await;
+
+    let status = harness.shutdown_and_wait().await;
+    assert!(status.success(), "binary exited non-zero: {status:?}");
+
+    assert_audit_records(&audit_path);
+}
+
+/// Drive the account-scoped tools and return the UID of the seeded message.
+async fn drive_account_scoped_tools(harness: &mut Harness) -> u32 {
+    // 1. use_account → draftsafe.
+    let _ = call_tool(harness, "use_account", json!({ "account": "draftsafe" })).await;
+
+    // 2. list_accounts (infrastructure).
+    let accounts_body = call_tool(harness, "list_accounts", json!({})).await;
+    assert_eq!(accounts_body["meta"]["count"].as_u64(), Some(2));
+
+    // 3. list_folders.
+    let folders_body = call_tool(harness, "draftsafe.list_folders", json!({})).await;
+    let folder_names: Vec<&str> = folders_body["meta"]["folders"]
+        .as_array()
+        .expect("folders array")
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .collect();
+    assert!(
+        folder_names.contains(&"INBOX"),
+        "INBOX missing: {folder_names:?}",
+    );
+
+    // 4. search → grab the seeded UID.
+    let uid = assert_search(harness).await;
+
+    // 5. fetch_message.
+    assert_fetch_message(harness, uid).await;
+
+    // 6 + 7. list_attachments + download_attachment.
+    let part_id = assert_list_attachments(harness, uid).await;
+    assert_download_attachment(harness, uid, &part_id).await;
+
+    // 8. flag / unflag pair.
+    let _ = call_tool(
+        harness,
+        "draftsafe.flag",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+    let _ = call_tool(
+        harness,
+        "draftsafe.unflag",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+
+    // 9. mark_read / mark_unread pair.
+    let _ = call_tool(
+        harness,
+        "draftsafe.mark_read",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+    let _ = call_tool(
+        harness,
+        "draftsafe.mark_unread",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+
+    // 10. add_label / list_labels / remove_label.
+    assert_label_round_trip(harness, uid).await;
+
+    // 11. create_draft (with reply context + plain).
+    let _ = call_tool(
+        harness,
+        "draftsafe.create_draft",
+        json!({
+            "to": [{"address": "reply@example.com"}],
+            "subject": "Re: e2e-wire-test-smoke",
+            "body_text": "Acknowledged.",
+            "in_reply_to_uid": uid,
+            "in_reply_to_folder": "INBOX",
+        }),
+    )
+    .await;
+    let _ = call_tool(
+        harness,
+        "draftsafe.create_draft",
+        json!({
+            "to": [{"address": "dest@example.com"}],
+            "subject": "wire e2e plain draft",
+            "body_text": "body",
+        }),
+    )
+    .await;
+
+    uid
+}
+
+async fn assert_tools_list(harness: &mut Harness) {
+    let tools_list = harness.request("tools/list", json!({})).await;
+    assert_valid(&tools_list["result"], "ListToolsResult");
+    let tools: BTreeMap<String, Value> = tools_list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| (t["name"].as_str().expect("name").to_string(), t.clone()))
+        .collect();
+
+    for required in [
+        "draftsafe.list_folders",
+        "draftsafe.search",
+        "draftsafe.fetch_message",
+        "draftsafe.list_attachments",
+        "draftsafe.download_attachment",
+        "draftsafe.list_labels",
+        "draftsafe.mark_read",
+        "draftsafe.mark_unread",
+        "draftsafe.flag",
+        "draftsafe.unflag",
+        "draftsafe.add_label",
+        "draftsafe.remove_label",
+        "draftsafe.move_message",
+        "draftsafe.create_draft",
+        "list_accounts",
+        "use_account",
+    ] {
+        assert!(tools.contains_key(required), "missing tool: {required}");
+    }
+
+    for forbidden in [
+        "readonly.move_message",
+        "readonly.create_draft",
+        "readonly.mark_read",
+        "readonly.mark_unread",
+        "readonly.flag",
+        "readonly.unflag",
+        "readonly.add_label",
+        "readonly.remove_label",
+    ] {
+        assert!(
+            !tools.contains_key(forbidden),
+            "readonly namespace must not advertise {forbidden}",
+        );
+    }
+}
+
+async fn assert_search(harness: &mut Harness) -> u32 {
+    let search_body = call_tool(
+        harness,
+        "draftsafe.search",
+        json!({ "folder": "INBOX", "subject": "e2e-wire-test-smoke" }),
+    )
+    .await;
+    let total = search_body["meta"]["total_matched"]
+        .as_u64()
+        .expect("total_matched");
+    assert!(total >= 1, "expected at least one match, got {total}");
+    let messages = search_body["untrusted"]["messages"]
+        .as_array()
+        .expect("messages array");
+    assert!(
+        !messages.is_empty(),
+        "messages unexpectedly empty despite total_matched={total}",
+    );
+    let uid_u64 = messages[0]["uid"].as_u64().expect("uid is integer");
+    let uid = u32::try_from(uid_u64).expect("uid fits u32");
+    assert!(uid > 0);
+    uid
+}
+
+async fn assert_fetch_message(harness: &mut Harness, uid: u32) {
+    let fetch_body = call_tool(
+        harness,
+        "draftsafe.fetch_message",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+    let body_text = fetch_body["untrusted"]["body_text"]
+        .as_str()
+        .expect("body_text");
+    assert!(
+        body_text.contains("Hello from the Phase 3 wire-driven e2e smoke test."),
+        "unexpected body_text: {body_text}",
+    );
+}
+
+async fn assert_list_attachments(harness: &mut Harness, uid: u32) -> String {
+    let list_att = call_tool(
+        harness,
+        "draftsafe.list_attachments",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+    let attachments = list_att["untrusted"]["attachments"]
+        .as_array()
+        .expect("attachments array");
+    assert_eq!(
+        attachments.len(),
+        1,
+        "expected 1 attachment, got {attachments:?}",
+    );
+    let part_id = attachments[0]["part_id"]
+        .as_str()
+        .expect("part_id")
+        .to_string();
+    let filename = attachments[0]["filename"].as_str().expect("filename");
+    assert_eq!(filename, fixtures::ATTACHMENT_FILENAME);
+    part_id
+}
+
+async fn assert_download_attachment(harness: &mut Harness, uid: u32, part_id: &str) {
+    let dl = call_tool(
+        harness,
+        "draftsafe.download_attachment",
+        json!({
+            "folder": "INBOX",
+            "uid": uid,
+            "part_id": part_id,
+        }),
+    )
+    .await;
+    let dl_path = dl["meta"]["path"].as_str().expect("path");
+    let dl_bytes = std::fs::read(dl_path).expect("read downloaded bytes");
+    assert_eq!(
+        dl_bytes.as_slice(),
+        fixtures::ATTACHMENT_BYTES,
+        "downloaded bytes must match seeded payload",
+    );
+}
+
+async fn assert_label_round_trip(harness: &mut Harness, uid: u32) {
+    let _ = call_tool(
+        harness,
+        "draftsafe.add_label",
+        json!({ "folder": "INBOX", "uid": uid, "label": "WireE2E" }),
+    )
+    .await;
+    let labels_body = call_tool(
+        harness,
+        "draftsafe.list_labels",
+        json!({ "folder": "INBOX", "uid": uid }),
+    )
+    .await;
+    let labels: Vec<&str> = labels_body["meta"]["labels"]
+        .as_array()
+        .expect("labels array")
+        .iter()
+        .filter_map(|l| l.as_str())
+        .collect();
+    assert!(
+        labels.contains(&"WireE2E"),
+        "labels missing WireE2E: {labels:?}",
+    );
+    let _ = call_tool(
+        harness,
+        "draftsafe.remove_label",
+        json!({ "folder": "INBOX", "uid": uid, "label": "WireE2E" }),
+    )
+    .await;
+}
+
+async fn assert_move_message(harness: &mut Harness, uid: u32) {
+    let move_body = call_tool(
+        harness,
+        "draftsafe.move_message",
+        json!({ "folder": "INBOX", "destination": "Trash", "uid": uid }),
+    )
+    .await;
+    let moves = move_body["meta"]["moves"].as_array().expect("moves array");
+    assert_eq!(moves.len(), 1);
+    assert_eq!(
+        moves[0]["old_uid"].as_u64().expect("old_uid"),
+        u64::from(uid),
+    );
+}
+
+fn assert_audit_records(audit_path: &std::path::Path) {
+    let records = read_audit_records(audit_path);
+
+    // Pair every tool_start with a tool_end (matching start_seq).
+    let mut start_seqs: BTreeMap<u64, &Value> = BTreeMap::new();
+    let mut end_start_seqs: Vec<u64> = Vec::new();
+    for rec in &records {
+        match rec["kind"].as_str() {
+            Some("tool_start") => {
+                let seq = rec["seq"].as_u64().expect("tool_start seq");
+                start_seqs.insert(seq, rec);
+            }
+            Some("tool_end") => {
+                let start = rec["start_seq"].as_u64().expect("tool_end start_seq");
+                end_start_seqs.push(start);
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        start_seqs.len(),
+        end_start_seqs.len(),
+        "tool_start / tool_end count mismatch: starts={} ends={}",
+        start_seqs.len(),
+        end_start_seqs.len(),
+    );
+    for start in &end_start_seqs {
+        assert!(
+            start_seqs.contains_key(start),
+            "tool_end.start_seq={start} has no matching tool_start; \
+             start_seqs={:?}",
+            start_seqs.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    // Namespace attribution: account-scoped tools carry `draftsafe`;
+    // infrastructure tools carry no `account` field.
+    let infrastructure = ["use_account", "list_accounts"];
+    for rec in &records {
+        let kind = rec["kind"].as_str().unwrap_or("");
+        if kind != "tool_start" && kind != "tool_end" {
+            continue;
+        }
+        let tool = rec["tool"].as_str().expect("tool name");
+        let account = rec.get("account").and_then(|a| a.as_str());
+        if infrastructure.contains(&tool) {
+            assert!(
+                account.is_none(),
+                "infrastructure tool {tool} must omit account, got {account:?}",
+            );
+        } else {
+            assert_eq!(
+                account,
+                Some("draftsafe"),
+                "account-scoped tool {tool} must attribute to draftsafe, \
+                 got {account:?}",
+            );
+        }
+    }
+}
+
+/// Invoke `tools/call` and validate the response against (a) the
+/// envelope schema, (b) `CallToolResult`, and (c) the per-tool response
+/// schema fixture under `tests/fixtures/rimap-tool-schemas/`.
+async fn call_tool(harness: &mut Harness, name: &str, args: Value) -> Value {
+    let resp = harness
+        .request("tools/call", json!({ "name": name, "arguments": args }))
+        .await;
+    assert!(resp["error"].is_null(), "tool {name} failed: {resp}");
+    assert_valid(&resp["result"], "CallToolResult");
+    let body = &resp["result"]["structuredContent"];
+    let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
+    let validator = validator_for_tool_response(static_tool_name(bare));
+    if !validator.is_valid(body) {
+        let errors: Vec<String> = validator.iter_errors(body).map(|e| e.to_string()).collect();
+        panic!(
+            "tool {name} response failed schema:\n  {}\n\nresponse: {body}",
+            errors.join("\n  ")
+        );
+    }
+    body.clone()
+}
+
+/// Map a bare tool name to its `'static str` form for the validator
+/// cache. Listing every wire-exercised tool here keeps the binding free
+/// of `Box::leak` and forces a runtime panic if a new tool is added
+/// without a corresponding `tests/fixtures/rimap-tool-schemas/` entry.
+fn static_tool_name(bare: &str) -> &'static str {
+    match bare {
+        "list_folders" => "list_folders",
+        "search" => "search",
+        "fetch_message" => "fetch_message",
+        "list_attachments" => "list_attachments",
+        "download_attachment" => "download_attachment",
+        "mark_read" => "mark_read",
+        "mark_unread" => "mark_unread",
+        "flag" => "flag",
+        "unflag" => "unflag",
+        "add_label" => "add_label",
+        "remove_label" => "remove_label",
+        "list_labels" => "list_labels",
+        "move_message" => "move_message",
+        "create_draft" => "create_draft",
+        "use_account" => "use_account",
+        "list_accounts" => "list_accounts",
+        other => panic!("no schema fixture mapping for tool: {other}"),
+    }
+}
+
+/// Parse the audit JSONL into a vector of `Value`s. Tolerates a single
+/// trailing empty line; any other parse failure panics with the line
+/// number.
+fn read_audit_records(path: &std::path::Path) -> Vec<Value> {
+    let raw = std::fs::read_to_string(path).expect("read audit file");
+    raw.lines()
+        .enumerate()
+        .filter(|(_, l)| !l.is_empty())
+        .map(|(i, l)| {
+            serde_json::from_str(l)
+                .unwrap_or_else(|e| panic!("audit line {} parse error: {e}: {l}", i + 1))
+        })
+        .collect()
+}
+
+async fn seed_multipart_message(dovecot: &DovecotHarness) {
+    let audit_dir = TempDir::new().expect("seed-audit tempdir");
+    let audit = AuditWriter::open(&AuditOptions {
+        path: audit_dir.path().join("seed.jsonl"),
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let cfg = ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: "127.0.0.1".into(),
+        port: dovecot.port(),
+        encryption: ImapEncryption::Tls,
+        username: "rimap-test".into(),
+        pinned_fingerprint: Some(*dovecot.fingerprint()),
+        connect_timeout: Duration::from_secs(10),
+        command_timeout: Duration::from_secs(30),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    let store: Arc<dyn CredentialStore> = Arc::new(StaticCreds);
+    let creds: Arc<dyn rimap_core::CredentialResolver> = Arc::new(KeyringCredentialResolver::new(
+        store,
+        FallbackMode::KeyringThenEnv,
+    ));
+    let sink: Arc<dyn rimap_core::auth_sink::AuthEventSink> = Arc::new(audit.clone());
+    let conn = Connection::new(cfg, sink, creds);
+    conn.append_message("INBOX", &fixtures::multipart_with_attachment(), &[], &[])
+        .await
+        .expect("APPEND multipart seed");
+}

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -134,7 +134,10 @@ async fn wire_e2e_full_session_draft_safe() {
     let uid = drive_account_scoped_tools(&mut harness).await;
     assert_move_message(&mut harness, uid).await;
 
-    let status = harness.shutdown_and_wait().await;
+    // Bind the returned tempdir guard so the audit file outlives the
+    // harness; dropping it before the assertion below would delete the
+    // file the test is about to read.
+    let (status, _tempdir_guard) = harness.shutdown_and_wait().await;
     assert!(status.success(), "binary exited non-zero: {status:?}");
 
     assert_audit_records(&audit_path);
@@ -573,7 +576,10 @@ async fn wire_e2e_readonly_posture_denial() {
     assert_readonly_success_path(&mut harness).await;
     assert_readonly_denial(&mut harness).await;
 
-    let status = harness.shutdown_and_wait().await;
+    // Bind the returned tempdir guard so the audit file outlives the
+    // harness; dropping it before the assertion below would delete the
+    // file the test is about to read.
+    let (status, _tempdir_guard) = harness.shutdown_and_wait().await;
     assert!(status.success(), "child must exit 0, got {status:?}");
 
     assert_readonly_audit_records(&audit_path);

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -530,6 +530,180 @@ fn read_audit_records(path: &std::path::Path) -> Vec<Value> {
         .collect()
 }
 
+// Pin the posture-denial JSON-RPC error code. If rmcp's error mapping or
+// the posture-denial bridge changes, update this constant and document why —
+// silent drift in posture wire shape is exactly what this test surfaces.
+// (-32602 = rmcp INVALID_PARAMS; posture denials bridge through ErrorData::invalid_params)
+const POSTURE_DENIAL_CODE: i64 = -32602;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wire_e2e_readonly_posture_denial() {
+    let Some(dovecot) = DovecotHarness::try_start() else {
+        return; // silent skip
+    };
+    let tempdir = TempDir::new().expect("tempdir");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path().to_path_buf();
+    let download_dir = tempdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("mkdir download_dir");
+
+    let config_path = tempdir.path().join("config.toml");
+    let fingerprint_hex = dovecot.fingerprint().to_hex();
+    let config = build_dovecot_config(
+        &fingerprint_hex,
+        dovecot.port(),
+        &audit_path,
+        &allowed_base,
+        &download_dir,
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let envs = [(PASSWORD_ENV_VAR, DOVECOT_PASSWORD)];
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &envs).await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    assert_readonly_tools_list(&mut harness).await;
+    assert_readonly_success_path(&mut harness).await;
+    assert_readonly_denial(&mut harness).await;
+
+    let status = harness.shutdown_and_wait().await;
+    assert!(status.success(), "child must exit 0, got {status:?}");
+
+    assert_readonly_audit_records(&audit_path);
+}
+
+/// Verify tools/list advertisement posture for the readonly namespace.
+async fn assert_readonly_tools_list(harness: &mut Harness) {
+    let tools_list = harness.request("tools/list", json!({})).await;
+    assert_valid(&tools_list["result"], "ListToolsResult");
+    let names: Vec<&str> = tools_list["result"]["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"draftsafe.move_message"),
+        "draftsafe.move_message must be advertised; got {names:?}",
+    );
+    assert!(
+        names.contains(&"readonly.list_folders"),
+        "readonly.list_folders must be advertised; got {names:?}",
+    );
+    assert!(
+        !names.contains(&"readonly.move_message"),
+        "readonly.move_message must not be advertised; got {names:?}",
+    );
+}
+
+/// Readonly success path: drive `list_folders` end-to-end.
+async fn assert_readonly_success_path(harness: &mut Harness) {
+    let readonly_folders = call_tool(harness, "readonly.list_folders", json!({})).await;
+    let folder_names: Vec<&str> = readonly_folders["meta"]["folders"]
+        .as_array()
+        .expect("folders")
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .collect();
+    assert!(
+        folder_names.contains(&"INBOX"),
+        "readonly.list_folders did not return INBOX: {folder_names:?}",
+    );
+}
+
+/// Posture denial on the wire: `readonly.move_message` must return an error envelope.
+async fn assert_readonly_denial(harness: &mut Harness) {
+    // Use harness.request directly — call_tool asserts error.is_null() and
+    // would panic here. We expect an error envelope, not a success result.
+    let resp = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "readonly.move_message",
+                "arguments": {"folder": "INBOX", "destination": "Trash", "uid": 1},
+            }),
+        )
+        .await;
+    assert!(
+        resp["error"].is_object(),
+        "expected error envelope, got {resp}",
+    );
+    assert_eq!(
+        resp["error"]["code"].as_i64(),
+        Some(POSTURE_DENIAL_CODE),
+        "posture-denial wire code drifted; got {resp}",
+    );
+}
+
+/// Verify audit records from the readonly posture denial test.
+fn assert_readonly_audit_records(audit_path: &std::path::Path) {
+    let records = read_audit_records(audit_path);
+
+    // Success path: list_folders pair, account="readonly".
+    let lf_starts: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "list_folders")
+        .collect();
+    assert_eq!(
+        lf_starts.len(),
+        1,
+        "expected exactly one list_folders tool_start"
+    );
+    assert_eq!(
+        lf_starts[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.list_folders tool_start must record account=\"readonly\": {records:#?}",
+    );
+    let lf_ends: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "list_folders")
+        .collect();
+    assert_eq!(
+        lf_ends.len(),
+        1,
+        "expected exactly one list_folders tool_end"
+    );
+    assert_eq!(
+        lf_ends[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.list_folders tool_end must record account=\"readonly\": {records:#?}",
+    );
+    assert_eq!(lf_ends[0]["start_seq"], lf_starts[0]["seq"]);
+
+    // Denial path: move_message pair, account="readonly".
+    let mm_starts: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "move_message")
+        .collect();
+    assert_eq!(
+        mm_starts.len(),
+        1,
+        "expected exactly one move_message tool_start"
+    );
+    assert_eq!(
+        mm_starts[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.move_message tool_start must record account=\"readonly\" \
+         (not collapsed to None): {records:#?}",
+    );
+    let mm_ends: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "move_message")
+        .collect();
+    assert_eq!(
+        mm_ends.len(),
+        1,
+        "expected exactly one move_message tool_end"
+    );
+    assert_eq!(
+        mm_ends[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.move_message tool_end must record account=\"readonly\": {records:#?}",
+    );
+    assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
+}
+
 async fn seed_multipart_message(dovecot: &DovecotHarness) {
     let audit_dir = TempDir::new().expect("seed-audit tempdir");
     let audit = AuditWriter::open(&AuditOptions {

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -30,7 +30,7 @@ use secrecy::SecretString;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use dovecot::{DovecotHarness, fixtures};
+use dovecot::{DovecotHarness, HarnessError, fixtures};
 // `Harness`, `PINNED_PROTOCOL_VERSION`, and `assert_valid` go through
 // `wire::*` (the same re-exports `mcp_wire_conformance.rs` uses) so
 // the re-exports in `support/wire/mod.rs` register as "used" in both
@@ -92,8 +92,10 @@ impl CredentialStore for StaticCreds {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn wire_e2e_full_session_draft_safe() {
-    let Some(dovecot) = DovecotHarness::try_start() else {
-        return; // silent skip — matches e2e_full_session
+    let dovecot = match DovecotHarness::try_start() {
+        Ok(d) => d,
+        Err(HarnessError::DockerUnavailable) => return,
+        Err(e) => panic!("Dovecot harness failed: {e}"),
     };
     dovecot.create_mailbox("Drafts");
     dovecot.create_mailbox("Trash");
@@ -538,8 +540,10 @@ const POSTURE_DENIAL_CODE: i64 = -32602;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn wire_e2e_readonly_posture_denial() {
-    let Some(dovecot) = DovecotHarness::try_start() else {
-        return; // silent skip
+    let dovecot = match DovecotHarness::try_start() {
+        Ok(d) => d,
+        Err(HarnessError::DockerUnavailable) => return,
+        Err(e) => panic!("Dovecot harness failed: {e}"),
     };
     let tempdir = TempDir::new().expect("tempdir");
     let audit_path = tempdir.path().join("audit.jsonl");

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -532,11 +532,13 @@ fn read_audit_records(path: &std::path::Path) -> Vec<Value> {
         .collect()
 }
 
-// Pin the posture-denial JSON-RPC error code. If rmcp's error mapping or
-// the posture-denial bridge changes, update this constant and document why —
-// silent drift in posture wire shape is exactly what this test surfaces.
-// (-32602 = rmcp INVALID_PARAMS; posture denials bridge through ErrorData::invalid_params)
-const POSTURE_DENIAL_CODE: i64 = -32602;
+// Pin the posture-denial JSON-RPC error code. If `to_mcp_error` (in
+// `crates/rimap-server/src/mcp/error.rs`) remaps `ErrorCode::PostureDenied`,
+// update this constant and document why — silent drift in posture wire
+// shape is exactly what this test surfaces.
+// (-32001 = custom server-error code reserved for posture denials; see
+//  the `POSTURE_DENIED` constant in `mcp/error.rs`.)
+const POSTURE_DENIAL_CODE: i64 = -32001;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn wire_e2e_readonly_posture_denial() {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -42,128 +164,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
@@ -1,0 +1,202 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for `add_label` and `remove_label` responses.",
+      "properties": {
+        "folder": {
+          "description": "Folder the label was applied to.",
+          "type": "string"
+        },
+        "label": {
+          "description": "Label that was added or removed.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "label",
+        "uids_updated"
+      ],
+      "title": "LabelsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -42,128 +164,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
@@ -1,0 +1,202 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `create_draft` response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the draft was appended to.",
+          "type": "string"
+        },
+        "keywords": {
+          "description": "IMAP keywords applied to the draft.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "message_id": {
+          "description": "RFC 2822 `Message-ID` assigned to the draft.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "UID assigned by the server, if returned.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "folder",
+        "keywords"
+      ],
+      "title": "CreateDraftMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
@@ -1,0 +1,235 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `download_attachment` response.",
+      "properties": {
+        "folder": {
+          "description": "IMAP folder the message was fetched from.",
+          "type": "string"
+        },
+        "mime_declared": {
+          "description": "`Content-Type` declared by the MIME part (`type/subtype`).",
+          "type": "string"
+        },
+        "mime_sniffed": {
+          "description": "Magic-byte-sniffed MIME type, if any signature matched.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "part_id": {
+          "description": "IMAP part ID that was extracted.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Absolute path of the written attachment inside the sandbox.",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "SHA-256 of the decoded bytes, hex-encoded.",
+          "type": "string"
+        },
+        "size_bytes": {
+          "description": "Attachment body size in bytes (post-transfer-decoding).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "uid": {
+          "description": "UID of the parent message.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "folder",
+        "uid",
+        "part_id",
+        "path",
+        "size_bytes",
+        "sha256",
+        "mime_declared"
+      ],
+      "title": "DownloadAttachmentMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "untrusted": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Untrusted payload for a `download_attachment` response.",
+      "properties": {
+        "filename_original": {
+          "description": "Original filename from `Content-Disposition` / `Content-Type`\nname parameter (sanitized).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "DownloadAttachmentUntrusted",
+      "type": "object"
+    }
+  },
+  "required": [
+    "meta",
+    "untrusted"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -59,128 +181,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
@@ -1,4 +1,165 @@
 {
+  "$defs": {
+    "AttachmentMeta": {
+      "description": "Metadata for a single attachment part. Body bytes are not retained.",
+      "properties": {
+        "content_id": {
+          "description": "Value of `Content-ID:` if present (without angle brackets), sanitized.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "content_type": {
+          "description": "Declared content type (e.g. `\"image/png\"`), sanitized.",
+          "type": "string"
+        },
+        "filename": {
+          "description": "Decoded filename if available (from `Content-Disposition` or\n`Content-Type` name parameter), sanitized.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_inline": {
+          "description": "`true` if the disposition was `inline`.",
+          "type": "boolean"
+        },
+        "size_bytes": {
+          "description": "Size of the attachment body in bytes (post-transfer-decoding).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "content_type",
+        "size_bytes",
+        "is_inline"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -44,128 +205,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {
@@ -197,47 +236,6 @@
       "type": "array"
     },
     "untrusted": {
-      "$defs": {
-        "AttachmentMeta": {
-          "description": "Metadata for a single attachment part. Body bytes are not retained.",
-          "properties": {
-            "content_id": {
-              "description": "Value of `Content-ID:` if present (without angle brackets), sanitized.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "content_type": {
-              "description": "Declared content type (e.g. `\"image/png\"`), sanitized.",
-              "type": "string"
-            },
-            "filename": {
-              "description": "Decoded filename if available (from `Content-Disposition` or\n`Content-Type` name parameter), sanitized.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "is_inline": {
-              "description": "`true` if the disposition was `inline`.",
-              "type": "boolean"
-            },
-            "size_bytes": {
-              "description": "Size of the attachment body in bytes (post-transfer-decoding).",
-              "format": "uint64",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "content_type",
-            "size_bytes",
-            "is_inline"
-          ],
-          "type": "object"
-        }
-      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Sanitized untrusted payload for a `fetch_message` response.",
       "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
@@ -1,0 +1,362 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `fetch_message` response.",
+      "properties": {
+        "folder": {
+          "description": "IMAP folder the message was fetched from.",
+          "type": "string"
+        },
+        "message_id": {
+          "description": "RFC 2822 `Message-ID` header, if present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "size": {
+          "description": "Raw size of the message body in bytes.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "truncated": {
+          "description": "Whether the body was truncated to `max_body_bytes`.",
+          "type": "boolean"
+        },
+        "uid": {
+          "description": "UID of the fetched message.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "folder",
+        "uid",
+        "size",
+        "truncated"
+      ],
+      "title": "FetchMessageMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "untrusted": {
+      "$defs": {
+        "AttachmentMeta": {
+          "description": "Metadata for a single attachment part. Body bytes are not retained.",
+          "properties": {
+            "content_id": {
+              "description": "Value of `Content-ID:` if present (without angle brackets), sanitized.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content_type": {
+              "description": "Declared content type (e.g. `\"image/png\"`), sanitized.",
+              "type": "string"
+            },
+            "filename": {
+              "description": "Decoded filename if available (from `Content-Disposition` or\n`Content-Type` name parameter), sanitized.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_inline": {
+              "description": "`true` if the disposition was `inline`.",
+              "type": "boolean"
+            },
+            "size_bytes": {
+              "description": "Size of the attachment body in bytes (post-transfer-decoding).",
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "content_type",
+            "size_bytes",
+            "is_inline"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Sanitized untrusted payload for a `fetch_message` response.",
+      "properties": {
+        "attachments": {
+          "description": "MIME attachment parts found in the message.",
+          "items": {
+            "$ref": "#/$defs/AttachmentMeta"
+          },
+          "type": "array"
+        },
+        "body_html": {
+          "description": "Sanitized HTML body, present only when `include_html=true`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "body_text": {
+          "description": "Plain-text body (sanitized).",
+          "type": "string"
+        },
+        "cc": {
+          "description": "`Cc` header recipients.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "date": {
+          "description": "`Date` header. Serialized as a 9-element integer tuple:\n`[year, ordinal, hour, minute, second, nanosecond,\n  offset_whole_hours, offset_minutes_past_hour,\n  offset_seconds_past_minute]`.\n\nNote: the `time` crate does not enable `serde-human-readable` in\nthis workspace, so `OffsetDateTime` always serializes as a tuple\nregardless of the serializer's `is_human_readable()` flag.",
+          "items": false,
+          "maxItems": 9,
+          "minItems": 9,
+          "prefixItems": [
+            {
+              "description": "year",
+              "type": "integer"
+            },
+            {
+              "description": "day_of_year (ordinal 1\u2013366)",
+              "type": "integer"
+            },
+            {
+              "description": "hour (0\u201323)",
+              "type": "integer"
+            },
+            {
+              "description": "minute (0\u201359)",
+              "type": "integer"
+            },
+            {
+              "description": "second (0\u201360)",
+              "type": "integer"
+            },
+            {
+              "description": "nanosecond (0\u2013999999999)",
+              "type": "integer"
+            },
+            {
+              "description": "UTC offset: whole hours (-23\u201323)",
+              "type": "integer"
+            },
+            {
+              "description": "UTC offset: minutes past hour (-59\u201359)",
+              "type": "integer"
+            },
+            {
+              "description": "UTC offset: seconds past minute (-59\u201359)",
+              "type": "integer"
+            }
+          ],
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "from": {
+          "description": "`From` header.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reply_to": {
+          "description": "`Reply-To` header.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subject": {
+          "description": "`Subject` header.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "to": {
+          "description": "`To` header recipients.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "body_text",
+        "to",
+        "cc",
+        "date",
+        "attachments"
+      ],
+      "title": "FetchMessageUntrusted",
+      "type": "object"
+    }
+  },
+  "required": [
+    "meta",
+    "untrusted"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -37,128 +159,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
@@ -1,0 +1,197 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a flag mutation response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the flags were updated in.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "uids_updated"
+      ],
+      "title": "FlagsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
@@ -1,0 +1,208 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$defs": {
+        "AccountEntry": {
+          "description": "A single account entry in a `list_accounts` response.",
+          "properties": {
+            "name": {
+              "description": "Account name.",
+              "type": "string"
+            },
+            "smtp_configured": {
+              "description": "Whether an SMTP configuration is present for this account.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "smtp_configured"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `list_accounts` response.",
+      "properties": {
+        "accounts": {
+          "description": "All configured accounts.",
+          "items": {
+            "$ref": "#/$defs/AccountEntry"
+          },
+          "type": "array"
+        },
+        "count": {
+          "description": "Total number of configured accounts.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "accounts",
+        "count"
+      ],
+      "title": "ListAccountsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
@@ -1,27 +1,147 @@
 {
+  "$defs": {
+    "AccountEntry": {
+      "description": "A single account entry in a `list_accounts` response.",
+      "properties": {
+        "name": {
+          "description": "Account name.",
+          "type": "string"
+        },
+        "smtp_configured": {
+          "description": "Whether an SMTP configuration is present for this account.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "smtp_configured"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
-      "$defs": {
-        "AccountEntry": {
-          "description": "A single account entry in a `list_accounts` response.",
-          "properties": {
-            "name": {
-              "description": "Account name.",
-              "type": "string"
-            },
-            "smtp_configured": {
-              "description": "Whether an SMTP configuration is present for this account.",
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "smtp_configured"
-          ],
-          "type": "object"
-        }
-      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Trusted metadata for a `list_accounts` response.",
       "properties": {
@@ -48,128 +168,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
@@ -1,0 +1,245 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `list_attachments` response.",
+      "properties": {
+        "attachment_count": {
+          "description": "Number of attachment parts found.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "folder": {
+          "description": "IMAP folder the message was fetched from.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the inspected message.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "folder",
+        "uid",
+        "attachment_count"
+      ],
+      "title": "ListAttachmentsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "untrusted": {
+      "$defs": {
+        "AttachmentInfo": {
+          "description": "Metadata for a single attachment discovered in the MIME tree.",
+          "properties": {
+            "filename": {
+              "description": "Filename from MIME content-type `name` or `filename` parameter.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mime_type": {
+              "description": "Full MIME type (e.g. `\"application/pdf\"`).",
+              "type": "string"
+            },
+            "part_id": {
+              "description": "IMAP part identifier (e.g. `\"2\"`, `\"1.2\"`).",
+              "type": "string"
+            },
+            "size_bytes": {
+              "description": "Size of the part in bytes as reported by `BODYSTRUCTURE`.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "part_id",
+            "mime_type",
+            "size_bytes"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Untrusted payload for a `list_attachments` response.",
+      "properties": {
+        "attachments": {
+          "description": "Attachment parts found in the MIME tree.",
+          "items": {
+            "$ref": "#/$defs/AttachmentInfo"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "attachments"
+      ],
+      "title": "ListAttachmentsUntrusted",
+      "type": "object"
+    }
+  },
+  "required": [
+    "meta",
+    "untrusted"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
@@ -1,4 +1,158 @@
 {
+  "$defs": {
+    "AttachmentInfo": {
+      "description": "Metadata for a single attachment discovered in the MIME tree.",
+      "properties": {
+        "filename": {
+          "description": "Filename from MIME content-type `name` or `filename` parameter.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mime_type": {
+          "description": "Full MIME type (e.g. `\"application/pdf\"`).",
+          "type": "string"
+        },
+        "part_id": {
+          "description": "IMAP part identifier (e.g. `\"2\"`, `\"1.2\"`).",
+          "type": "string"
+        },
+        "size_bytes": {
+          "description": "Size of the part in bytes as reported by `BODYSTRUCTURE`.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "part_id",
+        "mime_type",
+        "size_bytes"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -32,128 +186,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {
@@ -185,40 +217,6 @@
       "type": "array"
     },
     "untrusted": {
-      "$defs": {
-        "AttachmentInfo": {
-          "description": "Metadata for a single attachment discovered in the MIME tree.",
-          "properties": {
-            "filename": {
-              "description": "Filename from MIME content-type `name` or `filename` parameter.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "mime_type": {
-              "description": "Full MIME type (e.g. `\"application/pdf\"`).",
-              "type": "string"
-            },
-            "part_id": {
-              "description": "IMAP part identifier (e.g. `\"2\"`, `\"1.2\"`).",
-              "type": "string"
-            },
-            "size_bytes": {
-              "description": "Size of the part in bytes as reported by `BODYSTRUCTURE`.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "part_id",
-            "mime_type",
-            "size_bytes"
-          ],
-          "type": "object"
-        }
-      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Untrusted payload for a `list_attachments` response.",
       "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
@@ -1,220 +1,220 @@
 {
-  "additionalProperties": false,
-  "properties": {
-    "meta": {
-      "$defs": {
-        "FolderEntry": {
-          "description": "A single folder entry in a `list_folders` response.",
-          "properties": {
-            "delimiter": {
-              "description": "Hierarchy delimiter character reported by the server.",
-              "maxLength": 1,
-              "minLength": 1,
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "exists": {
-              "description": "Number of messages in the folder, if available.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "flags": {
-              "description": "IMAP folder attribute flags (e.g. `\"\\\\HasNoChildren\"`).",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "name": {
-              "description": "Sanitized, display-safe folder name. Bidi / zero-width / Unicode\nTag codepoints are stripped before this reaches the client.",
-              "type": "string"
-            },
-            "name_wire": {
-              "description": "Raw wire form of the folder name encoded as `\\u{H..}` Unicode\nescape sequences (see `escape_wire_name`), populated only when\n`name` differs from what the server sent. Clients pass this back\nfor SELECT / STATUS / MOVE / FETCH when `name_wire` is `Some(_)`;\notherwise they pass `name` directly.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "uid_validity": {
-              "description": "UID validity value for the folder, if available.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "unseen": {
-              "description": "Number of unseen messages, if available.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "name",
-            "flags"
-          ],
-          "type": "object"
+  "$defs": {
+    "FolderEntry": {
+      "description": "A single folder entry in a `list_folders` response.",
+      "properties": {
+        "delimiter": {
+          "description": "Hierarchy delimiter character reported by the server.",
+          "maxLength": 1,
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "SecurityWarning": {
-          "description": "A single warning emitted by the content pipeline.",
-          "properties": {
-            "code": {
-              "$ref": "#/$defs/WarningCode",
-              "description": "Classification of the warning."
-            },
-            "detail": {
-              "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "location": {
-              "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "code"
-          ],
-          "type": "object"
+        "exists": {
+          "description": "Number of messages in the folder, if available.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
         },
-        "WarningCode": {
-          "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-          "oneOf": [
-            {
-              "const": "unicode_zero_width_stripped",
-              "description": "Zero-width codepoints were present in input text and stripped.",
-              "type": "string"
-            },
-            {
-              "const": "unicode_bidi_override_stripped",
-              "description": "Bidi-override codepoints were present in input text and stripped.",
-              "type": "string"
-            },
-            {
-              "const": "unicode_c0_c1_stripped",
-              "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-              "type": "string"
-            },
-            {
-              "const": "parse_header_smuggling_blocked",
-              "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-              "type": "string"
-            },
-            {
-              "const": "parse_mime_type_mismatch",
-              "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-              "type": "string"
-            },
-            {
-              "const": "parse_bodystructure_type_mismatch",
-              "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-              "type": "string"
-            },
-            {
-              "const": "parse_attachment_polyglot",
-              "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-              "type": "string"
-            },
-            {
-              "const": "parse_body_truncated",
-              "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-              "type": "string"
-            },
-            {
-              "const": "parse_mime_depth_exceeded",
-              "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-              "type": "string"
-            },
-            {
-              "const": "parse_mime_part_count_exceeded",
-              "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-              "type": "string"
-            },
-            {
-              "const": "parse_header_count_exceeded",
-              "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-              "type": "string"
-            },
-            {
-              "const": "parse_attachment_filename_rewritten",
-              "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-              "type": "string"
-            },
-            {
-              "const": "html_hidden_content_detected",
-              "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-              "type": "string"
-            },
-            {
-              "const": "html_link_text_href_mismatch",
-              "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-              "type": "string"
-            },
-            {
-              "const": "html_script_stripped",
-              "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-              "type": "string"
-            },
-            {
-              "const": "html_style_stripped",
-              "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-              "type": "string"
-            },
-            {
-              "const": "html_remote_image_stripped",
-              "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-              "type": "string"
-            },
-            {
-              "const": "html_anchor_unparsable_href",
-              "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-              "type": "string"
-            },
-            {
-              "const": "lookalike_mixed_script",
-              "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-              "type": "string"
-            },
-            {
-              "const": "lookalike_homograph_domain",
-              "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-              "type": "string"
-            },
-            {
-              "const": "lookalike_idn_punycode",
-              "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-              "type": "string"
-            },
-            {
-              "const": "lookalike_filename_extension_spoof",
-              "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-              "type": "string"
-            },
-            {
-              "const": "server_non_atomic_move_fallback",
-              "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-              "type": "string"
-            }
+        "flags": {
+          "description": "IMAP folder attribute flags (e.g. `\"\\\\HasNoChildren\"`).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Sanitized, display-safe folder name. Bidi / zero-width / Unicode\nTag codepoints are stripped before this reaches the client.",
+          "type": "string"
+        },
+        "name_wire": {
+          "description": "Raw wire form of the folder name encoded as `\\u{H..}` Unicode\nescape sequences (see `escape_wire_name`), populated only when\n`name` differs from what the server sent. Clients pass this back\nfor SELECT / STATUS / MOVE / FETCH when `name_wire` is `Some(_)`;\notherwise they pass `name` directly.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid_validity": {
+          "description": "UID validity value for the folder, if available.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "unseen": {
+          "description": "Number of unseen messages, if available.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
           ]
         }
       },
+      "required": [
+        "name",
+        "flags"
+      ],
+      "type": "object"
+    },
+    "SecurityWarning": {
+      "description": "A single warning emitted by the content pipeline.",
+      "properties": {
+        "code": {
+          "$ref": "#/$defs/WarningCode",
+          "description": "Classification of the warning."
+        },
+        "detail": {
+          "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "code"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Trusted metadata for a `list_folders` response.",
       "properties": {
@@ -241,128 +241,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
@@ -1,0 +1,401 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$defs": {
+        "FolderEntry": {
+          "description": "A single folder entry in a `list_folders` response.",
+          "properties": {
+            "delimiter": {
+              "description": "Hierarchy delimiter character reported by the server.",
+              "maxLength": 1,
+              "minLength": 1,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "exists": {
+              "description": "Number of messages in the folder, if available.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "flags": {
+              "description": "IMAP folder attribute flags (e.g. `\"\\\\HasNoChildren\"`).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Sanitized, display-safe folder name. Bidi / zero-width / Unicode\nTag codepoints are stripped before this reaches the client.",
+              "type": "string"
+            },
+            "name_wire": {
+              "description": "Raw wire form of the folder name encoded as `\\u{H..}` Unicode\nescape sequences (see `escape_wire_name`), populated only when\n`name` differs from what the server sent. Clients pass this back\nfor SELECT / STATUS / MOVE / FETCH when `name_wire` is `Some(_)`;\notherwise they pass `name` directly.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid_validity": {
+              "description": "UID validity value for the folder, if available.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "unseen": {
+              "description": "Number of unseen messages, if available.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "flags"
+          ],
+          "type": "object"
+        },
+        "SecurityWarning": {
+          "description": "A single warning emitted by the content pipeline.",
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/WarningCode",
+              "description": "Classification of the warning."
+            },
+            "detail": {
+              "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "location": {
+              "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "code"
+          ],
+          "type": "object"
+        },
+        "WarningCode": {
+          "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+          "oneOf": [
+            {
+              "const": "unicode_zero_width_stripped",
+              "description": "Zero-width codepoints were present in input text and stripped.",
+              "type": "string"
+            },
+            {
+              "const": "unicode_bidi_override_stripped",
+              "description": "Bidi-override codepoints were present in input text and stripped.",
+              "type": "string"
+            },
+            {
+              "const": "unicode_c0_c1_stripped",
+              "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+              "type": "string"
+            },
+            {
+              "const": "parse_header_smuggling_blocked",
+              "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+              "type": "string"
+            },
+            {
+              "const": "parse_mime_type_mismatch",
+              "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+              "type": "string"
+            },
+            {
+              "const": "parse_bodystructure_type_mismatch",
+              "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+              "type": "string"
+            },
+            {
+              "const": "parse_attachment_polyglot",
+              "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+              "type": "string"
+            },
+            {
+              "const": "parse_body_truncated",
+              "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+              "type": "string"
+            },
+            {
+              "const": "parse_mime_depth_exceeded",
+              "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+              "type": "string"
+            },
+            {
+              "const": "parse_mime_part_count_exceeded",
+              "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+              "type": "string"
+            },
+            {
+              "const": "parse_header_count_exceeded",
+              "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+              "type": "string"
+            },
+            {
+              "const": "parse_attachment_filename_rewritten",
+              "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+              "type": "string"
+            },
+            {
+              "const": "html_hidden_content_detected",
+              "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+              "type": "string"
+            },
+            {
+              "const": "html_link_text_href_mismatch",
+              "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+              "type": "string"
+            },
+            {
+              "const": "html_script_stripped",
+              "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+              "type": "string"
+            },
+            {
+              "const": "html_style_stripped",
+              "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+              "type": "string"
+            },
+            {
+              "const": "html_remote_image_stripped",
+              "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+              "type": "string"
+            },
+            {
+              "const": "html_anchor_unparsable_href",
+              "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+              "type": "string"
+            },
+            {
+              "const": "lookalike_mixed_script",
+              "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+              "type": "string"
+            },
+            {
+              "const": "lookalike_homograph_domain",
+              "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+              "type": "string"
+            },
+            {
+              "const": "lookalike_idn_punycode",
+              "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+              "type": "string"
+            },
+            {
+              "const": "lookalike_filename_extension_spoof",
+              "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+              "type": "string"
+            },
+            {
+              "const": "server_non_atomic_move_fallback",
+              "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `list_folders` response.",
+      "properties": {
+        "folders": {
+          "description": "All folders returned by the server.",
+          "items": {
+            "$ref": "#/$defs/FolderEntry"
+          },
+          "type": "array"
+        },
+        "security_warnings": {
+          "description": "Security warnings accumulated while sanitizing folder names and\nflags against bidi overrides, zero-width characters, and C0/C1\ncontrol bytes (#98). Serialized only when non-empty.",
+          "items": {
+            "$ref": "#/$defs/SecurityWarning"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folders"
+      ],
+      "title": "ListFoldersMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
@@ -1,0 +1,202 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `list_labels` response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the labels were fetched from.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "Custom keyword labels on the message.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "uid": {
+          "description": "UID of the message.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the EXAMINE used for this operation. `None`\nwhen the server's EXAMINE response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "folder",
+        "uid",
+        "labels"
+      ],
+      "title": "ListLabelsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -42,128 +164,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -37,128 +159,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
@@ -1,0 +1,197 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a flag mutation response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the flags were updated in.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "uids_updated"
+      ],
+      "title": "FlagsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -37,128 +159,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
@@ -1,0 +1,197 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a flag mutation response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the flags were updated in.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "uids_updated"
+      ],
+      "title": "FlagsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
@@ -1,33 +1,153 @@
 {
+  "$defs": {
+    "MoveEntry": {
+      "description": "Per-UID move result entry.",
+      "properties": {
+        "new_uid": {
+          "description": "Destination UID assigned by the server, if returned.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "old_uid": {
+          "description": "Source UID that was moved.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "old_uid"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
-      "$defs": {
-        "MoveEntry": {
-          "description": "Per-UID move result entry.",
-          "properties": {
-            "new_uid": {
-              "description": "Destination UID assigned by the server, if returned.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "old_uid": {
-              "description": "Source UID that was moved.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "old_uid"
-          ],
-          "type": "object"
-        }
-      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Trusted metadata for a `move_message` response.",
       "properties": {
@@ -75,128 +195,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
@@ -1,0 +1,235 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$defs": {
+        "MoveEntry": {
+          "description": "Per-UID move result entry.",
+          "properties": {
+            "new_uid": {
+              "description": "Destination UID assigned by the server, if returned.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "old_uid": {
+              "description": "Source UID that was moved.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "old_uid"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `move_message` response.",
+      "properties": {
+        "destination": {
+          "description": "Destination folder.",
+          "type": "string"
+        },
+        "destination_uid_validity": {
+          "description": "Destination-folder UIDVALIDITY observed after the COPY+DELETE fallback\npath. `None` on the UID MOVE happy path (destination UIDVALIDITY not\nobservable without an extra STATUS) or when the server omitted the\nresponse code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "folder": {
+          "description": "Source folder.",
+          "type": "string"
+        },
+        "moves": {
+          "description": "Per-UID move results.",
+          "items": {
+            "$ref": "#/$defs/MoveEntry"
+          },
+          "type": "array"
+        },
+        "source_uid_validity": {
+          "description": "Source-folder UIDVALIDITY observed at the guard STATUS probe, or at\nthe source SELECT if no guard was requested. `None` when the server\nomitted the response code or no guard/probe occurred. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "folder",
+        "destination",
+        "moves"
+      ],
+      "title": "MoveMessageMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -42,128 +164,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
@@ -1,0 +1,202 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for `add_label` and `remove_label` responses.",
+      "properties": {
+        "folder": {
+          "description": "Folder the label was applied to.",
+          "type": "string"
+        },
+        "label": {
+          "description": "Label that was added or removed.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "label",
+        "uids_updated"
+      ],
+      "title": "LabelsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -1,0 +1,289 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `search` response.",
+      "properties": {
+        "folder": {
+          "description": "Folder that was searched.",
+          "type": "string"
+        },
+        "returned": {
+          "description": "Number of messages returned in this response.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_matched": {
+          "description": "Total number of messages matching the query (before pagination).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "truncated": {
+          "description": "Whether there are more results beyond this page.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "folder",
+        "total_matched",
+        "returned",
+        "truncated"
+      ],
+      "title": "SearchMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "untrusted": {
+      "$defs": {
+        "SearchResultEntry": {
+          "description": "A single message entry in a `search` untrusted payload.",
+          "properties": {
+            "date": {
+              "description": "Date header, sanitized.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "flags": {
+              "description": "IMAP flags on the message, if fetched.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "from": {
+              "description": "From addresses, sanitized. Omitted when empty.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "message_id": {
+              "description": "RFC 2822 `Message-ID`, sanitized.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "Message size in bytes, if fetched.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "subject": {
+              "description": "Subject header, sanitized.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "to": {
+              "description": "To addresses, sanitized. Omitted when empty.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "uid": {
+              "description": "UID of the message.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "uid",
+            "from",
+            "to"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Untrusted payload for a `search` response.",
+      "properties": {
+        "messages": {
+          "description": "Matching messages with sanitized header fields.",
+          "items": {
+            "$ref": "#/$defs/SearchResultEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "title": "SearchUntrusted",
+      "type": "object"
+    }
+  },
+  "required": [
+    "meta",
+    "untrusted"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -1,4 +1,197 @@
 {
+  "$defs": {
+    "SearchResultEntry": {
+      "description": "A single message entry in a `search` untrusted payload.",
+      "properties": {
+        "date": {
+          "description": "Date header, sanitized.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "flags": {
+          "description": "IMAP flags on the message, if fetched.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "from": {
+          "description": "From addresses, sanitized. Omitted when empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "message_id": {
+          "description": "RFC 2822 `Message-ID`, sanitized.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "size": {
+          "description": "Message size in bytes, if fetched.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "subject": {
+          "description": "Subject header, sanitized.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "to": {
+          "description": "To addresses, sanitized. Omitted when empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "uid": {
+          "description": "UID of the message.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "uid",
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -37,128 +230,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {
@@ -190,79 +261,6 @@
       "type": "array"
     },
     "untrusted": {
-      "$defs": {
-        "SearchResultEntry": {
-          "description": "A single message entry in a `search` untrusted payload.",
-          "properties": {
-            "date": {
-              "description": "Date header, sanitized.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "flags": {
-              "description": "IMAP flags on the message, if fetched.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "from": {
-              "description": "From addresses, sanitized. Omitted when empty.",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "message_id": {
-              "description": "RFC 2822 `Message-ID`, sanitized.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "size": {
-              "description": "Message size in bytes, if fetched.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "subject": {
-              "description": "Subject header, sanitized.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "to": {
-              "description": "To addresses, sanitized. Omitted when empty.",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "uid": {
-              "description": "UID of the message.",
-              "format": "uint32",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "uid",
-            "from",
-            "to"
-          ],
-          "type": "object"
-        }
-      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Untrusted payload for a `search` response.",
       "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -65,9 +65,7 @@
         }
       },
       "required": [
-        "uid",
-        "from",
-        "to"
+        "uid"
       ],
       "type": "object"
     },

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -37,128 +159,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
@@ -1,0 +1,197 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a flag mutation response.",
+      "properties": {
+        "folder": {
+          "description": "Folder the flags were updated in.",
+          "type": "string"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed at the SELECT used for this operation. `None`\nwhen the server's SELECT response omitted the response code. (#70)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uids_updated": {
+          "description": "UIDs that were updated.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "folder",
+        "uids_updated"
+      ],
+      "title": "FlagsMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
@@ -1,0 +1,185 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Trusted metadata for a `use_account` response.",
+      "properties": {
+        "account": {
+          "description": "The account that is now active.",
+          "type": "string"
+        },
+        "previous": {
+          "description": "The previously active account, or `None` if none was set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "account"
+      ],
+      "title": "UseAccountMeta",
+      "type": "object"
+    },
+    "security_warnings": {
+      "items": {
+        "$defs": {
+          "WarningCode": {
+            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+            "oneOf": [
+              {
+                "const": "unicode_zero_width_stripped",
+                "description": "Zero-width codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_bidi_override_stripped",
+                "description": "Bidi-override codepoints were present in input text and stripped.",
+                "type": "string"
+              },
+              {
+                "const": "unicode_c0_c1_stripped",
+                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_smuggling_blocked",
+                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_type_mismatch",
+                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_bodystructure_type_mismatch",
+                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_polyglot",
+                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+                "type": "string"
+              },
+              {
+                "const": "parse_body_truncated",
+                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_depth_exceeded",
+                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_mime_part_count_exceeded",
+                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_header_count_exceeded",
+                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+                "type": "string"
+              },
+              {
+                "const": "parse_attachment_filename_rewritten",
+                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+                "type": "string"
+              },
+              {
+                "const": "html_hidden_content_detected",
+                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+                "type": "string"
+              },
+              {
+                "const": "html_link_text_href_mismatch",
+                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+                "type": "string"
+              },
+              {
+                "const": "html_script_stripped",
+                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_style_stripped",
+                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_remote_image_stripped",
+                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+                "type": "string"
+              },
+              {
+                "const": "html_anchor_unparsable_href",
+                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_mixed_script",
+                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_homograph_domain",
+                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_idn_punycode",
+                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+                "type": "string"
+              },
+              {
+                "const": "lookalike_filename_extension_spoof",
+                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+                "type": "string"
+              },
+              {
+                "const": "server_non_atomic_move_fallback",
+                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A single warning emitted by the content pipeline.",
+        "properties": {
+          "code": {
+            "$ref": "#/$defs/WarningCode",
+            "description": "Classification of the warning."
+          },
+          "detail": {
+            "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "SecurityWarning",
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
@@ -1,4 +1,126 @@
 {
+  "$defs": {
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -25,128 +147,6 @@
     },
     "security_warnings": {
       "items": {
-        "$defs": {
-          "WarningCode": {
-            "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
-            "oneOf": [
-              {
-                "const": "unicode_zero_width_stripped",
-                "description": "Zero-width codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_bidi_override_stripped",
-                "description": "Bidi-override codepoints were present in input text and stripped.",
-                "type": "string"
-              },
-              {
-                "const": "unicode_c0_c1_stripped",
-                "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_smuggling_blocked",
-                "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_type_mismatch",
-                "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_bodystructure_type_mismatch",
-                "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_polyglot",
-                "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
-                "type": "string"
-              },
-              {
-                "const": "parse_body_truncated",
-                "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_depth_exceeded",
-                "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_mime_part_count_exceeded",
-                "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_header_count_exceeded",
-                "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
-                "type": "string"
-              },
-              {
-                "const": "parse_attachment_filename_rewritten",
-                "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
-                "type": "string"
-              },
-              {
-                "const": "html_hidden_content_detected",
-                "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
-                "type": "string"
-              },
-              {
-                "const": "html_link_text_href_mismatch",
-                "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
-                "type": "string"
-              },
-              {
-                "const": "html_script_stripped",
-                "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_style_stripped",
-                "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_remote_image_stripped",
-                "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
-                "type": "string"
-              },
-              {
-                "const": "html_anchor_unparsable_href",
-                "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_mixed_script",
-                "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_homograph_domain",
-                "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_idn_punycode",
-                "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
-                "type": "string"
-              },
-              {
-                "const": "lookalike_filename_extension_spoof",
-                "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
-                "type": "string"
-              },
-              {
-                "const": "server_non_atomic_move_fallback",
-                "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
-                "type": "string"
-              }
-            ]
-          }
-        },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "A single warning emitted by the content pipeline.",
         "properties": {

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -1,301 +1,21 @@
 //! MCP wire-shape conformance harness (issue #263, Phase 1).
 //!
-//! Spawns the production `rusty-imap-mcp` binary with a tempdir
-//! config that has zero accounts, drives a deterministic JSON-RPC
-//! sequence over its stdio, and validates every response against
-//! the vendored MCP spec schemas under
-//! `tests/fixtures/mcp-spec/2025-11-25/`.
-//!
-//! Permanent regression net for two real wire-shape bugs:
-//!  - #261: `initialize.result.capabilities` was serialized as `{}`.
-//!  - `fix/tool-input-schema-object-type`: tools advertised
-//!    `inputSchema: {}` with no `type` field.
+//! Drives the production `rusty-imap-mcp` binary over stdio with a
+//! zero-account config and validates every response against the
+//! vendored MCP spec schemas. See
+//! `docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md`.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
-#![expect(clippy::panic, reason = "test assertions render diagnostics")]
 
-use std::collections::HashMap;
-use std::process::Stdio;
-use std::sync::{Arc, Mutex, OnceLock};
+#[path = "support/mod.rs"]
+mod support;
+
 use std::time::Duration;
 
-use assert_cmd::cargo::cargo_bin;
 use rmcp::model::ProtocolVersion;
-use serde_json::{Value, json};
-use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::time::timeout;
+use serde_json::json;
 
-/// MCP protocol version pinned by this harness. Matches the
-/// directory under `tests/fixtures/mcp-spec/` and the `LATEST` value
-/// in `rmcp 1.5`. Update both when bumping.
-const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
-
-/// Vendored MCP spec schema, compiled in at build time so tests run
-/// hermetically (no network, no filesystem dependency beyond the
-/// crate source).
-const MCP_SCHEMA_JSON: &str = include_str!("fixtures/mcp-spec/2025-11-25/schema.json");
-
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-// Under `cargo nextest run` with the full workspace suite (~1100 tests
-// in parallel), the EOF-to-exit slice for `wire_clean_eof_shutdown_exits_zero`
-// can exceed a tight 1 s budget on CPU-contended runners. 5 s remains
-// tight enough to fail-fast on a real hang while absorbing scheduling
-// jitter when other tests are spawning binaries / parsers concurrently.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Owns the spawned child plus its piped stdio.
-struct Harness {
-    child: Child,
-    stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
-    next_id: u64,
-    // Hold the tempdir until the harness drops so the audit log path
-    // remains valid for the lifetime of the spawned process.
-    _tempdir: TempDir,
-}
-
-impl Harness {
-    /// Spawn the binary with a zero-account tempdir config.
-    #[expect(
-        clippy::unused_async,
-        reason = "harness API is uniformly async so tests await every constructor"
-    )]
-    async fn spawn() -> Self {
-        let tempdir = TempDir::new().expect("tempdir");
-        let config_path = tempdir.path().join("config.toml");
-        let audit_path = tempdir.path().join("audit.jsonl");
-        let allowed_base = tempdir.path();
-
-        // Multi-account format with zero accounts. Task 1 lifted the
-        // empty-accounts validator gate, so this is the canonical
-        // zero-account shape the loader accepts.
-        let config = format!(
-            r#"
-accounts = []
-
-[audit]
-path = "{}"
-allowed_base_dir = "{}"
-"#,
-            audit_path.display(),
-            allowed_base.display(),
-        );
-        std::fs::write(&config_path, config).expect("write config");
-
-        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
-        cmd.arg("--config")
-            .arg(&config_path)
-            // Production rejects `accounts = []`. The harness opts in
-            // to infrastructure-only boot via this test-support flag
-            // (Codex adversarial review on PR #270).
-            .arg("--allow-empty-accounts")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .kill_on_drop(true);
-
-        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
-
-        let stdin = child.stdin.take().expect("stdin");
-        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
-
-        Self {
-            child,
-            stdin,
-            stdout,
-            next_id: 0,
-            _tempdir: tempdir,
-        }
-    }
-
-    /// Send a JSON-RPC request and return the parsed response value.
-    /// Panics on timeout, EOF before a response arrives, or non-JSON output.
-    async fn request(&mut self, method: &str, params: Value) -> Value {
-        self.next_id += 1;
-        let id = self.next_id;
-        let envelope = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-            "params": params,
-        });
-        let line = format!("{envelope}\n");
-        self.stdin
-            .write_all(line.as_bytes())
-            .await
-            .expect("write request");
-        self.stdin.flush().await.expect("flush request");
-
-        let mut buf = String::new();
-        let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
-            .await
-            .expect("response within timeout")
-            .expect("read response");
-        assert!(read > 0, "stdout closed before responding to {method}");
-        let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
-        assert_eq!(response["id"], json!(id), "response id must match request");
-        assert_envelope_valid(&response);
-        response
-    }
-
-    /// Send a JSON-RPC notification (no `id`, no response expected).
-    async fn notify(&mut self, method: &str, params: Value) {
-        let envelope = json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        });
-        let line = format!("{envelope}\n");
-        self.stdin
-            .write_all(line.as_bytes())
-            .await
-            .expect("write notification");
-        self.stdin.flush().await.expect("flush notification");
-    }
-
-    /// Assert no bytes arrive on stdout for the given duration.
-    async fn assert_no_response_within(&mut self, dur: Duration) {
-        let mut buf = String::new();
-        match timeout(dur, self.stdout.read_line(&mut buf)).await {
-            Err(_) => {} // timeout → no response, as expected
-            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
-            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
-            Ok(Err(e)) => panic!("read error: {e}"),
-        }
-    }
-
-    /// Send an MCP `initialize` request with the pinned protocol
-    /// version and return the response.
-    async fn initialize_handshake(&mut self) -> Value {
-        self.request(
-            "initialize",
-            json!({
-                "protocolVersion": ProtocolVersion::LATEST.as_str(),
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "rusty-imap-mcp-conformance-harness",
-                    "version": env!("CARGO_PKG_VERSION"),
-                },
-            }),
-        )
-        .await
-    }
-
-    /// Send `notifications/initialized` after the handshake.
-    async fn send_initialized(&mut self) {
-        self.notify("notifications/initialized", json!({})).await;
-    }
-
-    /// Close stdin, await the child, and return its exit status.
-    async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
-        drop(self.stdin);
-        timeout(SHUTDOWN_TIMEOUT, self.child.wait())
-            .await
-            .expect("clean exit within timeout")
-            .expect("wait")
-    }
-}
-
-/// Compile (once) and return a validator for a top-level definition in
-/// the vendored MCP schema. `fragment` is the key under
-/// `definitions` / `$defs` (e.g. `"InitializeResult"`). Returns an
-/// `Arc` so multiple parallel tests can share the compiled validator
-/// without lifetime gymnastics.
-fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
-    // All function-scoped items declared up front so cache and parsed
-    // schema lifetimes are visible from the top of the body
-    // (clippy::items_after_statements).
-    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
-    static PARSED: OnceLock<(Value, &'static str)> = OnceLock::new();
-    static CACHE: OnceLock<Cache> = OnceLock::new();
-
-    // Parse the vendored schema exactly once and detect the
-    // definitions key (`$defs` for Draft 2020-12, `definitions` for
-    // older dialects). The full Value and the detected key are
-    // immutable for the lifetime of the test process.
-    let parsed = PARSED.get_or_init(|| {
-        let full: Value = serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
-        let defs_key = if full.get("$defs").is_some() {
-            "$defs"
-        } else {
-            "definitions"
-        };
-        (full, defs_key)
-    });
-    let full = &parsed.0;
-    let defs_key: &'static str = parsed.1;
-
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-
-    // Fast path: read under the lock, return if cached.
-    {
-        let guard = cache.lock().expect("validator cache mutex poisoned");
-        if let Some(v) = guard.get(fragment) {
-            return Arc::clone(v);
-        }
-    }
-
-    // Slow path: compile the fragment validator WITHOUT holding the
-    // cache lock, so parallel tests compiling different fragments
-    // don't serialize.
-    let wrapper = json!({
-        "$ref": format!("#/{defs_key}/{fragment}"),
-        defs_key: full.get(defs_key).cloned().unwrap_or(json!({})),
-    });
-    let new_validator =
-        Arc::new(jsonschema::validator_for(&wrapper).expect("compile fragment validator"));
-
-    // Insert. If a concurrent thread already inserted while we were
-    // compiling, prefer the existing entry to keep the Arc stable.
-    let mut guard = cache.lock().expect("validator cache mutex poisoned");
-    let entry = guard
-        .entry(fragment)
-        .or_insert_with(|| Arc::clone(&new_validator));
-    Arc::clone(entry)
-}
-
-/// Validate a value against a vendored fragment, panicking with the
-/// list of errors on failure.
-fn assert_valid(value: &Value, fragment: &'static str) {
-    let v = validator_for(fragment);
-    if !v.is_valid(value) {
-        let errors: Vec<String> = v.iter_errors(value).map(|e| e.to_string()).collect();
-        panic!(
-            "schema validation failed for fragment {fragment}:\n  {}",
-            errors.join("\n  ")
-        );
-    }
-}
-
-/// Validate the FULL JSON-RPC envelope returned by `Harness::request`.
-/// Success responses validate against `JSONRPCResultResponse`; error
-/// responses validate against `JSONRPCErrorResponse`. Asserts the
-/// `jsonrpc` version field on both paths. Codex adversarial review
-/// finding #2 (PR #270): the previous negative-path tests checked only
-/// `code` and `message` and would have missed a regression that
-/// stripped `jsonrpc` or otherwise mangled the envelope.
-fn assert_envelope_valid(response: &Value) {
-    assert_eq!(
-        response["jsonrpc"],
-        json!("2.0"),
-        "envelope must declare jsonrpc=\"2.0\"; got {response}",
-    );
-
-    let has_result = response.get("result").is_some();
-    let has_error = response.get("error").is_some();
-    match (has_result, has_error) {
-        (true, false) => assert_valid(response, "JSONRPCResultResponse"),
-        (false, true) => assert_valid(response, "JSONRPCErrorResponse"),
-        (true, true) => {
-            panic!("envelope must not contain both `result` and `error`; got {response}",)
-        }
-        (false, false) => {
-            panic!("envelope must contain either `result` or `error`; got {response}",)
-        }
-    }
-}
+use support::wire::{Harness, PINNED_PROTOCOL_VERSION, assert_valid};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wire_smoke_initialize_returns_valid_envelope() {
@@ -342,7 +62,7 @@ async fn wire_protocol_version_negotiation_matches_vendored_schema() {
     // Three-way drift check (Codex adversarial review finding #1):
     //
     //   1. rmcp::ProtocolVersion::LATEST.as_str()
-    //   2. PINNED_PROTOCOL_VERSION (the constant in this file)
+    //   2. PINNED_PROTOCOL_VERSION (constant in tests/support/wire/harness.rs)
     //   3. crates/rimap-server/tests/fixtures/mcp-spec/<version>/
     //
     // All three MUST agree. If any one drifts (rmcp bumps LATEST, the
@@ -358,7 +78,7 @@ async fn wire_protocol_version_negotiation_matches_vendored_schema() {
          PINNED_PROTOCOL_VERSION ({PINNED_PROTOCOL_VERSION}). Run \
          `scripts/refresh-mcp-spec.sh {rmcp_latest}` to vendor the new \
          schema, update PINNED_PROTOCOL_VERSION + MCP_SCHEMA_JSON in \
-         this file, and update the README under \
+         tests/support/wire/harness.rs, and update the README under \
          tests/fixtures/mcp-spec/.",
     );
 

--- a/crates/rimap-server/tests/mcp_wire_conformance.rs
+++ b/crates/rimap-server/tests/mcp_wire_conformance.rs
@@ -244,7 +244,7 @@ async fn wire_clean_eof_shutdown_exits_zero() {
     let mut harness = Harness::spawn().await;
     let _ = harness.initialize_handshake().await;
     harness.send_initialized().await;
-    let status = harness.shutdown_and_wait().await;
+    let (status, _tempdir) = harness.shutdown_and_wait().await;
     assert!(
         status.success(),
         "server must exit 0 on clean stdin EOF, got {status:?}",

--- a/crates/rimap-server/tests/support/dovecot/fixtures.rs
+++ b/crates/rimap-server/tests/support/dovecot/fixtures.rs
@@ -1,0 +1,72 @@
+//! Seed fixtures used by the wire-driven e2e tests. Constants and
+//! builders live here so the seed bytes and the assertion-side bytes
+//! reference the same source — no "what was seeded" / "what to check"
+//! duplication.
+// Phase 3 e2e_wire.rs (Task 10) uses all public items in this module.
+// Until that file exists, every item here is unreachable from e2e.rs,
+// so we suppress the lint at module scope rather than per-item.
+#![expect(dead_code, reason = "Phase 3 e2e_wire.rs will use these")]
+
+/// Filename declared in the attachment's `Content-Disposition`.
+pub const ATTACHMENT_FILENAME: &str = "attached.bin";
+
+/// Known byte payload of the attachment. 32 deterministic bytes —
+/// large enough that an off-by-one in part extraction is visible, small
+/// enough to print in test panic messages.
+pub const ATTACHMENT_BYTES: &[u8] = &[
+    0x52, 0x49, 0x4d, 0x41, 0x50, 0x2d, 0x50, 0x33, 0x2d, 0x41, 0x54, 0x54, 0x41, 0x43, 0x48, 0x45,
+    0x44, 0x2d, 0x42, 0x59, 0x54, 0x45, 0x53, 0x2d, 0x32, 0x30, 0x32, 0x36, 0x2d, 0x30, 0x35, 0x12,
+];
+
+/// MIME boundary for the multipart container. Fixed so the message
+/// bytes are deterministic across runs.
+const BOUNDARY: &str = "rimap-p3-boundary-c0ffee";
+
+/// Plain-text body content. Asserted by `fetch_message` in the wire flow.
+pub const PLAIN_BODY: &str = "Hello from the Phase 3 wire-driven e2e smoke test.";
+
+/// Returns the raw bytes of a `multipart/mixed` MIME message suitable
+/// for `Connection::append_message`. Contains one `text/plain` part
+/// with `PLAIN_BODY` and one `application/octet-stream` attachment
+/// part with filename `ATTACHMENT_FILENAME` and payload `ATTACHMENT_BYTES`.
+///
+/// The Content-Transfer-Encoding for the attachment is `base64`. The
+/// returned bytes are CRLF-terminated as required by RFC 5322.
+#[expect(clippy::expect_used, reason = "test fixture; base64 output is ASCII")]
+pub fn multipart_with_attachment() -> Vec<u8> {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+    let attachment_b64 = STANDARD.encode(ATTACHMENT_BYTES);
+    let mut wrapped = String::new();
+    // 76-char lines per RFC 2045.
+    for chunk in attachment_b64.as_bytes().chunks(76) {
+        let chunk_str = std::str::from_utf8(chunk).expect("base64 output is always valid ASCII");
+        wrapped.push_str(chunk_str);
+        wrapped.push_str("\r\n");
+    }
+
+    let body = format!(
+        "From: sender@example.com\r\n\
+         To: rimap-test@localhost\r\n\
+         Subject: e2e-wire-test-smoke\r\n\
+         Date: Sat, 12 May 2026 10:00:00 +0000\r\n\
+         Message-ID: <e2e-wire-smoke-001@example.com>\r\n\
+         MIME-Version: 1.0\r\n\
+         Content-Type: multipart/mixed; boundary=\"{BOUNDARY}\"\r\n\
+         \r\n\
+         --{BOUNDARY}\r\n\
+         Content-Type: text/plain; charset=utf-8\r\n\
+         Content-Transfer-Encoding: 7bit\r\n\
+         \r\n\
+         {PLAIN_BODY}\r\n\
+         --{BOUNDARY}\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Disposition: attachment; filename=\"{ATTACHMENT_FILENAME}\"\r\n\
+         Content-Transfer-Encoding: base64\r\n\
+         \r\n\
+         {wrapped}\
+         --{BOUNDARY}--\r\n",
+    );
+
+    body.into_bytes()
+}

--- a/crates/rimap-server/tests/support/dovecot/fixtures.rs
+++ b/crates/rimap-server/tests/support/dovecot/fixtures.rs
@@ -2,10 +2,10 @@
 //! builders live here so the seed bytes and the assertion-side bytes
 //! reference the same source — no "what was seeded" / "what to check"
 //! duplication.
-// Phase 3 e2e_wire.rs (Task 10) uses all public items in this module.
-// Until that file exists, every item here is unreachable from e2e.rs,
-// so we suppress the lint at module scope rather than per-item.
-#![expect(dead_code, reason = "Phase 3 e2e_wire.rs will use these")]
+//!
+//! `e2e_wire.rs` uses every public item below. `e2e.rs` pulls this
+//! module in through `support/dovecot/mod.rs` but never references the
+//! items — see [`force_use_for_dead_code_link`] for the per-binary dead-code suppression.
 
 /// Filename declared in the attachment's `Content-Disposition`.
 pub const ATTACHMENT_FILENAME: &str = "attached.bin";
@@ -69,4 +69,24 @@ pub fn multipart_with_attachment() -> Vec<u8> {
     );
 
     body.into_bytes()
+}
+
+/// Per-binary dead-code suppression. `e2e.rs` compiles this module
+/// through `support/dovecot/mod.rs` but never calls any item here; if
+/// we relied on `#![expect(dead_code)]` instead, that expectation
+/// would be unfulfilled in `e2e_wire.rs` (which does use them) and
+/// `clippy::allow_attributes = "deny"` forbids `#[allow]`. Referencing
+/// each public item inside a never-called function marks them as used
+/// in every compilation unit. The function name omits the leading `_`
+/// so the function itself is flagged dead and the `#[expect]` is
+/// fulfilled.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary dead-code in e2e.rs"
+)]
+fn force_use_for_dead_code_link() {
+    let _: &str = ATTACHMENT_FILENAME;
+    let _: &[u8] = ATTACHMENT_BYTES;
+    let _: &str = PLAIN_BODY;
+    let _ = multipart_with_attachment;
 }

--- a/crates/rimap-server/tests/support/dovecot/fixtures.rs
+++ b/crates/rimap-server/tests/support/dovecot/fixtures.rs
@@ -30,6 +30,15 @@ pub const PLAIN_BODY: &str = "Hello from the Phase 3 wire-driven e2e smoke test.
 /// with `PLAIN_BODY` and one `application/octet-stream` attachment
 /// part with filename `ATTACHMENT_FILENAME` and payload `ATTACHMENT_BYTES`.
 ///
+/// The filename is duplicated in both the `Content-Type` `name`
+/// parameter and `Content-Disposition` `filename` parameter. IMAP
+/// BODYSTRUCTURE only exposes the Content-Type params dict, so the
+/// `list_attachments` tool reads the filename from there (see
+/// `crates/rimap-server/src/tools/retrieval/list_attachments.rs::extract_filename`);
+/// repeating the value in Content-Disposition matches what real-world
+/// clients send and keeps the fixture forwards-compatible with a
+/// future server-side parser that walks the disposition field.
+///
 /// The Content-Transfer-Encoding for the attachment is `base64`. The
 /// returned bytes are CRLF-terminated as required by RFC 5322.
 #[expect(clippy::expect_used, reason = "test fixture; base64 output is ASCII")]
@@ -60,7 +69,7 @@ pub fn multipart_with_attachment() -> Vec<u8> {
          \r\n\
          {PLAIN_BODY}\r\n\
          --{BOUNDARY}\r\n\
-         Content-Type: application/octet-stream\r\n\
+         Content-Type: application/octet-stream; name=\"{ATTACHMENT_FILENAME}\"\r\n\
          Content-Disposition: attachment; filename=\"{ATTACHMENT_FILENAME}\"\r\n\
          Content-Transfer-Encoding: base64\r\n\
          \r\n\

--- a/crates/rimap-server/tests/support/dovecot/harness.rs
+++ b/crates/rimap-server/tests/support/dovecot/harness.rs
@@ -5,13 +5,72 @@
 //! See `AGENTS.md` "Container runtime for integration tests".
 
 #![expect(clippy::expect_used, reason = "integration tests")]
-#![expect(clippy::unwrap_used, reason = "integration tests")]
 
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
 use rimap_core::TlsFingerprint;
+
+/// Failure modes for `DovecotHarness::try_start`. `DockerUnavailable`
+/// is the silent-skip signal: it means the host genuinely cannot run
+/// the fixture (no runtime, wrong arch). All other variants represent
+/// real infrastructure failures that should fail tests when
+/// `RIMAP_REQUIRE_DOCKER=1` is set.
+#[derive(Debug)]
+pub enum HarnessError {
+    DockerUnavailable,
+    ComposeFailed(String),
+    ReadinessTimeout,
+    PortReservationFailed(String),
+    /// Last `read_fingerprint` error captured during the wait-for-ready
+    /// loop. Surfaced when the wait-for-ready timeout fires and the
+    /// last attempt to read the container's TLS fingerprint failed.
+    FingerprintReadFailed(String),
+}
+
+impl std::fmt::Display for HarnessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DockerUnavailable => {
+                f.write_str("no container runtime (docker or podman) is available")
+            }
+            Self::ComposeFailed(s) => write!(f, "compose up failed: {s}"),
+            Self::ReadinessTimeout => f.write_str("dovecot did not become ready within timeout"),
+            Self::PortReservationFailed(s) => write!(f, "host port reservation failed: {s}"),
+            Self::FingerprintReadFailed(s) => write!(f, "fingerprint read failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for HarnessError {}
+
+fn check_prerequisites() -> Result<(), HarnessError> {
+    let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
+
+    if std::env::consts::ARCH != "x86_64" {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(format!(
+                "host arch {} cannot run amd64 dovecot image but RIMAP_REQUIRE_DOCKER=1",
+                std::env::consts::ARCH
+            )))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    if !runtime_available() {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(
+                "neither docker nor podman found but RIMAP_REQUIRE_DOCKER=1".into(),
+            ))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    Ok(())
+}
 
 fn runtime() -> &'static str {
     static TOOL: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
@@ -55,20 +114,15 @@ pub struct DovecotHarness {
 }
 
 impl DovecotHarness {
-    pub fn try_start() -> Option<Self> {
+    pub fn try_start() -> Result<Self, HarnessError> {
         const BACKOFF_MS: [u64; 2] = [50, 250];
         const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
 
-        if std::env::consts::ARCH != "x86_64" {
-            return None;
-        }
-        if !runtime_available() {
-            return None;
-        }
+        check_prerequisites()?;
 
         let compose_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .unwrap()
+            .ok_or_else(|| HarnessError::ComposeFailed("manifest dir has no parent".into()))?
             .join("rimap-imap")
             .join("tests")
             .join("integration")
@@ -82,7 +136,10 @@ impl DovecotHarness {
                 .unwrap_or(0)
         );
 
-        let mut host_port = ReservedPort::acquire()?;
+        let mut host_port = ReservedPort::acquire()
+            .ok_or_else(|| HarnessError::PortReservationFailed("acquire returned None".into()))?;
+
+        let mut last_stderr = String::new();
 
         // Attempt 0 is the initial try (no prior sleep). Attempts 1 and 2
         // are retries preceded by teardown + backoff sleep + fresh port.
@@ -90,7 +147,9 @@ impl DovecotHarness {
             if attempt > 0 {
                 compose_down(&project, &compose_dir);
                 std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS[attempt - 1]));
-                host_port = ReservedPort::acquire()?;
+                host_port = ReservedPort::acquire().ok_or_else(|| {
+                    HarnessError::PortReservationFailed("retry acquire returned None".into())
+                })?;
             }
             host_port.release();
 
@@ -103,21 +162,23 @@ impl DovecotHarness {
                 .env("RIMAP_DOVECOT_HOST_PORT", host_port.port().to_string())
                 .current_dir(&compose_dir)
                 .output()
-                .ok()?;
+                .map_err(|e| HarnessError::ComposeFailed(format!("spawn failed: {e}")))?;
 
             if output.status.success() {
                 return wait_for_ready(&project, host_port.port(), &compose_dir);
             }
 
-            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
             if !is_port_collision(&stderr) {
-                // Non-collision failure: stop retrying.
-                return None;
+                return Err(HarnessError::ComposeFailed(stderr));
             }
+            last_stderr = stderr;
         }
 
         // All attempts hit port collisions.
-        None
+        Err(HarnessError::ComposeFailed(format!(
+            "exhausted {MAX_ATTEMPTS} port-collision retries; last stderr: {last_stderr}",
+        )))
     }
 
     /// Create a mailbox via `doveadm` inside the container.
@@ -149,21 +210,29 @@ fn wait_for_ready(
     project: &str,
     host_port: u16,
     compose_dir: &std::path::Path,
-) -> Option<DovecotHarness> {
+) -> Result<DovecotHarness, HarnessError> {
     let started = Instant::now();
     let timeout = Duration::from_secs(60);
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
+    let mut last_fp_err: Option<String> = None;
     loop {
         if started.elapsed() > timeout {
             compose_down(project, compose_dir);
-            return None;
+            return Err(match last_fp_err {
+                Some(e) => HarnessError::FingerprintReadFailed(e),
+                None => HarnessError::ReadinessTimeout,
+            });
         }
-        let Ok(fp) = read_fingerprint(project) else {
-            std::thread::sleep(Duration::from_millis(500));
-            continue;
+        let fp = match read_fingerprint(project) {
+            Ok(fp) => fp,
+            Err(e) => {
+                last_fp_err = Some(e);
+                std::thread::sleep(Duration::from_millis(500));
+                continue;
+            }
         };
         if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
-            return Some(DovecotHarness {
+            return Ok(DovecotHarness {
                 project: project.to_string(),
                 compose_dir: compose_dir.to_path_buf(),
                 fingerprint: fp,

--- a/crates/rimap-server/tests/support/dovecot/harness.rs
+++ b/crates/rimap-server/tests/support/dovecot/harness.rs
@@ -1,0 +1,247 @@
+//! Dovecot container harness lifted from the original
+//! `crates/rimap-server/tests/e2e.rs`. Honors the same env vars
+//! (`RIMAP_CONTAINER_TOOL`, `RIMAP_REQUIRE_DOCKER`) and silently skips
+//! on non-x86_64 hosts or when no container runtime is available.
+//! See `AGENTS.md` "Container runtime for integration tests".
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::unwrap_used, reason = "integration tests")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use rimap_core::TlsFingerprint;
+
+fn runtime() -> &'static str {
+    static TOOL: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    TOOL.get_or_init(|| {
+        match std::env::var("RIMAP_CONTAINER_TOOL").as_deref() {
+            Ok("docker") => return "docker",
+            Ok("podman") => return "podman",
+            _ => {}
+        }
+        if binary_present("docker") {
+            "docker"
+        } else if binary_present("podman") {
+            "podman"
+        } else {
+            "docker"
+        }
+    })
+}
+
+fn binary_present(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn runtime_available() -> bool {
+    binary_present("docker") || binary_present("podman")
+}
+
+fn container_name(project: &str) -> String {
+    format!("{project}-dovecot")
+}
+
+pub struct DovecotHarness {
+    project: String,
+    compose_dir: PathBuf,
+    fingerprint: TlsFingerprint,
+    port: u16,
+}
+
+impl DovecotHarness {
+    pub fn try_start() -> Option<Self> {
+        const BACKOFF_MS: [u64; 2] = [50, 250];
+        const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
+
+        if std::env::consts::ARCH != "x86_64" {
+            return None;
+        }
+        if !runtime_available() {
+            return None;
+        }
+
+        let compose_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("rimap-imap")
+            .join("tests")
+            .join("integration")
+            .join("dovecot");
+
+        let project = format!(
+            "rimap-e2e-{:x}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+
+        let mut host_port = ReservedPort::acquire()?;
+
+        // Attempt 0 is the initial try (no prior sleep). Attempts 1 and 2
+        // are retries preceded by teardown + backoff sleep + fresh port.
+        for attempt in 0..MAX_ATTEMPTS {
+            if attempt > 0 {
+                compose_down(&project, &compose_dir);
+                std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS[attempt - 1]));
+                host_port = ReservedPort::acquire()?;
+            }
+            host_port.release();
+
+            let output = Command::new(runtime())
+                .arg("compose")
+                .arg("-p")
+                .arg(&project)
+                .arg("up")
+                .arg("-d")
+                .env("RIMAP_DOVECOT_HOST_PORT", host_port.port().to_string())
+                .current_dir(&compose_dir)
+                .output()
+                .ok()?;
+
+            if output.status.success() {
+                return wait_for_ready(&project, host_port.port(), &compose_dir);
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !is_port_collision(&stderr) {
+                // Non-collision failure: stop retrying.
+                return None;
+            }
+        }
+
+        // All attempts hit port collisions.
+        None
+    }
+
+    /// Create a mailbox via `doveadm` inside the container.
+    pub fn create_mailbox(&self, name: &str) {
+        let status = Command::new(runtime())
+            .arg("exec")
+            .arg(container_name(&self.project))
+            .arg("doveadm")
+            .arg("mailbox")
+            .arg("create")
+            .arg("-u")
+            .arg("rimap-test")
+            .arg(name)
+            .status()
+            .expect("doveadm exec failed");
+        assert!(status.success(), "doveadm mailbox create {name} failed",);
+    }
+
+    pub fn fingerprint(&self) -> &TlsFingerprint {
+        &self.fingerprint
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+fn wait_for_ready(
+    project: &str,
+    host_port: u16,
+    compose_dir: &std::path::Path,
+) -> Option<DovecotHarness> {
+    let started = Instant::now();
+    let timeout = Duration::from_secs(60);
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
+    loop {
+        if started.elapsed() > timeout {
+            compose_down(project, compose_dir);
+            return None;
+        }
+        let Ok(fp) = read_fingerprint(project) else {
+            std::thread::sleep(Duration::from_millis(500));
+            continue;
+        };
+        if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
+            return Some(DovecotHarness {
+                project: project.to_string(),
+                compose_dir: compose_dir.to_path_buf(),
+                fingerprint: fp,
+                port: host_port,
+            });
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+impl Drop for DovecotHarness {
+    fn drop(&mut self) {
+        compose_down(&self.project, &self.compose_dir);
+    }
+}
+
+fn compose_down(project: &str, compose_dir: &std::path::Path) {
+    let _ = Command::new(runtime())
+        .arg("compose")
+        .arg("-p")
+        .arg(project)
+        .arg("down")
+        .arg("-v")
+        .arg("--remove-orphans")
+        .current_dir(compose_dir)
+        .status();
+}
+
+fn read_fingerprint(project: &str) -> Result<TlsFingerprint, String> {
+    let out = Command::new(runtime())
+        .arg("exec")
+        .arg(container_name(project))
+        .arg("cat")
+        .arg("/shared/fingerprint.hex")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err("not ready".into());
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    TlsFingerprint::from_hex(&s).map_err(|e| e.to_string())
+}
+
+/// Host port reserved by binding `127.0.0.1:0` and reading the
+/// kernel-assigned number. The `TcpListener` is kept open until
+/// `release()` is called, holding the kernel-level lease so docker
+/// (or any other process) cannot bind the same port in the meantime.
+struct ReservedPort {
+    port: u16,
+    listener: Option<std::net::TcpListener>,
+}
+
+impl ReservedPort {
+    fn acquire() -> Option<Self> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+        let port = listener.local_addr().ok()?.port();
+        Some(Self {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Drop the underlying `TcpListener`, releasing the kernel-level
+    /// port lease. Idempotent.
+    fn release(&mut self) {
+        self.listener.take();
+    }
+}
+
+/// Classify a stderr blob from a failed `compose up`: `true` when the
+/// failure looks like a host-port bind collision.
+fn is_port_collision(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("port is already allocated")
+        || s.contains("address already in use")
+        || s.contains("bind for 127.0.0.1")
+}

--- a/crates/rimap-server/tests/support/dovecot/mod.rs
+++ b/crates/rimap-server/tests/support/dovecot/mod.rs
@@ -1,0 +1,7 @@
+//! Dovecot container harness and seeded-fixture helpers shared by
+//! `e2e.rs` (in-process Rust API) and `e2e_wire.rs` (stdio wire).
+
+pub mod harness;
+// pub mod fixtures;  — seeded-fixture helpers, added when needed.
+
+pub use harness::DovecotHarness;

--- a/crates/rimap-server/tests/support/dovecot/mod.rs
+++ b/crates/rimap-server/tests/support/dovecot/mod.rs
@@ -1,7 +1,7 @@
 //! Dovecot container harness and seeded-fixture helpers shared by
 //! `e2e.rs` (in-process Rust API) and `e2e_wire.rs` (stdio wire).
 
+pub mod fixtures;
 pub mod harness;
-// pub mod fixtures;  — seeded-fixture helpers, added when needed.
 
 pub use harness::DovecotHarness;

--- a/crates/rimap-server/tests/support/dovecot/mod.rs
+++ b/crates/rimap-server/tests/support/dovecot/mod.rs
@@ -4,4 +4,4 @@
 pub mod fixtures;
 pub mod harness;
 
-pub use harness::DovecotHarness;
+pub use harness::{DovecotHarness, HarnessError};

--- a/crates/rimap-server/tests/support/mod.rs
+++ b/crates/rimap-server/tests/support/mod.rs
@@ -2,8 +2,11 @@
 //! the wire driver (Phase 1 + Phase 3) and the Dovecot harness
 //! (Phase 3 + the legacy `e2e_full_session`).
 //!
-//! Each integration-test file pulls this in with
-//! `#[path = "support/mod.rs"] mod support;` at the top.
+//! Each integration-test file pulls in the sub-module(s) it needs via
+//! `#[path = "support/<sub>/mod.rs"] mod <sub>;` rather than including
+//! this file wholesale, so that each test binary compiles only the code
+//! it actually uses and avoids spurious dead-code warnings.
 
 pub mod wire;
-// `pub mod dovecot;` added in Task 6.
+// `pub mod dovecot;` will be added when e2e_wire.rs (Task 10/11) needs
+// both the wire driver and the Dovecot harness in the same binary.

--- a/crates/rimap-server/tests/support/mod.rs
+++ b/crates/rimap-server/tests/support/mod.rs
@@ -1,0 +1,9 @@
+//! Shared support for `rimap-server` integration tests. Re-exports
+//! the wire driver (Phase 1 + Phase 3) and the Dovecot harness
+//! (Phase 3 + the legacy `e2e_full_session`).
+//!
+//! Each integration-test file pulls this in with
+//! `#[path = "support/mod.rs"] mod support;` at the top.
+
+pub mod wire;
+// `pub mod dovecot;` added in Task 6.

--- a/crates/rimap-server/tests/support/wire/config.rs
+++ b/crates/rimap-server/tests/support/wire/config.rs
@@ -63,7 +63,7 @@ encryption = "tls"
 tls_fingerprint_sha256 = "{fingerprint_hex}"
 
 [accounts.security]
-posture = "read-only"
+posture = "readonly"
 "#,
         audit_path = audit_path.display(),
         allowed_base = allowed_base.display(),

--- a/crates/rimap-server/tests/support/wire/config.rs
+++ b/crates/rimap-server/tests/support/wire/config.rs
@@ -1,0 +1,73 @@
+//! Two-account multi-account TOML builder for Phase 3's wire-driven
+//! Dovecot e2e. Both accounts target the same Dovecot user
+//! (`rimap-test@dovecot`); the surface under test is the posture
+//! matrix on the wire, not authentication isolation.
+
+use std::path::Path;
+
+/// Build the multi-account TOML for `e2e_wire.rs`. Caller is
+/// responsible for writing the returned string to `config_path` and
+/// for placing `audit_path` and `download_dir` inside `allowed_base`.
+///
+/// `fingerprint_hex` and `port` should be obtained from the
+/// `DovecotHarness` at the call site:
+/// ```ignore
+/// let cfg = build_dovecot_config(
+///     &dovecot.fingerprint().to_hex(),
+///     dovecot.port(),
+///     &audit_path,
+///     &allowed_base,
+///     &download_dir,
+/// );
+/// ```
+#[expect(dead_code, reason = "Phase 3 e2e_wire.rs will use this")]
+pub fn build_dovecot_config(
+    fingerprint_hex: &str,
+    port: u16,
+    audit_path: &Path,
+    allowed_base: &Path,
+    download_dir: &Path,
+) -> String {
+    format!(
+        r#"
+[audit]
+path = "{audit_path}"
+allowed_base_dir = "{allowed_base}"
+
+[attachments]
+download_dir = "{download_dir}"
+
+[defaults.credentials]
+fallback = "keyring-then-env"
+
+[[accounts]]
+name = "draftsafe"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = {port}
+username = "rimap-test"
+encryption = "tls"
+tls_fingerprint_sha256 = "{fingerprint_hex}"
+
+[accounts.security]
+posture = "draft-safe"
+
+[[accounts]]
+name = "readonly"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = {port}
+username = "rimap-test"
+encryption = "tls"
+tls_fingerprint_sha256 = "{fingerprint_hex}"
+
+[accounts.security]
+posture = "read-only"
+"#,
+        audit_path = audit_path.display(),
+        allowed_base = allowed_base.display(),
+        download_dir = download_dir.display(),
+    )
+}

--- a/crates/rimap-server/tests/support/wire/config.rs
+++ b/crates/rimap-server/tests/support/wire/config.rs
@@ -20,7 +20,6 @@ use std::path::Path;
 ///     &download_dir,
 /// );
 /// ```
-#[expect(dead_code, reason = "Phase 3 e2e_wire.rs will use this")]
 pub fn build_dovecot_config(
     fingerprint_hex: &str,
     port: u16,
@@ -70,4 +69,19 @@ posture = "read-only"
         allowed_base = allowed_base.display(),
         download_dir = download_dir.display(),
     )
+}
+
+/// Per-binary dead-code suppression. `mcp_wire_conformance.rs`
+/// compiles this module through `support/wire/mod.rs` but never calls
+/// `build_dovecot_config`; if we relied on `#[expect(dead_code)]`
+/// instead, that expectation would be unfulfilled in `e2e_wire.rs`
+/// (which does use it) and `clippy::allow_attributes = "deny"`
+/// forbids `#[allow]`. Referencing the function inside a never-called
+/// helper marks it as used in every compilation unit.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary dead-code in mcp_wire_conformance.rs"
+)]
+fn force_use_for_dead_code_link() {
+    let _ = build_dovecot_config;
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -185,12 +185,19 @@ allowed_base_dir = "{}"
             let envelope: Value =
                 serde_json::from_str(buf.trim_end()).expect("parse envelope JSON");
             // A notification is identified by the presence of `method` and
-            // an absent or null `id` field. Validate its envelope shape
-            // against the spec schema and keep reading.
+            // an absent or null `id` field. `assert_envelope_valid` is
+            // response-only (it demands `result` or `error`), so we
+            // intentionally do not validate the notification envelope
+            // here — we just check `jsonrpc=2.0` so a malformed line
+            // does not silently slip past, and continue reading.
             let is_notification =
                 envelope.get("method").is_some() && envelope.get("id").is_none_or(Value::is_null);
             if is_notification {
-                assert_envelope_valid(&envelope);
+                assert_eq!(
+                    envelope["jsonrpc"],
+                    json!("2.0"),
+                    "notification must declare jsonrpc=\"2.0\"; got {envelope}",
+                );
                 continue;
             }
             assert_eq!(envelope["id"], json!(id), "response id must match request");
@@ -247,12 +254,29 @@ allowed_base_dir = "{}"
         self.notify("notifications/initialized", json!({})).await;
     }
 
-    /// Close stdin, await the child, and return its exit status.
-    pub async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
-        drop(self.stdin);
-        timeout(SHUTDOWN_TIMEOUT, self.child.wait())
+    /// Close stdin, await the child, and hand the audit-log tempdir
+    /// back to the caller along with the exit status.
+    ///
+    /// The tempdir is kept alive only by the returned [`TempDir`] guard
+    /// — once it drops, the audit log path becomes invalid. Callers
+    /// that need to read the audit file after shutdown must bind the
+    /// returned `TempDir` to a variable that outlives those reads.
+    /// Callers that only care about the exit status can drop the
+    /// tempdir immediately with `let (status, _) = ...`.
+    pub async fn shutdown_and_wait(self) -> (std::process::ExitStatus, TempDir) {
+        let Self {
+            mut child,
+            stdin,
+            stdout: _,
+            next_id: _,
+            stderr_log: _,
+            _tempdir: tempdir,
+        } = self;
+        drop(stdin);
+        let status = timeout(SHUTDOWN_TIMEOUT, child.wait())
             .await
             .expect("clean exit within timeout")
-            .expect("wait")
+            .expect("wait");
+        (status, tempdir)
     }
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -9,13 +9,14 @@
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
 
 use std::process::Stdio;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin;
 use rmcp::model::ProtocolVersion;
 use serde_json::{Value, json};
 use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::timeout;
 
@@ -45,27 +46,40 @@ pub struct Harness {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
+    /// Stderr drain buffer, updated by a background task.
+    stderr_buf: Arc<Mutex<Vec<u8>>>,
     next_id: u64,
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
     _tempdir: TempDir,
 }
 
+/// Maximum bytes retained in the stderr drain buffer. The head is the most
+/// useful diagnostic, so we truncate rather than ring-buffer.
+const STDERR_CAP: usize = 64 * 1024;
+
+/// Snapshot the captured stderr for diagnostic messages.
+fn stderr_snapshot(buf: &Arc<Mutex<Vec<u8>>>) -> String {
+    buf.lock()
+        .map(|g| String::from_utf8_lossy(&g).into_owned())
+        .unwrap_or_default()
+}
+
+/// Log stderr drain errors to test output. Justification: test diagnostics.
+#[expect(clippy::print_stderr, reason = "test diagnostics")]
+fn log_stderr_drain_error(e: &std::io::Error) {
+    eprintln!("[harness] stderr drain error: {e}");
+}
+
 impl Harness {
-    /// Spawn the binary with a zero-account tempdir config.
-    #[expect(
-        clippy::unused_async,
-        reason = "harness API is uniformly async so tests await every constructor"
-    )]
+    /// Spawn with the legacy zero-account config (Phase 1 default).
+    /// Builds a multi-account TOML with `accounts = []`, an audit
+    /// path under a fresh tempdir, and calls `spawn_with_config`.
     pub async fn spawn() -> Self {
         let tempdir = TempDir::new().expect("tempdir");
         let config_path = tempdir.path().join("config.toml");
         let audit_path = tempdir.path().join("audit.jsonl");
         let allowed_base = tempdir.path();
-
-        // Multi-account format with zero accounts. Task 1 lifted the
-        // empty-accounts validator gate, so this is the canonical
-        // zero-account shape the loader accepts.
         let config = format!(
             r#"
 accounts = []
@@ -78,31 +92,81 @@ allowed_base_dir = "{}"
             allowed_base.display(),
         );
         std::fs::write(&config_path, config).expect("write config");
+        Self::spawn_with_config(&config_path, tempdir, &[]).await
+    }
 
+    /// Spawn the binary against a caller-supplied config. The
+    /// `tempdir` is held by the returned `Harness` so its lifetime
+    /// covers the child process's audit path.
+    ///
+    /// `extra_envs` is forwarded to the child verbatim. Phase 3 uses
+    /// this to inject `RUSTY_IMAP_MCP_PASSWORD` (the env-var
+    /// fallback for the keyring) without polluting the test
+    /// process's env.
+    #[expect(clippy::unused_async, reason = "uniform async surface")]
+    pub async fn spawn_with_config(
+        config_path: &std::path::Path,
+        tempdir: TempDir,
+        extra_envs: &[(&str, &str)],
+    ) -> Self {
         let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
         cmd.arg("--config")
-            .arg(&config_path)
-            // Production rejects `accounts = []`. The harness opts in
-            // to infrastructure-only boot via this test-support flag
-            // (Codex adversarial review on PR #270).
+            .arg(config_path)
             .arg("--allow-empty-accounts")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
+        for (k, v) in extra_envs {
+            cmd.env(k, v);
+        }
 
         let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
 
         let stdin = child.stdin.take().expect("stdin");
         let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let stderr = child.stderr.take().expect("stderr");
+
+        // Drain stderr into a shared buffer so the binary's tracing
+        // output is included in panic messages on assertion failure.
+        let stderr_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let stderr_clone = Arc::clone(&stderr_buf);
+        tokio::spawn(async move {
+            let mut reader = stderr;
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Err(e) => {
+                        log_stderr_drain_error(&e);
+                        break;
+                    }
+                    Ok(n) => {
+                        if let Ok(mut guard) = stderr_clone.lock() {
+                            guard.extend_from_slice(&buf[..n]);
+                            if guard.len() > STDERR_CAP {
+                                guard.truncate(STDERR_CAP);
+                            }
+                        }
+                    }
+                }
+            }
+        });
 
         Self {
             child,
             stdin,
             stdout,
+            stderr_buf,
             next_id: 0,
             _tempdir: tempdir,
         }
+    }
+
+    /// Snapshot the captured stderr for diagnostic messages.
+    #[expect(dead_code, reason = "Phase 3 e2e_wire.rs will use this")]
+    pub fn captured_stderr(&self) -> String {
+        stderr_snapshot(&self.stderr_buf)
     }
 
     /// Send a JSON-RPC request and return the parsed response value.
@@ -124,10 +188,21 @@ allowed_base_dir = "{}"
         self.stdin.flush().await.expect("flush request");
 
         let mut buf = String::new();
+        let stderr_handle = Arc::clone(&self.stderr_buf);
         let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
             .await
-            .expect("response within timeout")
-            .expect("read response");
+            .unwrap_or_else(|_| {
+                panic!(
+                    "response within timeout for {method}; child stderr:\n{}",
+                    stderr_snapshot(&stderr_handle)
+                )
+            })
+            .unwrap_or_else(|e| {
+                panic!(
+                    "read response for {method}: {e}; child stderr:\n{}",
+                    stderr_snapshot(&stderr_handle)
+                )
+            });
         assert!(read > 0, "stdout closed before responding to {method}");
         let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
         assert_eq!(response["id"], json!(id), "response id must match request");
@@ -153,11 +228,21 @@ allowed_base_dir = "{}"
     /// Assert no bytes arrive on stdout for the given duration.
     pub async fn assert_no_response_within(&mut self, dur: Duration) {
         let mut buf = String::new();
+        let stderr_handle = Arc::clone(&self.stderr_buf);
         match timeout(dur, self.stdout.read_line(&mut buf)).await {
             Err(_) => {} // timeout → no response, as expected
-            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
-            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
-            Ok(Err(e)) => panic!("read error: {e}"),
+            Ok(Ok(0)) => panic!(
+                "stdout closed unexpectedly; child stderr:\n{}",
+                stderr_snapshot(&stderr_handle)
+            ),
+            Ok(Ok(_)) => panic!(
+                "expected no response within {dur:?}, got: {buf:?}; child stderr:\n{}",
+                stderr_snapshot(&stderr_handle)
+            ),
+            Ok(Err(e)) => panic!(
+                "read error: {e}; child stderr:\n{}",
+                stderr_snapshot(&stderr_handle)
+            ),
         }
     }
 
@@ -186,9 +271,20 @@ allowed_base_dir = "{}"
     /// Close stdin, await the child, and return its exit status.
     pub async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
         drop(self.stdin);
+        let stderr_handle = Arc::clone(&self.stderr_buf);
         timeout(SHUTDOWN_TIMEOUT, self.child.wait())
             .await
-            .expect("clean exit within timeout")
-            .expect("wait")
+            .unwrap_or_else(|_| {
+                panic!(
+                    "clean exit within timeout; child stderr:\n{}",
+                    stderr_snapshot(&stderr_handle)
+                )
+            })
+            .unwrap_or_else(|e| {
+                panic!(
+                    "wait: {e}; child stderr:\n{}",
+                    stderr_snapshot(&stderr_handle)
+                )
+            })
     }
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -164,7 +164,10 @@ allowed_base_dir = "{}"
     }
 
     /// Snapshot the captured stderr for diagnostic messages.
-    #[expect(dead_code, reason = "Phase 3 e2e_wire.rs will use this")]
+    #[expect(
+        dead_code,
+        reason = "available for future diagnostic use; no test binary calls it yet"
+    )]
     pub fn captured_stderr(&self) -> String {
         stderr_snapshot(&self.stderr_buf)
     }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -154,32 +154,49 @@ allowed_base_dir = "{}"
             .expect("write request");
         self.stdin.flush().await.expect("flush request");
 
-        let mut buf = String::new();
-        let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
-        let read = match read_result {
-            Ok(io_result) => io_result.unwrap_or_else(|e| {
-                panic!(
-                    "read response error on {method}: {e}\n\
+        // MCP servers may interleave server-initiated notifications
+        // (e.g. `notifications/tools/list_changed` after a successful
+        // `use_account` — see crates/rimap-server/src/mcp/server.rs)
+        // ahead of the response to our request. Loop past notifications
+        // until we observe a response whose id matches our request.
+        loop {
+            let mut buf = String::new();
+            let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
+            let read = match read_result {
+                Ok(io_result) => io_result.unwrap_or_else(|e| {
+                    panic!(
+                        "read response error on {method}: {e}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )
+                }),
+                Err(elapsed) => panic!(
+                    "response to {method} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
                      --- captured child stderr ---\n{}",
                     self.captured_stderr(),
-                )
-            }),
-            Err(elapsed) => panic!(
-                "response to {method} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
+                ),
+            };
+            assert!(
+                read > 0,
+                "stdout closed before responding to {method}\n\
                  --- captured child stderr ---\n{}",
                 self.captured_stderr(),
-            ),
-        };
-        assert!(
-            read > 0,
-            "stdout closed before responding to {method}\n\
-             --- captured child stderr ---\n{}",
-            self.captured_stderr(),
-        );
-        let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
-        assert_eq!(response["id"], json!(id), "response id must match request");
-        assert_envelope_valid(&response);
-        response
+            );
+            let envelope: Value =
+                serde_json::from_str(buf.trim_end()).expect("parse envelope JSON");
+            // A notification is identified by the presence of `method` and
+            // an absent or null `id` field. Validate its envelope shape
+            // against the spec schema and keep reading.
+            let is_notification =
+                envelope.get("method").is_some() && envelope.get("id").is_none_or(Value::is_null);
+            if is_notification {
+                assert_envelope_valid(&envelope);
+                continue;
+            }
+            assert_eq!(envelope["id"], json!(id), "response id must match request");
+            assert_envelope_valid(&envelope);
+            return envelope;
+        }
     }
 
     /// Send a JSON-RPC notification (no `id`, no response expected).

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -8,6 +8,8 @@
 #![expect(clippy::expect_used, reason = "integration tests")]
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
 
+use std::fs::File;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -46,6 +48,13 @@ pub struct Harness {
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
     next_id: u64,
+    /// Path to the file capturing the child's stderr. Read on assertion
+    /// failure so the binary's `tracing::error!` output surfaces in the
+    /// panic message instead of being silently lost. Using a `File`-backed
+    /// stdio target (rather than an async drain) avoids the runtime
+    /// contention that made the prior `Stdio::piped()` capture hang every
+    /// wire test on the 2-second `REQUEST_TIMEOUT` (see commit 3a58304).
+    stderr_log: PathBuf,
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
     _tempdir: TempDir,
@@ -89,13 +98,16 @@ allowed_base_dir = "{}"
         tempdir: TempDir,
         extra_envs: &[(&str, &str)],
     ) -> Self {
+        let stderr_log = tempdir.path().join("rusty-imap-mcp.stderr.log");
+        let stderr_file = File::create(&stderr_log).expect("create stderr log file");
+
         let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
         cmd.arg("--config")
             .arg(config_path)
             .arg("--allow-empty-accounts")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(stderr_file))
             .kill_on_drop(true);
         for (k, v) in extra_envs {
             cmd.env(k, v);
@@ -111,8 +123,17 @@ allowed_base_dir = "{}"
             stdin,
             stdout,
             next_id: 0,
+            stderr_log,
             _tempdir: tempdir,
         }
+    }
+
+    /// Read whatever the child has written to its stderr log so far.
+    /// Used in assertion diagnostics; tolerates a missing or unreadable
+    /// file (returns an empty string) so callers can rely on it inside
+    /// panic messages.
+    pub fn captured_stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
     }
 
     /// Send a JSON-RPC request and return the parsed response value.
@@ -134,11 +155,27 @@ allowed_base_dir = "{}"
         self.stdin.flush().await.expect("flush request");
 
         let mut buf = String::new();
-        let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
-            .await
-            .expect("response within timeout")
-            .expect("read response");
-        assert!(read > 0, "stdout closed before responding to {method}");
+        let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
+        let read = match read_result {
+            Ok(io_result) => io_result.unwrap_or_else(|e| {
+                panic!(
+                    "read response error on {method}: {e}\n\
+                     --- captured child stderr ---\n{}",
+                    self.captured_stderr(),
+                )
+            }),
+            Err(elapsed) => panic!(
+                "response to {method} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
+                 --- captured child stderr ---\n{}",
+                self.captured_stderr(),
+            ),
+        };
+        assert!(
+            read > 0,
+            "stdout closed before responding to {method}\n\
+             --- captured child stderr ---\n{}",
+            self.captured_stderr(),
+        );
         let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
         assert_eq!(response["id"], json!(id), "response id must match request");
         assert_envelope_valid(&response);

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -9,14 +9,13 @@
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
 
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin;
 use rmcp::model::ProtocolVersion;
 use serde_json::{Value, json};
 use tempfile::TempDir;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::timeout;
 
@@ -46,29 +45,10 @@ pub struct Harness {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
-    /// Stderr drain buffer, updated by a background task.
-    stderr_buf: Arc<Mutex<Vec<u8>>>,
     next_id: u64,
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
     _tempdir: TempDir,
-}
-
-/// Maximum bytes retained in the stderr drain buffer. The head is the most
-/// useful diagnostic, so we truncate rather than ring-buffer.
-const STDERR_CAP: usize = 64 * 1024;
-
-/// Snapshot the captured stderr for diagnostic messages.
-fn stderr_snapshot(buf: &Arc<Mutex<Vec<u8>>>) -> String {
-    buf.lock()
-        .map(|g| String::from_utf8_lossy(&g).into_owned())
-        .unwrap_or_default()
-}
-
-/// Log stderr drain errors to test output. Justification: test diagnostics.
-#[expect(clippy::print_stderr, reason = "test diagnostics")]
-fn log_stderr_drain_error(e: &std::io::Error) {
-    eprintln!("[harness] stderr drain error: {e}");
 }
 
 impl Harness {
@@ -115,7 +95,7 @@ allowed_base_dir = "{}"
             .arg("--allow-empty-accounts")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::null())
             .kill_on_drop(true);
         for (k, v) in extra_envs {
             cmd.env(k, v);
@@ -125,51 +105,14 @@ allowed_base_dir = "{}"
 
         let stdin = child.stdin.take().expect("stdin");
         let stdout = BufReader::new(child.stdout.take().expect("stdout"));
-        let stderr = child.stderr.take().expect("stderr");
-
-        // Drain stderr into a shared buffer so the binary's tracing
-        // output is included in panic messages on assertion failure.
-        let stderr_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        let stderr_clone = Arc::clone(&stderr_buf);
-        tokio::spawn(async move {
-            let mut reader = stderr;
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf).await {
-                    Ok(0) => break,
-                    Err(e) => {
-                        log_stderr_drain_error(&e);
-                        break;
-                    }
-                    Ok(n) => {
-                        if let Ok(mut guard) = stderr_clone.lock() {
-                            guard.extend_from_slice(&buf[..n]);
-                            if guard.len() > STDERR_CAP {
-                                guard.truncate(STDERR_CAP);
-                            }
-                        }
-                    }
-                }
-            }
-        });
 
         Self {
             child,
             stdin,
             stdout,
-            stderr_buf,
             next_id: 0,
             _tempdir: tempdir,
         }
-    }
-
-    /// Snapshot the captured stderr for diagnostic messages.
-    #[expect(
-        dead_code,
-        reason = "available for future diagnostic use; no test binary calls it yet"
-    )]
-    pub fn captured_stderr(&self) -> String {
-        stderr_snapshot(&self.stderr_buf)
     }
 
     /// Send a JSON-RPC request and return the parsed response value.
@@ -191,21 +134,10 @@ allowed_base_dir = "{}"
         self.stdin.flush().await.expect("flush request");
 
         let mut buf = String::new();
-        let stderr_handle = Arc::clone(&self.stderr_buf);
         let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
             .await
-            .unwrap_or_else(|_| {
-                panic!(
-                    "response within timeout for {method}; child stderr:\n{}",
-                    stderr_snapshot(&stderr_handle)
-                )
-            })
-            .unwrap_or_else(|e| {
-                panic!(
-                    "read response for {method}: {e}; child stderr:\n{}",
-                    stderr_snapshot(&stderr_handle)
-                )
-            });
+            .expect("response within timeout")
+            .expect("read response");
         assert!(read > 0, "stdout closed before responding to {method}");
         let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
         assert_eq!(response["id"], json!(id), "response id must match request");
@@ -231,21 +163,11 @@ allowed_base_dir = "{}"
     /// Assert no bytes arrive on stdout for the given duration.
     pub async fn assert_no_response_within(&mut self, dur: Duration) {
         let mut buf = String::new();
-        let stderr_handle = Arc::clone(&self.stderr_buf);
         match timeout(dur, self.stdout.read_line(&mut buf)).await {
             Err(_) => {} // timeout → no response, as expected
-            Ok(Ok(0)) => panic!(
-                "stdout closed unexpectedly; child stderr:\n{}",
-                stderr_snapshot(&stderr_handle)
-            ),
-            Ok(Ok(_)) => panic!(
-                "expected no response within {dur:?}, got: {buf:?}; child stderr:\n{}",
-                stderr_snapshot(&stderr_handle)
-            ),
-            Ok(Err(e)) => panic!(
-                "read error: {e}; child stderr:\n{}",
-                stderr_snapshot(&stderr_handle)
-            ),
+            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
+            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
+            Ok(Err(e)) => panic!("read error: {e}"),
         }
     }
 
@@ -274,20 +196,9 @@ allowed_base_dir = "{}"
     /// Close stdin, await the child, and return its exit status.
     pub async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
         drop(self.stdin);
-        let stderr_handle = Arc::clone(&self.stderr_buf);
         timeout(SHUTDOWN_TIMEOUT, self.child.wait())
             .await
-            .unwrap_or_else(|_| {
-                panic!(
-                    "clean exit within timeout; child stderr:\n{}",
-                    stderr_snapshot(&stderr_handle)
-                )
-            })
-            .unwrap_or_else(|e| {
-                panic!(
-                    "wait: {e}; child stderr:\n{}",
-                    stderr_snapshot(&stderr_handle)
-                )
-            })
+            .expect("clean exit within timeout")
+            .expect("wait")
     }
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -1,0 +1,194 @@
+//! Stdio JSON-RPC harness used by both Phase 1 (`mcp_wire_conformance.rs`)
+//! and Phase 3 (`e2e_wire.rs`). Spawns the production `rusty-imap-mcp`
+//! binary (compiled with the `test-support` feature via the dev-dependency
+//! in Cargo.toml) and exchanges line-delimited JSON-RPC envelopes over stdin/stdout. See
+//! `docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md`
+//! and the Phase 3 sibling spec for the design context.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use rmcp::model::ProtocolVersion;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::timeout;
+
+use super::schema::assert_envelope_valid;
+
+/// MCP protocol version pinned by this harness. Matches the
+/// directory under `tests/fixtures/mcp-spec/` and the `LATEST` value
+/// in `rmcp 1.5`. Update both when bumping.
+pub const PINNED_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Vendored MCP spec schema, compiled in at build time so tests run
+/// hermetically (no network, no filesystem dependency beyond the
+/// crate source).
+pub(crate) const MCP_SCHEMA_JSON: &str =
+    include_str!("../../fixtures/mcp-spec/2025-11-25/schema.json");
+
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+// Under `cargo nextest run` with the full workspace suite (~1100 tests
+// in parallel), the EOF-to-exit slice for `wire_clean_eof_shutdown_exits_zero`
+// can exceed a tight 1 s budget on CPU-contended runners. 5 s remains
+// tight enough to fail-fast on a real hang while absorbing scheduling
+// jitter when other tests are spawning binaries / parsers concurrently.
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Owns the spawned child plus its piped stdio.
+pub struct Harness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+    // Hold the tempdir until the harness drops so the audit log path
+    // remains valid for the lifetime of the spawned process.
+    _tempdir: TempDir,
+}
+
+impl Harness {
+    /// Spawn the binary with a zero-account tempdir config.
+    #[expect(
+        clippy::unused_async,
+        reason = "harness API is uniformly async so tests await every constructor"
+    )]
+    pub async fn spawn() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+
+        // Multi-account format with zero accounts. Task 1 lifted the
+        // empty-accounts validator gate, so this is the canonical
+        // zero-account shape the loader accepts.
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            // Production rejects `accounts = []`. The harness opts in
+            // to infrastructure-only boot via this test-support flag
+            // (Codex adversarial review on PR #270).
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Send a JSON-RPC request and return the parsed response value.
+    /// Panics on timeout, EOF before a response arrives, or non-JSON output.
+    pub async fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+
+        let mut buf = String::new();
+        let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
+            .await
+            .expect("response within timeout")
+            .expect("read response");
+        assert!(read > 0, "stdout closed before responding to {method}");
+        let response: Value = serde_json::from_str(buf.trim_end()).expect("parse response JSON");
+        assert_eq!(response["id"], json!(id), "response id must match request");
+        assert_envelope_valid(&response);
+        response
+    }
+
+    /// Send a JSON-RPC notification (no `id`, no response expected).
+    pub async fn notify(&mut self, method: &str, params: Value) {
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write notification");
+        self.stdin.flush().await.expect("flush notification");
+    }
+
+    /// Assert no bytes arrive on stdout for the given duration.
+    pub async fn assert_no_response_within(&mut self, dur: Duration) {
+        let mut buf = String::new();
+        match timeout(dur, self.stdout.read_line(&mut buf)).await {
+            Err(_) => {} // timeout → no response, as expected
+            Ok(Ok(0)) => panic!("stdout closed unexpectedly"),
+            Ok(Ok(_)) => panic!("expected no response within {dur:?}, got: {buf:?}"),
+            Ok(Err(e)) => panic!("read error: {e}"),
+        }
+    }
+
+    /// Send an MCP `initialize` request with the pinned protocol
+    /// version and return the response.
+    pub async fn initialize_handshake(&mut self) -> Value {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-conformance-harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+        .await
+    }
+
+    /// Send `notifications/initialized` after the handshake.
+    pub async fn send_initialized(&mut self) {
+        self.notify("notifications/initialized", json!({})).await;
+    }
+
+    /// Close stdin, await the child, and return its exit status.
+    pub async fn shutdown_and_wait(mut self) -> std::process::ExitStatus {
+        drop(self.stdin);
+        timeout(SHUTDOWN_TIMEOUT, self.child.wait())
+            .await
+            .expect("clean exit within timeout")
+            .expect("wait")
+    }
+}

--- a/crates/rimap-server/tests/support/wire/mod.rs
+++ b/crates/rimap-server/tests/support/wire/mod.rs
@@ -1,10 +1,18 @@
 //! Wire driver and MCP spec schema validators shared by Phase 1
 //! (`mcp_wire_conformance.rs`) and Phase 3 (`e2e_wire.rs`).
 
+pub mod config;
 pub mod harness;
 pub mod schema;
 
+#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
+pub use config::build_dovecot_config;
 #[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use these")]
 pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
 #[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
-pub use schema::{assert_valid, validator_for_tool_response};
+pub use schema::assert_envelope_valid;
+pub use schema::assert_valid;
+#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
+pub use schema::validator_for;
+#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
+pub use schema::validator_for_tool_response;

--- a/crates/rimap-server/tests/support/wire/mod.rs
+++ b/crates/rimap-server/tests/support/wire/mod.rs
@@ -1,18 +1,17 @@
 //! Wire driver and MCP spec schema validators shared by Phase 1
 //! (`mcp_wire_conformance.rs`) and Phase 3 (`e2e_wire.rs`).
+//!
+//! Only items imported by `mcp_wire_conformance.rs` are re-exported
+//! here. `e2e_wire.rs` imports directly from the sub-modules
+//! (`wire::config::build_dovecot_config`, `wire::schema::assert_envelope_valid`,
+//! etc.) to avoid `unused_imports` warnings on re-exports that one
+//! binary uses and the other does not — `clippy::allow_attributes`
+//! is denied workspace-wide, and `#[expect(unused_imports)]` cannot
+//! satisfy both per-binary lint states at once.
 
 pub mod config;
 pub mod harness;
 pub mod schema;
 
-#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
-pub use config::build_dovecot_config;
-#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use these")]
-pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
-#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
-pub use schema::assert_envelope_valid;
+pub use harness::{Harness, PINNED_PROTOCOL_VERSION};
 pub use schema::assert_valid;
-#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
-pub use schema::validator_for;
-#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
-pub use schema::validator_for_tool_response;

--- a/crates/rimap-server/tests/support/wire/mod.rs
+++ b/crates/rimap-server/tests/support/wire/mod.rs
@@ -1,0 +1,9 @@
+//! Wire driver and MCP spec schema validators shared by Phase 1
+//! (`mcp_wire_conformance.rs`) and Phase 3 (`e2e_wire.rs`).
+
+pub mod harness;
+pub mod schema;
+
+#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use these")]
+pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
+pub use schema::assert_valid;

--- a/crates/rimap-server/tests/support/wire/mod.rs
+++ b/crates/rimap-server/tests/support/wire/mod.rs
@@ -6,4 +6,5 @@ pub mod schema;
 
 #[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use these")]
 pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
-pub use schema::assert_valid;
+#[expect(unused_imports, reason = "Phase 3 e2e_wire.rs will use this")]
+pub use schema::{assert_valid, validator_for_tool_response};

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -110,3 +110,44 @@ pub fn assert_envelope_valid(response: &Value) {
         }
     }
 }
+
+/// Compile (lazily, cached) a validator for the per-tool response
+/// schema at `tests/fixtures/rimap-tool-schemas/<tool>.schema.json`.
+/// Panics in the test process if the fixture is missing — that's the
+/// signal that `just regen-tool-schemas` was not run.
+#[expect(
+    dead_code,
+    reason = "Phase 3 e2e_wire.rs will call this to validate tool responses"
+)]
+pub fn validator_for_tool_response(tool: &'static str) -> Arc<jsonschema::Validator> {
+    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    {
+        let guard = cache.lock().expect("tool schema cache mutex poisoned");
+        if let Some(v) = guard.get(tool) {
+            return Arc::clone(v);
+        }
+    }
+
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/rimap-tool-schemas")
+        .join(format!("{tool}.schema.json"));
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "missing tool-response schema fixture for {tool} at {}: {e}\n\
+             Run `just regen-tool-schemas` to regenerate.",
+            path.display()
+        )
+    });
+    let parsed: Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("invalid JSON in {}: {e}", path.display()));
+    let compiled = jsonschema::validator_for(&parsed)
+        .unwrap_or_else(|e| panic!("invalid JSON Schema in {}: {e}", path.display()));
+    let arc = Arc::new(compiled);
+
+    let mut guard = cache.lock().expect("tool schema cache mutex poisoned");
+    let entry = guard.entry(tool).or_insert_with(|| Arc::clone(&arc));
+    Arc::clone(entry)
+}

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -165,3 +165,77 @@ fn force_use_for_dead_code_link() {
     let _ = validator_for_tool_response;
     let _ = validator_for;
 }
+
+#[cfg(test)]
+mod fixture_smoke_tests {
+    use super::*;
+
+    #[test]
+    fn every_fixture_compiles_against_jsonschema() {
+        let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/rimap-tool-schemas");
+        let entries: Vec<_> = std::fs::read_dir(&fixture_dir)
+            .expect("read fixture dir")
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".schema.json"))
+            .collect();
+        // Pin to the current 16-tool set. Update when adding or removing
+        // tools from `build_schemas()` in cli/dump_tool_schemas.rs.
+        assert_eq!(
+            entries.len(),
+            16,
+            "expected exactly 16 tool schema fixtures (pinned), found {}",
+            entries.len()
+        );
+
+        // Compile every fixture — catches dangling $refs at validator build time.
+        for entry in &entries {
+            let path = entry.path();
+            let raw = std::fs::read_to_string(&path).expect("read fixture");
+            let parsed: serde_json::Value = serde_json::from_str(&raw)
+                .unwrap_or_else(|e| panic!("invalid JSON in {path:?}: {e}"));
+            jsonschema::validator_for(&parsed)
+                .unwrap_or_else(|e| panic!("schema {path:?} failed to compile: {e}"));
+        }
+    }
+
+    #[test]
+    fn search_fixture_validates_realistic_payload() {
+        // Positive payload test: the search schema must accept a
+        // response that exercises a non-empty nested array AND a
+        // security_warnings entry.
+        //
+        // SearchMeta requires: folder, total_matched, returned, truncated.
+        // SearchUntrusted requires: messages (array of SearchResultEntry).
+        // SearchResultEntry requires: uid, from, to.
+        let search = validator_for_tool_response("search");
+        let payload = serde_json::json!({
+            "meta": {
+                "total_matched": 1u64,
+                "folder": "INBOX",
+                "returned": 1u64,
+                "truncated": false,
+            },
+            "untrusted": {
+                "messages": [
+                    {
+                        "uid": 42u32,
+                        "from": ["sender@example.com"],
+                        "to": ["recipient@example.com"],
+                    }
+                ],
+            },
+            "security_warnings": [],
+        });
+        if !search.is_valid(&payload) {
+            let errors: Vec<String> = search
+                .iter_errors(&payload)
+                .map(|e| e.to_string())
+                .collect();
+            panic!(
+                "constructed search payload should validate; errors:\n  {}\n\npayload: {payload}",
+                errors.join("\n  ")
+            );
+        }
+    }
+}

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -1,0 +1,112 @@
+//! MCP-spec JSON Schema validators shared by Phase 1 and Phase 3.
+//! `validator_for(fragment)` caches per-fragment validators in a
+//! process-wide map; the parsed spec document is parsed exactly once.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde_json::{Value, json};
+
+use super::harness::MCP_SCHEMA_JSON;
+
+/// Compile (once) and return a validator for a top-level definition in
+/// the vendored MCP schema. `fragment` is the key under
+/// `definitions` / `$defs` (e.g. `"InitializeResult"`). Returns an
+/// `Arc` so multiple parallel tests can share the compiled validator
+/// without lifetime gymnastics.
+pub(crate) fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+    // All function-scoped items declared up front so cache and parsed
+    // schema lifetimes are visible from the top of the body
+    // (clippy::items_after_statements).
+    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static PARSED: OnceLock<(Value, &'static str)> = OnceLock::new();
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+
+    // Parse the vendored schema exactly once and detect the
+    // definitions key (`$defs` for Draft 2020-12, `definitions` for
+    // older dialects). The full Value and the detected key are
+    // immutable for the lifetime of the test process.
+    let parsed = PARSED.get_or_init(|| {
+        let full: Value = serde_json::from_str(MCP_SCHEMA_JSON).expect("parse vendored MCP schema");
+        let defs_key = if full.get("$defs").is_some() {
+            "$defs"
+        } else {
+            "definitions"
+        };
+        (full, defs_key)
+    });
+    let full = &parsed.0;
+    let defs_key: &'static str = parsed.1;
+
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    // Fast path: read under the lock, return if cached.
+    {
+        let guard = cache.lock().expect("validator cache mutex poisoned");
+        if let Some(v) = guard.get(fragment) {
+            return Arc::clone(v);
+        }
+    }
+
+    // Slow path: compile the fragment validator WITHOUT holding the
+    // cache lock, so parallel tests compiling different fragments
+    // don't serialize.
+    let wrapper = json!({
+        "$ref": format!("#/{defs_key}/{fragment}"),
+        defs_key: full.get(defs_key).cloned().unwrap_or(json!({})),
+    });
+    let new_validator =
+        Arc::new(jsonschema::validator_for(&wrapper).expect("compile fragment validator"));
+
+    // Insert. If a concurrent thread already inserted while we were
+    // compiling, prefer the existing entry to keep the Arc stable.
+    let mut guard = cache.lock().expect("validator cache mutex poisoned");
+    let entry = guard
+        .entry(fragment)
+        .or_insert_with(|| Arc::clone(&new_validator));
+    Arc::clone(entry)
+}
+
+/// Validate a value against a vendored fragment, panicking with the
+/// list of errors on failure.
+pub fn assert_valid(value: &Value, fragment: &'static str) {
+    let v = validator_for(fragment);
+    if !v.is_valid(value) {
+        let errors: Vec<String> = v.iter_errors(value).map(|e| e.to_string()).collect();
+        panic!(
+            "schema validation failed for fragment {fragment}:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+}
+
+/// Validate the FULL JSON-RPC envelope returned by `Harness::request`.
+/// Success responses validate against `JSONRPCResultResponse`; error
+/// responses validate against `JSONRPCErrorResponse`. Asserts the
+/// `jsonrpc` version field on both paths. Codex adversarial review
+/// finding #2 (PR #270): the previous negative-path tests checked only
+/// `code` and `message` and would have missed a regression that
+/// stripped `jsonrpc` or otherwise mangled the envelope.
+pub fn assert_envelope_valid(response: &Value) {
+    assert_eq!(
+        response["jsonrpc"],
+        json!("2.0"),
+        "envelope must declare jsonrpc=\"2.0\"; got {response}",
+    );
+
+    let has_result = response.get("result").is_some();
+    let has_error = response.get("error").is_some();
+    match (has_result, has_error) {
+        (true, false) => assert_valid(response, "JSONRPCResultResponse"),
+        (false, true) => assert_valid(response, "JSONRPCErrorResponse"),
+        (true, true) => {
+            panic!("envelope must not contain both `result` and `error`; got {response}",)
+        }
+        (false, false) => {
+            panic!("envelope must contain either `result` or `error`; got {response}",)
+        }
+    }
+}

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -115,10 +115,6 @@ pub fn assert_envelope_valid(response: &Value) {
 /// schema at `tests/fixtures/rimap-tool-schemas/<tool>.schema.json`.
 /// Panics in the test process if the fixture is missing — that's the
 /// signal that `just regen-tool-schemas` was not run.
-#[expect(
-    dead_code,
-    reason = "Phase 3 e2e_wire.rs will call this to validate tool responses"
-)]
 pub fn validator_for_tool_response(tool: &'static str) -> Arc<jsonschema::Validator> {
     type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();
@@ -150,4 +146,22 @@ pub fn validator_for_tool_response(tool: &'static str) -> Arc<jsonschema::Valida
     let mut guard = cache.lock().expect("tool schema cache mutex poisoned");
     let entry = guard.entry(tool).or_insert_with(|| Arc::clone(&arc));
     Arc::clone(entry)
+}
+
+/// Per-binary dead-code suppression. `mcp_wire_conformance.rs`
+/// compiles this module through `support/wire/mod.rs` but never calls
+/// `assert_envelope_valid` or `validator_for_tool_response`; if we
+/// relied on per-item `#[expect(dead_code)]` instead, those
+/// expectations would be unfulfilled in `e2e_wire.rs` (which does use
+/// them) and `clippy::allow_attributes = "deny"` forbids `#[allow]`.
+/// Referencing each item inside a never-called function marks them as
+/// used in every compilation unit.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary dead-code in mcp_wire_conformance.rs"
+)]
+fn force_use_for_dead_code_link() {
+    let _ = assert_envelope_valid;
+    let _ = validator_for_tool_response;
+    let _ = validator_for;
 }

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -17,7 +17,7 @@ use super::harness::MCP_SCHEMA_JSON;
 /// `definitions` / `$defs` (e.g. `"InitializeResult"`). Returns an
 /// `Arc` so multiple parallel tests can share the compiled validator
 /// without lifetime gymnastics.
-pub(crate) fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+pub fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
     // All function-scoped items declared up front so cache and parsed
     // schema lifetimes are visible from the top of the body
     // (clippy::items_after_statements).

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -207,7 +207,8 @@ mod fixture_smoke_tests {
         //
         // SearchMeta requires: folder, total_matched, returned, truncated.
         // SearchUntrusted requires: messages (array of SearchResultEntry).
-        // SearchResultEntry requires: uid, from, to.
+        // SearchResultEntry requires: uid (from/to are optional —
+        // omitted when the parsed message had no headers).
         let search = validator_for_tool_response("search");
         let payload = serde_json::json!({
             "meta": {
@@ -234,6 +235,43 @@ mod fixture_smoke_tests {
                 .collect();
             panic!(
                 "constructed search payload should validate; errors:\n  {}\n\npayload: {payload}",
+                errors.join("\n  ")
+            );
+        }
+    }
+
+    #[test]
+    fn search_fixture_validates_payload_with_omitted_from_and_to() {
+        // Wire shape when the parsed message has no From / To headers:
+        // both fields are omitted (Vec::is_empty skip_serializing_if on
+        // SearchResultEntry). Pre-fix, the schema required them as keys
+        // and this payload would have been falsely rejected.
+        let search = validator_for_tool_response("search");
+        let payload = serde_json::json!({
+            "meta": {
+                "total_matched": 1u64,
+                "folder": "INBOX",
+                "returned": 1u64,
+                "truncated": false,
+            },
+            "untrusted": {
+                "messages": [
+                    {
+                        "uid": 42u32,
+                        // from and to are omitted, matching the wire
+                        // when both vectors are empty.
+                    }
+                ],
+            },
+            "security_warnings": [],
+        });
+        if !search.is_valid(&payload) {
+            let errors: Vec<String> = search
+                .iter_errors(&payload)
+                .map(|e| e.to_string())
+                .collect();
+            panic!(
+                "search schema must accept a result entry with omitted from/to; errors:\n  {}\n\npayload: {payload}",
                 errors.join("\n  ")
             );
         }

--- a/docs/superpowers/plans/2026-05-12-mcp-behavioral-conformance-plan.md
+++ b/docs/superpowers/plans/2026-05-12-mcp-behavioral-conformance-plan.md
@@ -1,0 +1,1987 @@
+# Phase 3 MCP Behavioral Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a Rust integration test (`e2e_wire`) that drives `rusty-imap-mcp` over its stdio JSON-RPC wire against the existing Dovecot fixture, exercising every draft-safe + read-only posture tool, validating responses against Phase 1's vendored MCP envelope schemas + new per-tool schemas generated from the Rust output structs, and asserting paired audit records with correct account attribution.
+
+**Architecture:** Extract Phase 1's wire harness and `e2e.rs`'s Dovecot harness into a shared `tests/support/` module so both phases share one driver. Add `schemars` derives (already a workspace dep) to existing `<Tool>Meta`/`<Tool>Untrusted` response structs under a `cfg(any(test, feature = "test-support"))` gate. A new `dump-tool-schemas` test-support subcommand emits per-tool composed schemas; `just regen-tool-schemas` writes them to `tests/fixtures/rimap-tool-schemas/`; CI fails on a non-empty diff. The new `e2e_wire.rs` builds a multipart-MIME seed, spawns the production binary with a Dovecot-backed two-account config (`draftsafe` + `readonly`), drives the wire flow, and reads back the audit log to verify pairing and namespace attribution.
+
+**Tech Stack:** Rust 2024 / edition 2024, MSRV 1.88.0. `tokio`, `rmcp` 1.5, `schemars` 1.0, `jsonschema` 0.46, `assert_cmd`, `tempfile`. Reuses existing infrastructure: `cargo-nextest`, the `test-support` feature gate, the Dovecot docker-compose fixture, and Phase 1's vendored MCP spec schema.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md`
+**Branch:** continue on `test/mcp-behavioral-conformance-spec` (already created).
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `crates/rimap-server/src/tools/admin/accounts.rs` | Modify | Add `JsonSchema` derives to `UseAccountMeta`, `ListAccountsMeta` (and helpers). |
+| `crates/rimap-server/src/tools/admin/list_folders.rs` | Modify | Add `JsonSchema` to `ListFoldersMeta`. |
+| `crates/rimap-server/src/tools/mailbox/labels.rs` | Modify | Add `JsonSchema` to `LabelsMeta`, `ListLabelsMeta`. |
+| `crates/rimap-server/src/tools/mailbox/flags.rs` | Modify | Add `JsonSchema` to `FlagsMeta`. |
+| `crates/rimap-server/src/tools/mailbox/move_message.rs` | Modify | Add `JsonSchema` to `MoveEntry`, `MoveMessageMeta`. |
+| `crates/rimap-server/src/tools/compose/create_draft.rs` | Modify | Add `JsonSchema` to `CreateDraftMeta`. |
+| `crates/rimap-server/src/tools/retrieval/search.rs` | Modify | Add `JsonSchema` to `SearchResultEntry`, `SearchMeta`, `SearchUntrusted`. |
+| `crates/rimap-server/src/tools/retrieval/fetch_message.rs` | Modify | Add `JsonSchema` to `FetchMessageMeta`, `FetchMessageUntrusted`. |
+| `crates/rimap-server/src/tools/retrieval/list_attachments.rs` | Modify | Add `JsonSchema` to `AttachmentInfo`, `ListAttachmentsMeta`, `ListAttachmentsUntrusted`. |
+| `crates/rimap-server/src/tools/retrieval/download_attachment.rs` | Modify | Add `JsonSchema` to `DownloadAttachmentMeta`, `DownloadAttachmentUntrusted`. |
+| `crates/rimap-server/src/cli/dump_tool_schemas.rs` | Create | Test-support subcommand that emits per-tool composed schemas as JSON to stdout. |
+| `crates/rimap-server/src/cli/mod.rs` | Modify | Register `DumpToolSchemas` enum variant under `cfg(feature = "test-support")`. |
+| `crates/rimap-server/src/main.rs` | Modify | Dispatch the new subcommand in `run_test_support_subcommands`. |
+| `justfile` | Modify | Add `regen-tool-schemas` recipe; wire it into `ci` after `mcp-conformance-node`. |
+| `crates/rimap-server/tests/fixtures/rimap-tool-schemas/<tool>.schema.json` | Create (14 files) | Generated per-tool combined `{meta, untrusted}` schemas. Checked in. |
+| `crates/rimap-server/tests/support/mod.rs` | Create | `pub mod wire; pub mod dovecot;` |
+| `crates/rimap-server/tests/support/wire/mod.rs` | Create | Re-exports for harness + schema validators. |
+| `crates/rimap-server/tests/support/wire/harness.rs` | Create | `Harness` lifted from `mcp_wire_conformance.rs` + new `spawn_with_config`. |
+| `crates/rimap-server/tests/support/wire/schema.rs` | Create | `validator_for`, `assert_envelope_valid`, `validator_for_tool_response`. |
+| `crates/rimap-server/tests/support/dovecot/mod.rs` | Create | Re-exports for `DovecotHarness` + fixtures. |
+| `crates/rimap-server/tests/support/dovecot/harness.rs` | Create | `DovecotHarness`, `ReservedPort` lifted from `e2e.rs`. |
+| `crates/rimap-server/tests/support/dovecot/fixtures.rs` | Create | `multipart_with_attachment()` raw-bytes seed builder + payload constants. |
+| `crates/rimap-server/tests/support/wire/config.rs` | Create | `build_dovecot_config(...)` two-account TOML builder. |
+| `crates/rimap-server/tests/mcp_wire_conformance.rs` | Modify | Replace inline `Harness` / schema items with `use` imports from `support::wire`. Test bodies unchanged. |
+| `crates/rimap-server/tests/e2e.rs` | Modify | Replace inline `DovecotHarness` with `use support::dovecot::DovecotHarness;`. Test bodies unchanged. |
+| `crates/rimap-server/tests/e2e_wire.rs` | Create | Two `#[tokio::test]` cases: `wire_e2e_full_session_draft_safe`, `wire_e2e_readonly_posture_denial`. |
+| `.github/workflows/ci.yml` | Modify | Add a step running `cargo nextest run -p rimap-server --test e2e_wire --no-tests=fail` and a step running `just regen-tool-schemas && git diff --exit-code`. |
+| `AGENTS.md` | Modify | Document Phase 3 wall-time + cross-link the spec. |
+
+---
+
+## Task 1: Add `schemars::JsonSchema` derives to 14 tool response structs
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/admin/accounts.rs:16-44`
+- Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:82-130`
+- Modify: `crates/rimap-server/src/tools/mailbox/labels.rs:111-140`
+- Modify: `crates/rimap-server/src/tools/mailbox/flags.rs:47-65`
+- Modify: `crates/rimap-server/src/tools/mailbox/move_message.rs:40-60`
+- Modify: `crates/rimap-server/src/tools/compose/create_draft.rs:14-30`
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs:54-100`
+- Modify: `crates/rimap-server/src/tools/retrieval/fetch_message.rs:35-60`
+- Modify: `crates/rimap-server/src/tools/retrieval/list_attachments.rs:31-70`
+- Modify: `crates/rimap-server/src/tools/retrieval/download_attachment.rs:39-80`
+
+- [ ] **Step 1: Verify schemars is already in scope (no Cargo.toml change required)**
+
+Run: `grep -nE "^schemars" /Users/dave/src/rusty-imap-mcp/Cargo.toml /Users/dave/src/rusty-imap-mcp/crates/rimap-server/Cargo.toml`
+Expected: `Cargo.toml:194:schemars = "1.0"` and `rimap-server/Cargo.toml:53:schemars = { workspace = true }`. No change needed.
+
+- [ ] **Step 2: Add the derive to every in-scope struct**
+
+For each struct listed in the file table for this task, replace its existing derive line. Example for `crates/rimap-server/src/tools/mailbox/flags.rs:47`:
+
+```rust
+// before
+#[derive(Debug, Serialize)]
+
+// after
+#[derive(Debug, Serialize)]
+#[cfg_attr(any(test, feature = "test-support"), derive(schemars::JsonSchema))]
+```
+
+Apply the same two-line pattern to each of these structs (every one already has `#[derive(Debug, Serialize)]`):
+
+- `accounts.rs`: `UseAccountMeta`, `AccountEntry`, `ListAccountsMeta`
+- `list_folders.rs`: every `#[derive(Debug, Serialize)]` struct in the file (currently `ListFoldersMeta` + 1 helper at line 82)
+- `labels.rs`: `LabelsMeta`, `ListLabelsMeta` (+ any helper structs the two reference)
+- `flags.rs`: `FlagsMeta`
+- `move_message.rs`: `MoveEntry`, `MoveMessageMeta`
+- `create_draft.rs`: `CreateDraftMeta`
+- `search.rs`: `SearchResultEntry`, `SearchMeta`, `SearchUntrusted`
+- `fetch_message.rs`: `FetchMessageMeta`, `FetchMessageUntrusted`
+- `list_attachments.rs`: `AttachmentInfo`, `ListAttachmentsMeta`, `ListAttachmentsUntrusted`
+- `download_attachment.rs`: `DownloadAttachmentMeta`, `DownloadAttachmentUntrusted`
+
+If a nested type does not implement `JsonSchema` (e.g. a third-party type), apply `#[cfg_attr(any(test, feature = "test-support"), schemars(with = "String"))]` on the offending field as a fallback.
+
+- [ ] **Step 3: Verify the workspace still compiles with the feature off**
+
+Run: `cargo check -p rimap-server --locked`
+Expected: clean compile. (Production build does not enable `test-support`, so derives are inert.)
+
+- [ ] **Step 4: Verify the workspace still compiles with the feature on**
+
+Run: `cargo check -p rimap-server --features test-support --locked`
+Expected: clean compile.
+
+- [ ] **Step 5: Run clippy with `-D warnings` to catch derive-induced lints**
+
+Run: `cargo clippy -p rimap-server --features test-support --all-targets --locked -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/
+git commit -m "feat(server): add schemars derives to tool response structs
+
+Test-support-only derives on every <Tool>Meta and <Tool>Untrusted in
+scope for Phase 3 wire conformance (#265). Gated behind
+cfg(any(test, feature = \"test-support\")) so production builds do not
+pull schemars into their dep graph.
+"
+```
+
+---
+
+## Task 2: `dump-tool-schemas` test-support subcommand
+
+**Files:**
+- Create: `crates/rimap-server/src/cli/dump_tool_schemas.rs`
+- Modify: `crates/rimap-server/src/cli/mod.rs:97-100`
+- Modify: `crates/rimap-server/src/main.rs:362-370`
+- Test: `crates/rimap-server/src/cli/dump_tool_schemas.rs` (inline `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing inline test**
+
+Append to `crates/rimap-server/src/cli/dump_tool_schemas.rs` (file does not exist yet; create with the test first):
+
+```rust
+//! `dump-tool-schemas` test-support CLI subcommand. Emits one JSON
+//! Schema per in-scope tool, composing `<Tool>Meta` and (where
+//! present) `<Tool>Untrusted` into a single `{meta, untrusted}`
+//! envelope schema. Used by the Phase 3 wire-conformance harness
+//! (issue #265) to validate every wire response against a per-tool
+//! schema regenerated from the Rust output structs.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use serde_json::Value;
+
+/// Emit `{ "<tool>": <schema>, ... }` as pretty-printed JSON to the
+/// given writer. Iteration order is deterministic (BTreeMap).
+///
+/// # Errors
+///
+/// Returns the I/O error if the writer fails or the serializer cannot
+/// encode an entry. Schemars produces valid JSON for every derive-using
+/// struct in scope; failure indicates a bug, not user input.
+pub fn dump_tool_schemas<W: Write>(writer: &mut W) -> std::io::Result<()> {
+    let schemas = build_schemas();
+    serde_json::to_writer_pretty(&mut *writer, &schemas)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+fn build_schemas() -> BTreeMap<&'static str, Value> {
+    use rimap_server::tools::{
+        admin::{accounts::{ListAccountsMeta, UseAccountMeta}, list_folders::ListFoldersMeta},
+        compose::create_draft::CreateDraftMeta,
+        mailbox::{flags::FlagsMeta, labels::{LabelsMeta, ListLabelsMeta}, move_message::MoveMessageMeta},
+        retrieval::{
+            download_attachment::{DownloadAttachmentMeta, DownloadAttachmentUntrusted},
+            fetch_message::{FetchMessageMeta, FetchMessageUntrusted},
+            list_attachments::{ListAttachmentsMeta, ListAttachmentsUntrusted},
+            search::{SearchMeta, SearchUntrusted},
+        },
+    };
+
+    let mut out = BTreeMap::<&'static str, Value>::new();
+
+    // meta-only tools (no untrusted payload on the wire)
+    out.insert("list_folders",  meta_only::<ListFoldersMeta>());
+    out.insert("list_accounts", meta_only::<ListAccountsMeta>());
+    out.insert("list_labels",   meta_only::<ListLabelsMeta>());
+    out.insert("mark_read",     meta_only::<FlagsMeta>());
+    out.insert("mark_unread",   meta_only::<FlagsMeta>());
+    out.insert("flag",          meta_only::<FlagsMeta>());
+    out.insert("unflag",        meta_only::<FlagsMeta>());
+    out.insert("add_label",     meta_only::<LabelsMeta>());
+    out.insert("remove_label",  meta_only::<LabelsMeta>());
+    out.insert("move_message",  meta_only::<MoveMessageMeta>());
+    out.insert("create_draft",  meta_only::<CreateDraftMeta>());
+    out.insert("use_account",   meta_only::<UseAccountMeta>());
+
+    // meta + untrusted tools
+    out.insert("search",
+        meta_and_untrusted::<SearchMeta, SearchUntrusted>());
+    out.insert("fetch_message",
+        meta_and_untrusted::<FetchMessageMeta, FetchMessageUntrusted>());
+    out.insert("list_attachments",
+        meta_and_untrusted::<ListAttachmentsMeta, ListAttachmentsUntrusted>());
+    out.insert("download_attachment",
+        meta_and_untrusted::<DownloadAttachmentMeta, DownloadAttachmentUntrusted>());
+
+    out
+}
+
+fn meta_only<M: schemars::JsonSchema>() -> Value {
+    let schema = schemars::schema_for!(M);
+    serde_json::json!({
+        "type": "object",
+        "properties": { "meta": schema },
+        "required": ["meta"],
+        "additionalProperties": true,
+    })
+}
+
+fn meta_and_untrusted<M: schemars::JsonSchema, U: schemars::JsonSchema>() -> Value {
+    let m = schemars::schema_for!(M);
+    let u = schemars::schema_for!(U);
+    serde_json::json!({
+        "type": "object",
+        "properties": { "meta": m, "untrusted": u },
+        "required": ["meta", "untrusted"],
+        "additionalProperties": true,
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dump_emits_one_key_per_in_scope_tool() {
+        let mut buf = Vec::new();
+        dump_tool_schemas(&mut buf).unwrap();
+        let parsed: serde_json::Map<String, Value> =
+            serde_json::from_slice(&buf).unwrap();
+
+        for name in [
+            "list_folders", "list_accounts", "list_labels",
+            "list_attachments", "download_attachment", "search",
+            "fetch_message", "mark_read", "mark_unread", "flag",
+            "unflag", "add_label", "remove_label", "move_message",
+            "create_draft", "use_account",
+        ] {
+            assert!(parsed.contains_key(name), "missing schema for {name}");
+            let entry = &parsed[name];
+            assert_eq!(entry["type"], "object");
+            assert!(entry["properties"]["meta"].is_object(),
+                "{name}.meta must be a JSON Schema object");
+        }
+    }
+
+    #[test]
+    fn meta_and_untrusted_tools_include_untrusted_key() {
+        let mut buf = Vec::new();
+        dump_tool_schemas(&mut buf).unwrap();
+        let parsed: serde_json::Map<String, Value> =
+            serde_json::from_slice(&buf).unwrap();
+        for name in ["search", "fetch_message", "list_attachments", "download_attachment"] {
+            assert!(parsed[name]["properties"]["untrusted"].is_object(),
+                "{name} must declare an untrusted schema");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p rimap-server --features test-support --lib cli::dump_tool_schemas -- --nocapture`
+Expected: FAIL because `pub mod dump_tool_schemas;` is not declared in `cli/mod.rs` yet (compile error: unresolved module).
+
+- [ ] **Step 3: Register the new module**
+
+Edit `crates/rimap-server/src/cli/mod.rs` (insert near line 14 next to `pub(crate) mod dump_tool_catalog;`):
+
+```rust
+#[cfg(feature = "test-support")]
+pub(crate) mod dump_tool_schemas;
+```
+
+Edit the `Command` enum at `crates/rimap-server/src/cli/mod.rs:97-100` to add a sibling variant immediately after `DumpToolCatalog`:
+
+```rust
+    /// Emit per-tool JSON Schemas (one entry per in-scope tool,
+    /// composing `<Tool>Meta` and `<Tool>Untrusted` into a single
+    /// `{meta, untrusted}` envelope) as pretty JSON on stdout. Used
+    /// by the Phase 3 wire-conformance harness (#265) and the
+    /// `just regen-tool-schemas` recipe. Hidden from `--help` because
+    /// it is a test-only utility.
+    #[cfg(feature = "test-support")]
+    #[command(name = "dump-tool-schemas", hide = true)]
+    DumpToolSchemas,
+```
+
+- [ ] **Step 4: Wire the subcommand into the test-support dispatcher**
+
+Edit `crates/rimap-server/src/main.rs:362-370`. Replace `run_test_support_subcommands` with:
+
+```rust
+#[cfg(feature = "test-support")]
+fn run_test_support_subcommands(cli: &Cli) -> Option<anyhow::Result<()>> {
+    match cli.command {
+        Some(Command::DumpToolCatalog) => {
+            let mut stdout = std::io::stdout().lock();
+            Some(cli::dump_tool_catalog::dump_tool_catalog(&mut stdout)
+                .context("dumping tool catalog"))
+        }
+        Some(Command::DumpToolSchemas) => {
+            let mut stdout = std::io::stdout().lock();
+            Some(cli::dump_tool_schemas::dump_tool_schemas(&mut stdout)
+                .context("dumping tool schemas"))
+        }
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 5: Make the in-scope structs public from `rimap-server` lib**
+
+The `build_schemas` body in Step 1 references each struct via `rimap_server::tools::…`. Verify each is reachable from the library root. Run:
+
+```bash
+grep -rEn "pub mod (admin|compose|mailbox|retrieval)" crates/rimap-server/src/tools/mod.rs
+```
+Expected: each submodule is `pub mod …`. If any is `pub(crate)`, change it to `pub`.
+
+Then verify each leaf struct is `pub struct …` (verified during file-structure mapping — currently true for all 14 in-scope structs). If any is not, change it.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p rimap-server --features test-support --lib cli::dump_tool_schemas -- --nocapture`
+Expected: 2 tests pass.
+
+- [ ] **Step 7: Smoke-test the subcommand end-to-end**
+
+Run:
+```bash
+cargo run -p rimap-server --features test-support --bin rusty-imap-mcp -- dump-tool-schemas | head -10
+```
+Expected: pretty-printed JSON object beginning with `{"add_label": {"type": "object", ...`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/ crates/rimap-server/src/main.rs
+git commit -m "feat(server): add dump-tool-schemas test-support subcommand
+
+Emits a per-tool JSON Schema map keyed by tool name; each entry is a
+composed {meta, untrusted} envelope schema. Wired under the same
+test-support feature gate as dump-tool-catalog (#264). Phase 3
+behavioral-conformance plan (#265) consumes the output via the
+new just regen-tool-schemas recipe.
+"
+```
+
+---
+
+## Task 3: `just regen-tool-schemas` recipe + initial schema commit
+
+**Files:**
+- Modify: `justfile` (append a new recipe before `ci:`)
+- Create: 16 files under `crates/rimap-server/tests/fixtures/rimap-tool-schemas/<tool>.schema.json`
+
+- [ ] **Step 1: Add the recipe to `justfile`**
+
+Insert after the `mcp-conformance-node` recipe (before `ci:`):
+
+```just
+# Regenerate per-tool JSON Schemas under
+# crates/rimap-server/tests/fixtures/rimap-tool-schemas/. Run after
+# changing any tool response struct (<Tool>Meta or <Tool>Untrusted).
+# CI fails on a non-empty diff under that directory.
+regen-tool-schemas:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    out_dir="crates/rimap-server/tests/fixtures/rimap-tool-schemas"
+    mkdir -p "$out_dir"
+    cargo build -p rimap-server --bin rusty-imap-mcp \
+        --features test-support --locked --quiet
+    dump="$(cargo run --quiet -p rimap-server --features test-support \
+        --bin rusty-imap-mcp -- dump-tool-schemas)"
+    # Split the top-level object into one file per tool. Sort keys
+    # so the on-disk byte order is deterministic across runs.
+    python3 - "$dump" "$out_dir" <<'PY'
+import json, sys, pathlib
+dump, out_dir = sys.argv[1], pathlib.Path(sys.argv[2])
+data = json.loads(dump)
+for tool, schema in sorted(data.items()):
+    path = out_dir / f"{tool}.schema.json"
+    path.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n")
+PY
+```
+
+- [ ] **Step 2: Run the recipe to generate the initial fixtures**
+
+Run: `just regen-tool-schemas`
+Expected: 16 files appear under `crates/rimap-server/tests/fixtures/rimap-tool-schemas/`. List them:
+```bash
+ls crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+```
+Expected names:
+```
+add_label.schema.json
+create_draft.schema.json
+download_attachment.schema.json
+fetch_message.schema.json
+flag.schema.json
+list_accounts.schema.json
+list_attachments.schema.json
+list_folders.schema.json
+list_labels.schema.json
+mark_read.schema.json
+mark_unread.schema.json
+move_message.schema.json
+remove_label.schema.json
+search.schema.json
+unflag.schema.json
+use_account.schema.json
+```
+
+- [ ] **Step 3: Spot-check one generated schema**
+
+Run: `python3 -c "import json; print(json.load(open('crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json'))['properties'].keys())"`
+Expected: `dict_keys(['meta', 'untrusted'])`
+
+- [ ] **Step 4: Verify the recipe is idempotent**
+
+Run: `just regen-tool-schemas && git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/`
+Expected: exit 0 (no diff). If a diff appears, the dump output is non-deterministic — fix by sorting in `build_schemas` (already BTreeMap) or in the Python splitter (already `sort_keys=True`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add justfile crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+git commit -m "build: add just regen-tool-schemas recipe + initial fixtures
+
+Generates one JSON Schema file per in-scope tool from the new
+dump-tool-schemas subcommand. Schemas are committed; Phase 3 CI step
+(separate commit) runs the recipe and fails on non-empty diff.
+"
+```
+
+---
+
+## Task 4: CI tool-schema drift detector
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Inspect existing job layout to choose the placement**
+
+Run: `grep -nE "^  [a-z-]+:|name:" .github/workflows/ci.yml | head -40`
+Expected: a list of jobs including `test (stable)`. Pick a placement after the existing test job and before `mcp-conformance-node` (so build artifacts can be reused if caching is in place; if not, the job is independent).
+
+- [ ] **Step 2: Add the drift job**
+
+Append the following job to `.github/workflows/ci.yml` (adjust indentation to match the existing file):
+
+```yaml
+  tool-schema-drift:
+    name: tool-schema drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<sha>  # vX.Y.Z   ← match the SHA already used elsewhere in this file
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@<sha>  # stable
+      - uses: Swatinem/rust-cache@<sha>  # vX.Y.Z
+      - name: Regenerate tool schemas
+        run: just regen-tool-schemas
+      - name: Verify no schema drift
+        run: |
+          git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/ \
+            || { echo "::error::Tool response struct changed without rerunning just regen-tool-schemas"; exit 1; }
+```
+
+Use the exact SHA + version pins already present in `.github/workflows/ci.yml` for `actions/checkout`, `dtolnay/rust-toolchain`, and `Swatinem/rust-cache`. Run: `grep -nE "uses: (actions/checkout|dtolnay/rust-toolchain|Swatinem/rust-cache)" .github/workflows/ci.yml` to find them.
+
+- [ ] **Step 3: Lint the workflow**
+
+Run: `actionlint .github/workflows/ci.yml && zizmor .github/workflows/ci.yml`
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add tool-schema drift detector (#265)
+
+Runs just regen-tool-schemas and fails the build if any file under
+crates/rimap-server/tests/fixtures/rimap-tool-schemas/ changes.
+Mirrors the Phase 1 MCP spec drift detector at
+.github/workflows/mcp-spec-drift.yml.
+"
+```
+
+---
+
+## Task 5: Extract Phase 1 harness into `tests/support/wire/`
+
+**Files:**
+- Create: `crates/rimap-server/tests/support/mod.rs`
+- Create: `crates/rimap-server/tests/support/wire/mod.rs`
+- Create: `crates/rimap-server/tests/support/wire/harness.rs`
+- Create: `crates/rimap-server/tests/support/wire/schema.rs`
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs`
+
+This task is a refactor — no test behavior changes. Phase 1's nine tests continue to pass byte-for-byte.
+
+- [ ] **Step 1: Create `tests/support/mod.rs`**
+
+```rust
+//! Shared support for `rimap-server` integration tests. Re-exports
+//! the wire driver (Phase 1 + Phase 3) and the Dovecot harness
+//! (Phase 3 + the legacy `e2e_full_session`).
+//!
+//! Each integration-test file pulls this in with
+//! `#[path = "support/mod.rs"] mod support;` at the top.
+
+#![expect(dead_code, reason = "different test files use different subsets")]
+
+pub mod wire;
+// `pub mod dovecot;` added in Task 6.
+```
+
+- [ ] **Step 2: Create `tests/support/wire/mod.rs`**
+
+```rust
+//! Wire driver and MCP spec schema validators shared by Phase 1
+//! (`mcp_wire_conformance.rs`) and Phase 3 (`e2e_wire.rs`).
+
+pub mod harness;
+pub mod schema;
+
+pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
+pub use schema::{assert_envelope_valid, assert_valid, validator_for};
+```
+
+- [ ] **Step 3: Move `Harness` + constants into `tests/support/wire/harness.rs`**
+
+Copy verbatim from `crates/rimap-server/tests/mcp_wire_conformance.rs` lines 30-200 (the `PINNED_PROTOCOL_VERSION`, `MCP_SCHEMA_JSON`, `REQUEST_TIMEOUT`, `SHUTDOWN_TIMEOUT` constants, and the `Harness` struct + `impl Harness`). Adjust the file header so it reads:
+
+```rust
+//! Stdio JSON-RPC harness used by both Phase 1 (`mcp_wire_conformance.rs`)
+//! and Phase 3 (`e2e_wire.rs`). Spawns the production `rusty-imap-mcp`
+//! binary with `--features test-support` and exchanges line-delimited
+//! JSON-RPC envelopes over stdin/stdout. See
+//! `docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md`
+//! and the Phase 3 sibling spec for the design context.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+```
+
+Re-export `MCP_SCHEMA_JSON` as `pub(crate) const`. Make `Harness`, its impl methods, the constants, and `REQUEST_TIMEOUT` / `SHUTDOWN_TIMEOUT` `pub`. Do not move the `validator_for` / `assert_*` helpers yet — those go in `schema.rs` in the next step.
+
+- [ ] **Step 4: Move validator helpers into `tests/support/wire/schema.rs`**
+
+Move `validator_for`, `assert_valid`, `assert_envelope_valid`, and the `MCP_SCHEMA_JSON` import into `schema.rs`:
+
+```rust
+//! MCP-spec JSON Schema validators shared by Phase 1 and Phase 3.
+//! `validator_for(fragment)` caches per-fragment validators in a
+//! process-wide map; the parsed spec document is parsed exactly once.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde_json::{Value, json};
+
+use super::harness::MCP_SCHEMA_JSON;
+
+pub fn validator_for(fragment: &'static str) -> Arc<jsonschema::Validator> {
+    // BODY copied verbatim from mcp_wire_conformance.rs lines 206-257
+}
+
+pub fn assert_valid(value: &Value, fragment: &'static str) {
+    // BODY copied verbatim from mcp_wire_conformance.rs lines 261-270
+}
+
+pub fn assert_envelope_valid(response: &Value) {
+    // BODY copied verbatim from mcp_wire_conformance.rs lines 279-298
+}
+```
+
+- [ ] **Step 5: Replace the inline definitions in `mcp_wire_conformance.rs`**
+
+Replace the moved content in `crates/rimap-server/tests/mcp_wire_conformance.rs` (top of file through line ~298) with:
+
+```rust
+//! MCP wire-shape conformance harness (issue #263, Phase 1).
+//!
+//! Drives the production `rusty-imap-mcp` binary over stdio with a
+//! zero-account config and validates every response against the
+//! vendored MCP spec schemas. See
+//! `docs/superpowers/specs/2026-05-12-mcp-wire-conformance-design.md`.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::time::Duration;
+
+use rmcp::model::ProtocolVersion;
+use serde_json::json;
+
+use support::wire::{
+    Harness, PINNED_PROTOCOL_VERSION, assert_envelope_valid, assert_valid, validator_for,
+};
+```
+
+Leave the nine `#[tokio::test]` test bodies (currently from line ~300 to end) byte-for-byte unchanged. They reference `Harness`, `PINNED_PROTOCOL_VERSION`, `assert_envelope_valid`, `assert_valid`, and `validator_for` — all now imported.
+
+The `Harness::spawn` body that builds the zero-account TOML stays in `support::wire::harness` for now (Task 7 splits it).
+
+- [ ] **Step 6: Run Phase 1's test suite to verify zero behavior change**
+
+Run: `cargo nextest run -p rimap-server --test mcp_wire_conformance --locked`
+Expected: all 9 tests pass.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/ crates/rimap-server/tests/mcp_wire_conformance.rs
+git commit -m "refactor(test): extract Phase 1 wire harness into tests/support/wire
+
+Pure relocation: tests/support/{mod.rs,wire/{mod.rs,harness.rs,schema.rs}}
+own the Harness, constants, and MCP spec schema validators that
+mcp_wire_conformance.rs used to declare inline. Test bodies and
+assertions are unchanged; the file imports the moved items via
+#[path = \"support/mod.rs\"] mod support; use support::wire::…;.
+
+Sets up the shared driver Phase 3 (#265) builds on.
+"
+```
+
+---
+
+## Task 6: Extract `DovecotHarness` into `tests/support/dovecot/`
+
+**Files:**
+- Create: `crates/rimap-server/tests/support/dovecot/mod.rs`
+- Create: `crates/rimap-server/tests/support/dovecot/harness.rs`
+- Modify: `crates/rimap-server/tests/support/mod.rs`
+- Modify: `crates/rimap-server/tests/e2e.rs`
+
+Also a refactor. `e2e_full_session` continues to pass byte-for-byte.
+
+- [ ] **Step 1: Create `tests/support/dovecot/mod.rs`**
+
+```rust
+//! Dovecot container harness and seeded-fixture helpers shared by
+//! `e2e.rs` (in-process Rust API) and `e2e_wire.rs` (stdio wire).
+
+pub mod harness;
+// `pub mod fixtures;` added in Task 9.
+
+pub use harness::DovecotHarness;
+```
+
+- [ ] **Step 2: Move `DovecotHarness` into `tests/support/dovecot/harness.rs`**
+
+Move the following items verbatim from `crates/rimap-server/tests/e2e.rs` lines 49-274:
+
+- `runtime()`, `binary_present()`, `runtime_available()`
+- `container_name(project)`
+- `DovecotHarness` struct + `impl DovecotHarness { try_start, create_mailbox }`
+- `wait_for_ready`, `compose_down`, `read_fingerprint`
+- `ReservedPort` struct + impl
+- `is_port_collision`
+- `impl Drop for DovecotHarness`
+
+File header:
+
+```rust
+//! Dovecot container harness lifted from the original
+//! `crates/rimap-server/tests/e2e.rs`. Honors the same env vars
+//! (`RIMAP_CONTAINER_TOOL`, `RIMAP_REQUIRE_DOCKER`) and silently skips
+//! on non-x86_64 hosts or when no container runtime is available.
+//! See `AGENTS.md` "Container runtime for integration tests".
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test diagnostics")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use rimap_core::TlsFingerprint;
+```
+
+Make `DovecotHarness` and its public methods (`try_start`, `create_mailbox`, `fingerprint()`, `port()`) `pub`. Add small `pub fn` accessors if any test code currently reaches into the struct fields directly (none in `e2e.rs`).
+
+- [ ] **Step 3: Update `tests/support/mod.rs`**
+
+Add `pub mod dovecot;` to the file from Task 5 step 1.
+
+- [ ] **Step 4: Replace the moved content in `e2e.rs`**
+
+In `crates/rimap-server/tests/e2e.rs`, replace lines 49-274 (the harness section) with:
+
+```rust
+#[path = "support/mod.rs"]
+mod support;
+
+use support::dovecot::DovecotHarness;
+```
+
+Leave the `StaticCreds`, `TestEnv`, `build_test_env`, and all the `assert_*` test functions byte-for-byte unchanged. They reference `DovecotHarness` — now imported.
+
+- [ ] **Step 5: Run `e2e_full_session` to verify zero behavior change**
+
+This needs Docker (or Podman). If unavailable locally, document the skip and rely on CI to verify. If available:
+
+Run: `cargo nextest run -p rimap-server --test e2e --locked --no-fail-fast --no-capture`
+Expected: `e2e_full_session` passes (or silently returns when no container runtime is present, same as before).
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/dovecot/ crates/rimap-server/tests/support/mod.rs crates/rimap-server/tests/e2e.rs
+git commit -m "refactor(test): extract DovecotHarness into tests/support/dovecot
+
+Pure relocation: tests/support/dovecot/{mod.rs,harness.rs} own the
+container lifecycle helpers that e2e.rs declared inline. Test bodies
+and assertions are unchanged; the file imports the moved harness via
+use support::dovecot::DovecotHarness;.
+
+Sets up shared infrastructure Phase 3 (#265) builds on.
+"
+```
+
+---
+
+## Task 7: Add `Harness::spawn_with_config` and stderr capture
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+
+This split lets Phase 3 reuse the harness with a Dovecot-backed config TOML instead of the inline zero-account TOML. Stderr capture lands in the same task because both changes touch the spawn path.
+
+- [ ] **Step 1: Refactor `Harness::spawn` to delegate to `spawn_with_config`**
+
+In `tests/support/wire/harness.rs`, replace the existing `pub async fn spawn() -> Self` with:
+
+```rust
+impl Harness {
+    /// Spawn with the legacy zero-account config (Phase 1 default).
+    /// Builds a multi-account TOML with `accounts = []`, an audit
+    /// path under a fresh tempdir, and calls `spawn_with_config`.
+    #[expect(clippy::unused_async, reason = "uniform async surface")]
+    pub async fn spawn() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+        Self::spawn_with_config(&config_path, tempdir, &[]).await
+    }
+
+    /// Spawn the binary against a caller-supplied config. The
+    /// `tempdir` is held by the returned `Harness` so its lifetime
+    /// covers the child process's audit path.
+    ///
+    /// `extra_envs` is forwarded to the child verbatim. Phase 3 uses
+    /// this to inject `RUSTY_IMAP_MCP_PASSWORD` (the env-var
+    /// fallback for the keyring) without polluting the test
+    /// process's env.
+    pub async fn spawn_with_config(
+        config_path: &std::path::Path,
+        tempdir: TempDir,
+        extra_envs: &[(&str, &str)],
+    ) -> Self {
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(config_path)
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        for (k, v) in extra_envs {
+            cmd.env(k, v);
+        }
+
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let stderr = child.stderr.take().expect("stderr");
+
+        // Drain stderr into a shared buffer so the binary's tracing
+        // output is included in panic messages on assertion failure.
+        let stderr_buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let stderr_clone = Arc::clone(&stderr_buf);
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut reader = stderr;
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if let Ok(mut guard) = stderr_clone.lock() {
+                            guard.extend_from_slice(&buf[..n]);
+                            // Bound the buffer to avoid OOM on a chatty child;
+                            // the head is the most useful diagnostic anyway.
+                            const CAP: usize = 64 * 1024;
+                            if guard.len() > CAP {
+                                guard.truncate(CAP);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            child,
+            stdin,
+            stdout,
+            stderr_buf,
+            next_id: 0,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Snapshot the captured stderr for diagnostic messages.
+    pub fn captured_stderr(&self) -> String {
+        self.stderr_buf
+            .lock()
+            .map(|g| String::from_utf8_lossy(&g).into_owned())
+            .unwrap_or_default()
+    }
+}
+```
+
+- [ ] **Step 2: Add the new fields to the struct**
+
+In the same file, update `struct Harness`:
+
+```rust
+pub struct Harness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    /// Stderr drain buffer, updated by a background task.
+    stderr_buf: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    next_id: u64,
+    _tempdir: TempDir,
+}
+```
+
+- [ ] **Step 3: Surface captured stderr in panic paths**
+
+In the `request` method's existing expect-on-read-line, change:
+
+```rust
+let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
+    .await
+    .expect("response within timeout")
+    .expect("read response");
+```
+
+to:
+
+```rust
+let read = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf))
+    .await
+    .unwrap_or_else(|_| panic!(
+        "response within timeout for {method}; child stderr:\n{}",
+        self.captured_stderr()
+    ))
+    .unwrap_or_else(|e| panic!(
+        "read response for {method}: {e}; child stderr:\n{}",
+        self.captured_stderr()
+    ));
+```
+
+Use the same pattern in `assert_no_response_within` and `shutdown_and_wait` for their panic branches.
+
+- [ ] **Step 4: Rerun Phase 1's tests**
+
+Run: `cargo nextest run -p rimap-server --test mcp_wire_conformance --locked`
+Expected: all 9 tests pass. Stderr capture is invisible to them on the happy path.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "feat(test): add Harness::spawn_with_config + stderr capture
+
+spawn_with_config takes a caller-built config path and a list of extra
+envs, letting Phase 3 (#265) point the spawned binary at a Dovecot-
+backed two-account TOML and inject RUSTY_IMAP_MCP_PASSWORD without
+polluting the test process. spawn() becomes a thin wrapper that
+builds the zero-account TOML and delegates.
+
+stderr is now piped and drained into a bounded buffer so a wire-call
+panic includes the binary's tracing output — the highest-signal
+diagnostic when a response is unexpected.
+"
+```
+
+---
+
+## Task 8: `validator_for_tool_response` helper
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/schema.rs`
+- Modify: `crates/rimap-server/tests/support/wire/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/rimap-server/tests/support/wire/schema.rs`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tool_response_tests {
+    use super::*;
+
+    #[test]
+    fn validates_a_well_formed_list_folders_response() {
+        let validator = validator_for_tool_response("list_folders");
+        let valid = serde_json::json!({
+            "meta": { "folders": [] }
+        });
+        assert!(validator.is_valid(&valid));
+    }
+
+    #[test]
+    fn rejects_a_response_missing_meta() {
+        let validator = validator_for_tool_response("list_folders");
+        let invalid = serde_json::json!({ "something_else": 1 });
+        assert!(!validator.is_valid(&invalid));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p rimap-server --tests support::wire::schema -- --nocapture`
+Expected: FAIL — `validator_for_tool_response` is not defined.
+
+Note: this is an integration-test-only inline test. `cargo test --tests` finds it via the `support` module included from `mcp_wire_conformance.rs` or another integration target. If the inline `mod tool_response_tests` cannot be reached because no integration test pulls it in yet, add a trivial `#[test]` in `mcp_wire_conformance.rs` that imports the helper — and remove that import after Task 10 covers it organically. Simpler alternative: put the test inside `tests/e2e_wire.rs` (created in Task 10) instead.
+
+For this plan, prefer the simpler alternative: hold the test until Task 10, and instead verify the implementation in Step 4 below by adding a `cargo check` step that confirms the new function compiles.
+
+- [ ] **Step 3: Add the helper**
+
+Append to `tests/support/wire/schema.rs`:
+
+```rust
+/// Compile (lazily, cached) a validator for the per-tool response
+/// schema at `tests/fixtures/rimap-tool-schemas/<tool>.schema.json`.
+/// Panics in the test process if the fixture is missing — that's the
+/// signal that `just regen-tool-schemas` was not run.
+pub fn validator_for_tool_response(tool: &'static str) -> Arc<jsonschema::Validator> {
+    type Cache = Mutex<HashMap<&'static str, Arc<jsonschema::Validator>>>;
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    {
+        let guard = cache.lock().expect("tool schema cache mutex poisoned");
+        if let Some(v) = guard.get(tool) {
+            return Arc::clone(v);
+        }
+    }
+
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/rimap-tool-schemas")
+        .join(format!("{tool}.schema.json"));
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "missing tool-response schema fixture for {tool} at {}: {e}\n\
+             Run `just regen-tool-schemas` to regenerate.",
+            path.display()
+        )
+    });
+    let parsed: Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("invalid JSON in {}: {e}", path.display()));
+    let compiled = jsonschema::validator_for(&parsed)
+        .unwrap_or_else(|e| panic!("invalid JSON Schema in {}: {e}", path.display()));
+    let arc = Arc::new(compiled);
+
+    let mut guard = cache.lock().expect("tool schema cache mutex poisoned");
+    let entry = guard.entry(tool).or_insert_with(|| Arc::clone(&arc));
+    Arc::clone(entry)
+}
+```
+
+- [ ] **Step 4: Re-export from `support::wire`**
+
+Add to `tests/support/wire/mod.rs`:
+
+```rust
+pub use schema::{
+    assert_envelope_valid, assert_valid, validator_for, validator_for_tool_response,
+};
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check -p rimap-server --tests --all-features --locked`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/
+git commit -m "feat(test): add validator_for_tool_response helper
+
+Loads and caches a validator per <tool>.schema.json under
+tests/fixtures/rimap-tool-schemas/. Panics with an actionable
+diagnostic (\"Run just regen-tool-schemas\") if the fixture is
+missing. Phase 3 wire flow uses this to validate every tool/call
+result against the schema regenerated from the Rust output structs.
+"
+```
+
+---
+
+## Task 9: Multipart MIME seed fixture + Dovecot config builder
+
+**Files:**
+- Create: `crates/rimap-server/tests/support/dovecot/fixtures.rs`
+- Create: `crates/rimap-server/tests/support/wire/config.rs`
+- Modify: `crates/rimap-server/tests/support/dovecot/mod.rs`
+- Modify: `crates/rimap-server/tests/support/wire/mod.rs`
+
+- [ ] **Step 1: Create `tests/support/dovecot/fixtures.rs`**
+
+```rust
+//! Seed fixtures used by the wire-driven e2e tests. Constants and
+//! builders live here so the seed bytes and the assertion-side bytes
+//! reference the same source — no "what was seeded" / "what to check"
+//! duplication.
+
+/// Filename declared in the attachment's `Content-Disposition`.
+pub const ATTACHMENT_FILENAME: &str = "attached.bin";
+
+/// Known byte payload of the attachment. 32 deterministic bytes —
+/// large enough that an off-by-one in part extraction is visible, small
+/// enough to print in test panic messages.
+pub const ATTACHMENT_BYTES: &[u8] = &[
+    0x52, 0x49, 0x4d, 0x41, 0x50, 0x2d, 0x50, 0x33, 0x2d, 0x41, 0x54, 0x54, 0x41, 0x43, 0x48, 0x45,
+    0x44, 0x2d, 0x42, 0x59, 0x54, 0x45, 0x53, 0x2d, 0x32, 0x30, 0x32, 0x36, 0x2d, 0x30, 0x35, 0x12,
+];
+
+/// MIME boundary for the multipart container. Fixed so the message
+/// bytes are deterministic across runs.
+const BOUNDARY: &str = "rimap-p3-boundary-c0ffee";
+
+/// Plain-text body content. Asserted by `fetch_message` in the wire flow.
+pub const PLAIN_BODY: &str = "Hello from the Phase 3 wire-driven e2e smoke test.";
+
+/// Returns the raw bytes of a `multipart/mixed` MIME message suitable
+/// for `Connection::append_message`. Contains one `text/plain` part
+/// with `PLAIN_BODY` and one `application/octet-stream` attachment
+/// part with filename `ATTACHMENT_FILENAME` and payload `ATTACHMENT_BYTES`.
+///
+/// The Content-Transfer-Encoding for the attachment is `base64`. The
+/// returned bytes are CRLF-terminated as required by RFC 5322.
+pub fn multipart_with_attachment() -> Vec<u8> {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+    let attachment_b64 = STANDARD.encode(ATTACHMENT_BYTES);
+    let mut wrapped = String::new();
+    // 76-char lines per RFC 2045.
+    for chunk in attachment_b64.as_bytes().chunks(76) {
+        wrapped.push_str(std::str::from_utf8(chunk).unwrap_or_default());
+        wrapped.push_str("\r\n");
+    }
+
+    let body = format!(
+        "From: sender@example.com\r\n\
+         To: rimap-test@localhost\r\n\
+         Subject: e2e-wire-test-smoke\r\n\
+         Date: Sat, 12 May 2026 10:00:00 +0000\r\n\
+         Message-ID: <e2e-wire-smoke-001@example.com>\r\n\
+         MIME-Version: 1.0\r\n\
+         Content-Type: multipart/mixed; boundary=\"{BOUNDARY}\"\r\n\
+         \r\n\
+         --{BOUNDARY}\r\n\
+         Content-Type: text/plain; charset=utf-8\r\n\
+         Content-Transfer-Encoding: 7bit\r\n\
+         \r\n\
+         {PLAIN_BODY}\r\n\
+         --{BOUNDARY}\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Disposition: attachment; filename=\"{ATTACHMENT_FILENAME}\"\r\n\
+         Content-Transfer-Encoding: base64\r\n\
+         \r\n\
+         {wrapped}\r\n\
+         --{BOUNDARY}--\r\n",
+    );
+
+    body.into_bytes()
+}
+```
+
+Add `base64` to `[dev-dependencies]` in `crates/rimap-server/Cargo.toml` if it's not already present. Check first:
+
+```bash
+grep -nE "^base64" Cargo.toml crates/rimap-server/Cargo.toml
+```
+
+If missing, append to `crates/rimap-server/Cargo.toml` under `[dev-dependencies]`:
+
+```toml
+base64 = { workspace = true }
+```
+
+And verify the workspace declares it; if not, add to `Cargo.toml` `[workspace.dependencies]`:
+
+```toml
+base64 = "0.22"
+```
+
+(Look up the current stable version before committing — never assume.)
+
+- [ ] **Step 2: Re-export from `support::dovecot`**
+
+Update `tests/support/dovecot/mod.rs`:
+
+```rust
+pub mod harness;
+pub mod fixtures;
+
+pub use harness::DovecotHarness;
+```
+
+- [ ] **Step 3: Create `tests/support/wire/config.rs`**
+
+```rust
+//! Two-account multi-account TOML builder for Phase 3's wire-driven
+//! Dovecot e2e. Both accounts target the same Dovecot user
+//! (`rimap-test@dovecot`); the surface under test is the posture
+//! matrix on the wire, not authentication isolation.
+
+use std::path::Path;
+
+use crate::support::dovecot::DovecotHarness;
+
+/// Build the multi-account TOML for `e2e_wire.rs`. Caller is
+/// responsible for writing the returned string to `config_path` and
+/// for placing `audit_path` and `download_dir` inside `allowed_base`.
+pub fn build_dovecot_config(
+    dovecot: &DovecotHarness,
+    audit_path: &Path,
+    allowed_base: &Path,
+    download_dir: &Path,
+) -> String {
+    let fingerprint_hex = dovecot.fingerprint().to_hex();
+    let port = dovecot.port();
+    format!(
+        r#"
+[audit]
+path = "{audit_path}"
+allowed_base_dir = "{allowed_base}"
+
+[attachments]
+download_dir = "{download_dir}"
+
+[defaults.credentials]
+fallback = "keyring-then-env"
+
+[[accounts]]
+name = "draftsafe"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = {port}
+username = "rimap-test"
+encryption = "tls"
+tls_fingerprint_sha256 = "{fingerprint_hex}"
+
+[accounts.security]
+posture = "draft-safe"
+
+[[accounts]]
+name = "readonly"
+
+[accounts.imap]
+host = "127.0.0.1"
+port = {port}
+username = "rimap-test"
+encryption = "tls"
+tls_fingerprint_sha256 = "{fingerprint_hex}"
+
+[accounts.security]
+posture = "read-only"
+"#,
+        audit_path = audit_path.display(),
+        allowed_base = allowed_base.display(),
+        download_dir = download_dir.display(),
+        port = port,
+        fingerprint_hex = fingerprint_hex,
+    )
+}
+```
+
+If `DovecotHarness::fingerprint()` or `DovecotHarness::port()` do not exist (they were private fields originally), add the accessors in `tests/support/dovecot/harness.rs`:
+
+```rust
+impl DovecotHarness {
+    pub fn fingerprint(&self) -> &TlsFingerprint { &self.fingerprint }
+    pub fn port(&self) -> u16 { self.port }
+}
+```
+
+`TlsFingerprint::to_hex` already exists (see `crates/rimap-core/src/tls.rs`). Verify with `grep -n "fn to_hex\|fn as_hex" crates/rimap-core/src/tls.rs`. If the method is named differently, adjust the call site to match.
+
+- [ ] **Step 4: Re-export from `support::wire`**
+
+Update `tests/support/wire/mod.rs`:
+
+```rust
+pub mod config;
+pub mod harness;
+pub mod schema;
+
+pub use config::build_dovecot_config;
+pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
+pub use schema::{
+    assert_envelope_valid, assert_valid, validator_for, validator_for_tool_response,
+};
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check -p rimap-server --tests --all-features --locked`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/dovecot/ crates/rimap-server/tests/support/wire/config.rs crates/rimap-server/tests/support/wire/mod.rs crates/rimap-server/Cargo.toml Cargo.toml
+git commit -m "feat(test): add multipart seed + Dovecot config builder
+
+multipart_with_attachment() builds the raw bytes of a multipart/mixed
+message with a known text/plain body and a 32-byte octet-stream
+attachment. build_dovecot_config() composes the two-account TOML
+(draftsafe + readonly) Phase 3's wire-driven e2e spawns the binary
+against. Both helpers live in tests/support so the new e2e_wire.rs
+and any future suite share the same fixtures.
+
+Adds base64 as a dev-dep (already in workspace) to encode the
+attachment payload into the MIME part.
+"
+```
+
+---
+
+## Task 10: `e2e_wire.rs` — full-session draft-safe wire flow
+
+**Files:**
+- Create: `crates/rimap-server/tests/e2e_wire.rs`
+
+This is the largest task. Each step adds one slice of the flow and is independently runnable.
+
+- [ ] **Step 1: Scaffold + initialize handshake**
+
+Create `crates/rimap-server/tests/e2e_wire.rs`:
+
+```rust
+//! Phase 3 wire-driven Dovecot e2e (#265). Drives `rusty-imap-mcp`
+//! over its stdio JSON-RPC wire against the existing Dovecot
+//! container fixture, exercising every draft-safe + read-only
+//! posture tool category and validating each response against
+//! Phase 1's vendored MCP spec schemas + per-tool response schemas
+//! under `tests/fixtures/rimap-tool-schemas/`.
+//!
+//! Silent-skip when no container runtime is available or the host
+//! arch is not x86_64; `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test diagnostics")]
+#![expect(clippy::unwrap_used, reason = "integration tests")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rimap_audit::{AuditOptions, AuditWriter, Seq};
+use rimap_config::credential::{CredentialStore, KeyringCredentialResolver, PASSWORD_ENV_VAR};
+use rimap_config::model::FallbackMode;
+use rimap_imap::{Connection, ConnectionConfig, ImapEncryption};
+use rmcp::model::ProtocolVersion;
+use secrecy::SecretString;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use support::dovecot::{DovecotHarness, fixtures};
+use support::wire::{
+    Harness, assert_envelope_valid, assert_valid, build_dovecot_config,
+    validator_for, validator_for_tool_response,
+};
+
+/// Dovecot's seeded test password. Matches the value injected via the
+/// docker-compose fixture; see e2e.rs StaticCreds for the in-process equivalent.
+const DOVECOT_PASSWORD: &str = "testpass";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wire_e2e_full_session_draft_safe() {
+    let Some(dovecot) = DovecotHarness::try_start() else {
+        return; // silent skip — matches e2e_full_session
+    };
+    dovecot.create_mailbox("Drafts");
+    dovecot.create_mailbox("Trash");
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path().to_path_buf();
+    let download_dir = tempdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("mkdir download_dir");
+
+    seed_multipart_message(&dovecot).await;
+
+    let config_path = tempdir.path().join("config.toml");
+    let config = build_dovecot_config(&dovecot, &audit_path, &allowed_base, &download_dir);
+    std::fs::write(&config_path, config).expect("write config");
+
+    let envs = [(PASSWORD_ENV_VAR, DOVECOT_PASSWORD)];
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &envs).await;
+
+    // Subsequent steps fill in the flow.
+    let init = harness.initialize_handshake().await;
+    let init_result = &init["result"];
+    assert_valid(init_result, "InitializeResult");
+    assert!(init_result["capabilities"]["tools"].is_object());
+    harness.send_initialized().await;
+
+    let _audit = audit_path; // used in the audit-assertion step below
+    let _ = harness.shutdown_and_wait().await;
+}
+
+async fn seed_multipart_message(dovecot: &DovecotHarness) {
+    // Build a Connection that mirrors e2e.rs's test_connection but
+    // sources credentials from a static stub. The seed is in-process
+    // so the wire surface remains the surface under test.
+    let audit_dir = TempDir::new().expect("seed-audit tempdir");
+    let audit = AuditWriter::open(&AuditOptions {
+        path: audit_dir.path().join("seed.jsonl"),
+        rotate_bytes: 0,
+        rotate_keep: 0,
+        retention_seconds: None,
+        fail_open: false,
+        initial_seq: Seq::FIRST,
+    })
+    .expect("audit open");
+
+    let cfg = ConnectionConfig {
+        account: None,
+        account_id: rimap_core::account::AccountId::default_account(),
+        host: "127.0.0.1".into(),
+        port: dovecot.port(),
+        encryption: ImapEncryption::Tls,
+        username: "rimap-test".into(),
+        pinned_fingerprint: Some(*dovecot.fingerprint()),
+        connect_timeout: Duration::from_secs(10),
+        command_timeout: Duration::from_secs(30),
+        max_fetch_body_bytes: 5_242_880,
+        max_append_bytes: 10_485_760,
+    };
+    struct StaticCreds;
+    impl CredentialStore for StaticCreds {
+        fn get_password(
+            &self,
+            _: &str,
+        ) -> Result<Option<SecretString>, rimap_config::ConfigError> {
+            Ok(Some(SecretString::from(DOVECOT_PASSWORD.to_string())))
+        }
+        #[expect(clippy::panic_in_result_fn, reason = "seed never writes")]
+        fn set_password(&self, _: &str, _: &str) -> Result<(), rimap_config::ConfigError> {
+            panic!("seed never writes credentials")
+        }
+    }
+    let store: Arc<dyn CredentialStore> = Arc::new(StaticCreds);
+    let creds: Arc<dyn rimap_core::CredentialResolver> = Arc::new(
+        KeyringCredentialResolver::new(store, FallbackMode::KeyringThenEnv),
+    );
+    let sink: Arc<dyn rimap_core::auth_sink::AuthEventSink> = Arc::new(audit.clone());
+    let conn = Connection::new(cfg, sink, creds);
+    conn.append_message("INBOX", &fixtures::multipart_with_attachment(), &[], &[])
+        .await
+        .expect("APPEND multipart seed");
+}
+```
+
+- [ ] **Step 2: Run the scaffold to verify it spawns + handshakes**
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked --no-capture`
+Expected: 1 test (`wire_e2e_full_session_draft_safe`) passes (Docker required). If no Docker available locally, run without `RIMAP_REQUIRE_DOCKER` and confirm it returns silently.
+
+- [ ] **Step 3: Add tools/list assertions + namespace check**
+
+Insert after `harness.send_initialized().await;`:
+
+```rust
+    let tools_list = harness.request("tools/list", json!({})).await;
+    assert_valid(&tools_list["result"], "ListToolsResult");
+    let tools: BTreeMap<String, Value> = tools_list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| (t["name"].as_str().expect("name").to_string(), t.clone()))
+        .collect();
+
+    // Draft-safe namespace advertises mutating tools.
+    for required in [
+        "draftsafe.list_folders",
+        "draftsafe.search",
+        "draftsafe.fetch_message",
+        "draftsafe.list_attachments",
+        "draftsafe.download_attachment",
+        "draftsafe.list_labels",
+        "draftsafe.mark_read",
+        "draftsafe.mark_unread",
+        "draftsafe.flag",
+        "draftsafe.unflag",
+        "draftsafe.add_label",
+        "draftsafe.remove_label",
+        "draftsafe.move_message",
+        "draftsafe.create_draft",
+        // Infrastructure tools are NOT namespaced.
+        "list_accounts",
+        "use_account",
+    ] {
+        assert!(tools.contains_key(required), "missing tool: {required}");
+    }
+
+    // Read-only namespace HIDES mutating tools.
+    for forbidden in [
+        "readonly.move_message",
+        "readonly.create_draft",
+        "readonly.mark_read",
+        "readonly.mark_unread",
+        "readonly.flag",
+        "readonly.unflag",
+        "readonly.add_label",
+        "readonly.remove_label",
+    ] {
+        assert!(
+            !tools.contains_key(forbidden),
+            "readonly namespace must not advertise {forbidden}",
+        );
+    }
+```
+
+- [ ] **Step 4: Drive each draft-safe tool through the wire**
+
+Insert a `call_and_validate` helper inside the test function (or above as a free fn) and the per-tool calls. Helper:
+
+```rust
+async fn call_tool(harness: &mut Harness, name: &str, args: Value) -> Value {
+    let resp = harness.request(
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    ).await;
+    assert_envelope_valid(&resp);
+    assert!(resp["error"].is_null(), "tool {name} failed: {resp}");
+    let body = &resp["result"]["structuredContent"];
+    // Per-tool schema: name is the bare tool name without the namespace prefix.
+    let bare = name.rsplit_once('.').map(|(_, b)| b).unwrap_or(name);
+    let validator = validator_for_tool_response(bare);
+    if !validator.is_valid(body) {
+        let errors: Vec<String> = validator.iter_errors(body).map(|e| e.to_string()).collect();
+        panic!("tool {name} response failed schema:\n  {}\n\nresponse: {body}",
+            errors.join("\n  "));
+    }
+    body.clone()
+}
+```
+
+Then the call sequence (replace the `let _audit = ...; let _ = harness.shutdown_and_wait()...` placeholder):
+
+```rust
+    // 1. list_folders — assert INBOX present
+    let folders = call_tool(&mut harness, "draftsafe.list_folders", json!({})).await;
+    let folder_names: Vec<&str> = folders["meta"]["folders"]
+        .as_array().expect("folders").iter()
+        .filter_map(|f| f["name"].as_str()).collect();
+    assert!(folder_names.contains(&"INBOX"), "INBOX missing: {folder_names:?}");
+
+    // 2. search — round-trip the seed uid
+    let search = call_tool(&mut harness, "draftsafe.search",
+        json!({"folder": "INBOX", "subject": "e2e-wire-test-smoke"})).await;
+    assert!(search["meta"]["total_matched"].as_u64().unwrap() >= 1);
+    let seed_uid = u32::try_from(
+        search["untrusted"]["messages"][0]["uid"].as_u64().expect("uid"),
+    ).expect("uid fits u32");
+    assert!(seed_uid > 0);
+
+    // 3. fetch_message — assert plain body
+    let fetched = call_tool(&mut harness, "draftsafe.fetch_message",
+        json!({"folder": "INBOX", "uid": seed_uid})).await;
+    assert!(
+        fetched["untrusted"]["body_text"].as_str().unwrap_or("")
+            .contains(fixtures::PLAIN_BODY),
+        "fetch_message body missing expected content: {fetched}",
+    );
+
+    // 4. list_attachments — must surface the seeded attachment
+    let attachments = call_tool(&mut harness, "draftsafe.list_attachments",
+        json!({"folder": "INBOX", "uid": seed_uid})).await;
+    let parts = attachments["untrusted"]["attachments"]
+        .as_array().expect("attachments array");
+    assert!(!parts.is_empty(), "attachments must be non-empty");
+    let part = &parts[0];
+    let part_id = part["part_id"].as_str().expect("part_id");
+    assert!(!part_id.is_empty(), "part_id must be non-empty");
+
+    // 5. download_attachment — bytes must equal the seed payload
+    let download = call_tool(&mut harness, "draftsafe.download_attachment",
+        json!({"folder": "INBOX", "uid": seed_uid, "part_id": part_id})).await;
+    let path_str = download["meta"]["path"].as_str().expect("download path");
+    let path = std::path::Path::new(path_str);
+    assert!(path.starts_with(&download_dir),
+        "downloaded path {} must be inside {}", path.display(), download_dir.display());
+    let bytes = std::fs::read(path).expect("read downloaded attachment");
+    assert_eq!(bytes, fixtures::ATTACHMENT_BYTES, "attachment bytes mismatch");
+
+    // 6. list_labels — empty or pre-seeded, just validate the shape
+    let _ = call_tool(&mut harness, "draftsafe.list_labels",
+        json!({"folder": "INBOX"})).await;
+
+    // 7. mark_read / mark_unread / flag / unflag — exercise both ToolName variants
+    for tool in ["draftsafe.mark_read", "draftsafe.mark_unread",
+                 "draftsafe.flag", "draftsafe.unflag"] {
+        call_tool(&mut harness, tool,
+            json!({"folder": "INBOX", "uid": seed_uid})).await;
+    }
+
+    // 8. add_label / remove_label
+    call_tool(&mut harness, "draftsafe.add_label",
+        json!({"folder": "INBOX", "uid": seed_uid, "label": "phase3-test"})).await;
+    call_tool(&mut harness, "draftsafe.remove_label",
+        json!({"folder": "INBOX", "uid": seed_uid, "label": "phase3-test"})).await;
+
+    // 9. create_draft × 2 — bare and reply-to
+    call_tool(&mut harness, "draftsafe.create_draft", json!({
+        "to": [{"address": "dest@example.com"}],
+        "subject": "wire-bare-draft",
+        "body_text": "bare",
+    })).await;
+    call_tool(&mut harness, "draftsafe.create_draft", json!({
+        "to": [{"address": "reply@example.com"}],
+        "subject": "Re: e2e-wire-test-smoke",
+        "body_text": "Acknowledged.",
+        "in_reply_to_uid": seed_uid,
+        "in_reply_to_folder": "INBOX",
+    })).await;
+
+    // 10. move_message → re-search to confirm gone from INBOX
+    call_tool(&mut harness, "draftsafe.move_message", json!({
+        "folder": "INBOX",
+        "destination": "Trash",
+        "uid": seed_uid,
+    })).await;
+    let after = call_tool(&mut harness, "draftsafe.search",
+        json!({"folder": "INBOX", "subject": "e2e-wire-test-smoke"})).await;
+    assert_eq!(after["meta"]["total_matched"].as_u64().unwrap(), 0);
+
+    // 11. use_account → switch to readonly, list_accounts as infrastructure tool
+    call_tool(&mut harness, "use_account", json!({"account": "readonly"})).await;
+    let accounts = call_tool(&mut harness, "list_accounts", json!({})).await;
+    let names: Vec<&str> = accounts["meta"]["accounts"]
+        .as_array().expect("accounts").iter()
+        .filter_map(|a| a["name"].as_str()).collect();
+    assert!(names.contains(&"draftsafe") && names.contains(&"readonly"));
+```
+
+Tool input shapes above mirror the existing handlers — verify each against the schemars-generated input schema if a call fails. If a tool name is namespaced differently or an input field name is wrong, follow the failure message back to the corresponding handler under `crates/rimap-server/src/tools/` and adjust the JSON argument.
+
+- [ ] **Step 5: Add audit assertions + clean shutdown**
+
+Replace the trailing `let _ = harness.shutdown_and_wait()...` with:
+
+```rust
+    let status = harness.shutdown_and_wait().await;
+    assert!(status.success(), "child must exit 0, got {status:?}");
+
+    let records = read_audit_records(&audit_path);
+
+    // Pairing: every tool_start has a tool_end with matching start_seq.
+    let starts: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_start").collect();
+    let ends: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_end").collect();
+    assert_eq!(starts.len(), ends.len(),
+        "tool_start/tool_end mismatch: {} starts, {} ends", starts.len(), ends.len());
+    for start in &starts {
+        let seq = &start["seq"];
+        let paired = ends.iter().find(|e| e["start_seq"] == *seq);
+        assert!(paired.is_some(),
+            "no tool_end paired with tool_start seq {seq}: {start}");
+    }
+
+    // Namespace: every account-scoped tool_* record carries `account = "draftsafe"`.
+    let account_scoped_tools: std::collections::HashSet<&str> = [
+        "list_folders", "search", "fetch_message", "list_attachments",
+        "download_attachment", "list_labels", "mark_read", "mark_unread",
+        "flag", "unflag", "add_label", "remove_label", "move_message",
+        "create_draft",
+    ].into_iter().collect();
+    for r in &records {
+        let kind = r["kind"].as_str().unwrap_or("");
+        if !matches!(kind, "tool_start" | "tool_end") { continue; }
+        let tool = r["tool"].as_str().unwrap_or("");
+        if account_scoped_tools.contains(tool) {
+            assert_eq!(r["account"].as_str(), Some("draftsafe"),
+                "account-scoped {kind} for {tool} must record account=\"draftsafe\": {r}");
+        }
+        if matches!(tool, "use_account" | "list_accounts") {
+            assert!(r["account"].is_null(),
+                "infrastructure {kind} for {tool} must record account=null: {r}");
+        }
+    }
+```
+
+Add the helper:
+
+```rust
+fn read_audit_records(path: &std::path::Path) -> Vec<Value> {
+    let contents = std::fs::read_to_string(path).expect("read audit log");
+    contents.lines()
+        .map(|line| serde_json::from_str(line).expect("parse audit line"))
+        .collect()
+}
+```
+
+- [ ] **Step 6: Run the full test**
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire wire_e2e_full_session_draft_safe --locked --no-capture --no-fail-fast`
+Expected: PASS. If individual tool calls fail, the wire harness's stderr capture will include the binary's tracing output in the panic message; adjust the argument JSON or the assertion to match the handler's actual contract.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/tests/e2e_wire.rs
+git commit -m "test(server): add Phase 3 wire-driven Dovecot e2e (#265)
+
+wire_e2e_full_session_draft_safe spawns rusty-imap-mcp against a
+two-account Dovecot-backed config and exercises every draft-safe
+tool over the stdio JSON-RPC wire: list_folders, search,
+fetch_message, list_attachments, download_attachment (with byte
+equality vs the seeded payload), list_labels, mark_read/unread,
+flag/unflag, add_label/remove_label, create_draft × 2, move_message,
+use_account, list_accounts.
+
+Every response validates against (a) the vendored MCP envelope/method
+schemas and (b) the per-tool response schema under
+tests/fixtures/rimap-tool-schemas/.
+
+Audit log assertions verify tool_start/tool_end pairing
+(start_seq correlation) and namespace attribution
+(account-scoped records carry account=\"draftsafe\";
+infrastructure records carry account=None).
+
+The readonly-posture sibling test lands in a follow-up commit.
+"
+```
+
+---
+
+## Task 11: `e2e_wire.rs` — read-only posture denial
+
+**Files:**
+- Modify: `crates/rimap-server/tests/e2e_wire.rs` (append a second test)
+
+- [ ] **Step 1: Append the test scaffold**
+
+At the bottom of `tests/e2e_wire.rs`, before the `read_audit_records` helper:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wire_e2e_readonly_posture_denial() {
+    let Some(dovecot) = DovecotHarness::try_start() else {
+        return;
+    };
+    let tempdir = TempDir::new().expect("tempdir");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path().to_path_buf();
+    let download_dir = tempdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("mkdir download_dir");
+
+    let config_path = tempdir.path().join("config.toml");
+    let config = build_dovecot_config(&dovecot, &audit_path, &allowed_base, &download_dir);
+    std::fs::write(&config_path, config).expect("write config");
+
+    let envs = [(PASSWORD_ENV_VAR, DOVECOT_PASSWORD)];
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &envs).await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // Negative tools/list check: readonly.move_message must NOT appear.
+    let tools_list = harness.request("tools/list", json!({})).await;
+    let names: Vec<&str> = tools_list["result"]["tools"]
+        .as_array().expect("tools").iter()
+        .filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"draftsafe.move_message"));
+    assert!(!names.contains(&"readonly.move_message"),
+        "readonly.move_message must not be advertised; got {names:?}");
+
+    // Posture denial on the wire.
+    let resp = harness.request(
+        "tools/call",
+        json!({
+            "name": "readonly.move_message",
+            "arguments": {"folder": "INBOX", "destination": "Trash", "uid": 1},
+        }),
+    ).await;
+    assert_envelope_valid(&resp);
+    assert!(resp["error"].is_object(), "expected error envelope, got {resp}");
+
+    // Pin the observed posture-denial code. If rmcp's error mapping or
+    // the posture-denial bridge changes, update this constant and
+    // document why — silent drift in posture wire shape is exactly
+    // what this test surfaces. Matches Phase 1's -32602 pin pattern.
+    const POSTURE_DENIAL_CODE: i64 = -32602;
+    assert_eq!(resp["error"]["code"].as_i64(), Some(POSTURE_DENIAL_CODE),
+        "posture-denial wire code drifted; got {resp}");
+
+    let status = harness.shutdown_and_wait().await;
+    assert!(status.success(), "child must exit 0, got {status:?}");
+
+    // Audit: exactly one tool_start for readonly.move_message paired
+    // with a tool_end, both carrying account="readonly".
+    let records = read_audit_records(&audit_path);
+    let starts: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "move_message")
+        .collect();
+    assert_eq!(starts.len(), 1, "expected exactly one move_message tool_start");
+    assert_eq!(starts[0]["account"].as_str(), Some("readonly"),
+        "tool_start.account must be \"readonly\" (not collapsed to None): {records:#?}");
+
+    let ends: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "move_message")
+        .collect();
+    assert_eq!(ends.len(), 1);
+    assert_eq!(ends[0]["account"].as_str(), Some("readonly"));
+    assert_eq!(ends[0]["start_seq"], starts[0]["seq"]);
+}
+```
+
+- [ ] **Step 2: Verify the actual posture-denial wire code**
+
+If `POSTURE_DENIAL_CODE = -32602` is wrong, the assertion fails with the observed value in the panic message. Read the panic, update the constant to match, and add a comment explaining what it is (e.g. `// rmcp INVALID_PARAMS = -32602; posture denials bridge through ErrorData::invalid_params(...)`).
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial --locked --no-capture`
+
+Expected after pin: PASS.
+
+- [ ] **Step 3: Run clippy + both tests**
+
+Run: `cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings`
+Expected: clean.
+
+Run: `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked --no-capture`
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/e2e_wire.rs
+git commit -m "test(server): add Phase 3 read-only posture denial test (#265)
+
+wire_e2e_readonly_posture_denial verifies that
+1. readonly.move_message is NOT advertised on tools/list,
+2. tools/call against readonly.move_message returns the pinned
+   posture-denial JSON-RPC error envelope, and
+3. the audit log records a tool_start+tool_end pair carrying
+   account=\"readonly\" (not collapsed to legacy None) — proving the
+   audit boundary is correctly scoped under the read-only namespace
+   even though DEFAULT_ACCOUNT_NAME would collapse it.
+
+The wire error code is pinned in a constant with a comment so silent
+drift in rmcp's error mapping or the posture-denial bridge surfaces
+as an immediate test failure with the observed value in the panic.
+"
+```
+
+---
+
+## Task 12: CI — Phase 3 target with zero-tests-selected guard
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a zero-tests guard step to the existing `test (stable)` job**
+
+The workspace nextest run (`cargo nextest run --workspace --locked --no-tests=pass`) already picks up `e2e_wire` because it's an integration test under the `rimap-server` crate. But that flag is `--no-tests=pass`, which would silently green-light a `e2e_wire` file rename. Add an explicit guard step.
+
+Find the existing `test (stable)` job block (around line 66). After its existing `cargo nextest run --workspace ...` step, append:
+
+```yaml
+      - name: Phase 3 wire e2e — fail if zero tests selected
+        run: |
+          cargo nextest run -p rimap-server --test e2e_wire \
+            --locked --no-tests=fail \
+            --no-capture
+        env:
+          RIMAP_REQUIRE_DOCKER: "1"
+```
+
+`--no-tests=fail` is the nextest flag that exits non-zero when the filter selects zero tests. If a future commit renames or deletes `e2e_wire.rs`, this step fails immediately with `no tests to run`.
+
+If the runner does not have Docker available, drop `RIMAP_REQUIRE_DOCKER` — but every linux GHA runner has Docker; the env var ensures a missing-runtime regression in the GHA image fails loudly.
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `actionlint .github/workflows/ci.yml && zizmor .github/workflows/ci.yml`
+Expected: no warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add Phase 3 wire e2e step with zero-tests guard (#265)
+
+The workspace nextest run already executes e2e_wire because it's an
+integration test under rimap-server, but it uses --no-tests=pass which
+would silently green-light a future rename. Add an explicit step that
+targets `--test e2e_wire` with --no-tests=fail; if the filter ever
+matches zero tests the step exits non-zero. RIMAP_REQUIRE_DOCKER=1
+upgrades a missing-runtime regression in the GHA image from a silent
+skip to a loud failure.
+"
+```
+
+---
+
+## Task 13: Wall-time measurement + AGENTS.md docs
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Measure wall time**
+
+Run on a warm machine:
+```bash
+RIMAP_REQUIRE_DOCKER=1 time cargo nextest run -p rimap-server --test e2e_wire --locked --no-capture
+```
+Record the elapsed wall time. Expected: 10–25 s (Dovecot bring-up dominates).
+
+- [ ] **Step 2: Decide whether env-flag gating is required**
+
+If wall time ≤ 60 s: no gating change needed.
+If wall time > 60 s: add a `RIMAP_RUN_E2E_WIRE` opt-in gate to both tests (early return when not set + `RIMAP_REQUIRE_DOCKER` is also unset). Document the threshold trigger in `AGENTS.md`.
+
+- [ ] **Step 3: Update `AGENTS.md`**
+
+Find the "Container runtime for integration tests" section (around line 64). After it, insert a new subsection:
+
+```markdown
+### Wire-driven Dovecot e2e (Phase 3, #265)
+
+`crates/rimap-server/tests/e2e_wire.rs` drives the production binary
+over its stdio JSON-RPC wire against the same Dovecot fixture
+`e2e_full_session` uses. It exercises every draft-safe and read-only
+posture tool, validates every response against the vendored MCP spec
+schemas + per-tool schemas under
+`crates/rimap-server/tests/fixtures/rimap-tool-schemas/`, and asserts
+audit-log pairing + namespace attribution.
+
+- Wall time: ~XX s on a warm developer machine; ~YY s on CI.
+  *(Fill in after the measurement step.)*
+- Gating: silent-skip when no container runtime is present;
+  `RIMAP_REQUIRE_DOCKER=1` flips to loud failure. Same convention
+  as the legacy in-process `e2e_full_session`.
+- Schema regen: when changing any `<Tool>Meta` or `<Tool>Untrusted`
+  struct in `crates/rimap-server/src/tools/`, run
+  `just regen-tool-schemas` and commit the diff. CI fails on a
+  non-empty diff under `tests/fixtures/rimap-tool-schemas/`.
+- Specs: see `docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md`.
+```
+
+Also append the spec to the "Source of truth" paragraph at the top of `AGENTS.md` (around line 22). After `2026-05-12-mcp-conformance-node-design.md`, add:
+
+```
+The Phase 3 behavioral-conformance spec
+(`2026-05-12-mcp-behavioral-conformance-design.md`) covers the
+wire-driven Dovecot e2e harness for tool dispatch + audit-log
+attribution.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: document Phase 3 wire e2e in AGENTS.md (#265)
+
+Add a Wire-driven Dovecot e2e subsection under Container runtime for
+integration tests with the measured wall-time, the gating convention,
+the schema regen requirement, and a spec cross-link.
+"
+```
+
+---
+
+## Task 14: Phase 1 + Phase 2 regression smoke
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Run Phase 1's full suite**
+
+Run: `cargo nextest run -p rimap-server --test mcp_wire_conformance --locked --no-capture`
+Expected: 9 tests pass. If any fail, the Task 5 extraction broke a subtle behavior — bisect against the Task 5 commit.
+
+- [ ] **Step 2: Run Phase 2's Node suite**
+
+Run: `just mcp-conformance-node`
+Expected: green. If the new test-support subcommand or feature wiring broke the binary spawn, this surfaces it.
+
+- [ ] **Step 3: Run the full local-CI equivalent**
+
+Run: `just ci`
+Expected: green.
+
+- [ ] **Step 4: No code commit — verification only**
+
+If anything fails, return to the offending task and fix forward. Do not commit a "fixup" that masks the regression; trace it back.
+
+---
+
+## Self-review notes
+
+Performed during plan authorship; no separate commit required.
+
+1. **Spec coverage:** Each section of the spec maps to a task — §3.1 layout → Tasks 5/6/9; §3.3 test-support layer → Tasks 1/2/3; §4.1 Harness extraction → Task 5; §4.2 DovecotHarness extraction → Task 6; §4.3 schema validator → Task 8; §4.4 dump-tool-schemas → Tasks 1/2/3; §4.5/§5.1 full-session test → Task 10; §4.6 multi-account config → Task 9; §5.2 posture-denial test → Task 11; §5.3 multipart seed → Task 9; §6 stderr capture → Task 7; §7.1 drift detector → Task 4; §7.3 wall-time + §7.4 CI → Tasks 12/13; §8 acceptance criteria → covered across Tasks 4/10/11/12/13.
+
+2. **Placeholder scan:** Wall-time numbers in Task 13 are deliberately measured at execution time (`XX`, `YY` are placeholders to fill from real output, not "TBD"). The posture-denial code constant in Task 11 has a documented fallback path (read panic message, update constant). The `<sha>` action pins in Task 4 are explicit "look up the SHA already used in this file" instructions, not unfilled blanks.
+
+3. **Type consistency:** `Harness::spawn_with_config(&Path, TempDir, &[(&str, &str)])` is used identically in Tasks 7, 10, 11. `validator_for_tool_response(&'static str)` defined in Task 8, called in Task 10. `DovecotHarness::fingerprint()` / `port()` defined in Task 9 Step 3 (with the "if not already present" guard), called in Tasks 9 and 10. `fixtures::PLAIN_BODY`, `fixtures::ATTACHMENT_BYTES`, `fixtures::ATTACHMENT_FILENAME` defined in Task 9, used in Task 10.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved. Use the writing-plans skill's execution-handoff prompt to pick subagent-driven vs inline.

--- a/docs/superpowers/plans/2026-05-12-mcp-behavioral-conformance-plan.md
+++ b/docs/superpowers/plans/2026-05-12-mcp-behavioral-conformance-plan.md
@@ -48,9 +48,14 @@
 
 ---
 
-## Task 1: Add `schemars::JsonSchema` derives to 14 tool response structs
+## Task 1: Add `schemars::JsonSchema` derives across `rimap-content` and `rimap-server`
 
 **Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.dependencies]` — enable schemars `time` feature)
+- Modify: `crates/rimap-content/Cargo.toml`
+- Modify: `crates/rimap-content/src/output.rs:80-160` (AttachmentMeta, SecurityWarning, WarningCode)
+- Modify: `crates/rimap-server/Cargo.toml` (propagate test-support feature)
+- Modify: `crates/rimap-server/src/mcp/response.rs:14-26` (ToolResponse envelope)
 - Modify: `crates/rimap-server/src/tools/admin/accounts.rs:16-44`
 - Modify: `crates/rimap-server/src/tools/admin/list_folders.rs:82-130`
 - Modify: `crates/rimap-server/src/tools/mailbox/labels.rs:111-140`
@@ -58,18 +63,107 @@
 - Modify: `crates/rimap-server/src/tools/mailbox/move_message.rs:40-60`
 - Modify: `crates/rimap-server/src/tools/compose/create_draft.rs:14-30`
 - Modify: `crates/rimap-server/src/tools/retrieval/search.rs:54-100`
-- Modify: `crates/rimap-server/src/tools/retrieval/fetch_message.rs:35-60`
-- Modify: `crates/rimap-server/src/tools/retrieval/list_attachments.rs:31-70`
-- Modify: `crates/rimap-server/src/tools/retrieval/download_attachment.rs:39-80`
+- Modify: `crates/rimap-server/src/tools/retrieval/fetch_message.rs:35-71`
+- Modify: `crates/rimap-server/src/tools/retrieval/list_attachments.rs:31-60`
+- Modify: `crates/rimap-server/src/tools/retrieval/download_attachment.rs:39-65`
 
-- [ ] **Step 1: Verify schemars is already in scope (no Cargo.toml change required)**
+**Why this is bigger than the original draft.** Codex adversarial review (#1) flagged that the wire envelope `ToolResponse<M, U>` carries a top-level `security_warnings: Vec<rimap_content::SecurityWarning>` field (see `crates/rimap-server/src/mcp/response.rs:24`), and `FetchMessageUntrusted::attachments: Vec<rimap_content::AttachmentMeta>` references another nested rimap-content type. `rimap-content` has no schemars dependency today, and `String`-fallback `schemars(with = ...)` would produce a schema that doesn't describe the actual wire bytes for these structured fields. So this task must:
 
-Run: `grep -nE "^schemars" /Users/dave/src/rusty-imap-mcp/Cargo.toml /Users/dave/src/rusty-imap-mcp/crates/rimap-server/Cargo.toml`
-Expected: `Cargo.toml:194:schemars = "1.0"` and `rimap-server/Cargo.toml:53:schemars = { workspace = true }`. No change needed.
+1. Add an opt-in `test-support` feature to `rimap-content` that pulls in `schemars` and derives `JsonSchema` on the wire-facing public types.
+2. Propagate the feature through `rimap-server`'s `test-support` feature.
+3. Tighten the gate from `any(test, feature = "test-support")` to just `feature = "test-support"` everywhere — `rimap-content`'s `cfg(test)` builds otherwise need schemars unconditionally, which churns the dep graph without benefit. The Task 2 inline tests already run via `cargo test --features test-support` so the narrower gate is sufficient.
 
-- [ ] **Step 2: Add the derive to every in-scope struct**
+- [ ] **Step 1: Enable schemars `time` feature in the workspace**
 
-For each struct listed in the file table for this task, replace its existing derive line. Example for `crates/rimap-server/src/tools/mailbox/flags.rs:47`:
+`FetchMessageUntrusted::date` is `time::OffsetDateTime`, which serializes as an RFC 3339 string on the wire. schemars 1.0 ships `JsonSchema` impls for the `time` crate behind a feature flag. Edit `Cargo.toml` at the workspace `[workspace.dependencies]` line for schemars (currently `schemars = "1.0"`):
+
+```toml
+schemars = { version = "1.0", features = ["time"] }
+```
+
+- [ ] **Step 2: Add a `test-support` feature to `rimap-content`**
+
+Edit `crates/rimap-content/Cargo.toml`. Under `[features]`, add:
+
+```toml
+# Optional JsonSchema derives on the wire-facing public types
+# (SecurityWarning, WarningCode, AttachmentMeta). Enabled transitively
+# by rimap-server's test-support feature so Phase 3's wire-conformance
+# harness can generate schemas for the full response envelope. Off in
+# production — schemars stays out of the runtime dep graph.
+test-support = ["dep:schemars"]
+```
+
+Under `[dependencies]`, add (it must be `optional = true` so the feature gate is meaningful):
+
+```toml
+schemars = { workspace = true, optional = true }
+```
+
+- [ ] **Step 3: Add `JsonSchema` derives to `rimap_content` wire-facing types**
+
+In `crates/rimap-content/src/output.rs`, add the derive next to the existing `Serialize` derive on each of:
+
+- `AttachmentMeta` (line 82)
+- `SecurityWarning` (line 118)
+- `WarningCode` enum (look up via `grep -n "pub enum WarningCode" crates/rimap-content/src/output.rs`)
+
+Pattern:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
+pub struct AttachmentMeta {
+    // unchanged fields
+}
+```
+
+If any nested field type (e.g. inner enums on `WarningCode`) lacks `JsonSchema`, follow the chain and derive on it too. The full transitive closure must be feasible without `with = "String"` fallbacks — Codex review #1 explicitly rules those out for structured wire fields.
+
+- [ ] **Step 4: Propagate the feature through `rimap-server`**
+
+Edit `crates/rimap-server/Cargo.toml`. Replace:
+
+```toml
+test-support = ["rimap-config/test-support"]
+```
+
+with:
+
+```toml
+test-support = ["rimap-config/test-support", "rimap-content/test-support"]
+```
+
+- [ ] **Step 5: Add the derive to `ToolResponse`**
+
+Edit `crates/rimap-server/src/mcp/response.rs:14-25`. Replace the struct definition with:
+
+```rust
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
+pub struct ToolResponse<M: Serialize = serde_json::Value, U: Serialize = serde_json::Value> {
+    pub meta: M,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub untrusted: Option<U>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security_warnings: Vec<rimap_content::SecurityWarning>,
+}
+```
+
+The generic bounds need updating — `schemars::JsonSchema` for the impl. Add `JsonSchema` to the `M` and `U` bounds **only** when the feature is on:
+
+```rust
+#[cfg(feature = "test-support")]
+impl<M: Serialize + schemars::JsonSchema, U: Serialize + schemars::JsonSchema> ToolResponse<M, U> {
+    // (no new methods — the bound carries through the derive)
+}
+```
+
+If the derive macro refuses the bound combination, fall back to a manual `JsonSchema` impl that emits the `{meta, untrusted?, security_warnings?}` shape with `for_M`/`for_U` recursion. Document the fallback inline if used.
+
+- [ ] **Step 6: Add the derive to the 14 rimap-server response structs**
+
+For each struct, add the derive next to the existing `Serialize` derive. Use the narrower gate:
 
 ```rust
 // before
@@ -77,10 +171,10 @@ For each struct listed in the file table for this task, replace its existing der
 
 // after
 #[derive(Debug, Serialize)]
-#[cfg_attr(any(test, feature = "test-support"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "test-support", derive(schemars::JsonSchema))]
 ```
 
-Apply the same two-line pattern to each of these structs (every one already has `#[derive(Debug, Serialize)]`):
+Apply to each of these structs (every one already has `#[derive(Debug, Serialize)]`):
 
 - `accounts.rs`: `UseAccountMeta`, `AccountEntry`, `ListAccountsMeta`
 - `list_folders.rs`: every `#[derive(Debug, Serialize)]` struct in the file (currently `ListFoldersMeta` + 1 helper at line 82)
@@ -89,37 +183,45 @@ Apply the same two-line pattern to each of these structs (every one already has 
 - `move_message.rs`: `MoveEntry`, `MoveMessageMeta`
 - `create_draft.rs`: `CreateDraftMeta`
 - `search.rs`: `SearchResultEntry`, `SearchMeta`, `SearchUntrusted`
-- `fetch_message.rs`: `FetchMessageMeta`, `FetchMessageUntrusted`
+- `fetch_message.rs`: `FetchMessageMeta`, `FetchMessageUntrusted` (the `Vec<rimap_content::AttachmentMeta>` field is now schema-able from Step 3; the `Option<time::OffsetDateTime>` field is schema-able from Step 1's `time` feature)
 - `list_attachments.rs`: `AttachmentInfo`, `ListAttachmentsMeta`, `ListAttachmentsUntrusted`
 - `download_attachment.rs`: `DownloadAttachmentMeta`, `DownloadAttachmentUntrusted`
 
-If a nested type does not implement `JsonSchema` (e.g. a third-party type), apply `#[cfg_attr(any(test, feature = "test-support"), schemars(with = "String"))]` on the offending field as a fallback.
+Do NOT use `schemars(with = "String")` as a fallback on any structured field — the schema would then misdescribe the wire shape (Codex review #1).
 
-- [ ] **Step 3: Verify the workspace still compiles with the feature off**
+- [ ] **Step 7: Verify the workspace still compiles with the feature off**
 
 Run: `cargo check -p rimap-server --locked`
 Expected: clean compile. (Production build does not enable `test-support`, so derives are inert.)
 
-- [ ] **Step 4: Verify the workspace still compiles with the feature on**
+- [ ] **Step 8: Verify the workspace still compiles with the feature on**
 
 Run: `cargo check -p rimap-server --features test-support --locked`
-Expected: clean compile.
+Expected: clean compile. If a `JsonSchema` derive fails because of a missing trait bound, locate the offending nested type and either (a) derive `JsonSchema` on it under the same gate, or (b) replace the field type with one that does — never `String` fallback for structured wire fields.
 
-- [ ] **Step 5: Run clippy with `-D warnings` to catch derive-induced lints**
+- [ ] **Step 9: Run clippy with `-D warnings` to catch derive-induced lints**
 
 Run: `cargo clippy -p rimap-server --features test-support --all-targets --locked -- -D warnings`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
-git add crates/rimap-server/src/tools/
-git commit -m "feat(server): add schemars derives to tool response structs
+git add Cargo.toml crates/rimap-content/Cargo.toml crates/rimap-content/src/output.rs \
+        crates/rimap-server/Cargo.toml crates/rimap-server/src/mcp/response.rs \
+        crates/rimap-server/src/tools/
+git commit -m "feat: add schemars derives for Phase 3 wire conformance (#265)
 
-Test-support-only derives on every <Tool>Meta and <Tool>Untrusted in
-scope for Phase 3 wire conformance (#265). Gated behind
-cfg(any(test, feature = \"test-support\")) so production builds do not
-pull schemars into their dep graph.
+Adds an opt-in test-support feature to rimap-content that derives
+JsonSchema on the wire-facing public types (AttachmentMeta,
+SecurityWarning, WarningCode) and propagates the feature through
+rimap-server. Adds JsonSchema to ToolResponse and the 14 in-scope
+<Tool>Meta and <Tool>Untrusted structs, plus enables schemars's time
+feature in the workspace so OffsetDateTime fields are schema-able.
+
+The derive gate is feature = \"test-support\" only (no any(test, ...))
+so cfg(test) builds of rimap-content do not need schemars in the dep
+graph. Production builds remain unchanged.
 "
 ```
 
@@ -207,13 +309,29 @@ fn build_schemas() -> BTreeMap<&'static str, Value> {
     out
 }
 
+// Top-level wire envelope is `{meta, untrusted?, security_warnings?}`
+// per crates/rimap-server/src/mcp/response.rs:14-25. untrusted and
+// security_warnings are skip-serialize-if-empty/None, so the schema
+// makes them optional, not required.
+
+fn warnings_schema() -> Value {
+    let schema = schemars::schema_for!(rimap_content::SecurityWarning);
+    serde_json::json!({
+        "type": "array",
+        "items": schema,
+    })
+}
+
 fn meta_only<M: schemars::JsonSchema>() -> Value {
     let schema = schemars::schema_for!(M);
     serde_json::json!({
         "type": "object",
-        "properties": { "meta": schema },
+        "properties": {
+            "meta": schema,
+            "security_warnings": warnings_schema(),
+        },
         "required": ["meta"],
-        "additionalProperties": true,
+        "additionalProperties": false,
     })
 }
 
@@ -222,9 +340,13 @@ fn meta_and_untrusted<M: schemars::JsonSchema, U: schemars::JsonSchema>() -> Val
     let u = schemars::schema_for!(U);
     serde_json::json!({
         "type": "object",
-        "properties": { "meta": m, "untrusted": u },
+        "properties": {
+            "meta": m,
+            "untrusted": u,
+            "security_warnings": warnings_schema(),
+        },
         "required": ["meta", "untrusted"],
-        "additionalProperties": true,
+        "additionalProperties": false,
     })
 }
 
@@ -457,21 +579,28 @@ dump-tool-schemas subcommand. Schemas are committed; Phase 3 CI step
 Run: `grep -nE "^  [a-z-]+:|name:" .github/workflows/ci.yml | head -40`
 Expected: a list of jobs including `test (stable)`. Pick a placement after the existing test job and before `mcp-conformance-node` (so build artifacts can be reused if caching is in place; if not, the job is independent).
 
-- [ ] **Step 2: Add the drift job**
+- [ ] **Step 2: Add the drift job with the same prerequisites the existing Ubuntu Rust jobs install**
 
-Append the following job to `.github/workflows/ci.yml` (adjust indentation to match the existing file):
+The existing `test (stable)` job installs `libdbus-1-dev pkg-config` before running cargo (the keyring crate depends on libdbus on Linux), installs `just` via `taiki-e/install-action`, and pins every action to a SHA with a version comment. The drift job must mirror that setup — Codex review #2 caught the bare-uses-action version of this step as a CI failure waiting to happen. Append to `.github/workflows/ci.yml` (match indentation to the existing file):
 
 ```yaml
   tool-schema-drift:
     name: tool-schema drift
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@<sha>  # vX.Y.Z   ← match the SHA already used elsewhere in this file
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@<sha>  # stable
-      - uses: Swatinem/rust-cache@<sha>  # vX.Y.Z
+      - name: Install libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: 1.94.0) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      - uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37  # v2.75.25
+        with:
+          tool: just
       - name: Regenerate tool schemas
         run: just regen-tool-schemas
       - name: Verify no schema drift
@@ -480,7 +609,7 @@ Append the following job to `.github/workflows/ci.yml` (adjust indentation to ma
             || { echo "::error::Tool response struct changed without rerunning just regen-tool-schemas"; exit 1; }
 ```
 
-Use the exact SHA + version pins already present in `.github/workflows/ci.yml` for `actions/checkout`, `dtolnay/rust-toolchain`, and `Swatinem/rust-cache`. Run: `grep -nE "uses: (actions/checkout|dtolnay/rust-toolchain|Swatinem/rust-cache)" .github/workflows/ci.yml` to find them.
+The SHAs and version comments above are copied verbatim from the existing `test (stable)` job (see `.github/workflows/ci.yml` lines 66-83 as of branch `test/mcp-behavioral-conformance-spec`). If those pins have advanced since this plan was written, regrep them with: `grep -nE "uses: (actions/checkout|dtolnay/rust-toolchain|Swatinem/rust-cache|taiki-e/install-action)" .github/workflows/ci.yml` and update both jobs in the same commit so the pin set stays consistent.
 
 - [ ] **Step 3: Lint the workflow**
 
@@ -1501,6 +1630,12 @@ async fn call_tool(harness: &mut Harness, name: &str, args: Value) -> Value {
     ).await;
     assert_envelope_valid(&resp);
     assert!(resp["error"].is_null(), "tool {name} failed: {resp}");
+    // Validate the MCP method-result shape (CallToolResult) on top of
+    // the envelope check. Codex review #4 surfaced that the previous
+    // helper would have missed a regression that mangled the
+    // tools/call result fields outside structuredContent (e.g. the
+    // `content` array, `isError`, or any future MCP fields).
+    assert_valid(&resp["result"], "CallToolResult");
     let body = &resp["result"]["structuredContent"];
     // Per-tool schema: name is the bare tool name without the namespace prefix.
     let bare = name.rsplit_once('.').map(|(_, b)| b).unwrap_or(name);
@@ -1740,14 +1875,32 @@ async fn wire_e2e_readonly_posture_denial() {
     let _ = harness.initialize_handshake().await;
     harness.send_initialized().await;
 
-    // Negative tools/list check: readonly.move_message must NOT appear.
+    // Both negative and positive tools/list checks: readonly hides
+    // mutating tools but ADVERTISES the read tools.
     let tools_list = harness.request("tools/list", json!({})).await;
     let names: Vec<&str> = tools_list["result"]["tools"]
         .as_array().expect("tools").iter()
         .filter_map(|t| t["name"].as_str()).collect();
     assert!(names.contains(&"draftsafe.move_message"));
+    assert!(names.contains(&"readonly.list_folders"),
+        "readonly.list_folders must be advertised under the read-only namespace; got {names:?}");
     assert!(!names.contains(&"readonly.move_message"),
         "readonly.move_message must not be advertised; got {names:?}");
+
+    // Readonly success path — Codex review #3 surfaced that the
+    // original plan only exercised the denial path. A regression that
+    // broke successful readonly dispatch, advertisement, or audit
+    // attribution would pass without this. Drive a real readonly read
+    // tool, validate it through the same call_tool helper used by the
+    // draft-safe test (which itself validates envelope + CallToolResult
+    // + per-tool response schema), and assert the audit pair carries
+    // account="readonly".
+    let readonly_folders = call_tool(&mut harness, "readonly.list_folders", json!({})).await;
+    let folder_names: Vec<&str> = readonly_folders["meta"]["folders"]
+        .as_array().expect("folders").iter()
+        .filter_map(|f| f["name"].as_str()).collect();
+    assert!(folder_names.contains(&"INBOX"),
+        "readonly.list_folders did not return INBOX: {folder_names:?}");
 
     // Posture denial on the wire.
     let resp = harness.request(
@@ -1771,22 +1924,43 @@ async fn wire_e2e_readonly_posture_denial() {
     let status = harness.shutdown_and_wait().await;
     assert!(status.success(), "child must exit 0, got {status:?}");
 
-    // Audit: exactly one tool_start for readonly.move_message paired
-    // with a tool_end, both carrying account="readonly".
+    // Audit assertions cover both the success and denial paths:
+    //   1. readonly.list_folders produces a paired tool_start/tool_end
+    //      under account="readonly" — confirms successful read-only
+    //      dispatch records with the correct namespace.
+    //   2. readonly.move_message produces a paired tool_start/tool_end
+    //      under account="readonly" carrying the posture-denial
+    //      outcome — confirms denial wire records carry the correct
+    //      namespace and are not collapsed to legacy None.
     let records = read_audit_records(&audit_path);
-    let starts: Vec<&Value> = records.iter()
+
+    // Success path: list_folders pair.
+    let lf_starts: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "list_folders")
+        .collect();
+    assert_eq!(lf_starts.len(), 1, "expected exactly one list_folders tool_start");
+    assert_eq!(lf_starts[0]["account"].as_str(), Some("readonly"),
+        "readonly.list_folders tool_start must record account=\"readonly\": {records:#?}");
+    let lf_ends: Vec<&Value> = records.iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "list_folders")
+        .collect();
+    assert_eq!(lf_ends.len(), 1);
+    assert_eq!(lf_ends[0]["account"].as_str(), Some("readonly"));
+    assert_eq!(lf_ends[0]["start_seq"], lf_starts[0]["seq"]);
+
+    // Denial path: move_message pair.
+    let mm_starts: Vec<&Value> = records.iter()
         .filter(|r| r["kind"] == "tool_start" && r["tool"] == "move_message")
         .collect();
-    assert_eq!(starts.len(), 1, "expected exactly one move_message tool_start");
-    assert_eq!(starts[0]["account"].as_str(), Some("readonly"),
-        "tool_start.account must be \"readonly\" (not collapsed to None): {records:#?}");
-
-    let ends: Vec<&Value> = records.iter()
+    assert_eq!(mm_starts.len(), 1, "expected exactly one move_message tool_start");
+    assert_eq!(mm_starts[0]["account"].as_str(), Some("readonly"),
+        "readonly.move_message tool_start must record account=\"readonly\" (not collapsed to None): {records:#?}");
+    let mm_ends: Vec<&Value> = records.iter()
         .filter(|r| r["kind"] == "tool_end" && r["tool"] == "move_message")
         .collect();
-    assert_eq!(ends.len(), 1);
-    assert_eq!(ends[0]["account"].as_str(), Some("readonly"));
-    assert_eq!(ends[0]["start_seq"], starts[0]["seq"]);
+    assert_eq!(mm_ends.len(), 1);
+    assert_eq!(mm_ends[0]["account"].as_str(), Some("readonly"));
+    assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
 }
 ```
 
@@ -1810,13 +1984,17 @@ Expected: 2 tests pass.
 
 ```bash
 git add crates/rimap-server/tests/e2e_wire.rs
-git commit -m "test(server): add Phase 3 read-only posture denial test (#265)
+git commit -m "test(server): add Phase 3 read-only posture coverage (#265)
 
 wire_e2e_readonly_posture_denial verifies that
-1. readonly.move_message is NOT advertised on tools/list,
-2. tools/call against readonly.move_message returns the pinned
-   posture-denial JSON-RPC error envelope, and
-3. the audit log records a tool_start+tool_end pair carrying
+1. readonly advertises read tools (list_folders) and hides mutating
+   tools (move_message) on tools/list,
+2. tools/call readonly.list_folders succeeds end-to-end (envelope +
+   CallToolResult + per-tool schema), proving readonly dispatch and
+   advertisement work as well as denial,
+3. tools/call readonly.move_message returns the pinned posture-denial
+   JSON-RPC error envelope, and
+4. both the success and denial tool_start/tool_end audit pairs carry
    account=\"readonly\" (not collapsed to legacy None) — proving the
    audit boundary is correctly scoped under the read-only namespace
    even though DEFAULT_ACCOUNT_NAME would collapse it.

--- a/docs/superpowers/plans/2026-05-13-mcp-conformance-codex-fixes-plan.md
+++ b/docs/superpowers/plans/2026-05-13-mcp-conformance-codex-fixes-plan.md
@@ -1,0 +1,679 @@
+# Phase 3 Codex-Findings Fix Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address the two `/codex:adversarial-review` findings on branch `test/mcp-behavioral-conformance-spec` before the PR merges to `main`.
+
+**Architecture:** Two tightly-scoped tasks. Task A makes `RIMAP_REQUIRE_DOCKER=1` actually fail loudly in the Phase 3 wire e2e by mirroring `rimap-imap`'s `HarnessError` pattern. Task B fixes the structurally-broken per-tool response schemas (currently embed nested `$defs` whose `$ref`s point nowhere) and adds a regression test that compiles every fixture and validates a realistic payload.
+
+**Tech Stack:** Rust 2024 / MSRV 1.88.0. `tokio`, `jsonschema` 0.46, `schemars` 1.x, `serde_json`.
+
+**Parent branch:** continue on `test/mcp-behavioral-conformance-spec` (do NOT branch off `main`).
+**Review source:** Codex adversarial review of the branch (#265).
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `crates/rimap-server/tests/support/dovecot/harness.rs` | Modify | Replace `try_start() -> Option<Self>` with `try_start() -> Result<Self, HarnessError>`; introduce `HarnessError`; honor `RIMAP_REQUIRE_DOCKER=1` on every failure branch. |
+| `crates/rimap-server/tests/e2e.rs` | Modify | Update call site for the new `try_start` signature; on `Err(HarnessError::DockerUnavailable)` return silently, otherwise `panic!(err)`. |
+| `crates/rimap-server/tests/e2e_wire.rs` | Modify | Same call-site update in both `wire_e2e_full_session_draft_safe` and `wire_e2e_readonly_posture_denial`. |
+| `crates/rimap-server/src/cli/dump_tool_schemas.rs` | Modify | Hoist nested `$defs` from each composed envelope to the envelope root; merge across `meta`/`untrusted`/`security_warnings` with name-collision detection. |
+| `crates/rimap-server/tests/fixtures/rimap-tool-schemas/<tool>.schema.json` | Regenerate | 16 files; bytes change after Task B Step 1 lands. Commit the diff. |
+| `crates/rimap-server/tests/support/wire/schema.rs` | Modify | Add a `#[test]` (under existing `#[cfg(test)] mod tests`) that walks every fixture, compiles its validator, and asserts a constructed positive payload validates. |
+| `AGENTS.md` | Modify (light) | One-line update to the "Wire-driven Dovecot e2e" subsection noting `RIMAP_REQUIRE_DOCKER=1` now reaches every failure mode (previously the doc claimed loud-failure but the harness didn't honor it). |
+
+---
+
+## Task A: Wire `RIMAP_REQUIRE_DOCKER` through `DovecotHarness` failure paths
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/dovecot/harness.rs`
+- Modify: `crates/rimap-server/tests/e2e.rs`
+- Modify: `crates/rimap-server/tests/e2e_wire.rs`
+- Modify: `AGENTS.md` (one line)
+
+The current `DovecotHarness::try_start()` returns `Option<Self>` and silent-skips on EVERY failure (no Docker, non-x86_64, port collision, compose-up failure, readiness timeout). The Phase 3 CI step sets `RIMAP_REQUIRE_DOCKER=1` to flip silent-skip to loud-failure, but the env var is never read — a broken Docker daemon, missing compose plugin, bad image, or Dovecot startup failure can therefore green the new CI job with zero behavioral coverage.
+
+The pattern lives in `crates/rimap-imap/tests/integration/support/container.rs:53-83` (the `HarnessError` enum + `check_prerequisites()` + `RIMAP_REQUIRE_DOCKER` handling). Mirror that pattern.
+
+- [ ] **Step 1: Define `HarnessError` in `support::dovecot::harness`**
+
+In `crates/rimap-server/tests/support/dovecot/harness.rs`, near the top (after the imports, before `pub struct DovecotHarness`), add:
+
+```rust
+/// Failure modes for `DovecotHarness::try_start`. `DockerUnavailable`
+/// is the silent-skip signal: it means the host genuinely cannot run
+/// the fixture (no runtime, wrong arch). All other variants represent
+/// real infrastructure failures that should fail tests when
+/// `RIMAP_REQUIRE_DOCKER=1` is set.
+#[derive(Debug)]
+pub enum HarnessError {
+    /// No container runtime installed or host arch is not x86_64.
+    /// Skip-OK unless `RIMAP_REQUIRE_DOCKER=1`.
+    DockerUnavailable,
+    /// `compose up` failed with stderr; or the host bound every retry
+    /// port out from under us.
+    ComposeFailed(String),
+    /// Dovecot container started but never accepted connections inside
+    /// the 60-second readiness timeout.
+    ReadinessTimeout,
+    /// Could not reserve a host port via the `127.0.0.1:0` trick.
+    PortReservationFailed(String),
+    /// `compose exec ... cat /shared/fingerprint.hex` failed.
+    FingerprintReadFailed(String),
+}
+
+impl std::fmt::Display for HarnessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DockerUnavailable => {
+                f.write_str("no container runtime (docker or podman) is available")
+            }
+            Self::ComposeFailed(s) => write!(f, "compose up failed: {s}"),
+            Self::ReadinessTimeout => f.write_str("dovecot did not become ready within timeout"),
+            Self::PortReservationFailed(s) => write!(f, "host port reservation failed: {s}"),
+            Self::FingerprintReadFailed(s) => write!(f, "fingerprint read failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for HarnessError {}
+```
+
+- [ ] **Step 2: Add `check_prerequisites` helper that honors `RIMAP_REQUIRE_DOCKER`**
+
+Below the `HarnessError` impls, before `impl DovecotHarness`, add:
+
+```rust
+/// Pre-flight checks for the Dovecot fixture. Returns
+/// `Err(DockerUnavailable)` when the host genuinely can't run the
+/// container — except when `RIMAP_REQUIRE_DOCKER=1` is set, in which
+/// case every failure mode is reported as `ComposeFailed` with
+/// human-readable context so the test panics with a diagnostic
+/// instead of silent-skipping.
+fn check_prerequisites() -> Result<(), HarnessError> {
+    let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
+
+    if std::env::consts::ARCH != "x86_64" {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(format!(
+                "host arch {} cannot run amd64 dovecot image but RIMAP_REQUIRE_DOCKER=1",
+                std::env::consts::ARCH
+            )))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    if !runtime_available() {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(
+                "neither docker nor podman found but RIMAP_REQUIRE_DOCKER=1".into(),
+            ))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Refactor `try_start` to return `Result`**
+
+Change `DovecotHarness::try_start` from:
+
+```rust
+pub fn try_start() -> Option<Self> {
+    if std::env::consts::ARCH != "x86_64" { return None; }
+    if !runtime_available() { return None; }
+    // ... existing body, returning None on every failure
+}
+```
+
+To:
+
+```rust
+pub fn try_start() -> Result<Self, HarnessError> {
+    check_prerequisites()?;
+
+    let compose_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .ok_or_else(|| HarnessError::ComposeFailed("manifest dir has no parent".into()))?
+        .join("rimap-imap")
+        .join("tests")
+        .join("integration")
+        .join("dovecot");
+
+    let project = format!(
+        "rimap-e2e-{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+
+    let mut host_port = ReservedPort::acquire()
+        .ok_or_else(|| HarnessError::PortReservationFailed("acquire returned None".into()))?;
+
+    // Retry loop on port collisions — return the LAST stderr on failure.
+    const BACKOFF_MS: [u64; 2] = [50, 250];
+    const MAX_ATTEMPTS: usize = BACKOFF_MS.len() + 1;
+    let mut last_stderr = String::new();
+    for attempt in 0..MAX_ATTEMPTS {
+        if attempt > 0 {
+            compose_down(&project, &compose_dir);
+            std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS[attempt - 1]));
+            host_port = ReservedPort::acquire().ok_or_else(|| {
+                HarnessError::PortReservationFailed("retry acquire returned None".into())
+            })?;
+        }
+        host_port.release();
+
+        let output = Command::new(runtime())
+            .arg("compose")
+            .arg("-p")
+            .arg(&project)
+            .arg("up")
+            .arg("-d")
+            .env("RIMAP_DOVECOT_HOST_PORT", host_port.port().to_string())
+            .current_dir(&compose_dir)
+            .output()
+            .map_err(|e| HarnessError::ComposeFailed(format!("spawn failed: {e}")))?;
+
+        if output.status.success() {
+            return wait_for_ready(&project, host_port.port(), &compose_dir).ok_or(
+                HarnessError::ReadinessTimeout,
+            );
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        if !is_port_collision(&stderr) {
+            return Err(HarnessError::ComposeFailed(stderr));
+        }
+        last_stderr = stderr;
+    }
+
+    Err(HarnessError::ComposeFailed(format!(
+        "exhausted {MAX_ATTEMPTS} port-collision retries; last stderr: {last_stderr}",
+    )))
+}
+```
+
+Notes:
+- Keep the existing helper functions (`runtime`, `binary_present`, `runtime_available`, `wait_for_ready`, `compose_down`, `is_port_collision`, `ReservedPort`) unchanged.
+- `wait_for_ready` still returns `Option<DovecotHarness>` — convert `None` to `Err(HarnessError::ReadinessTimeout)` at the call site (as shown). Alternatively, change `wait_for_ready` itself to return `Result`, but that's a larger churn; keep the conversion at the call site to minimize blast radius.
+
+- [ ] **Step 4: Update `e2e.rs` call site**
+
+In `crates/rimap-server/tests/e2e.rs`, find the call to `DovecotHarness::try_start()` in `e2e_full_session`. Currently:
+
+```rust
+let Some(harness) = DovecotHarness::try_start() else {
+    return; // silent skip
+};
+```
+
+Replace with:
+
+```rust
+let harness = match DovecotHarness::try_start() {
+    Ok(h) => h,
+    Err(dovecot::harness::HarnessError::DockerUnavailable) => return,
+    Err(e) => panic!("Dovecot harness failed: {e}"),
+};
+```
+
+(Adjust the import path — the test file imports `dovecot::DovecotHarness` directly via `#[path]`. The error type lives in the same module; `dovecot::harness::HarnessError` works because `harness::HarnessError` is `pub` from Step 1. If the import structure differs in the actual file, use whatever path makes `HarnessError` reachable.)
+
+- [ ] **Step 5: Update `e2e_wire.rs` call sites (both tests)**
+
+In `crates/rimap-server/tests/e2e_wire.rs`, both `wire_e2e_full_session_draft_safe` and `wire_e2e_readonly_posture_denial` have:
+
+```rust
+let Some(dovecot) = DovecotHarness::try_start() else {
+    return; // silent skip
+};
+```
+
+Replace each with:
+
+```rust
+let dovecot = match DovecotHarness::try_start() {
+    Ok(d) => d,
+    Err(dovecot::harness::HarnessError::DockerUnavailable) => return,
+    Err(e) => panic!("Dovecot harness failed: {e}"),
+};
+```
+
+- [ ] **Step 6: Re-export `HarnessError` from `support::dovecot`**
+
+In `crates/rimap-server/tests/support/dovecot/mod.rs`, add `HarnessError` to the re-exports:
+
+```rust
+pub use harness::{DovecotHarness, HarnessError};
+```
+
+This lets call sites do `use dovecot::HarnessError;` instead of the deeper path.
+
+- [ ] **Step 7: Update AGENTS.md**
+
+In `AGENTS.md` under the "Wire-driven Dovecot e2e (Phase 3, #265)" subsection, find the line about `RIMAP_REQUIRE_DOCKER` and add half a sentence noting it now reaches all failure modes. Current line (approximately):
+
+```markdown
+- Gating: silent-skip when no container runtime is present;
+  `RIMAP_REQUIRE_DOCKER=1` flips to loud failure. Same convention
+  as the legacy in-process `e2e_full_session`.
+```
+
+Change to:
+
+```markdown
+- Gating: silent-skip ONLY when no container runtime is genuinely
+  unavailable (missing docker/podman or non-x86_64 host).
+  `RIMAP_REQUIRE_DOCKER=1` flips every other failure mode
+  (compose-up, readiness timeout, port reservation, fingerprint read)
+  to a panic with diagnostic context. Same convention as the legacy
+  in-process `e2e_full_session`.
+```
+
+- [ ] **Step 8: Verify**
+
+Run:
+```bash
+cargo check -p rimap-server --tests --all-features --locked
+cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings
+cargo nextest run -p rimap-server --test mcp_wire_conformance --locked
+cargo nextest run -p rimap-server --test e2e --locked
+cargo nextest run -p rimap-server --test e2e_wire --locked
+```
+
+All must pass / silent-skip locally without Docker. Then exercise the loud-failure path manually:
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked 2>&1 | tail -20
+```
+
+Expected on arm64 macOS (no Docker): the test panics with the `ComposeFailed("host arch aarch64 cannot run amd64 dovecot image but RIMAP_REQUIRE_DOCKER=1")` diagnostic. If the test silent-skips instead, the wiring is wrong — investigate.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/dovecot/ \
+        crates/rimap-server/tests/e2e.rs \
+        crates/rimap-server/tests/e2e_wire.rs \
+        AGENTS.md
+git commit -m "fix(test): honor RIMAP_REQUIRE_DOCKER in DovecotHarness failure paths (#265)
+
+Codex adversarial review caught that DovecotHarness::try_start never
+read RIMAP_REQUIRE_DOCKER — every failure (missing runtime, non-x86_64
+host, port collision, compose failure, readiness timeout) silent-
+skipped. The Phase 3 CI step sets the env var to flip silent-skip
+to loud-failure, but the harness ignored it. A broken Docker daemon
+or Dovecot startup failure in CI could green the new e2e job with
+zero behavioral coverage.
+
+Mirror the rimap-imap harness: introduce HarnessError with
+DockerUnavailable as the silent-skip signal and ComposeFailed /
+ReadinessTimeout / PortReservationFailed / FingerprintReadFailed
+as loud-failure variants. check_prerequisites honors
+RIMAP_REQUIRE_DOCKER and upgrades every silent-skip to a real
+error when set. Call sites in e2e.rs and e2e_wire.rs (both tests)
+unwrap DockerUnavailable to silent-skip and panic on everything else.
+"
+```
+
+---
+
+## Task B: Fix tool-response schema `$defs` hoisting + regression test
+
+**Files:**
+- Modify: `crates/rimap-server/src/cli/dump_tool_schemas.rs`
+- Modify: `crates/rimap-server/tests/support/wire/schema.rs`
+- Regenerate: 16 files under `crates/rimap-server/tests/fixtures/rimap-tool-schemas/`
+
+Currently `dump_tool_schemas` embeds full `schemars`-generated root schemas directly into `properties.meta` and `properties.untrusted`. Each root schema carries its own `$defs` (e.g. `SearchResultEntry`, `WarningCode`), but a `$ref: "#/$defs/SearchResultEntry"` inside the nested schema resolves against the document root — which doesn't have those defs. Result: validators either reject the schema as malformed or silently misvalidate. Confirmed in the on-disk fixtures: `search.schema.json` has `$defs` under `properties.untrusted`, NOT at the envelope root.
+
+Fix: hoist every nested `$defs` to the envelope root, with collision detection. Add a regression test that compiles every fixture and validates a payload containing a non-empty nested array plus a `security_warnings` entry.
+
+- [ ] **Step 1: Update `dump_tool_schemas.rs` helpers to hoist `$defs`**
+
+In `crates/rimap-server/src/cli/dump_tool_schemas.rs`, replace the existing `meta_only`, `meta_and_untrusted`, and `warnings_schema` helpers with:
+
+```rust
+/// Strip the `$defs` block from `value` and return the extracted defs.
+/// `value` is mutated in place: after the call it no longer carries a
+/// `$defs` key at its top level. Returns an empty `Map` if there were
+/// no defs to hoist.
+fn extract_defs(value: &mut Value) -> serde_json::Map<String, Value> {
+    let Some(obj) = value.as_object_mut() else {
+        return serde_json::Map::new();
+    };
+    match obj.remove("$defs") {
+        Some(Value::Object(defs)) => defs,
+        _ => serde_json::Map::new(),
+    }
+}
+
+/// Merge `from` into `into`. Panics if any key in `from` already
+/// exists in `into` with a different value — that would be a real
+/// name collision and we want to surface it loudly rather than
+/// silently keep one side. For Phase 3's struct set this should
+/// never trigger; schemars uses the Rust type's identifier as the
+/// def key and the four root types we compose don't share inner
+/// types with different shapes.
+fn merge_defs(
+    into: &mut serde_json::Map<String, Value>,
+    from: serde_json::Map<String, Value>,
+) {
+    for (key, value) in from {
+        match into.get(&key) {
+            None => {
+                into.insert(key, value);
+            }
+            Some(existing) if existing == &value => { /* identical, skip */ }
+            Some(existing) => {
+                panic!(
+                    "duplicate $defs key {key:?} with conflicting shapes:\nexisting: {existing}\nincoming: {value}"
+                );
+            }
+        }
+    }
+}
+
+/// `Vec<rimap_content::SecurityWarning>` schema, with its nested $defs
+/// hoisted into the caller's accumulator.
+fn warnings_schema(defs: &mut serde_json::Map<String, Value>) -> Value {
+    let mut schema = serde_json::to_value(
+        schemars::schema_for!(rimap_content::SecurityWarning),
+    )
+    .expect("SecurityWarning schema serializes");
+    merge_defs(defs, extract_defs(&mut schema));
+    serde_json::json!({
+        "type": "array",
+        "items": schema,
+    })
+}
+
+fn meta_only<M: schemars::JsonSchema>() -> Value {
+    let mut meta = serde_json::to_value(schemars::schema_for!(M))
+        .expect("meta schema serializes");
+    let mut defs = extract_defs(&mut meta);
+    let warnings = warnings_schema(&mut defs);
+
+    let mut envelope = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "meta": meta,
+            "security_warnings": warnings,
+        },
+        "required": ["meta"],
+        "additionalProperties": false,
+    });
+    if !defs.is_empty() {
+        envelope
+            .as_object_mut()
+            .expect("envelope is object")
+            .insert("$defs".to_string(), Value::Object(defs));
+    }
+    envelope
+}
+
+fn meta_and_untrusted<M: schemars::JsonSchema, U: schemars::JsonSchema>() -> Value {
+    let mut meta = serde_json::to_value(schemars::schema_for!(M))
+        .expect("meta schema serializes");
+    let mut untrusted = serde_json::to_value(schemars::schema_for!(U))
+        .expect("untrusted schema serializes");
+    let mut defs = extract_defs(&mut meta);
+    merge_defs(&mut defs, extract_defs(&mut untrusted));
+    let warnings = warnings_schema(&mut defs);
+
+    let mut envelope = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "meta": meta,
+            "untrusted": untrusted,
+            "security_warnings": warnings,
+        },
+        "required": ["meta", "untrusted"],
+        "additionalProperties": false,
+    });
+    if !defs.is_empty() {
+        envelope
+            .as_object_mut()
+            .expect("envelope is object")
+            .insert("$defs".to_string(), Value::Object(defs));
+    }
+    envelope
+}
+```
+
+Important: `$ref` strings stay literally `"#/$defs/X"` because `#` is the document root and we now have `$defs` at the document root. No string rewriting needed.
+
+- [ ] **Step 2: Update the existing inline tests in `dump_tool_schemas.rs`**
+
+The two existing `#[cfg(test)] mod tests` cases (`dump_emits_one_key_per_in_scope_tool`, `meta_and_untrusted_tools_include_untrusted_key`) still pass after the refactor because they only inspect the top-level envelope shape, not `$defs`. Confirm by running:
+
+```bash
+cargo test -p rimap-server --features test-support --bin rusty-imap-mcp -- cli::dump_tool_schemas
+```
+
+Add one more inline test that exercises the hoist:
+
+```rust
+#[test]
+fn search_schema_hoists_defs_to_envelope_root() {
+    let mut buf = Vec::new();
+    dump_tool_schemas(&mut buf).unwrap();
+    let parsed: serde_json::Map<String, Value> =
+        serde_json::from_slice(&buf).unwrap();
+
+    let search = &parsed["search"];
+    assert!(
+        search.get("$defs").is_some(),
+        "search schema must hoist nested $defs to envelope root: {search}"
+    );
+    let defs = search["$defs"].as_object().expect("$defs is an object");
+    assert!(
+        defs.contains_key("SearchResultEntry"),
+        "envelope $defs must include SearchResultEntry: {defs:?}"
+    );
+
+    // No nested $defs anywhere under properties.
+    let props = search["properties"].as_object().expect("properties");
+    for (name, sub) in props {
+        assert!(
+            sub.get("$defs").is_none(),
+            "tool subschema {name} must not carry its own $defs after hoist: {sub}"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Regenerate the 16 fixture files**
+
+```bash
+just regen-tool-schemas
+git status crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+```
+
+Expected: 14 of the 16 files change (the 2 entirely-meta-only schemas with no nested types — `mark_read`, `mark_unread` or similar — may be byte-identical depending on the structs). The bytes that move are the `$defs` blocks shifting from `properties.*.\$defs` to the envelope root.
+
+Spot-check `search.schema.json`:
+
+```bash
+python3 -c "import json; d=json.load(open('crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json')); print('top-level keys:', sorted(d.keys())); print('defs keys:', sorted(d.get('\$defs', {}).keys()))"
+```
+
+Expected output (or similar):
+```
+top-level keys: ['$defs', 'additionalProperties', 'properties', 'required', 'type']
+defs keys: ['SearchResultEntry', 'SecurityWarning', 'WarningCode', 'WarningSeverity']
+```
+
+The `$defs` is at the document root with all the nested type definitions.
+
+- [ ] **Step 4: Add a schema-compile + payload-validation smoke test**
+
+Append to `crates/rimap-server/tests/support/wire/schema.rs` (inside the existing `#[cfg(test)] mod tests` if present, or in a new `#[cfg(test)] mod fixture_smoke_tests`):
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod fixture_smoke_tests {
+    use super::*;
+
+    /// Walk every per-tool fixture under
+    /// `tests/fixtures/rimap-tool-schemas/`, compile its validator,
+    /// and confirm at least the `search` schema validates a
+    /// payload that exercises (a) a non-empty nested array and
+    /// (b) a `security_warnings` entry — both of which would silently
+    /// pass under the dangling-$ref bug if it ever regresses.
+    #[test]
+    fn every_fixture_compiles_and_search_validates_realistic_payload() {
+        let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/rimap-tool-schemas");
+        let entries: Vec<_> = std::fs::read_dir(&fixture_dir)
+            .expect("read fixture dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .ends_with(".schema.json")
+            })
+            .collect();
+        assert!(
+            entries.len() >= 14,
+            "expected ≥14 tool schema fixtures, found {}: {fixture_dir:?}",
+            entries.len()
+        );
+
+        // Compile every fixture — catches dangling $refs at validator build time.
+        for entry in &entries {
+            let path = entry.path();
+            let raw = std::fs::read_to_string(&path).expect("read fixture");
+            let parsed: serde_json::Value =
+                serde_json::from_str(&raw).unwrap_or_else(|e| panic!("invalid JSON in {path:?}: {e}"));
+            jsonschema::validator_for(&parsed)
+                .unwrap_or_else(|e| panic!("schema {path:?} failed to compile: {e}"));
+        }
+
+        // Concrete positive test: `search` schema must accept a
+        // realistic response that exercises nested refs.
+        let search = validator_for_tool_response("search");
+        let payload = serde_json::json!({
+            "meta": {
+                "total_matched": 1u64,
+                "folder": "INBOX",
+                "since": null,
+                "before": null,
+            },
+            "untrusted": {
+                "messages": [
+                    {
+                        "uid": 42u32,
+                        "subject": "x",
+                        "from": null,
+                        "date": null,
+                    }
+                ],
+            },
+            "security_warnings": [],
+        });
+        if !search.is_valid(&payload) {
+            let errors: Vec<String> = search.iter_errors(&payload).map(|e| e.to_string()).collect();
+            panic!(
+                "constructed search payload should validate; errors:\n  {}\n\npayload: {payload}",
+                errors.join("\n  ")
+            );
+        }
+    }
+}
+```
+
+Notes:
+- The `payload` JSON shape must match what `search` actually emits. The plan author hand-checked the current handler returns roughly this shape; if the test fails because schemars enforces different field types (e.g. `total_matched` as integer not u64), tweak the payload at implementation time using the schemars-generated schema as the source of truth. The point is the test catches the dangling-`$ref` bug, not that it pins the entire wire shape.
+- This test runs inline under `cargo test -p rimap-server --tests`. It does NOT need Docker.
+
+- [ ] **Step 5: Verify all the things**
+
+```bash
+cargo check -p rimap-server --tests --all-features --locked
+cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings
+cargo nextest run -p rimap-server --test mcp_wire_conformance --locked
+cargo nextest run -p rimap-server --test e2e_wire --locked
+cargo test -p rimap-server --features test-support --bin rusty-imap-mcp -- cli::dump_tool_schemas
+just regen-tool-schemas && git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+```
+
+The last line is the drift detector: after the regen the fixtures should be byte-stable (idempotent regeneration).
+
+Also run the new smoke test in isolation:
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_conformance --locked fixture_smoke
+```
+
+(Or the equivalent — whichever test binary surfaces the new test depending on which integration test file's inline test module the helper lives in.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/cli/dump_tool_schemas.rs \
+        crates/rimap-server/tests/support/wire/schema.rs \
+        crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+git commit -m "fix(test): hoist per-tool schema \$defs to envelope root (#265)
+
+Codex adversarial review caught that dump_tool_schemas embedded full
+schemars root schemas directly under properties.meta and
+properties.untrusted, leaving each nested schema's \$defs at
+properties.<x>.\$defs while \$ref strings like #/\$defs/SearchResultEntry
+resolved against the document root — which had no defs. Validators
+could either reject the schema as malformed or silently misvalidate.
+
+extract_defs + merge_defs walk every nested schema, strip its \$defs,
+and hoist them into a single envelope-root \$defs map. \$ref strings
+stay literal (they always pointed at the document root); only the
+location of the \$defs object changes.
+
+Regenerated the 16 fixture files; spot-checked search.schema.json now
+has \$defs at the envelope root with SearchResultEntry, SecurityWarning,
+WarningCode, WarningSeverity all present.
+
+A new fixture_smoke test compiles every fixture via jsonschema and
+asserts the search schema validates a constructed response carrying
+both a non-empty nested array and a security_warnings entry — both
+shapes that the bug would have silently misvalidated.
+"
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
+- [ ] `cargo nextest run -p rimap-server` passes locally (silent-skip for Docker-required tests is OK; the new smoke test runs without Docker).
+- [ ] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire` panics with `ComposeFailed(...)` on a no-Docker host (loud failure, not silent skip).
+- [ ] `just regen-tool-schemas && git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/` reports no drift after the fix.
+- [ ] All 16 fixture files have `$defs` at the envelope root (verifiable with `python3 -c "import json; [print(p, '$defs' in json.load(open(p))) for p in __import__('glob').glob('crates/rimap-server/tests/fixtures/rimap-tool-schemas/*.schema.json')]"` — every line should be `True` except for the 2-3 truly-flat schemas).
+- [ ] Phase 1 (`mcp_wire_conformance`), Phase 2 (`just mcp-conformance-node`), and Phase 3 (`e2e_wire`) all pass / silent-skip as before.
+
+---
+
+## Self-review
+
+1. **Spec coverage:** Task A addresses Codex's high-severity `RIMAP_REQUIRE_DOCKER` finding; Task B addresses the medium-severity `$defs` finding. Both findings are fully covered.
+2. **Placeholder scan:** No `TBD` / `TODO`. The Step 4 payload JSON is illustrative (the plan explicitly notes "tweak the payload at implementation time using the schemars-generated schema as the source of truth"); that's a real implementation-time check, not a placeholder.
+3. **Type consistency:** `HarnessError` defined in Task A Step 1 is referenced in Steps 4, 5, 6 with the same enum and variant names. The `extract_defs` / `merge_defs` / `warnings_schema` helpers in Task B Step 1 are referenced consistently throughout that task. The new `fixture_smoke_tests::every_fixture_compiles_and_search_validates_realistic_payload` is defined once in Step 4 of Task B.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-13-mcp-conformance-codex-fixes-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task with two-stage review between tasks.
+
+**2. Inline Execution** — batch execution in this session with checkpoints.

--- a/docs/superpowers/plans/2026-05-13-mcp-conformance-search-required-fix-plan.md
+++ b/docs/superpowers/plans/2026-05-13-mcp-conformance-search-required-fix-plan.md
@@ -1,0 +1,222 @@
+# Phase 3 Codex-Findings Fix Plan (round 3)
+
+> **For agentic workers:** Use superpowers:executing-plans or apply inline. Single small task, no review/PR-sized scope.
+
+**Goal:** Address the third `/codex:adversarial-review` finding on branch `test/mcp-behavioral-conformance-spec`: per-tool response schemas mark `SearchResultEntry.from` and `to` as required, but the wire `skip_serializing_if = "Vec::is_empty"` annotations cause those keys to be omitted when empty. The Phase 3 validator can therefore reject legitimate server output.
+
+**Architecture:** One mechanical fix. Tell `schemars` that the two fields are optional (via `#[serde(default)]` — schemars 1.x respects serde's `default` attribute and omits the field from the schema's `required` list). Regenerate the one affected fixture. Add a smoke-test payload that omits both fields to confirm the schema accepts the empty-headers wire shape.
+
+**Parent branch:** continue on `test/mcp-behavioral-conformance-spec`.
+**Codex review source:** the third adversarial review pass; comparable to rounds 1 and 2 already addressed in earlier plans.
+
+---
+
+## Scope verification (already performed during plan drafting)
+
+The repo-wide grep is:
+
+```bash
+grep -rEn 'skip_serializing_if = "Vec::is_empty"' crates/rimap-server/src crates/rimap-content/src
+```
+
+Three sites surface:
+
+| Location | Field | Has `default`? | Schema `required`? | Mismatch? |
+|---|---|---|---|---|
+| `search.rs:72` | `SearchResultEntry.from: Vec<String>` | no | yes | **YES** |
+| `search.rs:75` | `SearchResultEntry.to: Vec<String>` | no | yes | **YES** |
+| `list_folders.rs:117` | `ListFoldersMeta.security_warnings: Vec<SecurityWarning>` | **yes** | no | ✓ |
+| `mcp/response.rs:24` | `ToolResponse.security_warnings: Vec<SecurityWarning>` | no | n/a (envelope built by hand, not via schema_for!) | ✓ |
+
+So the fix touches exactly two source lines and one regenerated fixture (`search.schema.json`). The envelope-level `ToolResponse.security_warnings` would be a problem only if a future change starts deriving the envelope via `schema_for!(ToolResponse<...>)`. The current `dump_tool_schemas.rs` builds the envelope manually and correctly omits `security_warnings` from `required`, so no fix is needed there. (Flag as a low-priority follow-up if anyone is concerned.)
+
+`Option<T>` fields with `skip_serializing_if = "Option::is_none"` are NOT affected — schemars 1.x already treats `Option<T>` as optional in derived schemas (confirmed by the search fixture: `size`, `flags`, `subject`, `date`, `message_id` are all `Option` and all correctly absent from `SearchResultEntry`'s `required` list).
+
+`FetchMessageUntrusted.date` IS in the `required` list, but the wire emits `"date": null` for None (no `skip_serializing_if`) and the custom `schema_with` accepts `["array", "null"]`. Wire and schema match — not affected.
+
+---
+
+## Task: Mark `from` and `to` optional in the schema
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs:72,75`
+- Regenerate: `crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json`
+- Modify: `crates/rimap-server/tests/support/wire/schema.rs` (extend `search_fixture_validates_realistic_payload` OR add a sibling test case for the empty-headers shape)
+
+- [ ] **Step 1: Add `#[serde(default)]` to the two fields**
+
+In `crates/rimap-server/src/tools/retrieval/search.rs`, find `SearchResultEntry::from` (line 72) and `SearchResultEntry::to` (line 75). Each currently looks like:
+
+```rust
+/// From addresses, sanitized. Omitted when empty.
+#[serde(skip_serializing_if = "Vec::is_empty")]
+pub from: Vec<String>,
+/// To addresses, sanitized. Omitted when empty.
+#[serde(skip_serializing_if = "Vec::is_empty")]
+pub to: Vec<String>,
+```
+
+Change each to:
+
+```rust
+/// From addresses, sanitized. Omitted when empty.
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub from: Vec<String>,
+/// To addresses, sanitized. Omitted when empty.
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub to: Vec<String>,
+```
+
+The `default` attribute makes schemars treat the field as not-required in the generated schema (and gives serde a deserialize path that defaults to `Vec::new()` if the field is absent, which is the right behavior on the consumer side too).
+
+- [ ] **Step 2: Verify the source compiles with the feature on and off**
+
+```bash
+cargo check -p rimap-server --locked
+cargo check -p rimap-server --features test-support --locked
+cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings
+```
+
+All exit 0. (No new lints expected — `serde(default)` on an already-`Vec<T>` field is benign.)
+
+- [ ] **Step 3: Regenerate the fixtures**
+
+```bash
+just regen-tool-schemas
+git diff crates/rimap-server/tests/fixtures/rimap-tool-schemas/ | head -40
+```
+
+Expected: only `search.schema.json` changes. The `SearchResultEntry` defn's `required` list drops from `["uid", "from", "to"]` to `["uid"]`.
+
+Spot-check:
+
+```bash
+python3 -c "
+import json
+d = json.load(open('crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json'))
+entry = d['\$defs']['SearchResultEntry']
+print('required:', entry.get('required'))
+"
+```
+
+Expected output:
+```
+required: ['uid']
+```
+
+If `from` or `to` still appears in the `required` list, schemars's `serde(default)` handling isn't kicking in. Fallback: try `#[schemars(default)]` directly instead of `#[serde(default)]` (schemars 1.x accepts both). Iterate until the regen produces a schema with only `uid` in the `SearchResultEntry::required` list.
+
+- [ ] **Step 4: Extend the smoke test**
+
+In `crates/rimap-server/tests/support/wire/schema.rs`, find the existing test `search_fixture_validates_realistic_payload` (added in Task B of the previous fix plan). It currently validates a payload that includes non-empty `from` and `to` arrays. ADD a second test case that omits both fields:
+
+```rust
+#[test]
+fn search_fixture_validates_payload_with_omitted_from_and_to() {
+    let search = validator_for_tool_response("search");
+    // Wire shape when the parsed message has no From / To headers:
+    // both fields are omitted (Vec::is_empty skip_serializing_if).
+    // Pre-fix, the schema required them as keys and this payload
+    // would have been falsely rejected.
+    let payload = serde_json::json!({
+        "meta": {
+            "total_matched": 1u64,
+            "folder": "INBOX",
+            "returned": 1u64,
+            "truncated": false,
+        },
+        "untrusted": {
+            "messages": [
+                {
+                    "uid": 42u32,
+                    // from and to are omitted, matching the wire when
+                    // both vectors are empty.
+                }
+            ],
+        },
+        "security_warnings": [],
+    });
+    if !search.is_valid(&payload) {
+        let errors: Vec<String> =
+            search.iter_errors(&payload).map(|e| e.to_string()).collect();
+        panic!(
+            "search schema must accept a result entry with omitted from/to; errors:\n  {}\n\npayload: {payload}",
+            errors.join("\n  ")
+        );
+    }
+}
+```
+
+If the existing payload test's required `meta` fields don't match what `SearchMeta` actually requires (the plan author hand-checked `folder`, `total_matched`, `returned`, `truncated` based on the fixture's `required` list, but the source struct may have changed since this plan was written), the test will fail with a clear schema diagnostic naming the missing fields. Adjust the payload until it validates.
+
+- [ ] **Step 5: Verify the new test passes and the existing positive case still passes**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_conformance --locked
+cargo nextest run -p rimap-server --test e2e_wire --locked
+cargo clippy -p rimap-server --tests --all-features --locked -- -D warnings
+just regen-tool-schemas && git diff --exit-code crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+```
+
+Expected:
+- `mcp_wire_conformance` runs 12 tests, all pass (was 11; +1 for the new omit-fields case which compiles into this binary via `support/wire/mod.rs`).
+- `e2e_wire` runs 5 tests, all pass (was 4; same reason).
+- Clippy clean.
+- Idempotent regen (no diff).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/search.rs \
+        crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json \
+        crates/rimap-server/tests/support/wire/schema.rs
+git commit -m "fix(test): mark SearchResultEntry.from/to as schema-optional (#265)
+
+Codex round-3 adversarial review caught that SearchResultEntry.from
+and SearchResultEntry.to use skip_serializing_if = \"Vec::is_empty\"
+on the wire, so the keys are omitted when the parsed message has
+no From/To addresses. The generated search.schema.json marked both
+as required, so the Phase 3 conformance validator could reject
+legitimate server output.
+
+Adding #[serde(default)] makes schemars treat the field as
+not-required in the generated schema (and gives serde the matching
+deserialize path that defaults to Vec::new() when the field is
+absent — relevant for round-trip tests or consumer-side parsing).
+
+Regenerated the one affected fixture; the SearchResultEntry defn
+now has required: [\"uid\"] only. Added a smoke-test payload that
+omits both fields to lock in the wire-vs-schema parity going
+forward.
+
+A repo-wide grep for skip_serializing_if = \"Vec::is_empty\" turned
+up exactly two other sites — list_folders.rs:117 and
+mcp/response.rs:24 — both of which already pair the skip with
+default (ListFoldersMeta.security_warnings) or live on a struct
+whose schema is built manually rather than via schema_for!
+(ToolResponse.security_warnings). Neither produces a false-required
+in any current fixture.
+"
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
+- [ ] `SearchResultEntry`'s `required` list in `search.schema.json` is exactly `["uid"]`.
+- [ ] `search_fixture_validates_payload_with_omitted_from_and_to` passes.
+- [ ] Existing `search_fixture_validates_realistic_payload` (with non-empty `from`/`to`) still passes.
+- [ ] `just regen-tool-schemas` is idempotent.
+- [ ] Phase 1 (`mcp_wire_conformance`) and Phase 3 (`e2e_wire`) suites pass / silent-skip.
+
+---
+
+## Notes for the reviewer
+
+- The fix is two-character: `default,` added to two existing attributes.
+- The fixture diff is one file, one nested `required` array.
+- The smoke-test addition is one new `#[test]` function.
+- Combined commit is small enough to land without subagent dispatch — single inline edit + regen + commit.
+
+If `#[serde(default)]` turns out NOT to remove the field from schemars's `required` list (i.e. schemars 1.x ignores it for this case), fall back to `#[schemars(default)]` directly on the same fields. Both should work — schemars 1.x documents respect for the serde attribute in derive scenarios.

--- a/docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md
@@ -1,0 +1,509 @@
+# MCP Behavioral Conformance via Stdio against Dovecot — Design
+
+**Status:** Draft 2026-05-12
+**Scope:** Phase 3 of 4 (issue #265) — a Rust integration test that drives
+`rusty-imap-mcp` over its stdio JSON-RPC wire against the existing
+Dovecot fixture, exercises every draft-safe-posture tool category at
+least once, validates every response against both Phase 1's vendored MCP
+spec schemas and a new set of project-local per-tool result schemas, and
+asserts audit-log pairing plus posture-denial wire shape. Phase 1
+(#263, landed) and Phase 2 (#264, landed) cover wire-shape conformance
+without IMAP. Phase 4 (#TBD, protocol fuzzing) covers negative-path
+wire traffic and is out of scope here.
+
+## 1. Motivation
+
+`crates/rimap-server/tests/e2e.rs::e2e_full_session` is comprehensive
+against the IMAP backend but calls `ImapMcpServer::dispatch_account_scoped`
+directly via the Rust API — it bypasses JSON-RPC serialization,
+dispatch routing, and the stdio transport entirely. Two real bugs
+slipped past it:
+
+- **#261** — `initialize.result.capabilities` serialized as `{}`.
+- **`fix/tool-input-schema-object-type`** — tools advertised
+  `inputSchema: {}` with no `type` field.
+
+Phases 1 and 2 catch wire-shape bugs in zero-account mode. They do not
+catch dispatch and serialization bugs that only surface when a tool
+actually executes against a real backend (e.g. response payload shape
+for `list_folders` with real folders, error envelopes for IMAP-side
+failures, attachment download with real bytes, audit envelope pairing
+under real dispatch). Phase 3 fills that gap.
+
+The phase reuses the existing fixture infrastructure:
+`crates/rimap-imap/tests/integration/support/container.rs`,
+`tests/integration/dovecot/docker-compose.yml`, the seeding helpers,
+and the port-race handling already in `e2e.rs`.
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- Drive a Dovecot-backed `rusty-imap-mcp` session over stdio JSON-RPC
+  from a new Rust integration test.
+- Exercise every category named in #265 at least once: list (folders,
+  attachments, labels, accounts), fetch (message, attachment download),
+  mutate (flag, label, move, draft), admin (use_account).
+- Validate every response against (a) Phase 1's vendored MCP spec
+  envelope + method schemas and (b) new project-local per-tool result
+  schemas generated from the tool output structs.
+- Exercise two postures — draft-safe and read-only — to surface
+  advertise/dispatch posture-matrix drift at the wire layer.
+- Assert paired `tool_start` / `tool_end` audit records for every wire
+  tool call, plus the posture-denial record for a read-only mutation
+  attempt.
+- Match `e2e_full_session`'s gating exactly: silent skip when no
+  container runtime is found or host arch is not `x86_64`;
+  `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+
+### Non-Goals
+
+- New IMAP fixtures — reuse what exists (Dovecot 2.3.21 amd64 image,
+  one seeded `rimap-test` user).
+- Replacing Phases 1 or 2 — all three coexist; they catch different
+  regression classes.
+- Negative-path / malformed-input wire traffic — Phase 4's job. Phase 3
+  stays on happy + posture-denial paths.
+- Auth isolation between MCP-side accounts — `rimap-imap` already
+  covers per-user IMAP login; Phase 3's two accounts share the same
+  Dovecot user because the surface under test is the posture matrix,
+  not authentication.
+- Schema validation of tool *input* shape — Phase 1 already pins every
+  tool's `inputSchema.type == "object"`; Phase 3 focuses on result
+  shape.
+- Refactoring `e2e_full_session` to wire-only — keep the in-process
+  Rust-API path for fast stack-trace debugging when wire tests fail
+  (per #265 motivation).
+
+## 3. Architecture
+
+### 3.1 Layout
+
+```
+crates/rimap-server/tests/
+├── support/                              # NEW shared module for integration tests
+│   ├── mod.rs                            #   pub mod wire; pub mod dovecot;
+│   ├── wire/
+│   │   ├── mod.rs                        #   Harness, request/notify, schema validators
+│   │   ├── harness.rs                    #   moved from mcp_wire_conformance.rs
+│   │   └── schema.rs                     #   moved validator_for + assert_envelope_valid
+│   └── dovecot.rs                        #   DovecotHarness moved out of e2e.rs
+├── mcp_wire_conformance.rs               # CHANGED: uses support::wire (no behavior change)
+├── e2e.rs                                # CHANGED: uses support::dovecot (no behavior change)
+├── e2e_wire.rs                           # NEW: Phase 3 test file
+└── fixtures/
+    ├── mcp-spec/2025-11-25/schema.json   # unchanged (Phase 1)
+    └── rimap-tool-schemas/                # NEW: generated, checked-in (one file per tool)
+        ├── list_folders.schema.json
+        ├── list_accounts.schema.json
+        ├── list_labels.schema.json
+        ├── list_attachments.schema.json
+        ├── download_attachment.schema.json
+        ├── search.schema.json
+        ├── fetch_message.schema.json
+        ├── mark_read.schema.json
+        ├── mark_unread.schema.json
+        ├── add_label.schema.json
+        ├── remove_label.schema.json
+        ├── move_message.schema.json
+        ├── create_draft.schema.json
+        └── use_account.schema.json
+```
+
+The Phase 1 file (`mcp_wire_conformance.rs`) is unchanged in behavior —
+only its `use` lines flip from inline module items to `support::wire::…`.
+The Phase 1 schema cache, validator, and harness shape are preserved
+byte-for-byte through the extraction so the regression net documented in
+Phase 1's design remains intact.
+
+### 3.2 Why a shared `support/` module
+
+Rust integration tests under `tests/` each compile as their own crate.
+The idiomatic share-pattern is a `tests/support/` (or `tests/common/`)
+directory included via `#[path = "support/mod.rs"] mod support;` at the
+top of each integration file. Phase 3 picks `support/` to match
+`crates/rimap-imap/tests/integration/support/` which already follows the
+same convention.
+
+The alternative (each test file inlines its own copy of the wire driver
+and schema validator) reproduces exactly the wire-shape duplication
+problem that motivated Phases 1–3 in the first place. Approach
+explicitly rejected during brainstorming.
+
+### 3.3 Two-binary support layer
+
+The `rusty-imap-mcp` binary already has the `--features test-support`
+flag for Phase 1's `--allow-empty-accounts` and Phase 2's
+`dump-tool-catalog` subcommand. Phase 3 adds a sibling subcommand
+`dump-tool-schemas` under the same feature gate, which serializes every
+`JsonSchema`-deriving tool output struct to a stable JSON Schema
+document keyed by tool name. A new `just regen-tool-schemas` recipe
+runs the subcommand and writes to `tests/fixtures/rimap-tool-schemas/`.
+CI runs the regen and fails on a non-empty `git diff` — same drift
+detector pattern Phase 1 uses for the vendored MCP spec fixtures.
+
+### 3.4 Gating
+
+Match `e2e_full_session` exactly:
+
+- `DovecotHarness::try_start()` returns `None` (silent skip) when no
+  container runtime is found or `std::env::consts::ARCH != "x86_64"`.
+- `RIMAP_REQUIRE_DOCKER=1` flips silent skip to a `panic!` with the
+  captured cause string.
+- No new env vars introduced.
+
+CI placement: add to the existing linux-x86_64 integration job that
+already runs `e2e.rs`. Dovecot bring-up is amortized across both tests.
+
+## 4. Components
+
+### 4.1 `support::wire::Harness`
+
+The `Harness` type, its methods, and the schema validators move from
+`mcp_wire_conformance.rs` into `support::wire`. Phase 1's test file is
+edited to swap inline definitions for `use crate::support::wire::…`
+imports — the test bodies and assertions are byte-for-byte unchanged.
+
+Existing surface: `spawn()`, `request()`, `notify()`,
+`initialize_handshake()`, `send_initialized()`,
+`assert_no_response_within()`, `shutdown_and_wait()`.
+
+One new constructor:
+
+```rust
+impl Harness {
+    /// Spawn with a caller-supplied config path. Used by Phase 3 to
+    /// point at a Dovecot-backed multi-account TOML; Phase 1's
+    /// `spawn()` becomes a thin wrapper that builds the zero-account
+    /// TOML and calls this.
+    async fn spawn_with_config(config_path: &Path, tempdir: TempDir) -> Self;
+}
+```
+
+`stderr` capture changes from `Stdio::null()` to `Stdio::piped()` with a
+drain task. The child's `tracing` output is the most useful diagnostic
+when a wire response is unexpected. Phase 1's tests are sub-second; the
+captured buffer is usually <4 KB per test and is included in panic
+messages on assertion failure.
+
+### 4.2 `support::dovecot::DovecotHarness`
+
+Lifted unchanged from `e2e.rs` (including `ReservedPort`,
+`wait_for_ready`, `read_fingerprint`, `compose_down`, the
+`MAX_ATTEMPTS` / `BACKOFF_MS` port-collision retry, and `Drop`).
+Container lifecycle stays per-test — keeps test isolation; the
+~5–15 s bring-up cost is amortized across only the two suites that
+need it (`e2e.rs` and `e2e_wire.rs`).
+
+### 4.3 `support::wire::schema`
+
+Phase 1's `validator_for(fragment: &'static str) -> Arc<jsonschema::Validator>`
+and `assert_envelope_valid(value)` move here unchanged. One addition:
+
+```rust
+/// Compile (lazily, cached) a validator for the per-tool response
+/// schema at `tests/fixtures/rimap-tool-schemas/<tool>.schema.json`.
+/// Panics in the test process if the fixture is missing — that's the
+/// signal that `just regen-tool-schemas` was not run.
+fn validator_for_tool_response(tool: &'static str) -> Arc<jsonschema::Validator>;
+```
+
+Same `OnceLock` + `Mutex<HashMap>` cache shape so parallel tests
+compiling different fragments do not serialize.
+
+### 4.4 `dump-tool-schemas` test-support subcommand
+
+Tool responses are emitted on the wire as `{"meta": {...},
+"untrusted": {...}}` (verified against `e2e.rs` assertions). Each tool
+that produces an `untrusted` payload has two separate response
+structs in source (`<Tool>Meta` and `<Tool>Untrusted`); tools that
+only produce metadata have just a `<Tool>Meta`. The `dump-tool-schemas`
+subcommand composes them into one JSON Schema per tool that describes
+the combined wire envelope, then writes one file per tool to stdout
+keyed by tool name. The `just regen-tool-schemas` recipe pipes the
+output into `tests/fixtures/rimap-tool-schemas/<tool>.schema.json`,
+one file per key.
+
+Sketch (gated behind `#[cfg(feature = "test-support")]` in
+`crates/rimap-server/src/main.rs`):
+
+```rust
+#[cfg(feature = "test-support")]
+fn dump_tool_schemas() -> Result<()> {
+    let mut g = schemars::SchemaGenerator::default();
+
+    // Helper: compose a {meta, untrusted} schema for tools that emit both.
+    let compose = |meta: schemars::Schema, untrusted: schemars::Schema| { /* ... */ };
+
+    let mut out = BTreeMap::<&'static str, schemars::Schema>::new();
+
+    // meta-only tools
+    out.insert("list_folders",  g.root_schema_for::<ListFoldersMeta>());
+    out.insert("list_accounts", g.root_schema_for::<ListAccountsMeta>());
+    out.insert("list_labels",   g.root_schema_for::<ListLabelsMeta>());
+    out.insert("mark_read",     g.root_schema_for::<FlagsMeta>());
+    out.insert("mark_unread",   g.root_schema_for::<FlagsMeta>());
+    out.insert("add_label",     g.root_schema_for::<LabelsMeta>());
+    out.insert("remove_label",  g.root_schema_for::<LabelsMeta>());
+    out.insert("move_message",  g.root_schema_for::<MoveMessageMeta>());
+    out.insert("create_draft",  g.root_schema_for::<CreateDraftMeta>());
+    out.insert("use_account",   g.root_schema_for::<UseAccountMeta>());
+
+    // meta + untrusted tools
+    out.insert("search", compose(
+        g.root_schema_for::<SearchMeta>(),
+        g.root_schema_for::<SearchUntrusted>(),
+    ));
+    out.insert("fetch_message", compose(
+        g.root_schema_for::<FetchMessageMeta>(),
+        g.root_schema_for::<FetchMessageUntrusted>(),
+    ));
+    out.insert("list_attachments", compose(
+        g.root_schema_for::<ListAttachmentsMeta>(),
+        g.root_schema_for::<ListAttachmentsUntrusted>(),
+    ));
+    out.insert("download_attachment", compose(
+        g.root_schema_for::<DownloadAttachmentMeta>(),
+        g.root_schema_for::<DownloadAttachmentUntrusted>(),
+    ));
+
+    // One file per tool, JSON-pretty-printed for review-friendly diffs.
+    for (name, schema) in &out {
+        let path = fixture_dir.join(format!("{name}.schema.json"));
+        std::fs::write(path, serde_json::to_string_pretty(schema)?)?;
+    }
+    Ok(())
+}
+```
+
+The struct names above are the actual public structs in the current
+tree (verified via `grep` against `crates/rimap-server/src/tools/`).
+The implementation plan adds `#[derive(schemars::JsonSchema)]` next to
+the existing `Serialize` derive on each struct, gated behind
+`#[cfg(any(test, feature = "test-support"))]` so the production binary
+does not depend on `schemars`.
+
+Tools advertised by the server but not in the dump set
+(`flag`, `unflag`, `send_email`, `delete_message`, `expunge`,
+`create_folder`, `rename_folder`, `delete_folder`) are out of scope
+for Phase 3 — they are either gated by postures Phase 3 does not
+exercise (`ready-to-send`, mutating-folder operations the suite does
+not seed for) or covered transitively by sibling tools with identical
+response shapes (`flag` ↔ `mark_read`, both produce `FlagsMeta`).
+They can be added in a follow-up without spec churn — the regen
+recipe just needs another line.
+
+### 4.5 `e2e_wire.rs`
+
+Two `#[tokio::test]` cases:
+
+- `wire_e2e_full_session_draft_safe` — mirrors `e2e_full_session`'s
+  sequence over the wire (list_folders → seed via in-process IMAP →
+  search → fetch_message → mark_read → create_draft × 2 →
+  move_message), plus the issue-named extras
+  (`list_attachments`, `download_attachment`, `list_labels`,
+  `list_accounts`, `use_account`).
+- `wire_e2e_readonly_posture_denial` — second account configured
+  `read-only`; `tools/list` asserts mutating tools are not advertised
+  under the read-only namespace; one `tools/call` against
+  `readonly.move_message` asserts the JSON-RPC error envelope is the
+  posture-denial shape, and the captured audit log contains a
+  denied-by-posture record paired with its `tool_start`.
+
+### 4.6 Multi-account config TOML builder
+
+`support::wire::config::build_dovecot_config(harness, audit_path,
+allowed_base) -> String` writes a `[[accounts]]`-table TOML with two
+accounts (`default` draft-safe, `readonly` read-only) both pointing at
+Dovecot's seeded `rimap-test` user.
+
+Two MCP accounts, one Dovecot user. The surface under test is the
+posture matrix on the wire; auth isolation is `rimap-imap`'s concern
+and is already tested there.
+
+Because the test config has more than one account, the binary
+advertises namespaced tool names (`<account>.<tool>`) — the same
+multi-account display path `e2e.rs` does not exercise today. This is
+intentional additional coverage.
+
+## 5. Data Flow
+
+### 5.1 `wire_e2e_full_session_draft_safe`
+
+```
+1. DovecotHarness::try_start()        → silent skip on no runtime / non-x86_64
+2. harness.create_mailbox("Drafts")
+   harness.create_mailbox("Trash")
+3. Build multi-account TOML in tempdir:
+     - [[accounts]] id="default"   posture="draft-safe"  → rimap-test@dovecot
+     - [[accounts]] id="readonly"  posture="read-only"   → rimap-test@dovecot
+     - [audit] path=<tempdir>/audit.jsonl  allowed_base_dir=<tempdir>
+4. Seed one message into INBOX via in-process Connection::append_message
+   (same path e2e.rs uses; no MCP tool appends an arbitrary raw message —
+   create_draft is opinionated).
+5. Harness::spawn_with_config(config_path)
+6. initialize → assert_valid(InitializeResult); capture protocol version
+7. notifications/initialized
+8. tools/list → assert_valid(ListToolsResult)
+   - Build a map { tool_name → tool_def } from the response
+   - Assert namespaced names exist: default.list_folders, readonly.list_folders, etc.
+   - Assert read-only namespace LACKS mutating tools
+     (move_message, create_draft, mark_read, …)
+9. For each step in the e2e_full_session sequence + issue-named extras:
+     a. tools/call name="default.<tool>" arguments=<json>
+     b. assert_envelope_valid(response)
+     c. assert_valid(response.result.structuredContent, tool_response_schema)
+     d. Apply the same behavioral assertion e2e.rs makes
+        (folders contains INBOX; search returns the seed uid; …)
+10. shutdown_and_wait() → assert exit 0
+11. Read audit.jsonl, group records by (tool_start, tool_end):
+    - For each tools/call from step 9, exactly one tool_start + one tool_end
+    - tool_end.start_seq == tool_start.seq (pairing invariant)
+```
+
+### 5.2 `wire_e2e_readonly_posture_denial`
+
+```
+1-7. Same harness/initialize/initialized as above.
+8. tools/list →
+   - Assert readonly.move_message is NOT advertised.
+   - Assert default.move_message IS advertised.
+9. tools/call name="readonly.move_message"
+   arguments={"folder":"INBOX","destination":"Trash","uid":1}
+   - assert_envelope_valid(response)
+   - Assert response.error.code is the posture-denial code
+     (pinned in a const near the assertion; comment "if this changes,
+     rmcp's error mapping or posture-denial bridge drifted; update with
+     rationale" — same pattern Phase 1 uses for the -32602 INVALID_PARAMS
+     pin on unknown-tool calls).
+10. shutdown_and_wait() → exit 0
+11. Read audit.jsonl → assert exactly one tool_start for
+    readonly.move_message paired with a tool_end carrying the
+    posture-denial outcome (exact field name from the current
+    AuditRecord shape; looked up during plan execution, not pinned
+    in this spec).
+```
+
+### 5.3 Seed strategy
+
+Use the in-process `Connection::append_message` shortcut that `e2e.rs`
+already uses, not a wire tool. There is no `append_raw_message` MCP
+tool — `create_draft` is opinionated and adds keywords
+(`$PendingReview`). Treating `create_draft` as the seed would couple
+the seeding step to one of the assertions later in the same flow.
+
+The wire surface is what's being exercised; the seed is plumbing.
+Keeping the seed in-process makes the test's intent honest.
+
+## 6. Error Handling
+
+Three failure classes, three diagnostic shapes:
+
+| Class | Symptom | Handling |
+|---|---|---|
+| Infrastructure | Docker missing, arch mismatch, Dovecot health-check timeout | Silent skip (`return;`) — matches `e2e_full_session`. `RIMAP_REQUIRE_DOCKER=1` flips silent skip to a `panic!` with the captured cause string. |
+| Wire / protocol | Spawned binary exits early, stdout closed mid-handshake, response is non-JSON, response `id` doesn't match request, envelope fails `assert_envelope_valid` | `panic!` with the captured stderr from the child plus the offending payload. |
+| Semantic | Tool call succeeded on the wire but a behavioral assertion fails (uid missing, body content wrong, audit pairing broken) | `assert!` / `assert_eq!` with the response value and audit-record context in the message. |
+
+**Spawned-binary stderr is captured, not silenced.** Phase 1 currently
+uses `Stdio::null()` for stderr. Phase 3 flips to `Stdio::piped()` with
+a stderr-drain task. When a wire call fails, the binary's own `tracing`
+output is the most useful diagnostic. The drain task lives in
+`support::wire::Harness` so Phase 1 also benefits; the cost is a
+post-test buffer of usually <4 KB.
+
+**Cleanup ordering.** `DovecotHarness::Drop` calls
+`compose down -v --remove-orphans` (unchanged from today). The
+`Harness` (spawned binary) holds `kill_on_drop(true)` like Phase 1 so a
+panicking test does not leak the child. Order: child dies first (test
+scope unwind), then Dovecot teardown, then tempdir cleanup. Container
+lifecycle outlives the spawned binary in every successful path.
+
+**Audit-log read timing.** Audit records are written from a
+`spawn_blocking` task. After the last `tools/call` returns successfully
+on the wire, the test calls `shutdown_and_wait()` *before* opening the
+audit file. Phase 1's `wire_clean_eof_shutdown_exits_zero` already
+proves the binary flushes audit before exit. This avoids the
+"did the last record get persisted" race that `dispatch_ticket.rs`
+solves with `drop(server)`; the wire-test equivalent is
+`shutdown_and_wait()`.
+
+**Posture-denial wire pin.** The exact JSON-RPC error code returned
+for a posture-denied tool call is whatever `rmcp`'s `ErrorData` bridge
+produces today. The test pins the observed code in a `const` near the
+assertion with a comment explaining the drift-detection intent. Same
+discipline Phase 1 uses for the `-32602` pin on unknown-tool calls.
+
+## 7. Testing the Test
+
+### 7.1 Tool-schema regen drift detector
+
+A new CI step runs `just regen-tool-schemas` followed by
+`git diff --exit-code tests/fixtures/rimap-tool-schemas/`. If a tool's
+output struct changes shape and the dev forgot to regen, CI fails with
+a precise diagnostic naming the divergent files. Local workflow:
+edit struct → `just regen-tool-schemas` → commit both diffs. Same
+pattern Phase 1 documents for `tests/fixtures/mcp-spec/`.
+
+### 7.2 MCP-spec version pin propagation
+
+Phase 1 already has a three-way drift check
+(`rmcp::ProtocolVersion::LATEST` ↔ `PINNED_PROTOCOL_VERSION` ↔ fixture
+directory). Phase 3's harness inherits that constant from
+`support::wire`, so a single test
+(`wire_protocol_version_negotiation_matches_vendored_schema`) gates
+both phases.
+
+### 7.3 Wall-time budget
+
+Issue #265 acceptance criterion: "Wall time documented; if >60s, gate
+behind an env flag." The implementation plan measures actual wall time
+after the test lands. Expected: ~10–20 s on a warm machine, Dovecot
+bring-up dominating; the wire flow itself is sub-second. If the
+measured time exceeds 60 s in practice, the plan adds
+`RIMAP_RUN_E2E_WIRE=1` gating and documents the trigger in
+`AGENTS.md` — that's a fallback path, not the primary one.
+
+### 7.4 CI placement
+
+No new workflow files. Add to the same job that already runs
+`e2e.rs` (the existing linux-x86_64 integration job — same Dovecot
+bring-up, amortized). Phase 1 and Phase 2 jobs are untouched.
+
+### 7.5 What Phase 3 does NOT cover
+
+Phase 4 (#TBD, protocol fuzzing) handles negative-path and
+malformed-input wire traffic. Phase 3 stays on the happy + posture-
+denial paths; treating malformed JSON-RPC or oversized payloads as
+Phase 3's job blurs the line with Phase 4 and inflates this PR.
+
+## 8. Acceptance criteria (from #265, refined)
+
+- [ ] `cargo test -p rimap-server --tests e2e_wire` exercises at least
+  one wire-driven Dovecot scenario.
+- [ ] Coverage of all draft-safe-posture tools named in the issue
+  scope is confirmed by tool-call audit records in the captured audit
+  log: list_folders, list_attachments, download_attachment,
+  list_labels, list_accounts, search, fetch_message, mark_read,
+  add_label, remove_label, move_message, create_draft, use_account.
+- [ ] Posture denial: at least one mutating tool call against the
+  read-only account returns the pinned posture-denial error envelope
+  and produces a paired tool_start/tool_end record in the audit log.
+- [ ] Every wire response validates against (a) Phase 1's vendored MCP
+  spec envelope/method schemas and (b) the per-tool response schema in
+  `tests/fixtures/rimap-tool-schemas/`.
+- [ ] Tool-schema regen drift detector lands as a CI step.
+- [ ] Skips cleanly when Docker/Podman are not available (silent
+  skip; `RIMAP_REQUIRE_DOCKER=1` flips to loud failure).
+- [ ] Wall time documented in `AGENTS.md` test-strategy section; if
+  >60 s, gated behind an env flag and the trigger documented.
+- [ ] Phase 1 (`mcp_wire_conformance.rs`) and Phase 2
+  (`tests/mcp-conformance/`) continue to pass with no behavior change.
+- [ ] Design doc (this file) and a cross-link from `AGENTS.md`.
+
+## 9. Phasing context
+
+Phase 3 of 4. Phase 1 (#263) and Phase 2 (#264) landed in May 2026 and
+share the wire driver this spec extracts into `support::wire`. Phase 4
+(#TBD, protocol fuzzing) is the final phase and is unblocked once
+Phase 3 lands.

--- a/docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-12-mcp-behavioral-conformance-design.md
@@ -103,6 +103,8 @@ crates/rimap-server/tests/
         ├── fetch_message.schema.json
         ├── mark_read.schema.json
         ├── mark_unread.schema.json
+        ├── flag.schema.json
+        ├── unflag.schema.json
         ├── add_label.schema.json
         ├── remove_label.schema.json
         ├── move_message.schema.json
@@ -243,6 +245,8 @@ fn dump_tool_schemas() -> Result<()> {
     out.insert("list_labels",   g.root_schema_for::<ListLabelsMeta>());
     out.insert("mark_read",     g.root_schema_for::<FlagsMeta>());
     out.insert("mark_unread",   g.root_schema_for::<FlagsMeta>());
+    out.insert("flag",          g.root_schema_for::<FlagsMeta>());
+    out.insert("unflag",        g.root_schema_for::<FlagsMeta>());
     out.insert("add_label",     g.root_schema_for::<LabelsMeta>());
     out.insert("remove_label",  g.root_schema_for::<LabelsMeta>());
     out.insert("move_message",  g.root_schema_for::<MoveMessageMeta>());
@@ -284,14 +288,20 @@ the existing `Serialize` derive on each struct, gated behind
 does not depend on `schemars`.
 
 Tools advertised by the server but not in the dump set
-(`flag`, `unflag`, `send_email`, `delete_message`, `expunge`,
-`create_folder`, `rename_folder`, `delete_folder`) are out of scope
-for Phase 3 — they are either gated by postures Phase 3 does not
-exercise (`ready-to-send`, mutating-folder operations the suite does
-not seed for) or covered transitively by sibling tools with identical
-response shapes (`flag` ↔ `mark_read`, both produce `FlagsMeta`).
-They can be added in a follow-up without spec churn — the regen
-recipe just needs another line.
+(`send_email`, `delete_message`, `expunge`, `create_folder`,
+`rename_folder`, `delete_folder`) are out of scope for Phase 3 — they
+are gated by postures Phase 3 does not exercise (`ready-to-send`,
+mutating-folder operations) or require seeded state the suite does not
+build (folder lifecycle). They can be added in a follow-up without
+spec churn — the regen recipe just needs another line and the test
+sequence one more `tools/call`.
+
+`flag` and `unflag` *are* in scope despite sharing `FlagsMeta` with
+`mark_read`/`mark_unread`: schema equivalence does not imply dispatch
+equivalence. They have separate `ToolName` variants, separate
+posture-matrix entries, separate handler functions, and mutate a
+different IMAP flag (`\Flagged` vs `\Seen`). A regression in either
+would pass a `mark_read`-only test.
 
 ### 4.5 `e2e_wire.rs`
 
@@ -314,12 +324,22 @@ Two `#[tokio::test]` cases:
 
 `support::wire::config::build_dovecot_config(harness, audit_path,
 allowed_base) -> String` writes a `[[accounts]]`-table TOML with two
-accounts (`default` draft-safe, `readonly` read-only) both pointing at
+accounts (`draftsafe` draft-safe, `readonly` read-only) both pointing at
 Dovecot's seeded `rimap-test` user.
 
 Two MCP accounts, one Dovecot user. The surface under test is the
 posture matrix on the wire; auth isolation is `rimap-imap`'s concern
 and is already tested there.
+
+**Why not the id `default`.** `crates/rimap-server/src/mcp/server.rs`
+records `account = None` in audit envelopes for any account whose id
+equals `rimap_core::account::DEFAULT_ACCOUNT_NAME` (`"default"`), even
+in multi-account deployments — a backwards-compat carve-out for the
+legacy single-account path. Naming one of the two test accounts
+`default` would mask the very thing the suite is meant to verify: that
+account-scoped tool calls are attributed to the right tenant in the
+audit log. Both Phase 3 accounts therefore use non-reserved ids
+(`draftsafe`, `readonly`).
 
 Because the test config has more than one account, the binary
 advertises namespaced tool names (`<account>.<tool>`) — the same
@@ -335,30 +355,58 @@ intentional additional coverage.
 2. harness.create_mailbox("Drafts")
    harness.create_mailbox("Trash")
 3. Build multi-account TOML in tempdir:
-     - [[accounts]] id="default"   posture="draft-safe"  → rimap-test@dovecot
+     - [[accounts]] id="draftsafe" posture="draft-safe"  → rimap-test@dovecot
      - [[accounts]] id="readonly"  posture="read-only"   → rimap-test@dovecot
      - [audit] path=<tempdir>/audit.jsonl  allowed_base_dir=<tempdir>
-4. Seed one message into INBOX via in-process Connection::append_message
-   (same path e2e.rs uses; no MCP tool appends an arbitrary raw message —
-   create_draft is opinionated).
+   (Neither id is "default" — see §4.6 for why DEFAULT_ACCOUNT_NAME
+   would mask audit attribution.)
+4. Seed one multipart MIME message into INBOX via in-process
+   Connection::append_message. The seed body has at least one
+   non-trivial attachment part (e.g. `application/octet-stream` with
+   filename `attached.bin` and a known byte payload) so the wire
+   `list_attachments` and `download_attachment` calls in step 9
+   exercise the real-bytes path, not an empty-list edge. The seed is
+   built once in `support::dovecot::fixtures::multipart_with_attachment()`.
 5. Harness::spawn_with_config(config_path)
 6. initialize → assert_valid(InitializeResult); capture protocol version
 7. notifications/initialized
 8. tools/list → assert_valid(ListToolsResult)
    - Build a map { tool_name → tool_def } from the response
-   - Assert namespaced names exist: default.list_folders, readonly.list_folders, etc.
+   - Assert namespaced names exist: draftsafe.list_folders,
+     readonly.list_folders, etc.
    - Assert read-only namespace LACKS mutating tools
-     (move_message, create_draft, mark_read, …)
+     (move_message, create_draft, mark_read, mark_unread, flag, unflag,
+     add_label, remove_label, …)
 9. For each step in the e2e_full_session sequence + issue-named extras:
-     a. tools/call name="default.<tool>" arguments=<json>
+     a. tools/call name="draftsafe.<tool>" arguments=<json>
      b. assert_envelope_valid(response)
      c. assert_valid(response.result.structuredContent, tool_response_schema)
      d. Apply the same behavioral assertion e2e.rs makes
         (folders contains INBOX; search returns the seed uid; …)
+   The sequence covers:
+     - list_folders                                  (list/folders)
+     - list_attachments → assert ≥1 part with a non-empty `part_id`
+     - download_attachment → assert the downloaded path is under the
+       per-account `download_dir` (sandboxed) and bytes equal the
+       seed attachment payload
+     - list_labels                                   (list/labels)
+     - search → fetch_message (round-trip the seed uid)
+     - mark_read / mark_unread                       (flag mutation,
+       Seen)
+     - flag / unflag                                 (flag mutation,
+       Flagged — distinct ToolName variants from mark_read/unread)
+     - add_label / remove_label                      (label mutation)
+     - create_draft × 2                              (one with
+       in_reply_to_uid, one bare)
+     - move_message → re-search to assert it's gone from INBOX
+     - use_account (admin, switches to readonly), list_accounts
 10. shutdown_and_wait() → assert exit 0
 11. Read audit.jsonl, group records by (tool_start, tool_end):
-    - For each tools/call from step 9, exactly one tool_start + one tool_end
-    - tool_end.start_seq == tool_start.seq (pairing invariant)
+    - For each account-scoped tools/call from step 9: exactly one
+      tool_start + one tool_end, both carrying `account = "draftsafe"`.
+    - For each infrastructure tools/call (`use_account`,
+      `list_accounts`): both records carry `account = None`.
+    - tool_end.start_seq == tool_start.seq (pairing invariant).
 ```
 
 ### 5.2 `wire_e2e_readonly_posture_denial`
@@ -367,7 +415,7 @@ intentional additional coverage.
 1-7. Same harness/initialize/initialized as above.
 8. tools/list →
    - Assert readonly.move_message is NOT advertised.
-   - Assert default.move_message IS advertised.
+   - Assert draftsafe.move_message IS advertised.
 9. tools/call name="readonly.move_message"
    arguments={"folder":"INBOX","destination":"Trash","uid":1}
    - assert_envelope_valid(response)
@@ -378,10 +426,12 @@ intentional additional coverage.
      pin on unknown-tool calls).
 10. shutdown_and_wait() → exit 0
 11. Read audit.jsonl → assert exactly one tool_start for
-    readonly.move_message paired with a tool_end carrying the
-    posture-denial outcome (exact field name from the current
-    AuditRecord shape; looked up during plan execution, not pinned
-    in this spec).
+    readonly.move_message carrying `account = "readonly"` (proving
+    the audit boundary is correctly scoped under the read-only
+    namespace, not collapsed to legacy `None`), paired with a
+    tool_end carrying the posture-denial outcome (exact field name
+    from the current AuditRecord shape; looked up during plan
+    execution, not pinned in this spec).
 ```
 
 ### 5.3 Seed strategy
@@ -394,6 +444,29 @@ the seeding step to one of the assertions later in the same flow.
 
 The wire surface is what's being exercised; the seed is plumbing.
 Keeping the seed in-process makes the test's intent honest.
+
+**Seed body shape.** Phase 3's seed differs from `e2e.rs`'s
+`test_message()`. Where `e2e_full_session` uses a single-part
+`text/plain` body — sufficient for its assertions — Phase 3 requires
+a multipart message because the wire flow exercises `list_attachments`
+and `download_attachment`. A `text/plain`-only seed makes both calls
+either empty or error paths, voiding the real-bytes attachment
+regression coverage Phase 3 claims.
+
+`support::dovecot::fixtures::multipart_with_attachment()` constructs a
+`multipart/mixed` MIME message with:
+
+- A `text/plain` body part with deterministic content (so
+  `fetch_message` assertions remain a one-line equality check).
+- One `application/octet-stream` attachment part with
+  `Content-Disposition: attachment; filename="attached.bin"` and a
+  small fixed byte payload (e.g. 16–64 deterministic bytes) so
+  `download_attachment` can byte-compare the downloaded file against
+  the known payload.
+
+The fixture is a `pub const`/`fn` in `support::dovecot::fixtures` so
+both seeds and assertions reference the same payload — no duplication
+between "what was seeded" and "what to compare against."
 
 ## 6. Error Handling
 
@@ -479,16 +552,33 @@ Phase 3's job blurs the line with Phase 4 and inflates this PR.
 
 ## 8. Acceptance criteria (from #265, refined)
 
-- [ ] `cargo test -p rimap-server --tests e2e_wire` exercises at least
-  one wire-driven Dovecot scenario.
+- [ ] `cargo test -p rimap-server --test e2e_wire` exercises at least
+  one wire-driven Dovecot scenario. (`--test` selects the integration
+  target; the earlier `--tests <name>` form would silently degrade to
+  a name-filter that matches nothing and pass with zero tests run.)
+- [ ] CI runs the Phase 3 target via `cargo nextest run -p rimap-server
+  --test e2e_wire` (or the `cargo test` equivalent) wrapped in a
+  zero-tests-selected guard — `nextest`'s `--no-tests=fail` or, with
+  `cargo test`, a `--list` count check — so a future rename / move /
+  delete of the test file cannot produce a green CI signal with no
+  Phase 3 scenarios actually run. Exact flag pinned in the plan.
 - [ ] Coverage of all draft-safe-posture tools named in the issue
   scope is confirmed by tool-call audit records in the captured audit
-  log: list_folders, list_attachments, download_attachment,
-  list_labels, list_accounts, search, fetch_message, mark_read,
+  log, every record carrying the correct account namespace
+  (`draftsafe` for account-scoped tools; `None` for the
+  `use_account` / `list_accounts` infrastructure tools): list_folders,
+  list_attachments, download_attachment, list_labels, list_accounts,
+  search, fetch_message, mark_read, mark_unread, flag, unflag,
   add_label, remove_label, move_message, create_draft, use_account.
+- [ ] Attachment coverage is concrete: the seed is a `multipart/mixed`
+  message with at least one non-trivial attachment; `list_attachments`
+  returns ≥1 part with a non-empty `part_id`; `download_attachment`
+  writes a file inside the sandboxed `download_dir` whose bytes equal
+  the seed attachment's known payload.
 - [ ] Posture denial: at least one mutating tool call against the
   read-only account returns the pinned posture-denial error envelope
-  and produces a paired tool_start/tool_end record in the audit log.
+  and produces a paired tool_start/tool_end record in the audit log
+  carrying `account = "readonly"` (not collapsed to `None`).
 - [ ] Every wire response validates against (a) Phase 1's vendored MCP
   spec envelope/method schemas and (b) the per-tool response schema in
   `tests/fixtures/rimap-tool-schemas/`.

--- a/justfile
+++ b/justfile
@@ -249,6 +249,14 @@ mcp-conformance-node:
         RUSTY_IMAP_MCP_BIN="{{justfile_directory()}}/target/debug/rusty-imap-mcp" \
         pnpm test
 
+# Regenerate per-tool JSON Schemas under
+# crates/rimap-server/tests/fixtures/rimap-tool-schemas/. Run after
+# changing any tool response struct (<Tool>Meta or <Tool>Untrusted).
+# CI fails on a non-empty diff under that directory.
+regen-tool-schemas:
+    #!/usr/bin/env bash
+    ./scripts/regen-tool-schemas.sh
+
 # Full local-CI equivalent. If this passes, CI will pass.
 ci: fmt-check lint test test-msrv deny mcp-conformance-node
     typos

--- a/scripts/regen-tool-schemas.sh
+++ b/scripts/regen-tool-schemas.sh
@@ -6,15 +6,19 @@ cd "$repo_root"
 
 out_dir="crates/rimap-server/tests/fixtures/rimap-tool-schemas"
 mkdir -p "$out_dir"
-dump="$(cargo run --quiet -p rimap-server --features test-support \
-    --bin rusty-imap-mcp --locked -- dump-tool-schemas)"
+# Pipe the dump on stdin instead of passing it as an argv element so
+# the script does not trip ARG_MAX on Linux when schemas grow large.
+# `python3 -c` keeps the script inline (a heredoc would shadow the
+# piped stdin).
 # Split the top-level object into one file per tool. Sort keys
 # so the on-disk byte order is deterministic across runs.
-python3 - "$dump" "$out_dir" <<'PY'
+cargo run --quiet -p rimap-server --features test-support \
+    --bin rusty-imap-mcp --locked -- dump-tool-schemas |
+    python3 -c '
 import json, sys, pathlib
-dump, out_dir = sys.argv[1], pathlib.Path(sys.argv[2])
-data = json.loads(dump)
+out_dir = pathlib.Path(sys.argv[1])
+data = json.load(sys.stdin)
 for tool, schema in sorted(data.items()):
     path = out_dir / f"{tool}.schema.json"
     path.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n")
-PY
+' "$out_dir"

--- a/scripts/regen-tool-schemas.sh
+++ b/scripts/regen-tool-schemas.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+out_dir="crates/rimap-server/tests/fixtures/rimap-tool-schemas"
+mkdir -p "$out_dir"
+dump="$(cargo run --quiet -p rimap-server --features test-support \
+    --bin rusty-imap-mcp --locked -- dump-tool-schemas)"
+# Split the top-level object into one file per tool. Sort keys
+# so the on-disk byte order is deterministic across runs.
+python3 - "$dump" "$out_dir" <<'PY'
+import json, sys, pathlib
+dump, out_dir = sys.argv[1], pathlib.Path(sys.argv[2])
+data = json.loads(dump)
+for tool, schema in sorted(data.items()):
+    path = out_dir / f"{tool}.schema.json"
+    path.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n")
+PY


### PR DESCRIPTION
Closes #265.

## Summary

Phase 3 of 4 in the MCP conformance test family. Adds a wire-driven Dovecot e2e (`crates/rimap-server/tests/e2e_wire.rs`) that drives `rusty-imap-mcp` over its stdio JSON-RPC wire against the existing Dovecot container fixture and validates every response against (a) the vendored MCP spec schemas (envelope + `CallToolResult`) and (b) per-tool response schemas regenerated from the Rust output structs via `schemars`. Two tests: `wire_e2e_full_session_draft_safe` exercises every draft-safe-posture tool category named in #265 (list/fetch/mutate/admin); `wire_e2e_readonly_posture_denial` covers the read-only success path AND the posture-denial wire envelope.

## What's in the diff

- **Spec + plan docs:** `2026-05-12-mcp-behavioral-conformance-design.md`, `2026-05-12-mcp-behavioral-conformance-plan.md`, plus two follow-up fix plans for Codex review findings.
- **`schemars` derives** on the 14 in-scope tool response structs + `rimap_content::SecurityWarning`/`AttachmentMeta`/`WarningCode`/`WarningSeverity`. Gated behind `feature = "test-support"`; production builds unaffected.
- **`dump-tool-schemas` subcommand** (mirrors Phase 2's `dump-tool-catalog`). Emits one JSON Schema per tool composing `{meta, untrusted?, security_warnings}` with all `$defs` hoisted to the envelope root.
- **`just regen-tool-schemas`** recipe + 16 checked-in fixtures under `crates/rimap-server/tests/fixtures/rimap-tool-schemas/`. CI fails on a non-empty diff.
- **Shared test-support infrastructure:** Phase 1's wire harness and `e2e.rs`'s `DovecotHarness` extracted into `tests/support/{wire,dovecot}/`. New `Harness::spawn_with_config` for caller-supplied configs + env injection.
- **`HarnessError`** with `DockerUnavailable` as the silent-skip signal; every other failure mode (compose-up, readiness timeout, port reservation, fingerprint read) panics loudly when `RIMAP_REQUIRE_DOCKER=1` is set.
- **CI:** new `tool-schema-drift` job + `--no-tests=fail` guard step on the `test (stable)` job so a future rename of `e2e_wire.rs` fails CI loudly.
- **AGENTS.md** documents the wire-driven e2e subsection, wall-time expectations, and gating semantics.

## Test plan

- [x] `cargo nextest run -p rimap-server` — 267/267 pass locally (silent-skip for Docker-required tests on arm64 macOS).
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean.
- [x] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire` — panics with the expected `compose up failed: host arch aarch64 ...` diagnostic on no-Docker hosts (verifies the loud-failure path).
- [x] `just regen-tool-schemas` is idempotent (no diff on re-run).
- [x] Phase 1 (`mcp_wire_conformance`) and Phase 2 (`just mcp-conformance-node`) suites continue to pass byte-for-byte.
- [ ] Linux x86_64 CI run executes both `e2e_wire` tests against live Dovecot (cannot verify locally; that's the CI gate this PR adds).
- [ ] PR review.

## Adversarial review history

The branch went through three rounds of `/codex:adversarial-review`. Each round caught real issues that subsequent commits addressed:

1. **Round 1:** spec/plan-level — schema-derive scope (nested `rimap_content` types), CI prerequisite gaps (libdbus, `just` installer), readonly success-path coverage, `CallToolResult` schema validation.
2. **Round 2:** post-implementation — `RIMAP_REQUIRE_DOCKER=1` was set in CI but never read by `DovecotHarness::try_start`; per-tool schemas had dangling `\$ref`s because nested `\$defs` weren't hoisted.
3. **Round 3:** `SearchResultEntry.from`/`to` marked as schema-`required` despite `skip_serializing_if = "Vec::is_empty"` on the wire.

All three findings are closed; the smoke-test pinning each acceptance criterion lives in `tests/support/wire/schema.rs::fixture_smoke_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)