### PR TITLE
Migrate Dovecot test fixture to multi-arch 2.4.4-root (#273)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,27 +66,19 @@ there, not in ad-hoc scripts.
 
 ### Container runtime for integration tests
 
-The rimap-imap Dovecot integration harness autodetects `docker` first, then
-falls back to `podman` (via `podman compose` / `podman-compose`). Both
-runtimes work on macOS, Ubuntu CI, and Fedora. Override with
-`RIMAP_CONTAINER_TOOL=docker` or `RIMAP_CONTAINER_TOOL=podman` if you need
-to force a specific one. Set `RIMAP_REQUIRE_DOCKER=1` to fail loudly
-instead of silently skipping when no runtime is installed (the env var
-name is historical — it gates both docker and podman).
+The Dovecot integration harness autodetects `docker` first, then falls
+back to `podman` (via `podman compose` / `podman-compose`). Both
+runtimes work on macOS (Apple Silicon and Intel), Ubuntu CI, and Fedora.
+Override with `RIMAP_CONTAINER_TOOL=docker` or
+`RIMAP_CONTAINER_TOOL=podman` if you need to force a specific one. Set
+`RIMAP_REQUIRE_DOCKER=1` to fail loudly instead of silently skipping
+when no runtime is installed.
 
-**Apple Silicon (arm64 macOS):** Docker Desktop *can* run x86_64 images via
-Rosetta emulation in general, **but the pinned `dovecot/dovecot:2.3.21`
-image fails under Rosetta** — the container starts and the IMAPS port
-binds, but dovecot's child processes (`anvil`, `log`, `auth`) die with
-`rosetta error: unable to mmap ExecutableHeap: 12` (ENOMEM emulating an
-executable heap) and `userdb lookup ... Disconnected unexpectedly`. The
-`dovecot/dovecot:2.4.x` line is multi-arch but has breaking config-format
-changes deferred out of scope (see commit `ae1bf8b` and
-`crates/rimap-imap/tests/integration/dovecot/docker-compose.yml`). For
-that reason the harness `std::env::consts::ARCH != "x86_64"` check in
-`crates/rimap-server/tests/support/dovecot/harness.rs` silently skips on
-arm64 hosts — the gate exists for this specific fixture incompatibility,
-not as a blanket assumption about Docker emulation.
+The fixture image is `docker.io/dovecot/dovecot:2.4.4-root` (rootful
+flavor, multi-arch `linux/amd64` + `linux/arm64`). It listens on
+container ports 143 (IMAP+STARTTLS) and 993 (IMAPS); the Rust harness
+maps host ports dynamically. There is no arch gate — every supported
+developer host can run the suite.
 
 ### Wire-driven Dovecot e2e (Phase 3, #265)
 
@@ -98,17 +90,14 @@ schemas + per-tool schemas under
 `crates/rimap-server/tests/fixtures/rimap-tool-schemas/`, and asserts
 audit-log pairing + namespace attribution.
 
-- Wall time: silent-skip path is sub-second (measured locally at ~0.019s
-  on macOS arm64 without Docker); with Docker on linux/x86_64 expected
-  ~10–25s on a warm machine (Dovecot bring-up dominates). Recorded in
-  CI logs.
+- Wall time: silent-skip path is sub-second when no container runtime
+  is available; with Docker on either linux/amd64 or macOS arm64,
+  expect ~10–60s on a warm machine (Dovecot bring-up dominates).
 - Gating: silent-skip ONLY when the host genuinely cannot run the
-  fixture — missing docker/podman, or an arm64 host where dovecot
-  2.3.21 amd64 crashes under Rosetta (see the Apple Silicon note
-  above). `RIMAP_REQUIRE_DOCKER=1` flips every other failure mode
-  (compose-up, readiness timeout, port reservation, fingerprint read)
-  to a panic with diagnostic context. Same convention as the legacy
-  in-process `e2e_full_session`.
+  fixture — missing docker/podman. `RIMAP_REQUIRE_DOCKER=1` flips
+  every failure mode (compose-up, readiness timeout, port reservation,
+  fingerprint read) to a panic with diagnostic context. Same
+  convention as the legacy in-process `e2e_full_session`.
 - Schema regen: when changing any `<Tool>Meta` or `<Tool>Untrusted`
   struct in `crates/rimap-server/src/tools/`, run
   `just regen-tool-schemas` and commit the diff. CI fails on a

--- a/crates/rimap-imap/tests/integration/dovecot/docker-compose.yml
+++ b/crates/rimap-imap/tests/integration/dovecot/docker-compose.yml
@@ -1,13 +1,10 @@
 services:
   dovecot:
-    # Pinned amd64-only. Multi-arch (arm64) is only available on dovecot/dovecot:2.4.x
-    # but the 2.4 line has breaking config-format changes that would require a
-    # parallel dovecot.conf migration. CI runs on Linux amd64 natively so this
-    # works there; local arm64 Mac hosts cannot run the suite under Rosetta
-    # because dovecot's child processes hit "mmap_anonymous_rw mmap failed".
-    # Fully-qualified so podman (with short-name-mode=enforcing, the Fedora
-    # default) does not try to prompt a TTY to disambiguate registries.
-    image: docker.io/dovecot/dovecot:2.3.21
+    # Pinned to the multi-arch `-root` flavor (2.4.x default images are
+    # rootless on non-privileged ports; the `-root` variant preserves the
+    # rootful contract this fixture's entrypoint relies on: writes to
+    # /etc/dovecot, /var/mail, /var/run/dovecot and binds 143/993).
+    image: docker.io/dovecot/dovecot:2.4.4-root
     container_name: ${COMPOSE_PROJECT_NAME:-rimap-it}-dovecot
     ports:
       # Loopback-only. The host port is pre-allocated by the Rust harness

--- a/crates/rimap-imap/tests/integration/dovecot/dovecot.conf
+++ b/crates/rimap-imap/tests/integration/dovecot/dovecot.conf
@@ -1,25 +1,30 @@
+dovecot_config_version = 2.4.4
+dovecot_storage_version = 2.4.4
+
 protocols = imap
 
 ssl = required
-ssl_cert = </etc/dovecot/cert.pem
-ssl_key = </etc/dovecot/key.pem
+ssl_server_cert_file = /etc/dovecot/cert.pem
+ssl_server_key_file = /etc/dovecot/key.pem
 ssl_min_protocol = TLSv1.2
 
-disable_plaintext_auth = yes
-# Explicitly clear trusted networks so that even loopback connections (127.0.0.1)
-# are subject to disable_plaintext_auth and must use STARTTLS before LOGIN.
+auth_allow_cleartext = no
 login_trusted_networks =
 
-mail_location = maildir:~/Maildir
+mail_driver = maildir
+mail_path = ~/Maildir
 
-passdb {
-  driver = passwd-file
-  args = scheme=PLAIN /etc/dovecot/users
+passdb passwd-file {
+  passwd_file_path = /etc/dovecot/users
+  default_password_scheme = PLAIN
 }
 
-userdb {
-  driver = static
-  args = uid=1000 gid=1000 home=/var/mail/%u
+userdb static {
+  fields {
+    uid = 1000
+    gid = 1000
+    home = /var/mail/%{user}
+  }
 }
 
 namespace inbox {

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -609,12 +609,16 @@ impl ReservedPort {
 const STALE_PROJECT_AGE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
 fn uuid_like() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    format!("{nanos:x}")
+    let pid = std::process::id();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos:x}-{pid:x}-{n:x}")
 }
 
 use rimap_audit::{AuditOptions, AuditWriter, Seq};

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -82,18 +82,10 @@ pub struct DovecotHarness {
 
 impl DovecotHarness {
     /// Start a fresh Dovecot container. Returns `Err(DockerUnavailable)`
-    /// and skips the test silently in any of these cases (unless
-    /// `RIMAP_REQUIRE_DOCKER=1` is set, in which case each becomes a
-    /// hard error):
-    ///
-    /// - Neither `docker` nor `podman` is installed. Pick one explicitly
-    ///   with `RIMAP_CONTAINER_TOOL={docker,podman}`.
-    /// - The host architecture is not `x86_64`. The pinned
-    ///   `dovecot/dovecot:2.3.21` image is amd64-only, and running it
-    ///   under Rosetta/QEMU emulation crashes dovecot's worker processes
-    ///   at startup with `mmap_anonymous_rw mmap failed` before anything
-    ///   can bind port 993. See the comment in `docker-compose.yml` for
-    ///   the full context and why a 2.4 bump isn't viable in Sprint 3.
+    /// and skips the test silently when neither `docker` nor `podman`
+    /// is installed (unless `RIMAP_REQUIRE_DOCKER=1` is set, in which
+    /// case the absence becomes a hard error). Pick a specific runtime
+    /// with `RIMAP_CONTAINER_TOOL={docker,podman}`.
     pub fn try_start() -> Result<Self, HarnessError> {
         check_prerequisites()?;
 
@@ -257,17 +249,6 @@ impl DovecotHarness {
 
 fn check_prerequisites() -> Result<(), HarnessError> {
     let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
-
-    if std::env::consts::ARCH != "x86_64" {
-        return if require_runtime {
-            Err(HarnessError::DockerCommandFailed(format!(
-                "host arch {} cannot run amd64 dovecot image but RIMAP_REQUIRE_DOCKER=1",
-                std::env::consts::ARCH
-            )))
-        } else {
-            Err(HarnessError::DockerUnavailable)
-        };
-    }
 
     if !runtime_available() {
         return if require_runtime {

--- a/crates/rimap-imap/tests/integration/support/container.rs
+++ b/crates/rimap-imap/tests/integration/support/container.rs
@@ -486,6 +486,24 @@ fn compose_down(project: &str, compose_dir: &std::path::Path) {
         .status();
 }
 
+/// Parse a compose project name into the embedded creation timestamp.
+/// Returns `Some(SystemTime)` if the name follows the
+/// `rimap-it-<hex-nanos>[-<other-segments>]` format, where the leading
+/// hex segment (before any `-`) is interpreted as nanoseconds since
+/// `UNIX_EPOCH`. Returns `None` for any name that does not start with
+/// `rimap-it-`, has no hex prefix, or whose hex prefix doesn't parse.
+fn project_creation_time(name: &str) -> Option<std::time::SystemTime> {
+    let suffix = name.strip_prefix("rimap-it-")?;
+    let hex_nanos = suffix.split('-').next()?;
+    if hex_nanos.is_empty() {
+        return None;
+    }
+    let nanos = u128::from_str_radix(hex_nanos, 16).ok()?;
+    let secs = u64::try_from(nanos / 1_000_000_000).ok()?;
+    let sub_nanos = u32::try_from(nanos % 1_000_000_000).ok()?;
+    Some(std::time::UNIX_EPOCH + std::time::Duration::new(secs, sub_nanos))
+}
+
 /// Best-effort cleanup of leaked `rimap-it-*` compose projects from previous
 /// runs that died via SIGKILL or power loss (Drop doesn't fire on either).
 /// Skips projects younger than `STALE_PROJECT_AGE` to avoid disturbing
@@ -514,22 +532,9 @@ fn prune_stale_projects(compose_dir: &std::path::Path) {
         let Some(name) = project.get("Name").and_then(|v| v.as_str()) else {
             continue;
         };
-        if !name.starts_with("rimap-it-") {
-            continue;
-        }
-        // Parse the embedded nanosecond timestamp from the project name.
-        // Project names look like "rimap-it-<hex-nanos>" where the suffix is
-        // hex-encoded `SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`.
-        let suffix = &name["rimap-it-".len()..];
-        let Ok(nanos) = u128::from_str_radix(suffix, 16) else {
+        let Some(created) = project_creation_time(name) else {
             continue;
         };
-        // Convert the nanos value to a SystemTime. u128 -> Duration requires
-        // splitting into seconds + sub-nanos because Duration::from_nanos
-        // only accepts u64.
-        let secs = u64::try_from(nanos / 1_000_000_000).unwrap_or(u64::MAX);
-        let sub_nanos = u32::try_from(nanos % 1_000_000_000).unwrap_or(0);
-        let created = std::time::UNIX_EPOCH + std::time::Duration::new(secs, sub_nanos);
         let age = now.duration_since(created).unwrap_or_default();
         if age < STALE_PROJECT_AGE {
             continue;
@@ -813,6 +818,52 @@ mod tests {
         let mut p = ReservedPort::acquire().expect("acquire");
         p.release();
         p.release(); // must not panic
+    }
+
+    #[test]
+    fn project_creation_time_parses_legacy_hex_only_format() {
+        // Old format before Task 6a: "rimap-it-<hex-nanos>".
+        // This may still appear for projects created before this fix is
+        // deployed.
+        let t = project_creation_time("rimap-it-18af360a97189210");
+        assert!(t.is_some(), "legacy hex-only format must parse");
+    }
+
+    #[test]
+    fn project_creation_time_parses_new_pid_counter_format() {
+        // New format from Task 6a: "rimap-it-<hex-nanos>-<hex-pid>-<hex-counter>".
+        let t = project_creation_time("rimap-it-18af360a97189210-3f0-0");
+        assert!(t.is_some(), "new pid+counter format must parse");
+    }
+
+    #[test]
+    fn project_creation_time_matches_for_both_formats() {
+        // Same leading hex must produce the same SystemTime regardless
+        // of trailing -pid-counter segments.
+        let legacy = project_creation_time("rimap-it-18af360a97189210");
+        let new = project_creation_time("rimap-it-18af360a97189210-3f0-0");
+        assert_eq!(legacy, new);
+    }
+
+    #[test]
+    fn project_creation_time_rejects_missing_prefix() {
+        assert!(project_creation_time("other-project-deadbeef").is_none());
+    }
+
+    #[test]
+    fn project_creation_time_rejects_non_hex_prefix() {
+        assert!(project_creation_time("rimap-it-not-hex-here").is_none());
+    }
+
+    #[test]
+    fn project_creation_time_rejects_empty_suffix() {
+        assert!(project_creation_time("rimap-it-").is_none());
+    }
+
+    #[test]
+    fn project_creation_time_rejects_empty_hex_segment_before_dash() {
+        // "rimap-it--3f0-0" — leading hex segment is empty.
+        assert!(project_creation_time("rimap-it--3f0-0").is_none());
     }
 
     use std::sync::Mutex;

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -1,8 +1,8 @@
 //! Dovecot e2e smoke test: exercises the full MCP tool chain against
 //! a real Dovecot IMAP server running in a container.
 //!
-//! Skips silently when no container runtime is available or the host
-//! architecture is not `x86_64` (dovecot image is amd64-only).
+//! Skips silently when no container runtime is available. Set
+//! `RIMAP_REQUIRE_DOCKER=1` to fail loudly instead.
 //!
 //! # Scope and structure
 //!

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -5,8 +5,8 @@
 //! Phase 1's vendored MCP spec schemas + per-tool response schemas
 //! under `tests/fixtures/rimap-tool-schemas/`.
 //!
-//! Silent-skip when no container runtime is available or the host
-//! arch is not `x86_64`; `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+//! Silent-skip when no container runtime is available;
+//! `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
 #![expect(clippy::panic, reason = "test diagnostics")]

--- a/crates/rimap-server/tests/support/dovecot/harness.rs
+++ b/crates/rimap-server/tests/support/dovecot/harness.rs
@@ -1,7 +1,7 @@
 //! Dovecot container harness lifted from the original
 //! `crates/rimap-server/tests/e2e.rs`. Honors the same env vars
 //! (`RIMAP_CONTAINER_TOOL`, `RIMAP_REQUIRE_DOCKER`) and silently skips
-//! on non-x86_64 hosts or when no container runtime is available.
+//! when no container runtime is available.
 //! See `AGENTS.md` "Container runtime for integration tests".
 
 #![expect(clippy::expect_used, reason = "integration tests")]
@@ -47,17 +47,6 @@ impl std::error::Error for HarnessError {}
 
 fn check_prerequisites() -> Result<(), HarnessError> {
     let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
-
-    if std::env::consts::ARCH != "x86_64" {
-        return if require_runtime {
-            Err(HarnessError::ComposeFailed(format!(
-                "host arch {} cannot run amd64 dovecot image but RIMAP_REQUIRE_DOCKER=1",
-                std::env::consts::ARCH
-            )))
-        } else {
-            Err(HarnessError::DockerUnavailable)
-        };
-    }
 
     if !runtime_available() {
         return if require_runtime {

--- a/docs/superpowers/plans/2026-05-13-dovecot-24-multiarch-fixture.md
+++ b/docs/superpowers/plans/2026-05-13-dovecot-24-multiarch-fixture.md
@@ -239,15 +239,23 @@ Keep everything from `container_name:` onwards unchanged.
 
 - [ ] **Step 2: If Task 2 Step 3 found inherited `conf.d/` defaults, also override the directory**
 
-Only if needed (skip this step otherwise). Under `volumes:` in the same compose file, add a tmpfs mount for the conf.d directory immediately after the existing `shared:/shared` line:
+Only if needed (skip this step otherwise). A bare path under `volumes:` does **not** mask the image contents — it creates an anonymous volume that Docker initializes from the image's directory at first run, so the upstream defaults would still leak through. Use a real empty tmpfs instead. Add a top-level `tmpfs:` service key (sibling of `volumes:`, `image:`, etc.) to the `dovecot` service:
 
 ```yaml
-      # Override upstream image's baked-in /etc/dovecot/conf.d/ with an
-      # empty tmpfs so its defaults cannot conflict with our config.
+    tmpfs:
+      # Empty tmpfs mounted over /etc/dovecot/conf.d so upstream image
+      # defaults cannot override the settings in our dovecot.conf. A
+      # bare-path entry under `volumes:` would NOT do this — Docker
+      # populates anonymous volumes from the image's directory contents
+      # at first run.
       - /etc/dovecot/conf.d
 ```
 
-(A bare path under `volumes:` creates an anonymous tmpfs-like volume scoped to the container, masking the image's directory.)
+If the long form is preferred (e.g., because tmpfs sizing matters), the equivalent under `volumes:` is:
+```yaml
+      - type: tmpfs
+        target: /etc/dovecot/conf.d
+```
 
 - [ ] **Step 3: Manual bring-up to validate**
 
@@ -270,9 +278,14 @@ Run:
 ```bash
 docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml exec dovecot id
 docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml exec dovecot doveconf -n > /tmp/dovecot-2.4-probe/runtime.conf 2>&1
-diff -u /tmp/dovecot-2.4-probe/canonical.conf /tmp/dovecot-2.4-probe/runtime.conf || true
+diff -u /tmp/dovecot-2.4-probe/canonical.conf /tmp/dovecot-2.4-probe/runtime.conf
 ```
-Expected: `id` reports `uid=0(root)`. The diff between the Task-2 canonical output and the runtime `doveconf -n` is empty (or only differs in setting-order trivia that `doveconf -n` itself normalizes).
+Expected: `id` reports `uid=0(root)`. `diff` exits 0 with empty output — runtime `doveconf -n` matches the Task-2 baseline exactly.
+
+**This check fails closed.** If `diff` exits non-zero, do not proceed. A non-empty diff means an inherited `conf.d/` default or a settings-format mismatch is silently changing the runtime config; this is the exact failure mode Task 2 Step 3 and this step were designed to catch. Triage:
+- If the diff is purely whitespace/comment lines, normalize with `diff -u -w` and re-evaluate.
+- If real settings differ (e.g., upstream `conf.d/` set `ssl_min_protocol = TLSv1.3`), apply the conditional `tmpfs:` override from Step 2 and re-run the bring-up loop (Steps 3 → 4) until `diff` reports clean.
+- If `doveconf -n` reorders entries deterministically but values match, treat that as parity and document the canonical form by re-capturing `/tmp/dovecot-2.4-probe/canonical.conf` from the running container (`cp runtime.conf canonical.conf`) — the runtime output is authoritative.
 
 - [ ] **Step 5: TLS handshake smoke test**
 

--- a/docs/superpowers/plans/2026-05-13-dovecot-24-multiarch-fixture.md
+++ b/docs/superpowers/plans/2026-05-13-dovecot-24-multiarch-fixture.md
@@ -1,0 +1,774 @@
+# Dovecot 2.4 Multi-Arch Test Fixture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the amd64-only `dovecot/dovecot:2.3.21` test fixture with multi-arch `dovecot/dovecot:2.4.4-root`, drop the `std::env::consts::ARCH != "x86_64"` silent-skip gates, and make the integration suites run on both `linux/amd64` (CI) and `arm64 macOS` (local Apple Silicon). Closes GitHub issue #273.
+
+**Architecture:** Single-step replacement. Bump the compose image, rewrite `dovecot.conf` from 2.3 to 2.4 syntax (named `passdb`/`userdb` sections, renamed SSL/auth settings, nested `fields { }` block, `%{user}` variables), delete arch gates from both harnesses, refresh AGENTS.md and caller-side doc comments, remove the obsolete memory note. The `-root` flavor preserves the existing rootful entrypoint contract (ports 143/993, `/etc/dovecot`, `/var/mail`). Rootless migration is an explicit non-goal.
+
+**Tech Stack:** Dovecot 2.4.4 (Docker image, `-root` flavor, multi-arch amd64+arm64), Docker / Podman, `docker compose`, Rust integration test harness (`crates/rimap-server/tests/support/dovecot/harness.rs` and `crates/rimap-imap/tests/integration/support/container.rs`).
+
+**Spec:** `docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md`
+
+**Branch:** continues `spec/dovecot-24-multiarch-fixture` (already has spec commit). Each task below is one logical commit on this branch.
+
+---
+
+## File Structure
+
+Files modified by this plan (no new files created):
+
+- `crates/rimap-imap/tests/integration/dovecot/docker-compose.yml` — image tag bump
+- `crates/rimap-imap/tests/integration/dovecot/dovecot.conf` — rewrite to 2.4 syntax
+- `crates/rimap-server/tests/support/dovecot/harness.rs` — drop arch gate (lines 48–73, rustdoc lines 1–6)
+- `crates/rimap-imap/tests/integration/support/container.rs` — drop arch gate (lines 258–283, rustdoc lines 84–96)
+- `crates/rimap-server/tests/e2e.rs` — rustdoc line 5 (skip caveat)
+- `crates/rimap-server/tests/e2e_wire.rs` — rustdoc lines 8–9 (skip caveat)
+- `crates/rimap-imap/tests/integration/dovecot.rs` — rustdoc line 3 (skip caveat)
+- `AGENTS.md` — replace lines 67–116 ("Container runtime …" + "Wire-driven Dovecot e2e" arch caveat) with arch-agnostic wording
+- `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/project_dovecot_rosetta_gate.md` — delete
+- `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/MEMORY.md` — drop the matching index line
+
+Files NOT modified (deliberate):
+- `crates/rimap-imap/tests/integration/dovecot/entrypoint.sh` — works against `-root` flavor unchanged
+- `crates/rimap-imap/tests/integration/dovecot/users` — passwd-file format unchanged in 2.4
+- `crates/rimap-imap/tests/integration/dovecot/fixtures/*.eml` — sample emails are content, not config
+
+---
+
+### Task 1: Verify image availability and arm64 manifest
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Pull the target image**
+
+Run:
+```bash
+docker pull docker.io/dovecot/dovecot:2.4.4-root
+```
+Expected: `Pull complete` for the host-native variant. If `2.4.4-root` no longer exists, list available `-root` tags with `docker run --rm anchore/skopeo:latest list-tags docker://docker.io/dovecot/dovecot | grep -E '^\s+"2\.4\.[0-9]+-root"'` and pick the highest 2.4.x. Record the chosen tag and use it consistently from this point on. Anywhere the plan says `2.4.4-root`, substitute the chosen tag.
+
+- [ ] **Step 2: Confirm the manifest has both amd64 and arm64 variants**
+
+Run:
+```bash
+docker manifest inspect docker.io/dovecot/dovecot:2.4.4-root | jq '.manifests[].platform | "\(.os)/\(.architecture)"'
+```
+Expected: output contains both `linux/amd64` and `linux/arm64`. If either is missing, stop — the spec's central premise (multi-arch availability) does not hold for the chosen tag.
+
+- [ ] **Step 3: Confirm host-native image is the right architecture**
+
+Run:
+```bash
+docker image inspect docker.io/dovecot/dovecot:2.4.4-root | jq -r '.[].Architecture'
+```
+Expected on Apple Silicon: `arm64`. Expected on Linux CI runners: `amd64`. Mismatch means Docker pulled the wrong variant (rare with manifest lists, but worth confirming).
+
+- [ ] **Step 4: No commit for this task** — verification only.
+
+---
+
+### Task 2: Capture upstream image's `doveconf -n` baseline
+
+**Files:** scratch directory under `/tmp`, none committed.
+
+Purpose: produce a `doveconf -n` reference output from a minimally-valid 2.4 config running inside the `2.4.4-root` image. This output is the source of truth for the rewritten `dovecot.conf` in Task 3 — anything we write must round-trip through `doveconf -n` without producing `Unknown setting` or `Conflicting setting` warnings.
+
+- [ ] **Step 1: Create a scratch config**
+
+Run:
+```bash
+mkdir -p /tmp/dovecot-2.4-probe
+cat > /tmp/dovecot-2.4-probe/dovecot.conf <<'EOF'
+dovecot_config_version = 2.4.4
+dovecot_storage_version = 2.4.4
+
+protocols = imap
+
+ssl = required
+ssl_server_cert_file = /etc/dovecot/cert.pem
+ssl_server_key_file = /etc/dovecot/key.pem
+ssl_min_protocol = TLSv1.2
+
+auth_allow_cleartext = no
+login_trusted_networks =
+
+mail_driver = maildir
+mail_path = ~/Maildir
+
+passdb passwd-file {
+  passwd_file_path = /etc/dovecot/users
+  default_password_scheme = PLAIN
+}
+
+userdb static {
+  fields {
+    uid = 1000
+    gid = 1000
+    home = /var/mail/%{user}
+  }
+}
+
+namespace inbox {
+  inbox = yes
+  separator = /
+
+  mailbox Drafts {
+    special_use = \Drafts
+    auto = subscribe
+  }
+  mailbox Junk {
+    special_use = \Junk
+    auto = subscribe
+  }
+  mailbox Sent {
+    special_use = \Sent
+    auto = subscribe
+  }
+  mailbox Trash {
+    special_use = \Trash
+    auto = subscribe
+  }
+}
+
+service imap-login {
+  inet_listener imap {
+    port = 143
+  }
+  inet_listener imaps {
+    port = 993
+    ssl = yes
+  }
+}
+
+log_path = /dev/stderr
+info_log_path = /dev/stderr
+debug_log_path = /dev/stderr
+EOF
+```
+
+- [ ] **Step 2: Run `doveconf -n` against the scratch config**
+
+Run:
+```bash
+docker run --rm \
+  -v /tmp/dovecot-2.4-probe/dovecot.conf:/etc/dovecot/dovecot.conf:ro \
+  docker.io/dovecot/dovecot:2.4.4-root \
+  doveconf -n 2>/tmp/dovecot-2.4-probe/stderr.log > /tmp/dovecot-2.4-probe/canonical.conf
+echo "--- stderr ---"
+cat /tmp/dovecot-2.4-probe/stderr.log
+echo "--- canonical.conf head ---"
+head -40 /tmp/dovecot-2.4-probe/canonical.conf
+```
+Expected: `stderr.log` contains no lines matching `Unknown setting`, `Conflicting setting`, or `Error`. `canonical.conf` starts with `# 2.4.4 ...` and lists the settings in canonical 2.4 form.
+
+- [ ] **Step 3: Triage any warnings**
+
+If `stderr.log` reports `Unknown setting <foo>`, that setting is misnamed or has been renamed again — consult `https://doc.dovecot.org/2.4.4/installation/upgrade/2.3-to-2.4.html` or run `docker run --rm docker.io/dovecot/dovecot:2.4.4-root doveconf -a | grep -i <foo>` to find the canonical name. Update `/tmp/dovecot-2.4-probe/dovecot.conf` and rerun Step 2 until warnings are clean.
+
+If `stderr.log` reports `Conflicting setting`, the upstream image's baked-in `/etc/dovecot/conf.d/*.conf` is overriding our value. Confirm with:
+```bash
+docker run --rm docker.io/dovecot/dovecot:2.4.4-root ls /etc/dovecot/conf.d/
+```
+If non-empty, plan to mount an empty directory over `/etc/dovecot/conf.d/` in Task 4. (The committed compose file uses a single `dovecot.conf` mount; the override is needed only if the upstream `dovecot.conf` `!include`s `conf.d/`.)
+
+- [ ] **Step 4: No commit for this task** — `/tmp/dovecot-2.4-probe/dovecot.conf` is the input to Task 3. Keep it on disk.
+
+---
+
+### Task 3: Rewrite `dovecot.conf` to 2.4 syntax
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/dovecot/dovecot.conf` (full rewrite)
+
+- [ ] **Step 1: Copy the validated scratch config into the repo**
+
+Run:
+```bash
+cp /tmp/dovecot-2.4-probe/dovecot.conf \
+  crates/rimap-imap/tests/integration/dovecot/dovecot.conf
+```
+
+- [ ] **Step 2: Diff against the previous version to confirm intent**
+
+Run:
+```bash
+git --no-pager diff crates/rimap-imap/tests/integration/dovecot/dovecot.conf
+```
+Expected: diff matches the rename table in the spec (Section 2). Every removed line maps to a renamed/restructured replacement; no settings are silently dropped.
+
+- [ ] **Step 3: Stage and commit**
+
+Run:
+```bash
+git add crates/rimap-imap/tests/integration/dovecot/dovecot.conf
+git commit -m "$(cat <<'EOF'
+test(fixture): rewrite dovecot.conf to 2.4 syntax (#273)
+
+Named passdb/userdb sections, dovecot_config_version preamble,
+ssl_server_{cert,key}_file rename, auth_allow_cleartext = no,
+nested userdb static.fields block, %{user} variable.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Bump compose image tag
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/dovecot/docker-compose.yml`
+
+- [ ] **Step 1: Edit the compose file**
+
+Replace lines 2–10 (the multi-line amd64-only comment plus the `image:` line) with:
+
+```yaml
+services:
+  dovecot:
+    # Pinned to the multi-arch `-root` flavor (2.4.x default images are
+    # rootless on non-privileged ports; the `-root` variant preserves the
+    # rootful contract this fixture's entrypoint relies on: writes to
+    # /etc/dovecot, /var/mail, /var/run/dovecot and binds 143/993).
+    image: docker.io/dovecot/dovecot:2.4.4-root
+```
+
+Keep everything from `container_name:` onwards unchanged.
+
+- [ ] **Step 2: If Task 2 Step 3 found inherited `conf.d/` defaults, also override the directory**
+
+Only if needed (skip this step otherwise). Under `volumes:` in the same compose file, add a tmpfs mount for the conf.d directory immediately after the existing `shared:/shared` line:
+
+```yaml
+      # Override upstream image's baked-in /etc/dovecot/conf.d/ with an
+      # empty tmpfs so its defaults cannot conflict with our config.
+      - /etc/dovecot/conf.d
+```
+
+(A bare path under `volumes:` creates an anonymous tmpfs-like volume scoped to the container, masking the image's directory.)
+
+- [ ] **Step 3: Manual bring-up to validate**
+
+Run:
+```bash
+RIMAP_DOVECOT_HOST_PORT=9993 \
+RIMAP_DOVECOT_HOST_PORT_STARTTLS=1143 \
+docker compose \
+  -p smoke \
+  -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml \
+  up -d
+sleep 3
+docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml logs dovecot | tail -30
+```
+Expected: log output includes `[entrypoint] start` ... `[entrypoint] ready`. No `dovecot_config_version` upgrade-required errors, no `Unknown setting`, no `Disconnected unexpectedly`.
+
+- [ ] **Step 4: Confirm container UID and ports**
+
+Run:
+```bash
+docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml exec dovecot id
+docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml exec dovecot doveconf -n > /tmp/dovecot-2.4-probe/runtime.conf 2>&1
+diff -u /tmp/dovecot-2.4-probe/canonical.conf /tmp/dovecot-2.4-probe/runtime.conf || true
+```
+Expected: `id` reports `uid=0(root)`. The diff between the Task-2 canonical output and the runtime `doveconf -n` is empty (or only differs in setting-order trivia that `doveconf -n` itself normalizes).
+
+- [ ] **Step 5: TLS handshake smoke test**
+
+Run:
+```bash
+echo "QUIT" | openssl s_client -connect 127.0.0.1:9993 -servername localhost -verify_return_error 2>&1 | head -10
+```
+Expected: handshake succeeds (a `subject=CN = rimap-test-dovecot` line appears); `verify error:num=18:self-signed certificate` is expected and acceptable.
+
+- [ ] **Step 6: doveadm mailbox sanity check**
+
+Run:
+```bash
+docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml \
+  exec dovecot doveadm mailbox list -u rimap-test
+```
+Expected: lists `INBOX` and the seeded sub-mailboxes (`INBOX/Drafts`, `INBOX/Sent`, etc.) without `Disconnected unexpectedly` errors.
+
+- [ ] **Step 7: Tear down**
+
+Run:
+```bash
+docker compose -p smoke -f crates/rimap-imap/tests/integration/dovecot/docker-compose.yml down -v --remove-orphans
+```
+
+- [ ] **Step 8: Stage and commit**
+
+Run:
+```bash
+git add crates/rimap-imap/tests/integration/dovecot/docker-compose.yml
+git commit -m "$(cat <<'EOF'
+test(fixture): bump dovecot image to 2.4.4-root multi-arch (#273)
+
+Replaces amd64-only 2.3.21 with the multi-arch -root flavor. Manifest
+verified for both linux/amd64 and linux/arm64. The -root variant
+preserves the existing rootful entrypoint contract (ports 143/993,
+/etc/dovecot, /var/mail).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Drop arch gate from `rimap-server` harness
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/dovecot/harness.rs` (lines 1–6 rustdoc, lines 48–73 `check_prerequisites`)
+
+- [ ] **Step 1: Update the module rustdoc**
+
+Replace lines 1–6:
+
+```rust
+//! Dovecot container harness lifted from the original
+//! `crates/rimap-server/tests/e2e.rs`. Honors the same env vars
+//! (`RIMAP_CONTAINER_TOOL`, `RIMAP_REQUIRE_DOCKER`) and silently skips
+//! on non-x86_64 hosts or when no container runtime is available.
+//! See `AGENTS.md` "Container runtime for integration tests".
+```
+
+with:
+
+```rust
+//! Dovecot container harness lifted from the original
+//! `crates/rimap-server/tests/e2e.rs`. Honors the same env vars
+//! (`RIMAP_CONTAINER_TOOL`, `RIMAP_REQUIRE_DOCKER`) and silently skips
+//! when no container runtime is available.
+//! See `AGENTS.md` "Container runtime for integration tests".
+```
+
+- [ ] **Step 2: Collapse `check_prerequisites`**
+
+Replace the existing function (currently lines 48–73) with:
+
+```rust
+fn check_prerequisites() -> Result<(), HarnessError> {
+    let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
+
+    if !runtime_available() {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(
+                "neither docker nor podman found but RIMAP_REQUIRE_DOCKER=1".into(),
+            ))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Compile-check the crate**
+
+Run:
+```bash
+cargo check -p rimap-server --tests --locked
+```
+Expected: clean compile. Warnings about unused `std::env::consts::ARCH` should not appear (the symbol was inline-used, not imported).
+
+- [ ] **Step 4: Run the wire e2e suite on this host (arm64 macOS)**
+
+Run:
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked
+```
+Expected: the suite executes (not silent-skipped) and passes. Wall-clock target: 30s–120s on a warm machine; bring-up dominates. If a test fails:
+- Inspect `docker compose -p <project> logs dovecot` while the harness still has the container alive (the harness tears down on drop, so add a `sleep 60` breakpoint locally if needed). Common failure modes: `Unknown setting` (config drift not caught in Task 2), `doveadm Disconnected unexpectedly` (userdb mismatch), TLS handshake EOF (entrypoint readiness ordering).
+- Do not silence the failure. Fix the config or harness and re-run.
+
+- [ ] **Step 5: Run the in-process e2e suite**
+
+Run:
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked
+```
+Expected: passes.
+
+- [ ] **Step 6: No-silent-skip regression guard**
+
+Run:
+```bash
+unset RIMAP_REQUIRE_DOCKER
+cargo nextest run -p rimap-server --test e2e_wire wire_e2e_full_session_draft_safe --locked --no-fail-fast 2>&1 | tail -20
+```
+Expected: the test executes and passes. If output says `0 tests run` or `(skipped)`, the harness has regressed into a new silent-skip path — investigate before continuing.
+
+- [ ] **Step 7: Stage and commit**
+
+Run:
+```bash
+git add crates/rimap-server/tests/support/dovecot/harness.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): drop arch gate from dovecot harness (#273)
+
+The 2.4.4-root image is multi-arch, so the arm64-skip gate no longer
+serves a purpose. Removing it allows the e2e and wire-conformance
+suites to run on Apple Silicon.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Drop arch gate from `rimap-imap` harness
+
+**Files:**
+- Modify: `crates/rimap-imap/tests/integration/support/container.rs` (rustdoc lines 84–96, `check_prerequisites` lines 258–283)
+
+- [ ] **Step 1: Update the rustdoc on `DovecotHarness::try_start`**
+
+Replace lines 84–96 (the `/// Start a fresh Dovecot container...` block down through the closing `///` line before `pub fn try_start`):
+
+```rust
+    /// Start a fresh Dovecot container. Returns `Err(DockerUnavailable)`
+    /// and skips the test silently when neither `docker` nor `podman`
+    /// is installed (unless `RIMAP_REQUIRE_DOCKER=1` is set, in which
+    /// case the absence becomes a hard error). Pick a specific runtime
+    /// with `RIMAP_CONTAINER_TOOL={docker,podman}`.
+```
+
+- [ ] **Step 2: Collapse `check_prerequisites`**
+
+Replace lines 258–283 (the existing function body):
+
+```rust
+fn check_prerequisites() -> Result<(), HarnessError> {
+    let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
+
+    if !runtime_available() {
+        return if require_runtime {
+            Err(HarnessError::DockerCommandFailed(
+                "neither docker nor podman found but RIMAP_REQUIRE_DOCKER=1".into(),
+            ))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+
+    Ok(())
+}
+```
+
+Note the error variant is `DockerCommandFailed` here (not `ComposeFailed` as in `rimap-server`); the two harnesses use different error enums. Use whatever variant the surrounding code already used for the prior runtime-missing case.
+
+- [ ] **Step 3: Compile-check**
+
+Run:
+```bash
+cargo check -p rimap-imap --tests --locked
+```
+Expected: clean.
+
+- [ ] **Step 4: Run the rimap-imap dovecot integration suite**
+
+Run:
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked
+```
+Expected: full suite executes and passes on arm64 macOS. Wall-clock target: 60–180s (this suite has more cases than rimap-server's e2e; `case_11` does a force-recreate which costs an extra ~10s).
+
+If `case_11` fails specifically (look for `--force-recreate` in the test name or `pinned fingerprint` in the assertion message), inspect the entrypoint's cert-persistence path:
+- `cert.pem`/`key.pem` must live on the named `shared` volume (they do — see `entrypoint.sh:30-46`).
+- The fingerprint published to `/shared/fingerprint.hex` must match across recreate. 2.4 doesn't touch openssl, so the cert generation should produce the same fingerprint deterministically.
+
+- [ ] **Step 5: Stage and commit**
+
+Run:
+```bash
+git add crates/rimap-imap/tests/integration/support/container.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-imap): drop arch gate from dovecot harness (#273)
+
+Mirror of the rimap-server change. The 2.4.4-root image is multi-arch,
+so the arm64-skip gate is removed; the rimap-imap dovecot integration
+suite now runs on Apple Silicon too.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Refresh caller-side rustdoc comments
+
+**Files:**
+- Modify: `crates/rimap-server/tests/e2e.rs` (line 5 region)
+- Modify: `crates/rimap-server/tests/e2e_wire.rs` (lines 8–9 region)
+- Modify: `crates/rimap-imap/tests/integration/dovecot.rs` (line 3 region)
+
+- [ ] **Step 1: Update `crates/rimap-server/tests/e2e.rs`**
+
+Replace the current line 4–5 block:
+```rust
+//! Skips silently when no container runtime is available or the host
+//! architecture is not `x86_64` (dovecot image is amd64-only).
+```
+with:
+```rust
+//! Skips silently when no container runtime is available. Set
+//! `RIMAP_REQUIRE_DOCKER=1` to fail loudly instead.
+```
+
+- [ ] **Step 2: Update `crates/rimap-server/tests/e2e_wire.rs`**
+
+Replace the current lines 8–9 block:
+```rust
+//! Silent-skip when no container runtime is available or the host
+//! arch is not `x86_64`; `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+```
+with:
+```rust
+//! Silent-skip when no container runtime is available;
+//! `RIMAP_REQUIRE_DOCKER=1` flips to loud failure.
+```
+
+- [ ] **Step 3: Update `crates/rimap-imap/tests/integration/dovecot.rs`**
+
+Replace the current lines 1–3 block:
+```rust
+//! Dovecot-in-container integration suite for rimap-imap. Runs against
+//! docker or podman (autodetected, override with `RIMAP_CONTAINER_TOOL`).
+//! Local devs without either runtime get the skip path automatically.
+```
+with (just confirm — this version already does not mention arch; leave as-is if it doesn't):
+```rust
+//! Dovecot-in-container integration suite for rimap-imap. Runs against
+//! docker or podman (autodetected, override with `RIMAP_CONTAINER_TOOL`).
+//! Local devs without either runtime get the skip path automatically.
+```
+
+(If the current text in this file already matches the target, skip this sub-step. The Task 6 rustdoc edit on `try_start` already cleaned up the arch caveat in the same crate.)
+
+- [ ] **Step 4: Compile-check**
+
+Run:
+```bash
+cargo check -p rimap-server -p rimap-imap --tests --locked
+```
+Expected: clean.
+
+- [ ] **Step 5: Stage and commit**
+
+Run:
+```bash
+git add crates/rimap-server/tests/e2e.rs \
+        crates/rimap-server/tests/e2e_wire.rs \
+        crates/rimap-imap/tests/integration/dovecot.rs
+git commit -m "$(cat <<'EOF'
+test: drop arch caveat from integration-test rustdoc (#273)
+
+Mirrors the harness change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Update AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md` (lines 67–116 — both the "Container runtime for integration tests" section and the arch caveat embedded in "Wire-driven Dovecot e2e (Phase 3, #265)")
+
+- [ ] **Step 1: Replace the "Container runtime for integration tests" section**
+
+Lines 67–89 currently read as one section ending just before "### Wire-driven Dovecot e2e (Phase 3, #265)". Replace the entire section (the heading line through line 89) with:
+
+```markdown
+### Container runtime for integration tests
+
+The Dovecot integration harness autodetects `docker` first, then falls
+back to `podman` (via `podman compose` / `podman-compose`). Both
+runtimes work on macOS (Apple Silicon and Intel), Ubuntu CI, and Fedora.
+Override with `RIMAP_CONTAINER_TOOL=docker` or
+`RIMAP_CONTAINER_TOOL=podman` if you need to force a specific one. Set
+`RIMAP_REQUIRE_DOCKER=1` to fail loudly instead of silently skipping
+when no runtime is installed.
+
+The fixture image is `docker.io/dovecot/dovecot:2.4.4-root` (rootful
+flavor, multi-arch `linux/amd64` + `linux/arm64`). It listens on
+container ports 143 (IMAP+STARTTLS) and 993 (IMAPS); the Rust harness
+maps host ports dynamically. There is no arch gate — every supported
+developer host can run the suite.
+```
+
+- [ ] **Step 2: Update the "Wire-driven Dovecot e2e" subsection**
+
+Within the section that begins `### Wire-driven Dovecot e2e (Phase 3, #265)`, replace the "Gating" bullet (lines 105–111 in the pre-edit file, which mentions Rosetta and the arch gate) with:
+
+```markdown
+- Gating: silent-skip ONLY when the host genuinely cannot run the
+  fixture — missing docker/podman. `RIMAP_REQUIRE_DOCKER=1` flips
+  every failure mode (compose-up, readiness timeout, port reservation,
+  fingerprint read) to a panic with diagnostic context. Same
+  convention as the legacy in-process `e2e_full_session`.
+```
+
+Also update the immediately-preceding "Wall time" bullet (lines 101–104) to drop the "without Docker" caveat that's no longer arch-conditioned:
+
+```markdown
+- Wall time: silent-skip path is sub-second when no container runtime
+  is available; with Docker on either linux/amd64 or macOS arm64,
+  expect ~10–60s on a warm machine (Dovecot bring-up dominates).
+```
+
+- [ ] **Step 3: Compile-check (sanity, even though it's a doc file)**
+
+Run:
+```bash
+just fmt-check && just lint
+```
+Expected: no formatting or lint regressions (the change is markdown only).
+
+- [ ] **Step 4: Stage and commit**
+
+Run:
+```bash
+git add AGENTS.md
+git commit -m "$(cat <<'EOF'
+docs(AGENTS): drop arm64 Rosetta caveat from integration-test docs (#273)
+
+The 2.4.4-root fixture is multi-arch; the arch gate is gone; the
+arch-specific Rosetta narrative is now obsolete.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Local CI parity check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full local-CI gate**
+
+Run:
+```bash
+just ci
+```
+Expected: all targets green — `fmt-check`, `lint`, `test`, `test-msrv`, `deny`. This is the same gate CI runs; if it passes locally, CI should pass on Linux amd64. Wall-clock: ~10–25 minutes depending on cache state.
+
+- [ ] **Step 2: Spot-check that the integration suites are actually executing**
+
+Run:
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked 2>&1 | grep -E '(test|passed|failed|skipped)'
+RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked 2>&1 | grep -E '(test|passed|failed|skipped)'
+```
+Expected: non-zero test counts, all passed.
+
+- [ ] **Step 3: No commit for this task** — verification only.
+
+---
+
+### Task 10: Push branch and verify CI on linux/amd64
+
+**Files:** none (CI verification).
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin spec/dovecot-24-multiarch-fixture
+```
+Expected: branch published to origin.
+
+- [ ] **Step 2: Open the pull request**
+
+Run:
+```bash
+gh pr create --title "Migrate Dovecot test fixture to multi-arch 2.4.4-root (#273)" --body "$(cat <<'EOF'
+## Summary
+- Replaces amd64-only `dovecot/dovecot:2.3.21` with multi-arch `dovecot/dovecot:2.4.4-root` so integration tests run on Apple Silicon.
+- Rewrites `dovecot.conf` to 2.4 syntax (named `passdb`/`userdb` sections, renamed SSL/auth settings, nested `fields { }` block, `%{user}` variables).
+- Drops the `std::env::consts::ARCH != "x86_64"` silent-skip gates from both `rimap-server` and `rimap-imap` harnesses.
+- Refreshes `AGENTS.md` and the integration-test rustdoc to remove the Rosetta caveat.
+
+Closes #273.
+
+## Test plan
+- [ ] `just ci` passes locally on arm64 macOS.
+- [ ] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked` passes on arm64 macOS.
+- [ ] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked` passes on arm64 macOS.
+- [ ] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked` passes on arm64 macOS.
+- [ ] Same three suites pass on CI (linux/amd64).
+- [ ] No-silent-skip guard: `cargo nextest run -p rimap-server --test e2e_wire wire_e2e_full_session_draft_safe --locked` (without `RIMAP_REQUIRE_DOCKER`) executes the test, does not return "0 tests".
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run:
+```bash
+gh pr checks --watch
+```
+Expected: every required check (`rustfmt`, `clippy`, `check (macOS)`, `test (stable)`, `test (MSRV 1.88.0)`, `cargo-deny`, `zizmor self-check`) goes green. If any fails, do not merge — investigate, push fix-up commits, repeat.
+
+The `test (stable)` and `check (macOS)` checks are where the Dovecot fixture work most likely breaks first. Inspect the job log for `Unknown setting` (config drift), `RIMAP_REQUIRE_DOCKER` failures, or fingerprint mismatches.
+
+- [ ] **Step 4: No local commit for this task** — verification only.
+
+---
+
+### Task 11: Delete obsolete memory note (post-merge)
+
+**Files:**
+- Delete: `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/project_dovecot_rosetta_gate.md`
+- Modify: `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/MEMORY.md` (drop the Rosetta-gate entry line)
+
+This task runs **after** the PR merges. The memory note specifically says "do not propose dropping the arch gate without first switching the fixture image"; that condition is now satisfied, so the note is actively misleading rather than useful.
+
+- [ ] **Step 1: Delete the memory file**
+
+Run:
+```bash
+trash /Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/project_dovecot_rosetta_gate.md
+```
+
+- [ ] **Step 2: Remove the index line from `MEMORY.md`**
+
+Open `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/MEMORY.md` and delete the line:
+```
+- [Dovecot arm64 gate is load-bearing](project_dovecot_rosetta_gate.md) — silent-skip on arm64 macOS is because dovecot:2.3.21 amd64 crashes under Rosetta (mmap ExecutableHeap ENOMEM), not a Docker-emulation misconception. Do not propose removing without migrating the fixture image first.
+```
+
+- [ ] **Step 3: No git commit for this task** — the memory directory is outside the repo. No tracking needed.
+
+---
+
+## Self-Review Checklist
+
+(Maintainer: tick before declaring the plan complete.)
+
+- Spec section 1 (Image bump) → Task 1 + Task 4. ✓
+- Spec section 2 (Config rewrite) → Task 2 (capture baseline) + Task 3 (commit). ✓
+- Spec section 3 (Harness arch gate removal) → Task 5 (rimap-server) + Task 6 (rimap-imap). ✓
+- Spec section 4 (Caller-side doc sweep) → Task 7. ✓
+- Spec section 5 (AGENTS.md) → Task 8. ✓
+- Spec section 6 (Memory cleanup) → Task 11. ✓
+- Verification: bring-up steps → Task 4 (steps 3–6). ✓
+- Verification: automated suites on both arches → Task 5 (steps 4–6) + Task 6 (step 4) on arm64; Task 10 (step 3) on amd64 CI. ✓
+- Verification: no-silent-skip guard → Task 5 step 6. ✓
+- Open Question 1 (latest 2.4.x tag) → Task 1 Step 1 explicitly checks. ✓
+- Open Question 2 (mail_path/mail_driver split) → Task 2 Step 2 (`doveconf -n` is the source of truth). ✓
+- Open Question 3 (static userdb fields block) → Task 2 Step 2 same. ✓
+- Open Question 4 (inherited conf.d defaults) → Task 2 Step 3 + Task 4 Step 2 (conditional override). ✓
+- Open Question 5 (`%`-variable sweep outside dovecot.conf) → no `%`-variables found outside `dovecot.conf` (verified during plan drafting via `rg '%[a-z]\\b' crates/rimap-imap/tests/integration/dovecot/`). If a future change introduces one, the `doveconf -n` step in Task 4 will catch it.

--- a/docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md
+++ b/docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md
@@ -1,0 +1,154 @@
+# Dovecot 2.4 Multi-Arch Test Fixture
+
+**Date:** 2026-05-13
+**Status:** Spec (pending implementation plan)
+**Tracking:** GitHub issue #273
+
+## Problem
+
+The integration-test Dovecot fixture is pinned to `docker.io/dovecot/dovecot:2.3.21`, which is published only for `linux/amd64`. Two test harnesses (`crates/rimap-server/tests/support/dovecot/harness.rs` and `crates/rimap-imap/tests/integration/support/container.rs`) silently skip on `std::env::consts::ARCH != "x86_64"` because the 2.3.21 image crashes under Rosetta on arm64 macOS (`rosetta error: unable to mmap ExecutableHeap: 12` — `ENOMEM` in dovecot worker processes). Consequence: every integration test for `rimap-imap` and `rimap-server` silently skips for any developer working on Apple Silicon, and only CI exercises that surface.
+
+## Goal
+
+Run the Dovecot-backed integration suites on both `linux/amd64` (CI) and `arm64 macOS` (local Apple-Silicon dev hosts) using the same fixture, same harness, same assertions. Close issue #273.
+
+## Non-Goals
+
+- Deduplicating the two harnesses that both call into the same compose tree.
+- Switching from `docker compose` to a Rust container library.
+- Supporting a non-container fallback.
+- Pinning the Docker image by SHA digest (separate Dependabot/supply-chain decision).
+
+## Approach
+
+Single-step replacement: bump the fixture to `dovecot/dovecot:2.4.4`, rewrite `dovecot.conf` to 2.4 syntax, and delete the arch gate from both harnesses. No 2.3 fallback, no runtime config translation, no dual-image branching — consistent with the project's "replace, don't deprecate" rule.
+
+## Components Touched
+
+### 1. Image bump
+- File: `crates/rimap-imap/tests/integration/dovecot/docker-compose.yml`
+- Change: `image: docker.io/dovecot/dovecot:2.3.21` → `image: docker.io/dovecot/dovecot:2.4.4`
+- Drop the multi-line comment that explained the amd64-only constraint; the new image is multi-arch.
+
+`2.4.4` was published 2026-05-12 and ships both `linux/amd64` and `linux/arm64` manifests. The plan stage will confirm the tag is still the latest stable at implementation time and bump if a newer 2.4.x has shipped.
+
+### 2. Config rewrite
+
+File: `crates/rimap-imap/tests/integration/dovecot/dovecot.conf`. Rewritten from scratch in 2.4 syntax. Final text is verified at implementation time against `doveconf -n` inside the running 2.4.4 container; the table below records intent.
+
+| 2.3 (current) | 2.4 target | Notes |
+|---|---|---|
+| (none) | `dovecot_config_version = 2.4.4` | new required first line in 2.4 |
+| (none) | `dovecot_storage_version = 2.4.4` | new required setting in 2.4 |
+| `protocols = imap` | unchanged | |
+| `ssl = required` | unchanged | tightened semantics: login_trusted_networks also requires TLS; our list is empty so test path is unaffected |
+| `ssl_cert = </etc/dovecot/cert.pem` | unchanged | |
+| `ssl_key = </etc/dovecot/key.pem` | unchanged | |
+| `ssl_min_protocol = TLSv1.2` | unchanged | `SSLv3` removed in 2.4; we don't use it |
+| `disable_plaintext_auth = yes` | unchanged | |
+| `login_trusted_networks =` | unchanged | empty list preserved |
+| `mail_location = maildir:~/Maildir` | `mail_path = ~/Maildir` + `mail_driver = maildir` | per 2.4 rename; exact split verified via `doveconf -n` in the new image |
+| `passdb { driver = passwd-file; args = scheme=PLAIN /etc/dovecot/users }` | `passdb passwd-file { passwd_file_path = /etc/dovecot/users; default_password_scheme = PLAIN }` | sections require names in 2.4; `args =` removed in favour of named settings |
+| `userdb { driver = static; args = uid=1000 gid=1000 home=/var/mail/%u }` | `userdb static { fields = uid=1000 gid=1000 home=/var/mail/%u }` | named section; `args` → `fields` |
+| `namespace inbox { … mailbox Drafts/Junk/Sent/Trash { special_use=…; auto=subscribe } }` | structurally unchanged | already named `inbox`; mailbox blocks already named |
+| `service imap-login { inet_listener imap { port=143 } inet_listener imaps { port=993; ssl=yes } }` | structurally unchanged | already-named sections satisfy 2.4 rule |
+| `log_path = /dev/stderr` / `info_log_path = /dev/stderr` / `debug_log_path = /dev/stderr` | unchanged | `auth_debug`/`mail_debug` removed but we don't use them |
+
+**Implementation-time follow-up:** if the upstream image's baked-in `/etc/dovecot/conf.d/*.conf` overrides our settings, explicitly disable the conf.d include (drop the `!include conf.d/*.conf` line if our config inherits it, or rely on `dovecot -c /etc/dovecot/dovecot.conf` mounting our file directly, which is already the layout).
+
+### 3. Harness arch gate removal
+
+**`crates/rimap-server/tests/support/dovecot/harness.rs`** (lines 48–73). `check_prerequisites` collapses to:
+
+```rust
+fn check_prerequisites() -> Result<(), HarnessError> {
+    let require_runtime = std::env::var("RIMAP_REQUIRE_DOCKER").is_ok();
+    if !runtime_available() {
+        return if require_runtime {
+            Err(HarnessError::ComposeFailed(
+                "neither docker nor podman found but RIMAP_REQUIRE_DOCKER=1".into(),
+            ))
+        } else {
+            Err(HarnessError::DockerUnavailable)
+        };
+    }
+    Ok(())
+}
+```
+
+Module `//!` doc comment (lines 1–6) loses the "silently skips on non-x86_64" sentence.
+
+**`crates/rimap-imap/tests/integration/support/container.rs`** — equivalent change at lines 259–276 plus rustdoc at lines 86–95.
+
+### 4. Caller-side doc comment sweep
+
+- `crates/rimap-server/tests/e2e.rs:5`
+- `crates/rimap-server/tests/e2e_wire.rs:9`
+- `crates/rimap-imap/tests/integration/dovecot.rs:2`
+
+Each currently mentions the arch skip; each gets a one-line update reflecting the new "container runtime required on any arch" reality.
+
+### 5. AGENTS.md
+
+Lines 72–108 currently encode the Rosetta failure mode and arch-gate rationale. Replace with a shorter section: container runtime is required on any host; `RIMAP_REQUIRE_DOCKER=1` flips silent-skip to a hard error when the runtime is missing; no arch caveats.
+
+### 6. Memory cleanup
+
+Delete `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/project_dovecot_rosetta_gate.md` and remove its line from `MEMORY.md`. The memo exists specifically to discourage removing the arch gate; once the gate is gone the memo is actively misleading.
+
+## Out of Scope
+
+- Deduplicating the two harnesses (`rimap-server` and `rimap-imap` both have a near-identical `runtime_available` + prerequisite-check stack).
+- Replacing `docker compose` with a Rust container library.
+- Image digest pinning.
+- Adding a non-container fallback for environments without Docker/Podman.
+
+## Verification
+
+The migration is complete only when verification passes on **both** `linux/amd64` and `arm64 macOS`. Asymmetric verification is the known failure mode.
+
+### Bring-up (manual, both arches)
+
+1. `docker pull docker.io/dovecot/dovecot:2.4.4`; confirm host-native manifest with `docker image inspect | jq '.[].Architecture'`.
+2. `RIMAP_DOVECOT_HOST_PORT=9993 RIMAP_DOVECOT_HOST_PORT_STARTTLS=1143 docker compose -p smoke up -d`
+3. `docker compose -p smoke logs dovecot` — no `dovecot_config_version` upgrade-required error, no unknown-setting errors, `[entrypoint] ready` line emitted.
+4. `openssl s_client -connect 127.0.0.1:9993 -servername localhost` returns the self-signed cert.
+5. `docker exec <name> doveadm mailbox list -u rimap-test` returns INBOX and the seeded sub-folders without `Disconnected unexpectedly`.
+6. `docker compose -p smoke down -v --remove-orphans` cleans up.
+
+### Automated (CI on amd64, local on arm64 macOS)
+
+7. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked`
+8. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked`
+9. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked`
+
+Each suite must pass on both arches. Silent-skip on arm64 = failure of this migration's central goal.
+
+### Specific risks
+
+- **`case_11` force-recreate flow** (rimap-imap). Relies on the shared volume persisting `cert.pem` / `key.pem` across `docker compose up --force-recreate` so the pinned TLS fingerprint stays stable. 2.4 doesn't touch volume semantics, but this test exercises a real TCP/TLS race and is the most likely regression site.
+- **`doveadm -u rimap-test`**. 2.4 tightened `doveadm` USER-env-var semantics, but our calls already pass `-u`, so should be unaffected.
+- **Entrypoint wait-for-LISTEN ordering**. The current `entrypoint.sh` parses `/proc/net/tcp{,6}` to wait for port 993 before publishing readiness markers; 2.4's child-process startup order may differ. Step 4 of bring-up + step 9 of automated verification jointly cover this.
+
+### No-silent-skip regression guard
+
+Run `cargo nextest run -p rimap-server --test e2e_wire wire_e2e_full_session_draft_safe` *without* `RIMAP_REQUIRE_DOCKER=1` on a host with Docker available; the test must execute and pass, not return "0 tests executed". If silent-skip re-appears, the harness has regressed.
+
+## Implementation Order
+
+The plan derived from this spec should sequence work so that intermediate states are testable:
+
+1. Bring up the new image with an exploratory config on arm64 macOS (offline, not committed).
+2. Extract `doveconf -n` output as the source of truth for the rewritten `dovecot.conf`.
+3. Commit the new compose tree (image bump + config) on a branch.
+4. Remove the arch gates from both harnesses on the same branch — there's no env-var bypass today, so a local patch and a gate removal are the same edit. Run the suites on arm64 macOS at this point.
+5. Update AGENTS.md and caller-side doc comments to reflect the new "container runtime required on any arch" rule.
+6. Verify on CI (linux/amd64) before merging.
+7. Delete the obsolete memory note (`project_dovecot_rosetta_gate.md`) and its `MEMORY.md` index line.
+
+## Open Questions for the Plan Stage
+
+1. **Exact image tag.** Plan-time check: is `2.4.4` still latest stable, or has `2.4.5+` shipped? Pin to whatever is current.
+2. **`mail_location` replacement form.** `mail_path` + `mail_driver` is the most likely split per the 2.4 docs; `doveconf -n` from the running image is authoritative.
+3. **`userdb static.args` → `fields` rename.** Same — confirm via `doveconf -n`.
+4. **Inherited `/etc/dovecot/conf.d/*.conf`.** Does the upstream image ship them? If yes, do they interfere? The current 2.3 mount uses a single `dovecot.conf` that does not include `conf.d/` — verify same behaviour on 2.4.4.

--- a/docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md
+++ b/docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md
@@ -21,20 +21,22 @@ Run the Dovecot-backed integration suites on both `linux/amd64` (CI) and `arm64 
 
 ## Approach
 
-Single-step replacement: bump the fixture to `dovecot/dovecot:2.4.4`, rewrite `dovecot.conf` to 2.4 syntax, and delete the arch gate from both harnesses. No 2.3 fallback, no runtime config translation, no dual-image branching — consistent with the project's "replace, don't deprecate" rule.
+Single-step replacement: bump the fixture to `dovecot/dovecot:2.4.4-root`, rewrite `dovecot.conf` to 2.4 syntax, and delete the arch gate from both harnesses. No 2.3 fallback, no runtime config translation, no dual-image branching — consistent with the project's "replace, don't deprecate" rule.
+
+The `-root` flavor (not the default `2.4.4`) is the intentional choice: upstream's default 2.4 images are rootless, run as `vmail` UID 1000, listen on non-privileged ports (`31143`/`31993`), and expect config drop-ins under `/etc/dovecot/conf.d` plus mail data under `/srv/vmail`. Our existing entrypoint writes under `/etc/dovecot`, `/var/run/dovecot`, and `/var/mail`, binds 143/993 directly, and runs as root. Adopting rootless would require simultaneously rewriting the entrypoint, ports, paths, and volume layout — a wider change than this work needs. The `-root` flavor preserves the existing fixture contract; migrating to rootless is a separate, optional follow-up.
 
 ## Components Touched
 
 ### 1. Image bump
 - File: `crates/rimap-imap/tests/integration/dovecot/docker-compose.yml`
-- Change: `image: docker.io/dovecot/dovecot:2.3.21` → `image: docker.io/dovecot/dovecot:2.4.4`
-- Drop the multi-line comment that explained the amd64-only constraint; the new image is multi-arch.
+- Change: `image: docker.io/dovecot/dovecot:2.3.21` → `image: docker.io/dovecot/dovecot:2.4.4-root`
+- Drop the multi-line comment that explained the amd64-only constraint.
 
-`2.4.4` was published 2026-05-12 and ships both `linux/amd64` and `linux/arm64` manifests. The plan stage will confirm the tag is still the latest stable at implementation time and bump if a newer 2.4.x has shipped.
+Both `2.4.4` (rootless) and `2.4.4-root` (rootful) ship `linux/amd64` and `linux/arm64` manifests on Docker Hub (verified 2026-05-13). The plan stage confirms the tag is still the latest stable at implementation time and that the `-root` variant carries an arm64 manifest before pinning.
 
 ### 2. Config rewrite
 
-File: `crates/rimap-imap/tests/integration/dovecot/dovecot.conf`. Rewritten from scratch in 2.4 syntax. Final text is verified at implementation time against `doveconf -n` inside the running 2.4.4 container; the table below records intent.
+File: `crates/rimap-imap/tests/integration/dovecot/dovecot.conf`. Rewritten from scratch in 2.4 syntax against the upstream upgrade guide (`https://doc.dovecot.org/2.4.3/installation/upgrade/2.3-to-2.4.html`) and verified at implementation time by capturing `doveconf -n` output from the running 2.4.4-root container and treating that as the source of truth. The table records the renames the upgrade guide names explicitly; anything ambiguous is resolved by `doveconf -n`, not by guessing.
 
 | 2.3 (current) | 2.4 target | Notes |
 |---|---|---|
@@ -42,19 +44,21 @@ File: `crates/rimap-imap/tests/integration/dovecot/dovecot.conf`. Rewritten from
 | (none) | `dovecot_storage_version = 2.4.4` | new required setting in 2.4 |
 | `protocols = imap` | unchanged | |
 | `ssl = required` | unchanged | tightened semantics: login_trusted_networks also requires TLS; our list is empty so test path is unaffected |
-| `ssl_cert = </etc/dovecot/cert.pem` | unchanged | |
-| `ssl_key = </etc/dovecot/key.pem` | unchanged | |
+| `ssl_cert = </etc/dovecot/cert.pem` | `ssl_server_cert_file = /etc/dovecot/cert.pem` | renamed; `<file` literal-load syntax replaced with a plain path |
+| `ssl_key = </etc/dovecot/key.pem` | `ssl_server_key_file = /etc/dovecot/key.pem` | same rename pattern |
 | `ssl_min_protocol = TLSv1.2` | unchanged | `SSLv3` removed in 2.4; we don't use it |
-| `disable_plaintext_auth = yes` | unchanged | |
+| `disable_plaintext_auth = yes` | `auth_allow_cleartext = no` | renamed (and inverted polarity) |
 | `login_trusted_networks =` | unchanged | empty list preserved |
-| `mail_location = maildir:~/Maildir` | `mail_path = ~/Maildir` + `mail_driver = maildir` | per 2.4 rename; exact split verified via `doveconf -n` in the new image |
+| `mail_location = maildir:~/Maildir` | `mail_path = ~/Maildir` + `mail_driver = maildir` | per 2.4 rename; verify exact split via `doveconf -n` |
 | `passdb { driver = passwd-file; args = scheme=PLAIN /etc/dovecot/users }` | `passdb passwd-file { passwd_file_path = /etc/dovecot/users; default_password_scheme = PLAIN }` | sections require names in 2.4; `args =` removed in favour of named settings |
-| `userdb { driver = static; args = uid=1000 gid=1000 home=/var/mail/%u }` | `userdb static { fields = uid=1000 gid=1000 home=/var/mail/%u }` | named section; `args` → `fields` |
+| `userdb { driver = static; args = uid=1000 gid=1000 home=/var/mail/%u }` | `userdb static { fields { uid = 1000; gid = 1000; home = /var/mail/%{user} } }` | named section; static-userdb fields are a nested block in 2.4 (not `fields = ...`); `%u` removed, use `%{user}` |
 | `namespace inbox { … mailbox Drafts/Junk/Sent/Trash { special_use=…; auto=subscribe } }` | structurally unchanged | already named `inbox`; mailbox blocks already named |
-| `service imap-login { inet_listener imap { port=143 } inet_listener imaps { port=993; ssl=yes } }` | structurally unchanged | already-named sections satisfy 2.4 rule |
+| `service imap-login { inet_listener imap { port=143 } inet_listener imaps { port=993; ssl=yes } }` | structurally unchanged | already-named sections satisfy 2.4 rule; we still bind 143/993 inside the container because we run the `-root` flavor |
 | `log_path = /dev/stderr` / `info_log_path = /dev/stderr` / `debug_log_path = /dev/stderr` | unchanged | `auth_debug`/`mail_debug` removed but we don't use them |
 
-**Implementation-time follow-up:** if the upstream image's baked-in `/etc/dovecot/conf.d/*.conf` overrides our settings, explicitly disable the conf.d include (drop the `!include conf.d/*.conf` line if our config inherits it, or rely on `dovecot -c /etc/dovecot/dovecot.conf` mounting our file directly, which is already the layout).
+**Variable syntax:** anywhere the existing config or entrypoint emits a one-letter `%`-variable (only `%u` in `userdb static.fields.home` here), it must become the new `%{...}` form (e.g., `%{user}`). All one-letter variables were removed in 2.4.
+
+**Implementation-time follow-up:** the `-root` image still ships baked-in defaults under `/etc/dovecot/conf.d/`. Our compose mounts a single `dovecot.conf` over `/etc/dovecot/dovecot.conf`, so confirm during bring-up that the mounted file does not `!include conf.d/*.conf`. If it does, drop the include or mount an empty `conf.d/` over the inherited one to prevent upstream defaults from overriding our test config.
 
 ### 3. Harness arch gate removal
 
@@ -109,26 +113,30 @@ The migration is complete only when verification passes on **both** `linux/amd64
 
 ### Bring-up (manual, both arches)
 
-1. `docker pull docker.io/dovecot/dovecot:2.4.4`; confirm host-native manifest with `docker image inspect | jq '.[].Architecture'`.
+1. `docker pull docker.io/dovecot/dovecot:2.4.4-root`; confirm host-native manifest with `docker image inspect docker.io/dovecot/dovecot:2.4.4-root | jq '.[].Architecture'` and that it reports `arm64` on Apple Silicon (and `amd64` on Linux CI).
 2. `RIMAP_DOVECOT_HOST_PORT=9993 RIMAP_DOVECOT_HOST_PORT_STARTTLS=1143 docker compose -p smoke up -d`
-3. `docker compose -p smoke logs dovecot` — no `dovecot_config_version` upgrade-required error, no unknown-setting errors, `[entrypoint] ready` line emitted.
-4. `openssl s_client -connect 127.0.0.1:9993 -servername localhost` returns the self-signed cert.
-5. `docker exec <name> doveadm mailbox list -u rimap-test` returns INBOX and the seeded sub-folders without `Disconnected unexpectedly`.
-6. `docker compose -p smoke down -v --remove-orphans` cleans up.
+3. `docker compose -p smoke exec dovecot id` reports `uid=0` (the `-root` flavor runs as root, satisfying our entrypoint's `/etc/dovecot` / `/var/mail` writes and 143/993 bind).
+4. `docker compose -p smoke logs dovecot` — no `dovecot_config_version` upgrade-required error, no unknown-setting errors, `[entrypoint] ready` line emitted.
+5. `docker compose -p smoke exec dovecot doveconf -n` returns a config file with no `Conflicting/unknown setting` warnings. Capture this output and diff it against the committed `dovecot.conf` for parity — any drift indicates an inherited `conf.d/` default sneaking through.
+6. `openssl s_client -connect 127.0.0.1:9993 -servername localhost` returns the self-signed cert.
+7. `docker exec <name> doveadm mailbox list -u rimap-test` returns INBOX and the seeded sub-folders without `Disconnected unexpectedly`.
+8. `docker compose -p smoke down -v --remove-orphans` cleans up.
 
 ### Automated (CI on amd64, local on arm64 macOS)
 
-7. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked`
-8. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked`
-9. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked`
+9. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked`
+10. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked`
+11. `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked`
 
 Each suite must pass on both arches. Silent-skip on arm64 = failure of this migration's central goal.
 
 ### Specific risks
 
+- **`-root` image deprecation.** Upstream's strategic direction is rootless; the `-root` flavor exists to ease migration. If upstream stops publishing `-root` images for 2.5+, the next Dovecot version bump will force a rootless redesign of the entrypoint, ports, paths, and volumes. That's a known, accepted follow-up — not blocker for #273.
 - **`case_11` force-recreate flow** (rimap-imap). Relies on the shared volume persisting `cert.pem` / `key.pem` across `docker compose up --force-recreate` so the pinned TLS fingerprint stays stable. 2.4 doesn't touch volume semantics, but this test exercises a real TCP/TLS race and is the most likely regression site.
 - **`doveadm -u rimap-test`**. 2.4 tightened `doveadm` USER-env-var semantics, but our calls already pass `-u`, so should be unaffected.
-- **Entrypoint wait-for-LISTEN ordering**. The current `entrypoint.sh` parses `/proc/net/tcp{,6}` to wait for port 993 before publishing readiness markers; 2.4's child-process startup order may differ. Step 4 of bring-up + step 9 of automated verification jointly cover this.
+- **Entrypoint wait-for-LISTEN ordering**. The current `entrypoint.sh` parses `/proc/net/tcp{,6}` to wait for port 993 before publishing readiness markers; 2.4's child-process startup order may differ. Bring-up step 4 + automated step 11 jointly cover this.
+- **Inherited `/etc/dovecot/conf.d/` defaults.** The upstream image bakes in default drop-ins; bring-up step 5 (`doveconf -n` diff) is the explicit guard.
 
 ### No-silent-skip regression guard
 
@@ -148,7 +156,8 @@ The plan derived from this spec should sequence work so that intermediate states
 
 ## Open Questions for the Plan Stage
 
-1. **Exact image tag.** Plan-time check: is `2.4.4` still latest stable, or has `2.4.5+` shipped? Pin to whatever is current.
-2. **`mail_location` replacement form.** `mail_path` + `mail_driver` is the most likely split per the 2.4 docs; `doveconf -n` from the running image is authoritative.
-3. **`userdb static.args` → `fields` rename.** Same — confirm via `doveconf -n`.
-4. **Inherited `/etc/dovecot/conf.d/*.conf`.** Does the upstream image ship them? If yes, do they interfere? The current 2.3 mount uses a single `dovecot.conf` that does not include `conf.d/` — verify same behaviour on 2.4.4.
+1. **Exact image tag.** Plan-time check: is `2.4.4-root` still latest stable in the `-root` line, or has `2.4.5-root+` shipped? Pin to whatever is current and confirm the tag carries an arm64 manifest.
+2. **`mail_location` replacement form.** `mail_path` + `mail_driver` is the rename per the 2.4 docs; `doveconf -n` from the running image is authoritative.
+3. **Static `userdb` field block.** This spec writes `userdb static { fields { uid = 1000; ... } }` per the upstream 2.4 static-userdb docs. Confirm against `doveconf -n` — if upstream emits a flat form instead of a nested block, match what `doveconf -n` produces.
+4. **Inherited `/etc/dovecot/conf.d/*.conf` defaults.** The upstream image ships drop-ins. Bring-up step 5 catches any conflict; if a drop-in does override one of our settings, either mount an empty `conf.d/` over the inherited one or drop the offending include line.
+5. **Are there other `%`-variables hiding outside `dovecot.conf`?** Sweep `entrypoint.sh`, fixture `.eml` files, and any test harness arguments for one-letter `%` variables before declaring the migration complete.


### PR DESCRIPTION
## Summary
- Replaces amd64-only `dovecot/dovecot:2.3.21` with multi-arch `dovecot/dovecot:2.4.4-root` so integration tests run on Apple Silicon for the first time.
- Rewrites `dovecot.conf` to 2.4 syntax (`dovecot_config_version` preamble, named `passdb passwd-file` / `userdb static` sections, `ssl_server_{cert,key}_file` rename, `auth_allow_cleartext = no`, nested `fields { }` block, `%{user}` variable).
- Drops the `std::env::consts::ARCH != "x86_64"` silent-skip gate from both `rimap-server` (`tests/support/dovecot/harness.rs`) and `rimap-imap` (`tests/integration/support/container.rs`) test harnesses.
- Fixes a latent `uuid_like()` flake that was unmasked by the arch-gate removal — compose project names now combine `SystemTime` nanos with `std::process::id()` and a process-local `AtomicU64` counter so cross-process collisions are impossible on the same host.
- Refreshes `AGENTS.md` and integration-test rustdoc to drop the Rosetta/x86_64 caveat.

Closes #273.

## Test plan
- [x] `just ci` passes locally on arm64 macOS (1157 tests run, all pass).
- [x] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e_wire --locked` passes on arm64 macOS (3 wire tests + 3 schema fixture tests).
- [x] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-server --test e2e --locked` passes on arm64 macOS.
- [x] `RIMAP_REQUIRE_DOCKER=1 cargo nextest run -p rimap-imap --test dovecot --locked` passes on arm64 macOS (36 tests, ~22s parallel wall-clock, three consecutive runs clean).
- [x] No-silent-skip guard: target test executes without `RIMAP_REQUIRE_DOCKER=1` when Docker is available.
- [ ] CI green on linux/amd64.

## Spec & plan
- Design: `docs/superpowers/specs/2026-05-13-dovecot-24-multiarch-fixture-design.md`
- Plan: `docs/superpowers/plans/2026-05-13-dovecot-24-multiarch-fixture.md`

Both documents passed Codex adversarial review (one round of revisions each).

## Out of scope (explicit non-goals)
- Migrating to rootless `dovecot/dovecot:2.4.x` (default flavor). Would require rewriting the entrypoint, ports, paths, and volume layout. The `-root` flavor preserves the existing fixture contract; rootless can be a future follow-up.
- Image digest pinning, harness deduplication, switching to a Rust container library — separate scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)