### PR TITLE
test(mcp): Phase 4 — protocol fuzzing and negative-path coverage (#266) [WIP]

### DIFF
--- a/.github/workflows/mcp-fuzz-nightly.yml
+++ b/.github/workflows/mcp-fuzz-nightly.yml
@@ -43,14 +43,44 @@ jobs:
           # property functions (which are named prop_*). Phase 4 §6.1.
           OUTPUT=$(cargo test -p rimap-server --test mcp_wire_proptest -- --nocapture 2>&1 | tee /dev/stderr)
           echo "$OUTPUT" > proptest-output.log
-          # Extract the "running N tests" lines and sum.
+
+          # Per-property assertion: every expected property must have
+          # appeared in the output as "test <name> ... ok". Counting the
+          # global "running N tests" line is insufficient because a
+          # property marked #[ignore] (e.g. one blocked on an open
+          # server-side bug) is reported as "ignored, ..." and would
+          # not fire its proptest cases — the nightly fuzz claim would
+          # be vacuous. Phase 4 Codex review finding #3.
+          #
+          # EXPECTED_PROPERTIES is the source of truth for which
+          # property functions must run cases in the nightly job. Add
+          # to this list when a new prop_* test lands; remove only when
+          # the property is intentionally retired (with a comment).
+          EXPECTED_PROPERTIES=(
+            "prop_tools_call_unknown_tool"
+            "prop_tools_call_use_account_argument_shape"
+            "prop_envelope_never_panics"
+          )
+          MISSING=()
+          for prop in "${EXPECTED_PROPERTIES[@]}"; do
+            if ! echo "$OUTPUT" | grep -qE "^test ${prop} \\.\\.\\. ok"; then
+              MISSING+=("$prop")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::Nightly fuzz did not run the following expected properties (each must report 'test <name> ... ok'): ${MISSING[*]}. A property marked #[ignore] or filtered out by the --test selector silently fails this guard. Phase 4 §6.1, Codex finding #3."
+            exit 1
+          fi
+
+          # Defense-in-depth: also require a non-zero total test count.
           TESTS_RUN=$(echo "$OUTPUT" | grep -oE 'running [0-9]+ tests?' | awk '{s+=$2} END {print s+0}')
           echo "tests_run=$TESTS_RUN" >> "$GITHUB_OUTPUT"
           if [ "$TESTS_RUN" -eq 0 ]; then
-            echo "::error::Zero tests reported as executed. The --test selector likely missed the binary. Phase 4 §6.1 guard."
+            echo "::error::Zero tests reported as executed. The --test selector likely missed the binary."
             exit 1
           fi
           echo "Total tests executed: $TESTS_RUN"
+          echo "All ${#EXPECTED_PROPERTIES[@]} expected properties ran successfully."
 
       - name: Upload proptest output on failure
         if: failure()

--- a/.github/workflows/mcp-fuzz-nightly.yml
+++ b/.github/workflows/mcp-fuzz-nightly.yml
@@ -1,0 +1,61 @@
+name: MCP Fuzz Nightly
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak relative to other scheduled jobs.
+    - cron: '17 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: proptest 100k cases
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PROPTEST_CASES: '100000'
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          shared-key: mcp-fuzz-nightly
+
+      - name: Run proptest binary at 100k cases
+        id: proptest
+        run: |
+          set -euo pipefail
+          # --test (singular) selects the integration-test binary by name.
+          # --tests (plural) is a "run all integration tests" flag that would
+          # turn 'mcp_wire_proptest' into a name filter and silently run zero
+          # property functions (which are named prop_*). Phase 4 §6.1.
+          OUTPUT=$(cargo test -p rimap-server --test mcp_wire_proptest -- --nocapture 2>&1 | tee /dev/stderr)
+          echo "$OUTPUT" > proptest-output.log
+          # Extract the "running N tests" lines and sum.
+          TESTS_RUN=$(echo "$OUTPUT" | grep -oE 'running [0-9]+ tests?' | awk '{s+=$2} END {print s+0}')
+          echo "tests_run=$TESTS_RUN" >> "$GITHUB_OUTPUT"
+          if [ "$TESTS_RUN" -eq 0 ]; then
+            echo "::error::Zero tests reported as executed. The --test selector likely missed the binary. Phase 4 §6.1 guard."
+            exit 1
+          fi
+          echo "Total tests executed: $TESTS_RUN"
+
+      - name: Upload proptest output on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: proptest-output
+          path: proptest-output.log
+          retention-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,11 +124,11 @@ repos:
   # Pre-push stage: slower tests and audits.
   - repo: local
     hooks:
-      - id: cargo-nextest
-        name: just test (prune stale containers + cargo nextest)
-        entry: just test
+      - id: cargo-check
+        name: cargo check --workspace --all-targets --locked
+        entry: cargo check --workspace --all-targets --locked
         language: system
-        types: [rust]
+        always_run: true
         pass_filenames: false
         stages: [pre-push]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,9 +1416,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1671,7 +1671,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2554,7 +2554,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3030,7 +3030,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ dependencies = [
  "mail-builder",
  "mail-parser",
  "predicates",
+ "proptest",
  "rimap-audit",
  "rimap-authz",
  "rimap-config",

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -82,3 +82,4 @@ rimap-server = { path = ".", version = "0.1.0", features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "io-util"] }
 tempfile = { workspace = true }
 base64 = { workspace = true }
+proptest = { workspace = true }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -30,7 +30,19 @@ default = []
 # binary's wire shape rather than the production binary's, silently
 # voiding its regression nets. See:
 #   docs/superpowers/specs/2026-05-12-mcp-conformance-node-design.md §4.7
-test-support = ["rimap-config/test-support", "rimap-content/test-support"]
+test-support = [
+    "rimap-config/test-support",
+    "rimap-content/test-support",
+    # `rimap-audit/test-injection` exposes `AuditWriter::force_next_write_failure`,
+    # which `main.rs`'s `maybe_arm_audit_write_failure` calls when
+    # `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1` is set. Without this
+    # flag, `cargo check -p rimap-server --features test-support
+    # --bin rusty-imap-mcp` fails (Phase 4 #266, Codex review finding #2).
+    # Adding it does not change the wire shape — the method only mutates
+    # an internal failure-injection flag — so it complies with the
+    # test-support wire-shape invariant above.
+    "rimap-audit/test-injection",
+]
 
 [lib]
 name = "rimap_server"

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -24,6 +24,7 @@ use rimap_config::loader::{load_and_validate, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
 use rimap_config::validate::ValidatedAccountConfig;
 use rimap_imap::Connection;
+use rmcp::model::ErrorCode as McpErrorCode;
 use rmcp::service::ServerInitializeError;
 use secrecy::ExposeSecret;
 use tokio::io::AsyncWriteExt;
@@ -200,6 +201,24 @@ async fn emit_pre_init_error_envelope(
         .context("flushing pre-init error envelope")?;
     tracing::info!("rejected pre-initialize request with -32002 envelope");
     Ok(())
+}
+
+/// Classify a `ServerInitializeError::InitializeFailed` outcome by its
+/// inner `ErrorData.code`. Returns `true` for client-side bad-input
+/// codes that the wire envelope already communicated cleanly; the
+/// caller treats these as handled rejections (exit 0, audit `Eof`).
+/// Returns `false` for server-fault classes (`INTERNAL_ERROR` and
+/// anything else) so they propagate as non-zero exit with audit
+/// `Error`, keeping initialize-time outages observable. (#276)
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into main.rs::run in the next commit (#276 task 4)"
+    )
+)]
+fn initialize_failure_is_handled_rejection(code: McpErrorCode) -> bool {
+    matches!(code, McpErrorCode::INVALID_PARAMS)
 }
 
 /// Resolve the config file path from `--config` or the
@@ -502,5 +521,48 @@ mod resolve_download_dir_tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o700, "expected 0700, got {mode:o}");
+    }
+}
+
+#[cfg(test)]
+mod initialize_failure_classifier_tests {
+    use rmcp::model::ErrorCode as McpErrorCode;
+
+    use super::initialize_failure_is_handled_rejection;
+
+    #[test]
+    fn invalid_params_is_handled_rejection() {
+        assert!(initialize_failure_is_handled_rejection(
+            McpErrorCode::INVALID_PARAMS
+        ));
+    }
+
+    #[test]
+    fn internal_error_is_not_handled_rejection() {
+        assert!(!initialize_failure_is_handled_rejection(
+            McpErrorCode::INTERNAL_ERROR
+        ));
+    }
+
+    #[test]
+    fn method_not_found_is_not_handled_rejection() {
+        assert!(!initialize_failure_is_handled_rejection(
+            McpErrorCode::METHOD_NOT_FOUND
+        ));
+    }
+
+    #[test]
+    fn unknown_codes_are_not_handled_rejection() {
+        // Future-proofing: any code we haven't explicitly allow-listed
+        // must propagate as a server fault.
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(
+            -32099
+        )));
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(
+            -32603 - 1
+        )));
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(
+            -32700
+        )));
     }
 }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -24,7 +24,9 @@ use rimap_config::loader::{load_and_validate, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
 use rimap_config::validate::ValidatedAccountConfig;
 use rimap_imap::Connection;
+use rmcp::service::ServerInitializeError;
 use secrecy::ExposeSecret;
+use tokio::io::AsyncWriteExt;
 
 use crate::cli::{AuditAction, Cli, Command};
 
@@ -135,9 +137,14 @@ fn run(cli: Cli) -> anyhow::Result<()> {
 
         let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
         let transport = rmcp::transport::io::stdio();
-        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
-            .await
-            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                emit_pre_init_error_envelope(&msg).await?;
+                return Ok(());
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
         // waiting() takes ownership of service, consuming it and dropping the
         // ImapMcpServer (including all cancellation sender clones) when it
         // returns. The drainer task exits once all senders have dropped.
@@ -171,6 +178,28 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     }
 
     mcp_result
+}
+
+/// Write the JSON-RPC -32002 error envelope for a pre-initialize request
+/// to stdout (newline-terminated, flushed). Notification / Response /
+/// Error variants synthesize no envelope (per JSON-RPC §4.1) and this
+/// helper is a no-op. Write failures (broken pipe, closed reader) are
+/// propagated via `?` so the caller records `process_end.reason: Error`.
+async fn emit_pre_init_error_envelope(
+    msg: &rmcp::model::ClientJsonRpcMessage,
+) -> anyhow::Result<()> {
+    let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(msg) else {
+        return Ok(());
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(line.as_bytes())
+        .await
+        .context("writing pre-init error envelope to stdout")?;
+    out.flush()
+        .await
+        .context("flushing pre-init error envelope")?;
+    tracing::info!("rejected pre-initialize request with -32002 envelope");
+    Ok(())
 }
 
 /// Resolve the config file path from `--config` or the

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -59,14 +59,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         username,
     }) = &cli.command
     {
-        let store = KeyringStore;
-        let account_id = rimap_core::account::AccountId::new(account)
-            .with_context(|| format!("invalid account name `{account}`"))?;
-        run_login(&store, &account_id, username, host, tty_prompt)
-            .with_context(|| format!("storing credential for {username}@{host}"))?;
-        let mut stdout = std::io::stdout().lock();
-        writeln!(stdout, "credential stored for {username}@{host}")?;
-        return Ok(());
+        return run_login_command(account, username, host);
     }
 
     if let Some(Command::MigrateKeyring {
@@ -121,6 +114,9 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     let multi = load_validated_multi(&cli, &config_path)?;
     let audit = audit_init::init_audit_writer_multi(&multi, &config_path)
         .with_context(|| format!("opening audit log at {}", multi.audit.path.display()))?;
+
+    #[cfg(feature = "test-support")]
+    maybe_arm_audit_write_failure(&audit);
 
     let credentials: Arc<dyn CredentialStore> = Arc::new(KeyringStore);
     let download_dir: Arc<std::path::Path> =
@@ -351,6 +347,23 @@ fn resolve_download_dir_multi(
     Ok(dir)
 }
 
+/// Arm the `AuditWriter`'s forced-write-failure hook when the
+/// `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1` env var is set.
+///
+/// Used by `mcp_audit_failure.rs` to exercise the real
+/// lock/append/error-mapping path without adding a sentinel sink.
+/// This hook changes the audit write OUTCOME, not the wire shape,
+/// so it complies with the `test-support` convention.
+#[cfg(feature = "test-support")]
+fn maybe_arm_audit_write_failure(audit: &rimap_audit::AuditWriter) {
+    if std::env::var("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        audit.force_next_write_failure();
+    }
+}
+
 /// Dispatch subcommands that are gated behind `#[cfg(feature = "test-support")]`.
 ///
 /// Returns `Some(result)` if a test-support subcommand handled the request,
@@ -377,6 +390,18 @@ fn run_test_support_subcommands(cli: &Cli) -> Option<anyhow::Result<()>> {
         }
         _ => None,
     }
+}
+
+/// Handle the `login` subcommand: store the credential and print confirmation.
+fn run_login_command(account: &str, username: &str, host: &str) -> anyhow::Result<()> {
+    let store = KeyringStore;
+    let account_id = rimap_core::account::AccountId::new(account)
+        .with_context(|| format!("invalid account name `{account}`"))?;
+    run_login(&store, &account_id, username, host, tty_prompt)
+        .with_context(|| format!("storing credential for {username}@{host}"))?;
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "credential stored for {username}@{host}")?;
+    Ok(())
 }
 
 /// Handle the `migrate-keyring` subcommand.

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -144,6 +144,9 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 emit_pre_init_error_envelope(&msg).await?;
                 return Ok(());
             }
+            Err(ServerInitializeError::InitializeFailed(error_data)) => {
+                return handle_initialize_failed(&error_data);
+            }
             Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
         };
         // waiting() takes ownership of service, consuming it and dropping the
@@ -162,8 +165,17 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Ok(())
     });
 
-    // Best-effort process_end emission.
-    let reason = match &mcp_result {
+    emit_process_end(&audit_for_shutdown, &mcp_result);
+
+    mcp_result
+}
+
+/// Emit the `process_end` audit record at process shutdown. Reason
+/// reflects whether the MCP server loop completed cleanly (`Eof`)
+/// or with an error (`Error`). Failures to write are logged but do
+/// not propagate.
+fn emit_process_end(audit: &rimap_audit::AuditWriter, mcp_result: &anyhow::Result<()>) {
+    let reason = match mcp_result {
         Ok(()) => rimap_audit::ProcessEndReason::Eof,
         Err(_) => rimap_audit::ProcessEndReason::Error,
     };
@@ -173,12 +185,10 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         reason,
         total_tool_calls: 0,
     };
-    match audit_for_shutdown.log_process_end(process_end) {
+    match audit.log_process_end(process_end) {
         Ok(seq) => tracing::info!(seq = %seq, "process_end audit record written"),
         Err(e) => tracing::error!(error = %e, "failed to write process_end audit record"),
     }
-
-    mcp_result
 }
 
 /// Write the JSON-RPC -32002 error envelope for a pre-initialize request
@@ -210,15 +220,29 @@ async fn emit_pre_init_error_envelope(
 /// Returns `false` for server-fault classes (`INTERNAL_ERROR` and
 /// anything else) so they propagate as non-zero exit with audit
 /// `Error`, keeping initialize-time outages observable. (#276)
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into main.rs::run in the next commit (#276 task 4)"
-    )
-)]
 fn initialize_failure_is_handled_rejection(code: McpErrorCode) -> bool {
     matches!(code, McpErrorCode::INVALID_PARAMS)
+}
+
+/// Classify and react to a `ServerInitializeError::InitializeFailed`
+/// outcome. `INVALID_PARAMS` is a handled client rejection (rmcp already
+/// sent the wire envelope — log at info and exit clean). Anything else
+/// is a server-fault class that must propagate as a non-zero exit so
+/// `process_end.reason: Error` is recorded. (#276)
+fn handle_initialize_failed(error_data: &rmcp::model::ErrorData) -> anyhow::Result<()> {
+    if initialize_failure_is_handled_rejection(error_data.code) {
+        tracing::info!(
+            code = error_data.code.0,
+            "rejected initialize with error envelope",
+        );
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "MCP server init failed: code {}: {}",
+            error_data.code.0,
+            error_data.message,
+        ))
+    }
 }
 
 /// Resolve the config file path from `--config` or the

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -141,7 +141,11 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
             Ok(svc) => svc,
             Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
-                emit_pre_init_error_envelope(&msg).await?;
+                // TODO Task 3.2: replace this temporary local with validated.stdout
+                // once the transport swap to wire_validator::stdio_with_validation lands.
+                let stdout_for_preinit =
+                    std::sync::Arc::new(tokio::sync::Mutex::new(tokio::io::stdout()));
+                emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
                 return Ok(());
             }
             Err(ServerInitializeError::InitializeFailed(error_data)) => {
@@ -196,13 +200,20 @@ fn emit_process_end(audit: &rimap_audit::AuditWriter, mcp_result: &anyhow::Resul
 /// Error variants synthesize no envelope (per JSON-RPC §4.1) and this
 /// helper is a no-op. Write failures (broken pipe, closed reader) are
 /// propagated via `?` so the caller records `process_end.reason: Error`.
+///
+/// Holds the shared stdout mutex for the duration of the write+flush so
+/// it serializes against the validator and passthrough bridge tasks
+/// added in #277 (see `mcp::wire_validator`). Callers MUST pass the
+/// same `Arc<Mutex<Stdout>>` that `wire_validator::stdio_with_validation`
+/// returned in `ValidatedStdio.stdout`.
 async fn emit_pre_init_error_envelope(
     msg: &rmcp::model::ClientJsonRpcMessage,
+    stdout: &std::sync::Arc<tokio::sync::Mutex<tokio::io::Stdout>>,
 ) -> anyhow::Result<()> {
     let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(msg) else {
         return Ok(());
     };
-    let mut out = tokio::io::stdout();
+    let mut out = stdout.lock().await;
     out.write_all(line.as_bytes())
         .await
         .context("writing pre-init error envelope to stdout")?;

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -191,17 +191,56 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         // waiting() takes ownership of service, consuming it and dropping the
         // ImapMcpServer (including all cancellation sender clones) when it
         // returns. The drainer task exits once all senders have dropped.
-        service
-            .waiting()
-            .await
-            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+        //
+        // Phase 1: race service against bridge errors so a validator
+        // BrokenPipe (e.g. closed stdout) during normal operation
+        // surfaces as a non-zero exit rather than silently leaving rmcp
+        // wedged on an unwritable transport.
+        let mut service_fut = Box::pin(service.waiting());
+        let service_outcome: anyhow::Result<()> = tokio::select! {
+            biased;
+            bridge = supervisor.watch_for_error() => match bridge {
+                Err(e) => Err(anyhow::anyhow!("validator bridge: {e}")),
+                Ok(()) => {
+                    // Both bridges exited cleanly while service is still
+                    // running (exotic). Let service finish — it'll see EOF.
+                    (&mut service_fut)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))
+                }
+            },
+            result = &mut service_fut =>
+                result.map(|_| ()).map_err(|e| anyhow::anyhow!("MCP server error: {e}")),
+        };
+
+        // Phase 2: drop service future to release rmcp's transport ends,
+        // then shut down the supervisor. On success, `drain()` awaits
+        // both bridges (inbound already saw EOF via rmcp); on failure,
+        // `shutdown_after_failure()` aborts inbound first because the
+        // client may keep stdin open while waiting for the error
+        // response.
+        drop(service_fut);
+        let shutdown_outcome = match &service_outcome {
+            Ok(()) => supervisor.drain().await,
+            Err(_) => supervisor.shutdown_after_failure().await,
+        }
+        .map_err(|e| anyhow::anyhow!("validator bridge shutdown: {e}"));
+
+        let mcp_result: anyhow::Result<()> = match (service_outcome, shutdown_outcome) {
+            // Race-phase failure dominates; otherwise shutdown-phase
+            // surfaces. The `|` arm collapses both Err shapes because
+            // the resulting `Err(e)` has identical type.
+            (Err(e), _) | (Ok(()), Err(e)) => Err(e),
+            (Ok(()), Ok(())) => Ok(()),
+        };
 
         // All senders dropped above. Wait for the drainer to flush any
         // remaining queued cancellation records before the runtime exits.
         if let Err(e) = drainer_handle.await {
             tracing::error!(error = %e, "cancellation drainer join error");
         }
-        Ok(())
+        mcp_result
     });
 
     emit_process_end(&audit_for_shutdown, &mcp_result);

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -55,6 +55,22 @@ fn main() -> ExitCode {
     }
 }
 
+/// Disambiguates the failure source of the init-phase `tokio::select!`
+/// in `run`: either a validator bridge errored before init completed,
+/// or rmcp's `serve_server` returned an init failure. `Rmcp` is boxed
+/// because `ServerInitializeError` is significantly larger than the
+/// `io::Result<()>` variant (`clippy::large_enum_variant`).
+enum InitOutcome {
+    Bridge(std::io::Result<()>),
+    Rmcp(Box<ServerInitializeError>),
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "Server mode setup + init-phase select! race against \
+              validator bridges (#277). Splitting further would obscure \
+              the lifecycle ordering that's the whole point."
+)]
 fn run(cli: Cli) -> anyhow::Result<()> {
     if let Some(Command::Login {
         account,
@@ -137,19 +153,40 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         let drainer_handle = rimap_audit::spawn_drainer(cancellation_rx, audit.clone());
 
         let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
-        let validated = rimap_server::mcp::wire_validator::stdio_with_validation();
-        let stdout_for_preinit = std::sync::Arc::clone(&validated.stdout);
-        let transport = validated.transport;
-        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+        // Wrap stdio with #277 envelope validator: rejects malformed frames
+        // before rmcp sees them. Destructure so `supervisor` is its own
+        // binding (its methods take `&mut self` / consume `self`).
+        let rimap_server::mcp::wire_validator::ValidatedStdio {
+            transport,
+            stdout,
+            mut supervisor,
+        } = rimap_server::mcp::wire_validator::stdio_with_validation();
+        let stdout_for_preinit = std::sync::Arc::clone(&stdout);
+
+        let mut init_fut = Box::pin(rmcp::serve_server(mcp_server, transport));
+        let init_result: Result<_, InitOutcome> = tokio::select! {
+            biased;
+            bridge = supervisor.watch_for_error() => Err(InitOutcome::Bridge(bridge)),
+            result = &mut init_fut => match result {
+                Ok(svc) => Ok(svc),
+                Err(e) => Err(InitOutcome::Rmcp(Box::new(e))),
+            },
+        };
+        drop(init_fut);
+
+        let service = match init_result {
             Ok(svc) => svc,
-            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
-                emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
-                return Ok(());
+            Err(InitOutcome::Bridge(bridge_result)) => {
+                let primary = bridge_result.err().map_or_else(
+                    || anyhow::anyhow!("validator bridges exited before init completed"),
+                    |e| anyhow::anyhow!("validator bridge during init: {e}"),
+                );
+                let _ = supervisor.shutdown_after_failure().await;
+                return Err(primary);
             }
-            Err(ServerInitializeError::InitializeFailed(error_data)) => {
-                return handle_initialize_failed(&error_data);
+            Err(InitOutcome::Rmcp(boxed)) => {
+                return handle_init_failure(*boxed, &stdout_for_preinit, supervisor).await;
             }
-            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
         };
         // waiting() takes ownership of service, consuming it and dropping the
         // ImapMcpServer (including all cancellation sender clones) when it
@@ -220,6 +257,39 @@ async fn emit_pre_init_error_envelope(
         .context("flushing pre-init error envelope")?;
     tracing::info!("rejected pre-initialize request with -32002 envelope");
     Ok(())
+}
+
+/// Dispatch an `rmcp::serve_server` init failure: emit the pre-init
+/// envelope (when applicable), classify `InitializeFailed`, then shut
+/// down the validator supervisor. Every failure path runs
+/// `shutdown_after_failure` so the bridge tasks are awaited (or
+/// aborted) before the runtime drops; otherwise inbound's blocking
+/// stdin read can prevent the process from exiting promptly.
+async fn handle_init_failure(
+    error: ServerInitializeError,
+    stdout_for_preinit: &std::sync::Arc<tokio::sync::Mutex<tokio::io::Stdout>>,
+    supervisor: rimap_server::mcp::wire_validator::ValidatorSupervisor,
+) -> anyhow::Result<()> {
+    match error {
+        ServerInitializeError::ExpectedInitializeRequest(Some(msg)) => {
+            emit_pre_init_error_envelope(&msg, stdout_for_preinit).await?;
+            match supervisor.shutdown_after_failure().await {
+                Ok(()) => Ok(()),
+                Err(e) => Err(anyhow::anyhow!("validator bridge after pre-init: {e}")),
+            }
+        }
+        ServerInitializeError::InitializeFailed(error_data) => {
+            let handled = handle_initialize_failed(&error_data);
+            match supervisor.shutdown_after_failure().await {
+                Ok(()) => handled,
+                Err(e) => Err(anyhow::anyhow!("validator bridge after init failure: {e}")),
+            }
+        }
+        other => {
+            let _ = supervisor.shutdown_after_failure().await;
+            Err(anyhow::anyhow!("MCP server init: {other}"))
+        }
+    }
 }
 
 /// Classify a `ServerInitializeError::InitializeFailed` outcome by its

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -137,14 +137,12 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         let drainer_handle = rimap_audit::spawn_drainer(cancellation_rx, audit.clone());
 
         let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
-        let transport = rmcp::transport::io::stdio();
+        let validated = rimap_server::mcp::wire_validator::stdio_with_validation();
+        let stdout_for_preinit = std::sync::Arc::clone(&validated.stdout);
+        let transport = validated.transport;
         let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
             Ok(svc) => svc,
             Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
-                // TODO Task 3.2: replace this temporary local with validated.stdout
-                // once the transport swap to wire_validator::stdio_with_validation lands.
-                let stdout_for_preinit =
-                    std::sync::Arc::new(tokio::sync::Mutex::new(tokio::io::stdout()));
                 emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
                 return Ok(());
             }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -206,6 +206,19 @@ fn run(cli: Cli) -> anyhow::Result<()> {
 
     emit_process_end(&audit_for_shutdown, &mcp_result);
 
+    // Shut down the runtime without waiting for blocking tasks. The
+    // validator's `validate_inbound` bridge owns a `tokio::io::stdin()`
+    // handle whose underlying blocking read of real stdin is
+    // uncancelable (per tokio docs, `spawn_blocking` tasks cannot be
+    // aborted). The implicit `Runtime::drop` would otherwise block
+    // forever waiting for that read to return on a client that
+    // legitimately keeps stdin open after the server has decided to
+    // shut down — the regression observed when the #277 envelope
+    // validator wraps stdio. Using `shutdown_background` makes the
+    // process exit promptly; pending blocking reads are abandoned and
+    // the OS reaps the threads when the process terminates.
+    rt.shutdown_background();
+
     mcp_result
 }
 

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -330,9 +330,11 @@ mod tests {
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<_> = contents.lines().collect();
-        assert!(
-            lines.len() >= 2,
-            "expected >= 2 records (tool_start + cancellation tool_end), got: {contents}",
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected exactly 2 records (tool_start + cancellation tool_end), got {} records:\n{contents}",
+            lines.len(),
         );
         let last = lines.last().unwrap();
         assert!(
@@ -346,6 +348,101 @@ mod tests {
         assert!(
             last.contains(&format!(r#""start_seq":{start_seq}"#)),
             "last record should reference primed tool_start seq {start_seq}: {last}",
+        );
+    }
+
+    /// Wrapper-level test: drive `run_with_audit_envelope` end-to-end with a
+    /// body future that never completes, then abort the outer task. The
+    /// abort drops the wrapper future between `emit_tool_start` and the
+    /// normal `emit_tool_end`, so the only `tool_end` written must come
+    /// from `AuditEnvelopeGuard::drop`. Expectation: exactly two records
+    /// — one `tool_start` and one `tool_end {status: cancelled}` — in
+    /// order. This catches regressions where guard construction is
+    /// reordered relative to `tool_start` emission or where the disarm
+    /// call is moved/removed on the normal path. The guard-level tests
+    /// above would not catch those (they construct `AuditEnvelopeGuard`
+    /// directly). Codex review finding #4.
+    ///
+    /// `spawn` + `abort` is used (rather than `pin!` + `timeout` + drop)
+    /// to match the proven cancellation pattern from
+    /// `tests/dispatch_ticket.rs::drop_during_body_enqueues_cancellation_tool_end`.
+    /// The multi-thread flavor lets the aborted task and the drainer
+    /// task make progress concurrently with the test driver.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropped_run_with_audit_envelope_emits_exactly_one_cancellation() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer(path.clone());
+
+        let (tx, rx) = cancellation_channel();
+        let drainer = spawn_drainer(rx, writer.clone());
+
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx.clone()));
+
+        // Spawn `run_with_audit_envelope` with a body that pends forever.
+        // After `emit_tool_start` has had time to fire, `abort()` the
+        // task; the wrapper future is dropped between `tool_start` and
+        // `emit_tool_end`, exercising the guard's `Drop` path.
+        let server_clone = Arc::clone(&server);
+        let task = tokio::spawn(async move {
+            let args = serde_json::Map::new();
+            server_clone
+                .run_with_audit_envelope(
+                    ToolName::ListAccounts,
+                    None,
+                    PostureContext::Infrastructure,
+                    &args,
+                    |_ticket| {
+                        std::future::pending::<Result<serde_json::Value, rimap_core::RimapError>>()
+                    },
+                )
+                .await
+        });
+
+        // Give the envelope time to emit `tool_start` and enter the
+        // body's pending await before aborting. 50ms matches the
+        // headroom used by `dispatch_ticket::drop_during_body_*`.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        task.abort();
+        let _ = task.await; // wait for the abort to settle
+
+        // Give the drainer time to flush the queued cancellation record.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Drop the last sender so the drainer task can exit.
+        drop(tx);
+        drop(server);
+        drainer.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected exactly 2 records (tool_start + cancellation tool_end), got {} records:\n{contents}",
+            lines.len(),
+        );
+        assert!(
+            lines[0].contains(r#""tool_start""#),
+            "first record must be tool_start: {}",
+            lines[0],
+        );
+        assert!(
+            lines[1].contains(r#""status":"cancelled""#),
+            "second record must be cancellation tool_end: {}",
+            lines[1],
+        );
+        assert!(
+            lines[1].contains(r#""error_code":"ERR_CANCELLED""#),
+            "second record must carry ERR_CANCELLED: {}",
+            lines[1],
         );
     }
 

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -3,6 +3,7 @@
 //! Custom error codes in the JSON-RPC "server error" range
 //! (-32000 to -32099):
 //! - -32001: posture denied
+//! - -32002: server not initialized (pre-initialize request)
 //! - -32003: rate limited
 //! - -32004: circuit breaker open
 //! - -32005: attachment too large
@@ -21,6 +22,12 @@ pub const CIRCUIT_OPEN: McpCode = McpCode(-32004);
 
 /// Attachment exceeded size cap.
 pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
+
+/// Server has not yet received the MCP `initialize` request. The first
+/// message a client sends MUST be `initialize` (or `ping`). Any other
+/// pre-initialize request is rejected with this code and a clean
+/// session shutdown.
+pub const NOT_INITIALIZED: McpCode = McpCode(-32002);
 
 /// Convert a `RimapError` into an rmcp `ErrorData`.
 ///
@@ -109,6 +116,11 @@ mod tests {
         let err = authz_error(ErrorCode::RateLimited, "slow down");
         let mcp = to_mcp_error(&err);
         assert!(mcp.message.contains("slow down"));
+    }
+
+    #[test]
+    fn not_initialized_code_value() {
+        assert_eq!(super::NOT_INITIALIZED, McpCode(-32002));
     }
 
     #[test]

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod audit_envelope;
 pub mod content;
 pub(crate) mod dispatch;
 pub mod error;
-pub(crate) mod preinit;
+pub mod preinit;
 pub mod response;
 pub mod server;
 // `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod audit_envelope;
 pub mod content;
 pub(crate) mod dispatch;
 pub mod error;
+pub(crate) mod preinit;
 pub mod response;
 pub mod server;
 // `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -13,6 +13,7 @@ pub mod server;
 // `dispatch` and `server` and do not import this module directly.
 pub mod tool_catalog;
 pub(crate) mod tool_name;
+pub mod wire_validator;
 
 /// Render a `tokio::task::JoinError` from `spawn_blocking` as
 /// `RimapError::InternalSourced`. Shared by every `mcp/*` async wrapper so

--- a/crates/rimap-server/src/mcp/preinit.rs
+++ b/crates/rimap-server/src/mcp/preinit.rs
@@ -1,0 +1,144 @@
+//! Pre-initialize request handler.
+//!
+//! Synthesizes the JSON-RPC error envelope that the MCP server sends
+//! when a client violates the lifecycle by issuing any non-`initialize`,
+//! non-`ping` request as its first message (#275). The helper is pure:
+//! it does no I/O and holds no state. The transport write happens in
+//! `main.rs::run`.
+//!
+//! Notifications and Responses pre-initialize return `None`: per
+//! JSON-RPC §4.1 notifications never receive a response, and a
+//! standalone Response is malformed (no matching server request).
+
+use rmcp::model::ClientJsonRpcMessage;
+use serde_json::json;
+
+use crate::mcp::error::NOT_INITIALIZED;
+
+/// Build the newline-terminated JSON-RPC error line to emit for an
+/// offending pre-initialize message. Returns `Some` only for the
+/// `Request` variant.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into main.rs::run in the next commit (#275 task 4)"
+    )
+)]
+pub(crate) fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
+    match msg {
+        ClientJsonRpcMessage::Request(req) => {
+            let id = req.id.clone().into_json_value();
+            let envelope = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": NOT_INITIALIZED.0,
+                    "message": "Server not initialized: send `initialize` \
+                                before any other request",
+                },
+            });
+            Some(format!("{envelope}\n"))
+        }
+        ClientJsonRpcMessage::Notification(_)
+        | ClientJsonRpcMessage::Response(_)
+        | ClientJsonRpcMessage::Error(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::unwrap_used, reason = "tests")]
+
+    use std::sync::Arc;
+
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientNotification, ClientRequest, ClientResult, ErrorData,
+        JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcVersion2_0,
+        ListToolsRequest, NumberOrString, PaginatedRequestParams, ProgressNotification,
+        ProgressNotificationParam, ProgressToken,
+    };
+    use serde_json::{Value, json};
+
+    use super::synthesize_pre_init_error_envelope;
+
+    /// Build a Request variant carrying a `tools/list` request with the
+    /// supplied id.
+    fn request_msg(id: NumberOrString) -> ClientJsonRpcMessage {
+        let list_tools = ListToolsRequest::with_param(PaginatedRequestParams::default());
+        ClientJsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            request: ClientRequest::ListToolsRequest(list_tools),
+        })
+    }
+
+    #[test]
+    fn request_with_numeric_id_produces_minus_32002_envelope() {
+        let msg = request_msg(NumberOrString::Number(42));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert!(line.ends_with('\n'), "must be newline-terminated");
+        let parsed: Value = serde_json::from_str(line.trim_end()).expect("envelope is valid JSON");
+        assert_eq!(parsed["jsonrpc"], json!("2.0"));
+        assert_eq!(parsed["id"], json!(42));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+        assert!(
+            parsed["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Server not initialized")
+        );
+    }
+
+    #[test]
+    fn request_with_string_id_preserves_string_id() {
+        let msg = request_msg(NumberOrString::String(Arc::from("abc-123")));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], json!("abc-123"));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+    }
+
+    #[test]
+    fn line_is_single_line_with_one_trailing_newline() {
+        let msg = request_msg(NumberOrString::Number(1));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert_eq!(line.matches('\n').count(), 1, "exactly one newline");
+        assert!(line.ends_with('\n'), "newline is trailing");
+        assert!(!line.trim_end().contains('\n'), "no embedded newlines");
+    }
+
+    #[test]
+    fn notification_returns_none() {
+        let progress = ProgressNotification::new(ProgressNotificationParam::new(
+            ProgressToken(NumberOrString::Number(1)),
+            0.0,
+        ));
+        let msg = ClientJsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: JsonRpcVersion2_0,
+            notification: ClientNotification::ProgressNotification(progress),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn response_returns_none() {
+        let msg = ClientJsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            result: ClientResult::empty(()),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn error_variant_returns_none() {
+        let msg = ClientJsonRpcMessage::Error(JsonRpcError {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            error: ErrorData::internal_error("synthetic".to_string(), None),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+}

--- a/crates/rimap-server/src/mcp/preinit.rs
+++ b/crates/rimap-server/src/mcp/preinit.rs
@@ -18,14 +18,8 @@ use crate::mcp::error::NOT_INITIALIZED;
 /// Build the newline-terminated JSON-RPC error line to emit for an
 /// offending pre-initialize message. Returns `Some` only for the
 /// `Request` variant.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into main.rs::run in the next commit (#275 task 4)"
-    )
-)]
-pub(crate) fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
+#[must_use]
+pub fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
     match msg {
         ClientJsonRpcMessage::Request(req) => {
             let id = req.id.clone().into_json_value();

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -18,16 +18,10 @@ use rmcp::RoleServer;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ErrorCode as McpCode, ErrorData, Implementation,
-    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion, RawResource,
-    ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ServerCapabilities,
-    ServerInfo, Tool,
+    InitializeRequestParams, InitializeResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, ProtocolVersion, RawResource, ReadResourceRequestParams,
+    ReadResourceResult, Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
 };
-// Wired into ImapMcpServer::initialize in the next commit (#276 task 2).
-#[expect(
-    unused_imports,
-    reason = "wired into ImapMcpServer::initialize in the next commit (#276 task 2)"
-)]
-use rmcp::model::{InitializeRequestParams, InitializeResult};
 use rmcp::service::RequestContext;
 
 use crate::boot::registry::{AccountRegistry, AccountState};
@@ -278,6 +272,29 @@ impl ServerHandler for ImapMcpServer {
         ))
     }
 
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, ErrorData> {
+        // LATEST-only acceptance per spec §"Why LATEST-only" (#276):
+        // rmcp 1.5 emits LATEST wire shapes regardless of negotiated
+        // version, so accepting older known versions would echo the
+        // peer's version string while serving 2025-11-25 capabilities.
+        // The exact-equality check is the only honest option.
+        if request.protocol_version != ProtocolVersion::LATEST {
+            return Err(unsupported_protocol_version_error(
+                &request.protocol_version,
+            ));
+        }
+        // Preserve the default-impl behavior for the happy path so the
+        // peer's ClientInfo is captured for subsequent dispatch.
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        Ok(self.get_info())
+    }
+
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -503,13 +520,6 @@ impl ServerHandler for ImapMcpServer {
 /// `supported_versions` as a single-element array so clients have a
 /// machine-readable retry hint, and the message echoes the offending
 /// version in single quotes for log readability. (#276)
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into ImapMcpServer::initialize in the next commit (#276 task 2)"
-    )
-)]
 fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorData {
     let supported = [ProtocolVersion::LATEST.as_str()];
     let message = format!(

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -18,10 +18,16 @@ use rmcp::RoleServer;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ErrorCode as McpCode, ErrorData, Implementation,
-    ListResourcesResult, ListToolsResult, PaginatedRequestParams, RawResource,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion, RawResource,
     ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ServerCapabilities,
     ServerInfo, Tool,
 };
+// Wired into ImapMcpServer::initialize in the next commit (#276 task 2).
+#[expect(
+    unused_imports,
+    reason = "wired into ImapMcpServer::initialize in the next commit (#276 task 2)"
+)]
+use rmcp::model::{InitializeRequestParams, InitializeResult};
 use rmcp::service::RequestContext;
 
 use crate::boot::registry::{AccountRegistry, AccountState};
@@ -488,5 +494,114 @@ impl ServerHandler for ImapMcpServer {
 
         self.dispatch_account_scoped(account, tool_name, &args)
             .await
+    }
+}
+
+/// Build the `ErrorData` payload returned by `ImapMcpServer::initialize`
+/// when the peer's `protocolVersion` is not exactly
+/// `ProtocolVersion::LATEST`. The envelope's `data` field carries
+/// `supported_versions` as a single-element array so clients have a
+/// machine-readable retry hint, and the message echoes the offending
+/// version in single quotes for log readability. (#276)
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into ImapMcpServer::initialize in the next commit (#276 task 2)"
+    )
+)]
+fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorData {
+    let supported = [ProtocolVersion::LATEST.as_str()];
+    let message = format!(
+        "Unsupported protocol version: '{}'. Server supports: {}.",
+        peer_version.as_str(),
+        supported.join(", "),
+    );
+    let data = serde_json::json!({ "supported_versions": supported });
+    ErrorData::invalid_params(message, Some(data))
+}
+
+#[cfg(test)]
+mod protocol_version_tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+
+    use rmcp::model::{ErrorCode as McpCode, ProtocolVersion};
+    use serde_json::json;
+
+    use super::unsupported_protocol_version_error;
+
+    /// Build a `ProtocolVersion` carrying an arbitrary version string.
+    /// The rmcp deserializer accepts any string and produces a
+    /// `ProtocolVersion(Cow::Owned(s))` for unknown values, so this is
+    /// the cleanest way to construct one for tests.
+    fn version_from_str(s: &str) -> ProtocolVersion {
+        serde_json::from_value(json!(s)).expect("deserialize ProtocolVersion")
+    }
+
+    #[test]
+    fn shape_matches_spec() {
+        let v = version_from_str("1999-01-01");
+        let err = unsupported_protocol_version_error(&v);
+
+        assert_eq!(err.code, McpCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("1999-01-01"),
+            "message must echo the peer version, got {:?}",
+            err.message,
+        );
+        assert!(
+            err.message.contains("2025-11-25"),
+            "message must include the supported version, got {:?}",
+            err.message,
+        );
+
+        let data = err.data.as_ref().expect("data field present");
+        assert_eq!(
+            data["supported_versions"],
+            json!(["2025-11-25"]),
+            "supported_versions must be a single-element array of LATEST, got {data}",
+        );
+    }
+
+    #[test]
+    fn uses_runtime_latest() {
+        // Pins the contract that `supported_versions[0]` is built from
+        // `ProtocolVersion::LATEST.as_str()` at runtime, not a hard-
+        // coded literal. If a future rmcp bump shifts LATEST, this
+        // test stays green; the literal-pinning `shape_matches_spec`
+        // test will then surface the change visibly.
+        let v = version_from_str("anything-goes");
+        let err = unsupported_protocol_version_error(&v);
+        let data = err.data.as_ref().expect("data field present");
+        let arr = data["supported_versions"]
+            .as_array()
+            .expect("supported_versions is an array");
+        assert_eq!(arr.len(), 1, "single-element array");
+        assert_eq!(
+            arr[0].as_str().expect("string"),
+            ProtocolVersion::LATEST.as_str(),
+        );
+    }
+
+    #[test]
+    fn empty_peer_version_still_produces_envelope() {
+        let v = version_from_str("");
+        let err = unsupported_protocol_version_error(&v);
+        assert_eq!(err.code, McpCode::INVALID_PARAMS);
+        // Single-quoted empty string in the message: "...'%s'..."
+        assert!(
+            err.message.contains("''"),
+            "empty peer version should appear as '' in message, got {:?}",
+            err.message,
+        );
+    }
+
+    #[test]
+    fn data_field_is_present() {
+        // Guards against accidentally constructing the error without
+        // the data payload (would break machine-readable retry).
+        let v = version_from_str("1999-01-01");
+        let err = unsupported_protocol_version_error(&v);
+        assert!(err.data.is_some(), "data field must be present");
     }
 }

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -106,6 +106,35 @@ impl ImapMcpServer {
     }
 }
 
+/// In-crate unit-test constructor. Compiled only under `cfg(test)` so it
+/// never ships in the released binary. Builds an `ImapMcpServer` with an
+/// empty `AccountRegistry` and the caller-supplied audit writer +
+/// cancellation sender — the minimum surface needed to drive
+/// [`ImapMcpServer::run_with_audit_envelope`] (which reads only `audit`,
+/// `redaction_salt`, and `cancellation_sender`) without the heavyweight
+/// boot machinery that real `ImapMcpServer::new` requires.
+#[cfg(test)]
+impl ImapMcpServer {
+    /// Minimal test constructor — only fields touched by
+    /// `run_with_audit_envelope` (and its inner callees `redact_tool_args`,
+    /// `emit_tool_start`, `emit_tool_end`) get caller-supplied values.
+    /// The `AccountRegistry` is empty; tool dispatch through this server
+    /// will fail at account resolution, which is fine because the
+    /// wrapper-level test injects its own body closure and never reaches
+    /// dispatch.
+    pub(crate) fn new_for_tests(
+        audit: AuditWriter,
+        cancellation_sender: CancelledToolEndSender,
+    ) -> Self {
+        Self {
+            registry: AccountRegistry::new(std::collections::BTreeMap::new()),
+            audit,
+            cancellation_sender,
+            redaction_salt: Arc::new(RedactionSalt::new_random()),
+        }
+    }
+}
+
 /// Integration-test entry point. Exposed under `#[cfg(any(test, feature =
 /// "test-support"))]` so tests exercise the exact same pipeline (account
 /// resolve → `pre_dispatch` → audit envelope → `dispatch_tool`) as real

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -322,6 +322,7 @@ impl ValidatorSupervisor {
                         Err(e) => return Err(e),
                     }
                 }
+                else => return Ok(()),
             }
         }
     }
@@ -373,7 +374,7 @@ impl ValidatorSupervisor {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -725,5 +726,24 @@ mod tests {
         let inner = r.unwrap();
         assert!(inner.is_err());
         assert!(inner.unwrap_err().to_string().contains("inbound failed"));
+    }
+
+    #[tokio::test]
+    async fn watch_for_error_returns_ok_when_both_bridges_finish() {
+        // Both bridges exit Ok cleanly. watch_for_error must return
+        // Ok(()) without panicking, even if both `is_finished()`
+        // guards evaluate to false in the same select! iteration.
+        let inbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        // Give the runtime a tick so both handles transition to finished.
+        tokio::task::yield_now().await;
+        let mut supervisor = ValidatorSupervisor { inbound, outbound };
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.watch_for_error(),
+        )
+        .await
+        .expect("watch_for_error must return promptly when both bridges have finished");
+        assert!(r.is_ok(), "expected Ok, got {r:?}");
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -183,6 +183,19 @@ pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
 /// (preserving the trailing `\n`), validates each line, and forwards
 /// or rejects.
 ///
+/// # Cancellation
+///
+/// This function is intended to be `tokio::spawn`'d and managed by
+/// `ValidatorSupervisor`. If `JoinHandle::abort()` lands between
+/// `write_all` and `flush` on the rejection path, a partial line
+/// may reach real stdout — breaking the stdout serialization
+/// invariant. The supervisor's `shutdown_after_failure` (Task 2.3)
+/// uses abort only on failure paths where stdout integrity is
+/// already lost (e.g. `BrokenPipe`). Cooperative cancellation via
+/// `tokio_util::sync::CancellationToken` could close this gap if
+/// stronger guarantees become necessary; deferred per Task 2.3
+/// design.
+///
 /// Returns `Ok(())` on stdin EOF. Returns `Err(io::Error)` if a write
 /// to either the inbound duplex (forwarding) or shared stdout
 /// (rejection) fails — `BrokenPipe` on stdout is the most common
@@ -223,9 +236,9 @@ where
             Some(&b'\r') => &trimmed[..trimmed.len() - 1],
             _ => trimmed,
         };
-        let line_for_validation = std::str::from_utf8(trimmed).unwrap_or("");
+        let line_for_validation = String::from_utf8_lossy(trimmed);
 
-        match validate(line_for_validation) {
+        match validate(&line_for_validation) {
             ValidationOutcome::Skip => {}
             ValidationOutcome::Forward => {
                 // Forward the buffer including its trailing \n so
@@ -504,5 +517,31 @@ mod tests {
 
         let s = std::str::from_utf8(&forwarded).unwrap();
         assert_eq!(s.lines().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn validate_inbound_non_utf8_returns_parse_error() {
+        // Pass invalid UTF-8 bytes (\xFF is not valid UTF-8) followed
+        // by EOF. The validator should see lossy-decoded U+FFFD which
+        // serde_json rejects → validator emits -32700 to stdout (not
+        // observable from the test) AND does not forward to rmcp.
+        let stdin = std::io::Cursor::new(vec![0xFF, 0xFE, b'\n']);
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        // Nothing reaches rmcp (the invalid-UTF-8 line was rejected
+        // and the rejection went to stdout, not the duplex).
+        assert!(
+            forwarded.is_empty(),
+            "non-UTF-8 line should not be forwarded to rmcp, got {forwarded:?}"
+        );
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -260,6 +260,48 @@ where
     }
 }
 
+/// Outbound bridge task. Reads newline-framed frames from rmcp's
+/// outbound duplex (rmcp's `FramedWrite` terminates each envelope
+/// with `\n`) and writes each frame through the shared stdout mutex.
+///
+/// Returns `Ok(())` when rmcp drops its outbound duplex end (EOF).
+/// Returns `Err(io::Error)` if writing to real stdout fails —
+/// typically `BrokenPipe`, which surfaces to `main.rs::run` via the
+/// supervisor so `process_end.reason: Error` is recorded.
+///
+/// # Cancellation
+///
+/// Same caveat as `validate_inbound`: an abort between `write_all`
+/// and `flush` may leave a partial frame on stdout. The supervisor's
+/// `shutdown_after_failure` (Task 2.3) uses abort only on failure
+/// paths where stdout integrity is already suspect.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by stdio_with_validation entry point in Task 2.4"
+    )
+)]
+pub(crate) async fn passthrough_outbound(
+    from_rmcp: DuplexStream,
+    stdout: Arc<Mutex<Stdout>>,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(from_rmcp);
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await?;
+        if n == 0 {
+            return Ok(()); // rmcp dropped outbound — clean shutdown.
+        }
+        let mut sout = stdout.lock().await;
+        sout.write_all(&buf).await?;
+        sout.flush().await?;
+        // Lock released; loop.
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
@@ -543,5 +585,17 @@ mod tests {
             forwarded.is_empty(),
             "non-UTF-8 line should not be forwarded to rmcp, got {forwarded:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn passthrough_outbound_drops_on_eof() {
+        let (rmcp_end, our_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        // Drop the rmcp side immediately — passthrough should see EOF
+        // and return Ok cleanly.
+        drop(rmcp_end);
+        let result = passthrough_outbound(our_end, stdout).await;
+        assert!(result.is_ok(), "expected Ok on EOF, got {result:?}");
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -11,17 +11,13 @@
 use std::sync::Arc;
 
 use serde_json::Value;
-use tokio::io::{DuplexStream, Stdout};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader, DuplexStream, Stdout};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 /// Bridge-task duplex buffer. Large enough that one well-formed
 /// envelope fits in a single write; both directions are independent
 /// tasks so inbound stalls cannot cause outbound deadlock.
-#[expect(
-    dead_code,
-    reason = "consumed by validate_inbound/passthrough_outbound in Tasks 2.1/2.2"
-)]
 const BUF_SIZE: usize = 64 * 1024;
 
 /// What the validator decides for a given line.
@@ -116,13 +112,6 @@ pub(crate) fn invalid_request(id: Value) -> ErrorEnvelope {
 }
 
 /// Validate one line of input and decide what to do with it.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by validate_inbound bridge task in Task 2.1"
-    )
-)]
 pub(crate) fn validate(line: &str) -> ValidationOutcome {
     if line.trim().is_empty() {
         return ValidationOutcome::Skip;
@@ -175,13 +164,6 @@ pub(crate) fn validate(line: &str) -> ValidationOutcome {
 /// Serialize a rejection envelope to a single wire line, terminated
 /// with `\n`. The shape matches JSON-RPC §5: `{jsonrpc, id, error}`
 /// with `error.{code, message}` and no `data`.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by validate_inbound bridge task in Task 2.1"
-    )
-)]
 pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
     let body = serde_json::json!({
         "jsonrpc": "2.0",
@@ -195,6 +177,74 @@ pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
     let mut line = body.to_string();
     line.push('\n');
     line
+}
+
+/// Inbound bridge task. Reads from real stdin one line at a time
+/// (preserving the trailing `\n`), validates each line, and forwards
+/// or rejects.
+///
+/// Returns `Ok(())` on stdin EOF. Returns `Err(io::Error)` if a write
+/// to either the inbound duplex (forwarding) or shared stdout
+/// (rejection) fails — `BrokenPipe` on stdout is the most common
+/// failure mode and surfaces to `main.rs::run` via the supervisor so
+/// `process_end.reason: Error` is recorded.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by stdio_with_validation entry point in Task 2.4"
+    )
+)]
+pub(crate) async fn validate_inbound<R>(
+    stdin: R,
+    mut to_rmcp: DuplexStream,
+    stdout: Arc<Mutex<Stdout>>,
+) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stdin);
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await?;
+        if n == 0 {
+            return Ok(()); // stdin EOF — clean shutdown.
+        }
+
+        // Strip trailing \n and optional \r for the validation view.
+        // rmcp's codec also strips \r; matching its grammar.
+        let trimmed: &[u8] = match buf.last() {
+            Some(&b'\n') => &buf[..buf.len() - 1],
+            _ => &buf[..],
+        };
+        let trimmed: &[u8] = match trimmed.last() {
+            Some(&b'\r') => &trimmed[..trimmed.len() - 1],
+            _ => trimmed,
+        };
+        let line_for_validation = std::str::from_utf8(trimmed).unwrap_or("");
+
+        match validate(line_for_validation) {
+            ValidationOutcome::Skip => {}
+            ValidationOutcome::Forward => {
+                // Forward the buffer including its trailing \n so
+                // rmcp's framed reader sees the complete envelope.
+                if buf.last() != Some(&b'\n') {
+                    buf.push(b'\n');
+                }
+                to_rmcp.write_all(&buf).await?;
+                to_rmcp.flush().await?;
+            }
+            ValidationOutcome::Reject(env) => {
+                let line = synthesize_error_line(&env);
+                let mut sout = stdout.lock().await;
+                sout.write_all(line.as_bytes()).await?;
+                sout.flush().await?;
+                // Lock released here; loop continues.
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -408,5 +458,51 @@ mod tests {
         let line = synthesize_error_line(&env);
         let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
         assert_eq!(parsed["id"], "abc");
+    }
+
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn validate_inbound_forwards_valid_envelope() {
+        let stdin = std::io::Cursor::new(
+            b"{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}\n".to_vec(),
+        );
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        // Spawn the validator and consume rmcp's side concurrently.
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        let s = std::str::from_utf8(&forwarded).unwrap();
+        assert!(
+            s.contains("\"method\":\"tools/list\""),
+            "expected forwarded line, got {s:?}",
+        );
+        assert!(s.ends_with('\n'));
+    }
+
+    #[tokio::test]
+    async fn validate_inbound_skips_empty_lines() {
+        let stdin =
+            std::io::Cursor::new(b"\n\n{\"jsonrpc\":\"2.0\",\"method\":\"x\",\"id\":1}\n".to_vec());
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        let s = std::str::from_utf8(&forwarded).unwrap();
+        assert_eq!(s.lines().count(), 1);
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -1,0 +1,340 @@
+//! JSON-RPC 2.0 envelope validator (#277).
+//!
+//! Wraps rmcp's stdio transport: reads stdin, validates each line as a
+//! JSON-RPC 2.0 envelope, forwards valid envelopes to rmcp via an
+//! in-memory duplex stream, and synthesizes `-32600 Invalid Request` /
+//! `-32700 Parse error` envelopes for malformed input. Without this
+//! layer rmcp 1.5's `JsonRpcMessageCodec` silently drops envelopes
+//! that fail its compatibility shim — see
+//! `docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md`.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::io::{DuplexStream, Stdout};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Bridge-task duplex buffer. Large enough that one well-formed
+/// envelope fits in a single write; both directions are independent
+/// tasks so inbound stalls cannot cause outbound deadlock.
+#[expect(
+    dead_code,
+    reason = "consumed by validate_inbound/passthrough_outbound in Tasks 2.1/2.2"
+)]
+const BUF_SIZE: usize = 64 * 1024;
+
+/// What the validator decides for a given line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValidationOutcome {
+    /// Forward the line byte-for-byte to rmcp.
+    Forward,
+    /// Empty or whitespace-only line — drop silently.
+    Skip,
+    /// Reject with the synthesized error envelope.
+    Reject(ErrorEnvelope),
+}
+
+/// A synthesized JSON-RPC error response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ErrorEnvelope {
+    pub code: i32,
+    pub message: &'static str,
+    pub id: Value, // `Value::Null` if absent or invalid; otherwise echoed string/number.
+}
+
+/// Public bundle handed back to `main.rs::run`. `transport` plugs into
+/// `rmcp::serve_server(server, validated.transport)`; `stdout` is the
+/// shared writer that all synchronized output paths (validator
+/// rejections, passthrough frames, AND `emit_pre_init_error_envelope`)
+/// lock; `supervisor` exposes the bridge-task lifecycle.
+pub struct ValidatedStdio {
+    pub transport: (DuplexStream, DuplexStream),
+    pub stdout: Arc<Mutex<Stdout>>,
+    pub supervisor: ValidatorSupervisor,
+}
+
+/// Supervises the two bridge tasks (`validate_inbound` and
+/// `passthrough_outbound`). See the spec for the three-method lifecycle
+/// contract: race-phase fail-fast (`watch_for_error`), success-path
+/// drain (`drain`), and failure-path abort+drain (`shutdown_after_failure`).
+#[expect(
+    dead_code,
+    reason = "inbound/outbound are read by watch_for_error/drain/shutdown_after_failure in Task 2.4"
+)]
+pub struct ValidatorSupervisor {
+    pub(crate) inbound: JoinHandle<std::io::Result<()>>,
+    pub(crate) outbound: JoinHandle<std::io::Result<()>>,
+}
+
+// ============================================================
+// Pure validator (no I/O — unit-testable in isolation).
+// ============================================================
+
+/// `id` accepted by rmcp's `RxJsonRpcMessage`. Null is excluded
+/// because rmcp 1.5's `RequestId = NumberOrString` rejects null.
+pub(crate) fn is_forwardable_id(v: &Value) -> bool {
+    v.is_string() || v.is_number()
+}
+
+/// `error` body matches JSON-RPC §5.1: an object with numeric
+/// `code` and string `message`. `data` is optional.
+pub(crate) fn is_well_formed_error(v: &Value) -> bool {
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    obj.get("code").is_some_and(Value::is_number)
+        && obj.get("message").is_some_and(Value::is_string)
+}
+
+/// Read the top-level `id` field for echo on a rejection envelope.
+/// Returns `Value::Null` if `id` is missing or of a disallowed type;
+/// otherwise echoes the original value verbatim. JSON-RPC §5 says
+/// the id on a synthesized error response MUST be null when the
+/// original could not be detected.
+pub(crate) fn extract_id(obj: &serde_json::Map<String, Value>) -> Value {
+    match obj.get("id") {
+        Some(v) if v.is_string() || v.is_number() || v.is_null() => v.clone(),
+        _ => Value::Null,
+    }
+}
+
+pub(crate) fn parse_error() -> ErrorEnvelope {
+    ErrorEnvelope {
+        code: -32700,
+        message: "Parse error",
+        id: Value::Null,
+    }
+}
+
+pub(crate) fn invalid_request(id: Value) -> ErrorEnvelope {
+    ErrorEnvelope {
+        code: -32600,
+        message: "Invalid Request",
+        id,
+    }
+}
+
+/// Validate one line of input and decide what to do with it.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by validate_inbound bridge task in Task 2.1"
+    )
+)]
+pub(crate) fn validate(line: &str) -> ValidationOutcome {
+    if line.trim().is_empty() {
+        return ValidationOutcome::Skip;
+    }
+    let parsed: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return ValidationOutcome::Reject(parse_error()),
+    };
+    let Some(obj) = parsed.as_object() else {
+        return ValidationOutcome::Reject(invalid_request(Value::Null));
+    };
+    if obj.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return ValidationOutcome::Reject(invalid_request(extract_id(obj)));
+    }
+
+    // id (if present) must be string|number — null is rejected here
+    // because rmcp's RequestId = NumberOrString won't deserialize null.
+    let id_present_and_valid = match obj.get("id") {
+        None => false,
+        Some(v) if is_forwardable_id(v) => true,
+        Some(_) => return ValidationOutcome::Reject(invalid_request(Value::Null)),
+    };
+
+    let method = obj.get("method");
+    let result = obj.get("result");
+    let error = obj.get("error");
+
+    match (method, result, error) {
+        // Request: method+id, no result, no error
+        (Some(m), None, None) if m.is_string() && id_present_and_valid => {
+            ValidationOutcome::Forward
+        }
+        // Notification: method, no id, no result, no error
+        (Some(m), None, None) if m.is_string() && !id_present_and_valid => {
+            ValidationOutcome::Forward
+        }
+        // Response: id+result, no method, no error
+        (None, Some(_), None) if id_present_and_valid => ValidationOutcome::Forward,
+        // Error response: id+error, no method, no result, error well-formed
+        (None, None, Some(err)) if id_present_and_valid && is_well_formed_error(err) => {
+            ValidationOutcome::Forward
+        }
+        // Catch-all: non-string method, empty object, response/error without
+        // id, malformed error, both result+error, method mixed with
+        // result/error.
+        _ => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn reject(code: i32, id: Value) -> ValidationOutcome {
+        ValidationOutcome::Reject(ErrorEnvelope {
+            code,
+            message: if code == -32700 {
+                "Parse error"
+            } else {
+                "Invalid Request"
+            },
+            id,
+        })
+    }
+
+    #[test]
+    fn empty_line_skips() {
+        assert_eq!(validate(""), ValidationOutcome::Skip);
+        assert_eq!(validate("   "), ValidationOutcome::Skip);
+        assert_eq!(validate("\r"), ValidationOutcome::Skip);
+    }
+
+    #[test]
+    fn invalid_json_returns_parse_error() {
+        assert_eq!(validate("not valid json"), reject(-32700, Value::Null));
+    }
+
+    #[test]
+    fn non_object_returns_invalid_request() {
+        assert_eq!(validate("[1, 2, 3]"), reject(-32600, Value::Null));
+        assert_eq!(validate("\"a string\""), reject(-32600, Value::Null));
+        assert_eq!(validate("42"), reject(-32600, Value::Null));
+        assert_eq!(validate("null"), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn missing_jsonrpc_returns_invalid_request() {
+        assert_eq!(validate(r#"{"method":"a"}"#), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn wrong_jsonrpc_value_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"1.0","method":"x","id":1}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn valid_request_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#),
+            ValidationOutcome::Forward
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":"abc"}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn valid_notification_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"notifications/cancelled"}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn null_id_returns_invalid_request() {
+        // Even though JSON-RPC §5 allows null id on responses, rmcp's
+        // RequestId = NumberOrString rejects it on the wire; we match
+        // that grammar.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":null}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn array_or_object_id_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":[1,2]}"#),
+            reject(-32600, Value::Null)
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":{"k":"v"}}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn non_string_method_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":42,"id":1}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn valid_response_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":99,"result":{"x":1}}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn valid_error_response_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"not found"}}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn response_without_id_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","result":{}}"#),
+            reject(-32600, Value::Null)
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","error":{"code":1,"message":"x"}}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn both_result_and_error_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":1,"message":"x"}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn malformed_error_body_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":"x","message":"y"}}"#),
+            reject(-32600, json!(1))
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"message":"only message"}}"#),
+            reject(-32600, json!(1))
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":"not even an object"}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn empty_object_returns_invalid_request() {
+        assert_eq!(validate(r"{}"), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn mixed_method_and_result_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"result":{}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+}

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -88,14 +88,20 @@ pub(crate) fn is_forwardable_id(v: &Value) -> bool {
     v.as_i64().is_some()
 }
 
-/// `error` body matches JSON-RPC §5.1: an object with numeric
-/// `code` and string `message`. `data` is optional.
+/// `error` body matches JSON-RPC §5.1: an object with i32-representable
+/// `code` and string `message`. `data` is optional. rmcp 1.5's
+/// `ErrorCode = i32`, so fractional values and numbers outside i32
+/// range fail rmcp's deserialization and are rejected here.
 pub(crate) fn is_well_formed_error(v: &Value) -> bool {
     let Some(obj) = v.as_object() else {
         return false;
     };
-    obj.get("code").is_some_and(Value::is_number)
-        && obj.get("message").is_some_and(Value::is_string)
+    let code_ok = obj
+        .get("code")
+        .and_then(Value::as_i64)
+        .is_some_and(|n| i32::try_from(n).is_ok());
+    let message_ok = obj.get("message").is_some_and(Value::is_string);
+    code_ok && message_ok
 }
 
 /// Read the top-level `id` field for echo on a rejection envelope.
@@ -656,6 +662,22 @@ mod tests {
         );
         assert_eq!(
             validate(r#"{"jsonrpc":"2.0","id":1,"error":"not even an object"}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn fractional_error_code_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":1.5,"message":"x"}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn out_of_i32_range_error_code_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":2147483648,"message":"x"}}"#),
             reject(-32600, json!(1))
         );
     }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -257,9 +257,21 @@ where
             Some(&b'\r') => &trimmed[..trimmed.len() - 1],
             _ => trimmed,
         };
-        let line_for_validation = String::from_utf8_lossy(trimmed);
 
-        match validate(&line_for_validation) {
+        // Non-UTF-8 bytes never reach rmcp. Synthesize -32700 and
+        // continue reading the next line. JSON-RPC §4.2 / §5.1. A
+        // lossy-decode-then-validate path would let invalid bytes
+        // inside a syntactically valid JSON string slip through to
+        // rmcp (Codex review 2026-05-16).
+        let Ok(line_for_validation) = std::str::from_utf8(trimmed) else {
+            let line = synthesize_error_line(&parse_error());
+            let mut sout = stdout.lock().await;
+            sout.write_all(line.as_bytes()).await?;
+            sout.flush().await?;
+            continue;
+        };
+
+        match validate(line_for_validation) {
             ValidationOutcome::Skip => {}
             ValidationOutcome::Forward => {
                 // Forward the buffer including its trailing \n so
@@ -739,9 +751,10 @@ mod tests {
     #[tokio::test]
     async fn validate_inbound_non_utf8_returns_parse_error() {
         // Pass invalid UTF-8 bytes (\xFF is not valid UTF-8) followed
-        // by EOF. The validator should see lossy-decoded U+FFFD which
-        // serde_json rejects → validator emits -32700 to stdout (not
-        // observable from the test) AND does not forward to rmcp.
+        // by EOF. The strict `std::str::from_utf8` check returns Err
+        // first, so serde_json never sees the input — validator emits
+        // -32700 to stdout (not observable from the test) AND does not
+        // forward to rmcp.
         let stdin = std::io::Cursor::new(vec![0xFF, 0xFE, b'\n']);
         let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
         let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
@@ -759,6 +772,34 @@ mod tests {
         assert!(
             forwarded.is_empty(),
             "non-UTF-8 line should not be forwarded to rmcp, got {forwarded:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_utf8_inside_valid_json_string_returns_parse_error() {
+        // Lossy-decode would have produced parseable JSON (U+FFFD inside
+        // the string literal), so the pre-fix forwarding path would have
+        // shipped the raw \xFF byte to rmcp. The strict from_utf8 check
+        // catches it first. Codex review finding #2 (2026-05-16).
+        let mut line: Vec<u8> = br#"{"jsonrpc":"2.0","id":1,"method":"x","params":{"k":""#.to_vec();
+        line.push(0xFF);
+        line.extend_from_slice(br#""}}"#);
+        line.push(b'\n');
+
+        let stdin = std::io::Cursor::new(line);
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "bad UTF-8 inside JSON string must NOT be forwarded, got {forwarded:?}",
         );
     }
 

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -197,13 +197,6 @@ pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
 /// (rejection) fails — `BrokenPipe` on stdout is the most common
 /// failure mode and surfaces to `main.rs::run` via the supervisor so
 /// `process_end.reason: Error` is recorded.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by stdio_with_validation entry point in Task 2.4"
-    )
-)]
 pub(crate) async fn validate_inbound<R>(
     stdin: R,
     mut to_rmcp: DuplexStream,
@@ -271,13 +264,6 @@ where
 /// and `flush` may leave a partial frame on stdout. The supervisor's
 /// `shutdown_after_failure` (Task 2.3) uses abort only on failure
 /// paths where stdout integrity is already suspect.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by stdio_with_validation entry point in Task 2.4"
-    )
-)]
 pub(crate) async fn passthrough_outbound(
     from_rmcp: DuplexStream,
     stdout: Arc<Mutex<Stdout>>,
@@ -370,6 +356,38 @@ impl ValidatorSupervisor {
             Err(je) if je.is_cancelled() => Ok(()),
             Err(je) => Err(std::io::Error::other(format!("bridge task panic: {je}"))),
         }
+    }
+}
+
+/// Build the validated stdio transport. The two bridge tasks are
+/// spawned immediately; their lifecycle is exposed via `supervisor`.
+/// The returned `transport` plugs into `rmcp::serve_server(server,
+/// validated.transport)` and the returned `stdout` is the shared
+/// writer that `main.rs::run`'s pre-init error emitter must also
+/// lock so all stdout writes (validator rejections, passthrough
+/// frames, pre-init envelopes) serialize through a single mutex.
+///
+/// Drop the returned `transport` ends to signal EOF to rmcp; drop
+/// the supervisor (via `drain`/`shutdown_after_failure`) to await
+/// the bridge tasks' final exits.
+#[must_use]
+pub fn stdio_with_validation() -> ValidatedStdio {
+    let (inbound_our_end, inbound_rmcp_end) = tokio::io::duplex(BUF_SIZE);
+    let (outbound_rmcp_end, outbound_our_end) = tokio::io::duplex(BUF_SIZE);
+
+    let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+    let inbound = tokio::spawn(validate_inbound(
+        tokio::io::stdin(),
+        inbound_our_end,
+        Arc::clone(&stdout),
+    ));
+    let outbound = tokio::spawn(passthrough_outbound(outbound_our_end, Arc::clone(&stdout)));
+
+    ValidatedStdio {
+        transport: (inbound_rmcp_end, outbound_rmcp_end),
+        stdout,
+        supervisor: ValidatorSupervisor { inbound, outbound },
     }
 }
 
@@ -745,5 +763,23 @@ mod tests {
         .await
         .expect("watch_for_error must return promptly when both bridges have finished");
         assert!(r.is_ok(), "expected Ok, got {r:?}");
+    }
+
+    #[tokio::test]
+    async fn stdio_with_validation_constructs_cleanly() {
+        let validated = stdio_with_validation();
+        // Verify the supervisor is present and we can drop everything.
+        drop(validated.transport);
+        // After dropping the duplex ends, both bridges should exit cleanly
+        // (stdin EOF or read 0 bytes from a dropped duplex).
+        let r = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            validated.supervisor.drain(),
+        )
+        .await;
+        // Either Ok (drained cleanly) OR Err (stdin returned an error
+        // on the test runner) is acceptable — we mainly want to confirm
+        // no panic and no hang.
+        assert!(r.is_ok(), "drain hung after dropping transport");
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -88,6 +88,17 @@ pub(crate) fn is_forwardable_id(v: &Value) -> bool {
     v.as_i64().is_some()
 }
 
+/// `params` accepted on JSON-RPC requests and notifications. JSON-RPC §4
+/// requires a Structured value (Array or Object) when present; we also
+/// accept Null because some clients send it as "no parameters" and rmcp
+/// tolerates it. Number, String, and Boolean shapes get dropped silently
+/// by rmcp's codec and cause the server to appear hung — found via
+/// `prop_envelope_never_panics` on
+/// `{"id":0,"jsonrpc":"2.0","method":"tools/list","params":0}`.
+pub(crate) fn is_valid_params(v: &Value) -> bool {
+    v.is_object() || v.is_array() || v.is_null()
+}
+
 /// `error` body matches JSON-RPC §5.1: an object with i32-representable
 /// `code` and string `message`. `data` is optional. rmcp 1.5's
 /// `ErrorCode = i32`, so fractional values and numbers outside i32
@@ -159,14 +170,15 @@ pub(crate) fn validate(line: &str) -> ValidationOutcome {
     let method = obj.get("method");
     let result = obj.get("result");
     let error = obj.get("error");
+    let params_ok = obj.get("params").is_none_or(is_valid_params);
 
     match (method, result, error) {
-        // Request: method+id, no result, no error
-        (Some(m), None, None) if m.is_string() && id_present_and_valid => {
+        // Request: method+id, no result, no error, valid params shape
+        (Some(m), None, None) if m.is_string() && id_present_and_valid && params_ok => {
             ValidationOutcome::Forward
         }
-        // Notification: method, no id, no result, no error
-        (Some(m), None, None) if m.is_string() && !id_present_and_valid => {
+        // Notification: method, no id, no result, no error, valid params shape
+        (Some(m), None, None) if m.is_string() && !id_present_and_valid && params_ok => {
             ValidationOutcome::Forward
         }
         // Response: id+result, no method, no error
@@ -177,7 +189,7 @@ pub(crate) fn validate(line: &str) -> ValidationOutcome {
         }
         // Catch-all: non-string method, empty object, response/error without
         // id, malformed error, both result+error, method mixed with
-        // result/error.
+        // result/error, request/notification with non-structured params.
         _ => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
     }
 }
@@ -679,6 +691,63 @@ mod tests {
         assert_eq!(
             validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":2147483648,"message":"x"}}"#),
             reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn params_as_number_rejects() {
+        // Regression for the prop_envelope_never_panics shrunk case
+        // `{"id":0,"jsonrpc":"2.0","method":"tools/list","params":0}`:
+        // rmcp's codec silently drops non-structured params and the
+        // server appears to hang.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":0,"params":0}"#),
+            reject(-32600, json!(0))
+        );
+    }
+
+    #[test]
+    fn params_as_string_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"params":"foo"}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn params_as_bool_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"params":true}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn params_as_array_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"params":[1,2,3]}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn params_as_null_forwards() {
+        // rmcp tolerates `params: null` as "no parameters"; matching
+        // that grammar avoids over-rejecting legitimate clients.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"params":null}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn notification_with_bad_params_rejects() {
+        // §4.1 notifications get the same params shape constraint as
+        // requests. Notifications have no id, so the rejection echoes
+        // null (no id to echo).
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"notifications/x","params":0}"#),
+            reject(-32600, Value::Null)
         );
     }
 

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -172,7 +172,33 @@ pub(crate) fn validate(line: &str) -> ValidationOutcome {
     }
 }
 
+/// Serialize a rejection envelope to a single wire line, terminated
+/// with `\n`. The shape matches JSON-RPC §5: `{jsonrpc, id, error}`
+/// with `error.{code, message}` and no `data`.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by validate_inbound bridge task in Task 2.1"
+    )
+)]
+pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": env.id,
+        "error": {
+            "code": env.code,
+            "message": env.message,
+        },
+    });
+    // Use to_string (not pretty) so it's exactly one line.
+    let mut line = body.to_string();
+    line.push('\n');
+    line
+}
+
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -263,6 +289,10 @@ mod tests {
             validate(r#"{"jsonrpc":"2.0","method":"x","id":{"k":"v"}}"#),
             reject(-32600, Value::Null)
         );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":true}"#),
+            reject(-32600, Value::Null)
+        );
     }
 
     #[test]
@@ -336,5 +366,47 @@ mod tests {
             validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"result":{}}"#),
             reject(-32600, json!(1))
         );
+    }
+
+    #[test]
+    fn synthesize_invalid_request_with_null_id() {
+        let env = ErrorEnvelope {
+            code: -32600,
+            message: "Invalid Request",
+            id: Value::Null,
+        };
+        let line = synthesize_error_line(&env);
+        assert!(line.ends_with('\n'));
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], Value::Null);
+        assert_eq!(parsed["error"]["code"], -32600);
+        assert_eq!(parsed["error"]["message"], "Invalid Request");
+        // No data field.
+        assert!(parsed["error"].get("data").is_none());
+    }
+
+    #[test]
+    fn synthesize_parse_error_has_correct_code() {
+        let line = synthesize_error_line(&parse_error());
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["error"]["code"], -32700);
+        assert_eq!(parsed["error"]["message"], "Parse error");
+    }
+
+    #[test]
+    fn synthesize_echoes_numeric_id() {
+        let env = invalid_request(json!(42));
+        let line = synthesize_error_line(&env);
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], 42);
+    }
+
+    #[test]
+    fn synthesize_echoes_string_id() {
+        let env = invalid_request(json!("abc"));
+        let line = synthesize_error_line(&env);
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], "abc");
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -54,9 +54,22 @@ pub struct ValidatedStdio {
 /// `passthrough_outbound`). See the spec for the three-method lifecycle
 /// contract: race-phase fail-fast (`watch_for_error`), success-path
 /// drain (`drain`), and failure-path abort+drain (`shutdown_after_failure`).
+///
+/// **`JoinHandle` lifecycle.** `watch_for_error` may poll either or
+/// both `JoinHandle`s to completion. Once a `JoinHandle` has been
+/// polled to completion, re-polling panics (tokio invariant: see
+/// `tokio::runtime::task::core` line 422 — "`JoinHandle` polled after
+/// completion"). The `_consumed` flags track this so the success-path
+/// `drain` and failure-path `shutdown_after_failure` can skip the
+/// re-await on already-consumed handles. The skipped result is treated
+/// as `Ok(())` per the invariant that `drain` is only called after
+/// `watch_for_error` returned `Ok` (both bridges exited cleanly) and
+/// `shutdown_after_failure` always aborts before awaiting.
 pub struct ValidatorSupervisor {
     pub(crate) inbound: JoinHandle<std::io::Result<()>>,
     pub(crate) outbound: JoinHandle<std::io::Result<()>>,
+    pub(crate) inbound_consumed: bool,
+    pub(crate) outbound_consumed: bool,
 }
 
 // ============================================================
@@ -304,25 +317,38 @@ pub(crate) async fn passthrough_outbound(
 }
 
 impl ValidatorSupervisor {
-    /// Non-consuming. Resolves with the first bridge-task error
-    /// encountered, OR `Ok(())` once both bridges exit `Ok` cleanly
-    /// (exotic mid-service condition — usually one side stays alive
-    /// until the service ends). Used for fail-fast during the
-    /// `service.waiting()` / `serve_server` race in `main.rs::run`.
+    /// Polls each bridge `JoinHandle` in turn. Resolves with the
+    /// first bridge-task error encountered, OR `Ok(())` once both
+    /// bridges exit `Ok` cleanly (exotic mid-service condition —
+    /// usually one side stays alive until the service ends). Used for
+    /// fail-fast during the `service.waiting()` / `serve_server` race
+    /// in `main.rs::run`.
+    ///
+    /// **Side effect.** When an arm fires, the corresponding
+    /// `JoinHandle` has been polled to completion and its value
+    /// consumed; the `*_consumed` flag is set so the success-path
+    /// `drain` and failure-path `shutdown_after_failure` skip the
+    /// already-polled handle (tokio panics on re-poll of a completed
+    /// `JoinHandle`). The skipped result is treated as `Ok(())` per
+    /// the invariant that this method only returns `Ok` when both
+    /// bridges exited `Ok` (the `Err` arms return early and `drain`
+    /// is not called on the error path).
     pub async fn watch_for_error(&mut self) -> std::io::Result<()> {
         loop {
             tokio::select! {
                 biased;
-                r = &mut self.inbound, if !self.inbound.is_finished() => {
+                r = &mut self.inbound, if !self.inbound_consumed => {
+                    self.inbound_consumed = true;
                     match Self::flatten(r) {
-                        Ok(()) if self.outbound.is_finished() => return Ok(()),
+                        Ok(()) if self.outbound_consumed => return Ok(()),
                         Ok(()) => {}
                         Err(e) => return Err(e),
                     }
                 }
-                r = &mut self.outbound, if !self.outbound.is_finished() => {
+                r = &mut self.outbound, if !self.outbound_consumed => {
+                    self.outbound_consumed = true;
                     match Self::flatten(r) {
-                        Ok(()) if self.inbound.is_finished() => return Ok(()),
+                        Ok(()) if self.inbound_consumed => return Ok(()),
                         Ok(()) => {}
                         Err(e) => return Err(e),
                     }
@@ -342,10 +368,14 @@ impl ValidatorSupervisor {
     /// exits on real stdin EOF, but a client may legitimately keep
     /// stdin open while waiting for the error response, causing this
     /// to hang. Use `shutdown_after_failure` instead.
-    pub async fn drain(self) -> std::io::Result<()> {
-        let (in_r, out_r) = tokio::join!(self.inbound, self.outbound);
-        let in_r = Self::flatten(in_r);
-        let out_r = Self::flatten(out_r);
+    ///
+    /// **Already-consumed handles are skipped.** If `watch_for_error`
+    /// previously polled a `JoinHandle` to completion, its `_consumed`
+    /// flag is set and the await is skipped (re-polling panics).
+    /// The invariant guarantees the skipped result was `Ok`.
+    pub async fn drain(mut self) -> std::io::Result<()> {
+        let in_r = Self::take_or_await(&mut self.inbound, &mut self.inbound_consumed).await;
+        let out_r = Self::take_or_await(&mut self.outbound, &mut self.outbound_consumed).await;
         in_r.and(out_r)
     }
 
@@ -360,13 +390,34 @@ impl ValidatorSupervisor {
     /// Used on EVERY failure path — pre-init `ExpectedInitializeRequest`,
     /// `InitializeFailed`, post-init bridge race error, and post-init
     /// `service.waiting()` error.
-    pub async fn shutdown_after_failure(self) -> std::io::Result<()> {
+    ///
+    /// **Already-consumed handles are skipped.** Same contract as
+    /// `drain` — re-polling a completed `JoinHandle` panics, so the
+    /// `_consumed` flags gate the awaits.
+    pub async fn shutdown_after_failure(mut self) -> std::io::Result<()> {
+        // `abort` is always safe (no-op on a finished task); it does
+        // not poll the `JoinHandle` so the consumed flag is irrelevant.
         self.inbound.abort();
-        // Either it raced to EOF (Ok) or got aborted (JoinError). We
-        // don't care about the inbound result on this path — the
-        // outbound may still have queued frames to flush.
-        let _ = self.inbound.await;
-        Self::flatten(self.outbound.await)
+        // Either it raced to EOF (Ok), got aborted (JoinError), or
+        // was already consumed by `watch_for_error`. We don't care
+        // about the inbound result on this path — the outbound may
+        // still have queued frames to flush.
+        let _ = Self::take_or_await(&mut self.inbound, &mut self.inbound_consumed).await;
+        Self::take_or_await(&mut self.outbound, &mut self.outbound_consumed).await
+    }
+
+    /// Await `handle` if its `consumed` flag is `false`, then mark it
+    /// consumed. Returns `Ok(())` if already consumed — guarded by
+    /// the invariant documented on `drain` and `shutdown_after_failure`.
+    async fn take_or_await(
+        handle: &mut JoinHandle<std::io::Result<()>>,
+        consumed: &mut bool,
+    ) -> std::io::Result<()> {
+        if *consumed {
+            return Ok(());
+        }
+        *consumed = true;
+        Self::flatten(handle.await)
     }
 
     fn flatten(r: Result<std::io::Result<()>, tokio::task::JoinError>) -> std::io::Result<()> {
@@ -406,7 +457,12 @@ pub fn stdio_with_validation() -> ValidatedStdio {
     ValidatedStdio {
         transport: (inbound_rmcp_end, outbound_rmcp_end),
         stdout,
-        supervisor: ValidatorSupervisor { inbound, outbound },
+        supervisor: ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        },
     }
 }
 
@@ -722,7 +778,12 @@ mod tests {
     async fn drain_returns_ok_when_both_bridges_exit_ok() {
         let inbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
         let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
-        let supervisor = ValidatorSupervisor { inbound, outbound };
+        let supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
         assert!(supervisor.drain().await.is_ok());
     }
 
@@ -732,7 +793,12 @@ mod tests {
             Err::<(), std::io::Error>(std::io::Error::other("inbound boom"))
         });
         let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
-        let supervisor = ValidatorSupervisor { inbound, outbound };
+        let supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
         let r = supervisor.drain().await;
         assert!(r.is_err());
         assert!(r.unwrap_err().to_string().contains("inbound boom"));
@@ -744,7 +810,12 @@ mod tests {
         // holding stdin open.
         let inbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
         let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
-        let supervisor = ValidatorSupervisor { inbound, outbound };
+        let supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
 
         // Should return promptly (within a few ms) thanks to abort.
         let r = tokio::time::timeout(
@@ -763,7 +834,12 @@ mod tests {
             Err::<(), std::io::Error>(std::io::Error::other("inbound failed"))
         });
         let outbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
-        let mut supervisor = ValidatorSupervisor { inbound, outbound };
+        let mut supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
 
         let r = tokio::time::timeout(
             std::time::Duration::from_millis(500),
@@ -785,7 +861,12 @@ mod tests {
         let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
         // Give the runtime a tick so both handles transition to finished.
         tokio::task::yield_now().await;
-        let mut supervisor = ValidatorSupervisor { inbound, outbound };
+        let mut supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
         let r = tokio::time::timeout(
             std::time::Duration::from_millis(500),
             supervisor.watch_for_error(),

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -76,10 +76,16 @@ pub struct ValidatorSupervisor {
 // Pure validator (no I/O — unit-testable in isolation).
 // ============================================================
 
-/// `id` accepted by rmcp's `RxJsonRpcMessage`. Null is excluded
-/// because rmcp 1.5's `RequestId = NumberOrString` rejects null.
+/// `id` accepted by rmcp's `RxJsonRpcMessage`. rmcp 1.5's
+/// `RequestId = NumberOrString` rejects null; strings are unrestricted;
+/// numbers must be i64-representable (rejects fractional values and
+/// numbers outside i64 range — `serde_json` parses very large ints as
+/// f64 which `as_i64` also rejects).
 pub(crate) fn is_forwardable_id(v: &Value) -> bool {
-    v.is_string() || v.is_number()
+    if v.is_string() {
+        return true;
+    }
+    v.as_i64().is_some()
 }
 
 /// `error` body matches JSON-RPC §5.1: an object with numeric
@@ -581,6 +587,24 @@ mod tests {
         assert_eq!(
             validate(r#"{"jsonrpc":"2.0","method":42,"id":1}"#),
             reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn fractional_id_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1.5}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn out_of_i64_range_id_rejects() {
+        // serde_json may parse very large integers as f64; either way
+        // as_i64() returns None and we reject.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":9223372036854775808}"#),
+            reject(-32600, Value::Null)
         );
     }
 

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -89,12 +89,11 @@ pub(crate) fn is_forwardable_id(v: &Value) -> bool {
 }
 
 /// `params` accepted on JSON-RPC requests and notifications. JSON-RPC §4
-/// requires a Structured value (Array or Object) when present; we also
-/// accept Null because some clients send it as "no parameters" and rmcp
-/// tolerates it. Number, String, and Boolean shapes get dropped silently
-/// by rmcp's codec and cause the server to appear hung — found via
-/// `prop_envelope_never_panics` on
-/// `{"id":0,"jsonrpc":"2.0","method":"tools/list","params":0}`.
+/// requires a Structured value (Array or Object) when present; Null is
+/// also accepted because rmcp tolerates it as "no parameters" and
+/// rejecting it would over-strict legitimate clients. Number, String,
+/// and Boolean shapes are silently dropped by rmcp's codec and cause
+/// the server to appear hung.
 pub(crate) fn is_valid_params(v: &Value) -> bool {
     v.is_object() || v.is_array() || v.is_null()
 }
@@ -282,11 +281,10 @@ where
             _ => trimmed,
         };
 
-        // Non-UTF-8 bytes never reach rmcp. Synthesize -32700 and
-        // continue reading the next line. JSON-RPC §4.2 / §5.1. A
-        // lossy-decode-then-validate path would let invalid bytes
-        // inside a syntactically valid JSON string slip through to
-        // rmcp (Codex review 2026-05-16).
+        // Non-UTF-8 bytes never reach rmcp. A lossy-decode-then-validate
+        // path would let invalid bytes inside a syntactically valid JSON
+        // string slip through (U+FFFD makes the string parseable), so
+        // the strict check happens before any parsing. JSON-RPC §4.2 / §5.1.
         let Ok(line_for_validation) = std::str::from_utf8(trimmed) else {
             let line = synthesize_error_line(&parse_error());
             let mut sout = stdout.lock().await;
@@ -696,10 +694,8 @@ mod tests {
 
     #[test]
     fn params_as_number_rejects() {
-        // Regression for the prop_envelope_never_panics shrunk case
-        // `{"id":0,"jsonrpc":"2.0","method":"tools/list","params":0}`:
-        // rmcp's codec silently drops non-structured params and the
-        // server appears to hang.
+        // rmcp's codec silently drops non-structured params, making the
+        // server appear to hang; the validator rejects before forwarding.
         assert_eq!(
             validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":0,"params":0}"#),
             reject(-32600, json!(0))
@@ -743,8 +739,7 @@ mod tests {
     #[test]
     fn notification_with_bad_params_rejects() {
         // §4.1 notifications get the same params shape constraint as
-        // requests. Notifications have no id, so the rejection echoes
-        // null (no id to echo).
+        // requests.
         assert_eq!(
             validate(r#"{"jsonrpc":"2.0","method":"notifications/x","params":0}"#),
             reject(-32600, Value::Null)
@@ -865,11 +860,8 @@ mod tests {
 
     #[tokio::test]
     async fn validate_inbound_non_utf8_returns_parse_error() {
-        // Pass invalid UTF-8 bytes (\xFF is not valid UTF-8) followed
-        // by EOF. The strict `std::str::from_utf8` check returns Err
-        // first, so serde_json never sees the input — validator emits
-        // -32700 to stdout (not observable from the test) AND does not
-        // forward to rmcp.
+        // Bare non-UTF-8 bytes: the rejection goes to stdout (not
+        // observable from this test) and nothing reaches rmcp.
         let stdin = std::io::Cursor::new(vec![0xFF, 0xFE, b'\n']);
         let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
         let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
@@ -892,10 +884,10 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_utf8_inside_valid_json_string_returns_parse_error() {
-        // Lossy-decode would have produced parseable JSON (U+FFFD inside
-        // the string literal), so the pre-fix forwarding path would have
-        // shipped the raw \xFF byte to rmcp. The strict from_utf8 check
-        // catches it first. Codex review finding #2 (2026-05-16).
+        // Bad UTF-8 inside an otherwise-parseable JSON string literal:
+        // lossy decoding would replace the byte with U+FFFD and pass
+        // validation, leaving the raw byte to reach rmcp. The strict
+        // check rejects before parsing.
         let mut line: Vec<u8> = br#"{"jsonrpc":"2.0","id":1,"method":"x","params":{"k":""#.to_vec();
         line.push(0xFF);
         line.extend_from_slice(br#""}}"#);

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -54,10 +54,6 @@ pub struct ValidatedStdio {
 /// `passthrough_outbound`). See the spec for the three-method lifecycle
 /// contract: race-phase fail-fast (`watch_for_error`), success-path
 /// drain (`drain`), and failure-path abort+drain (`shutdown_after_failure`).
-#[expect(
-    dead_code,
-    reason = "inbound/outbound are read by watch_for_error/drain/shutdown_after_failure in Task 2.4"
-)]
 pub struct ValidatorSupervisor {
     pub(crate) inbound: JoinHandle<std::io::Result<()>>,
     pub(crate) outbound: JoinHandle<std::io::Result<()>>,
@@ -299,6 +295,80 @@ pub(crate) async fn passthrough_outbound(
         sout.write_all(&buf).await?;
         sout.flush().await?;
         // Lock released; loop.
+    }
+}
+
+impl ValidatorSupervisor {
+    /// Non-consuming. Resolves with the first bridge-task error
+    /// encountered, OR `Ok(())` once both bridges exit `Ok` cleanly
+    /// (exotic mid-service condition — usually one side stays alive
+    /// until the service ends). Used for fail-fast during the
+    /// `service.waiting()` / `serve_server` race in `main.rs::run`.
+    pub async fn watch_for_error(&mut self) -> std::io::Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                r = &mut self.inbound, if !self.inbound.is_finished() => {
+                    match Self::flatten(r) {
+                        Ok(()) if self.outbound.is_finished() => return Ok(()),
+                        Ok(()) => {}
+                        Err(e) => return Err(e),
+                    }
+                }
+                r = &mut self.outbound, if !self.outbound.is_finished() => {
+                    match Self::flatten(r) {
+                        Ok(()) if self.inbound.is_finished() => return Ok(()),
+                        Ok(()) => {}
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Success-path shutdown. Awaits both bridge tasks; returns the
+    /// first error encountered, else `Ok(())`. Use when
+    /// `service.waiting()` resolved `Ok` (which implies rmcp saw EOF
+    /// on its read, which implies inbound already exited — drain is
+    /// then essentially instant on inbound and bounded on outbound).
+    ///
+    /// **Do not call on failure paths** — the inbound bridge only
+    /// exits on real stdin EOF, but a client may legitimately keep
+    /// stdin open while waiting for the error response, causing this
+    /// to hang. Use `shutdown_after_failure` instead.
+    pub async fn drain(self) -> std::io::Result<()> {
+        let (in_r, out_r) = tokio::join!(self.inbound, self.outbound);
+        let in_r = Self::flatten(in_r);
+        let out_r = Self::flatten(out_r);
+        in_r.and(out_r)
+    }
+
+    /// Failure-path shutdown. Aborts the inbound bridge (the client
+    /// may keep stdin open while waiting for an error response;
+    /// without abort, we'd block forever in `read_until` on real
+    /// stdin), then awaits the outbound bridge to drain rmcp's
+    /// queued error envelope plus any validator-synthesized
+    /// rejections. Returns the first error from the outbound path;
+    /// inbound cancellation is expected and ignored.
+    ///
+    /// Used on EVERY failure path — pre-init `ExpectedInitializeRequest`,
+    /// `InitializeFailed`, post-init bridge race error, and post-init
+    /// `service.waiting()` error.
+    pub async fn shutdown_after_failure(self) -> std::io::Result<()> {
+        self.inbound.abort();
+        // Either it raced to EOF (Ok) or got aborted (JoinError). We
+        // don't care about the inbound result on this path — the
+        // outbound may still have queued frames to flush.
+        let _ = self.inbound.await;
+        Self::flatten(self.outbound.await)
+    }
+
+    fn flatten(r: Result<std::io::Result<()>, tokio::task::JoinError>) -> std::io::Result<()> {
+        match r {
+            Ok(inner) => inner,
+            Err(je) if je.is_cancelled() => Ok(()),
+            Err(je) => Err(std::io::Error::other(format!("bridge task panic: {je}"))),
+        }
     }
 }
 
@@ -597,5 +667,63 @@ mod tests {
         drop(rmcp_end);
         let result = passthrough_outbound(our_end, stdout).await;
         assert!(result.is_ok(), "expected Ok on EOF, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn drain_returns_ok_when_both_bridges_exit_ok() {
+        let inbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+        assert!(supervisor.drain().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn drain_surfaces_first_error() {
+        let inbound = tokio::spawn(async {
+            Err::<(), std::io::Error>(std::io::Error::other("inbound boom"))
+        });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+        let r = supervisor.drain().await;
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("inbound boom"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_after_failure_aborts_inbound() {
+        // Inbound never completes on its own — simulates a client
+        // holding stdin open.
+        let inbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+
+        // Should return promptly (within a few ms) thanks to abort.
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.shutdown_after_failure(),
+        )
+        .await;
+        assert!(r.is_ok(), "shutdown_after_failure did not abort inbound");
+        assert!(r.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn watch_for_error_returns_on_first_error() {
+        let inbound = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            Err::<(), std::io::Error>(std::io::Error::other("inbound failed"))
+        });
+        let outbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let mut supervisor = ValidatorSupervisor { inbound, outbound };
+
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.watch_for_error(),
+        )
+        .await;
+        assert!(r.is_ok());
+        let inner = r.unwrap();
+        assert!(inner.is_err());
+        assert!(inner.unwrap_err().to_string().contains("inbound failed"));
     }
 }

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -160,15 +160,34 @@ pub(crate) fn validate(line: &str) -> ValidationOutcome {
 /// Serialize a rejection envelope to a single wire line, terminated
 /// with `\n`. The shape matches JSON-RPC §5: `{jsonrpc, id, error}`
 /// with `error.{code, message}` and no `data`.
+///
+/// **`id` is omitted when null**, not emitted as `"id": null`. MCP's
+/// `RequestId` schema (`integer | string`) disallows null, so emitting
+/// `null` would make the envelope fail the MCP schema validator the
+/// test harness applies via `assert_envelope_valid`. JSON-RPC 2.0 §5
+/// requires `id: null` for parse / invalid-request errors, but MCP's
+/// `JSONRPCErrorResponse` schema marks `id` as OPTIONAL — so omitting
+/// it satisfies both the MCP contract (the protocol we serve) and
+/// the JSON-RPC §5 intent of "no recoverable id available."
 pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": env.id,
-        "error": {
-            "code": env.code,
-            "message": env.message,
-        },
-    });
+    let body = if env.id.is_null() {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "error": {
+                "code": env.code,
+                "message": env.message,
+            },
+        })
+    } else {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": env.id,
+            "error": {
+                "code": env.code,
+                "message": env.message,
+            },
+        })
+    };
     // Use to_string (not pretty) so it's exactly one line.
     let mut line = body.to_string();
     line.push('\n');
@@ -563,7 +582,14 @@ mod tests {
     }
 
     #[test]
-    fn synthesize_invalid_request_with_null_id() {
+    fn synthesize_invalid_request_with_null_id_omits_id_field() {
+        // Pins the MCP-schema accommodation: when the original request
+        // had no recoverable id, the synthesizer OMITS `id` rather than
+        // emitting `"id": null`. MCP's `JSONRPCErrorResponse` schema
+        // marks `id` optional but its type is `integer | string` —
+        // emitting null would fail `assert_envelope_valid` and break
+        // the negative-path wire tests (e.g.
+        // `valid_json_invalid_envelope_returns_minus_32600`).
         let env = ErrorEnvelope {
             code: -32600,
             message: "Invalid Request",
@@ -573,7 +599,11 @@ mod tests {
         assert!(line.ends_with('\n'));
         let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
         assert_eq!(parsed["jsonrpc"], "2.0");
-        assert_eq!(parsed["id"], Value::Null);
+        let obj = parsed.as_object().unwrap();
+        assert!(
+            !obj.contains_key("id"),
+            "id field MUST be omitted when null; got {parsed}",
+        );
         assert_eq!(parsed["error"]["code"], -32600);
         assert_eq!(parsed["error"]["message"], "Invalid Request");
         // No data field.

--- a/crates/rimap-server/tests/e2e_wire_cancellation.rs
+++ b/crates/rimap-server/tests/e2e_wire_cancellation.rs
@@ -1,0 +1,192 @@
+//! Wire-layer cancellation acceptance (issue #266, Phase 4 §4.4).
+//!
+//! Race-free assertions only. The audit-layer Drop contract from
+//! #71/#99 (`tool_end {status: cancelled}` on Drop) is pinned by the
+//! in-process tests at
+//! `crates/rimap-server/src/mcp/audit_envelope.rs::tests` and by
+//! `tests/dispatch_ticket.rs::drop_during_body_enqueues_cancellation_tool_end`.
+//! This file only asserts that the server accepts
+//! `notifications/cancelled` without crashing and remains responsive
+//! afterwards.
+//!
+//! Silent-skip on `DockerUnavailable` mirrors the existing repo
+//! contract from `e2e_wire.rs`; `RIMAP_REQUIRE_DOCKER=1` flips that to
+//! loud failure inside `DovecotHarness::try_start`.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+// Each integration-test binary imports only its needed support
+// submodules directly to avoid cross-binary dead-code warnings.
+#[path = "support/dovecot/mod.rs"]
+mod dovecot;
+#[path = "support/wire/mod.rs"]
+mod wire;
+
+use std::time::Duration;
+
+use rimap_config::credential::PASSWORD_ENV_VAR;
+use serde_json::json;
+use tempfile::TempDir;
+
+use dovecot::{DovecotHarness, HarnessError};
+use wire::config::build_dovecot_config;
+use wire::harness::Harness;
+
+// Per-binary dead-code cross-talk: each integration-test binary
+// compiles `support/` independently, but items that other binaries
+// use appear dead here. Workspace lint `clippy::allow_attributes`
+// forbids `#[allow]`, so we reference cross-binary items in a
+// never-called helper — the reference itself counts as "use" for
+// dead-code analysis. Mirrors `e2e_wire.rs::force_use_for_dead_code_link`.
+#[expect(
+    dead_code,
+    reason = "type-link to items used only by other integration-test binaries"
+)]
+fn force_use_for_dead_code_link() {
+    // Used by mcp_wire_negative, mcp_wire_conformance, mcp_wire_proptest.
+    let _ = Harness::spawn;
+    // Used by e2e_wire to seed Drafts / Trash mailboxes.
+    let _ = DovecotHarness::create_mailbox;
+}
+
+/// Dovecot's seeded test password. Matches `e2e_wire.rs`.
+const DOVECOT_PASSWORD: &str = "testpass";
+
+/// Hold the spawned `Harness` together with the `DovecotHarness` that
+/// owns the underlying container. Dropping the latter tears the
+/// container down, so it MUST outlive the `Harness`.
+struct CancellationSession {
+    harness: Harness,
+    /// Held to keep the container alive for the duration of the test.
+    /// Dropping `_dovecot` after `harness` lets the child process
+    /// finish its TLS teardown before the IMAP listener disappears.
+    _dovecot: DovecotHarness,
+}
+
+/// Spawn the wire harness against a fresh Dovecot container, walk the
+/// `initialize` / `notifications/initialized` / `use_account
+/// "draftsafe"` handshake, and return the ready-to-drive session.
+/// Returns `None` (silent skip) when the container runtime is absent,
+/// matching the contract enforced at `e2e_wire.rs:95-98`.
+async fn spawn_with_dovecot() -> Option<CancellationSession> {
+    let dovecot = match DovecotHarness::try_start() {
+        Ok(d) => d,
+        Err(HarnessError::DockerUnavailable) => return None,
+        Err(e) => panic!("Dovecot harness failed: {e}"),
+    };
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path().to_path_buf();
+    let download_dir = tempdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("mkdir download_dir");
+
+    let fingerprint_hex = dovecot.fingerprint().to_hex();
+    let config = build_dovecot_config(
+        &fingerprint_hex,
+        dovecot.port(),
+        &audit_path,
+        &allowed_base,
+        &download_dir,
+    );
+    let config_path = tempdir.path().join("config.toml");
+    std::fs::write(&config_path, config).expect("write config");
+
+    let envs = [(PASSWORD_ENV_VAR, DOVECOT_PASSWORD)];
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &envs).await;
+
+    let _init = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // Pin the session to the "draftsafe" account so subsequent tool
+    // calls can use the bare `draftsafe.<tool>` namespaced names.
+    let use_account = harness
+        .request(
+            "tools/call",
+            json!({ "name": "use_account", "arguments": { "account": "draftsafe" } }),
+        )
+        .await;
+    assert!(
+        use_account["error"].is_null(),
+        "use_account failed: {use_account}",
+    );
+
+    Some(CancellationSession {
+        harness,
+        _dovecot: dovecot,
+    })
+}
+
+/// Send a `tools/call` for `draftsafe.search` then immediately a
+/// `notifications/cancelled` for that request id. The server must
+/// produce ONE response envelope for the cancelled id (race-dependent:
+/// result OR error) and remain responsive to a follow-up `tools/list`.
+/// No panic, no envelope corruption.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_during_inflight_tools_call_keeps_session_alive() {
+    let Some(mut session) = spawn_with_dovecot().await else {
+        return;
+    };
+
+    let search_id = session
+        .harness
+        .send_request_no_wait(
+            "tools/call",
+            json!({
+                "name": "draftsafe.search",
+                "arguments": { "folder": "INBOX", "criteria": "ALL" },
+            }),
+        )
+        .await;
+
+    session
+        .harness
+        .notify(
+            "notifications/cancelled",
+            json!({ "requestId": search_id, "reason": "test cancel" }),
+        )
+        .await;
+
+    let response = session.harness.recv_until_id(search_id).await;
+    assert_eq!(response["id"], json!(search_id));
+    assert!(
+        response.get("result").is_some() || response.get("error").is_some(),
+        "expected a result or error envelope for cancelled id, got {response}",
+    );
+
+    let list = session.harness.request("tools/list", json!({})).await;
+    assert!(
+        list["result"].is_object(),
+        "server must remain responsive after cancellation, got {list}",
+    );
+}
+
+/// `notifications/cancelled` for an id that was never issued. The
+/// server must accept it silently (no response envelope) and remain
+/// responsive to a follow-up `tools/list`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_unknown_request_id_is_noop() {
+    let Some(mut session) = spawn_with_dovecot().await else {
+        return;
+    };
+
+    session
+        .harness
+        .notify(
+            "notifications/cancelled",
+            json!({ "requestId": 999_999, "reason": "test cancel unknown" }),
+        )
+        .await;
+
+    session
+        .harness
+        .assert_no_response_within(Duration::from_millis(200))
+        .await;
+
+    let list = session.harness.request("tools/list", json!({})).await;
+    assert!(
+        list["result"].is_object(),
+        "server must remain responsive after no-op cancellation, got {list}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_audit_failure.rs
+++ b/crates/rimap-server/tests/mcp_audit_failure.rs
@@ -1,0 +1,109 @@
+//! Audit fail-closed boundary tests (issue #266, Phase 4 §4.3).
+//!
+//! Arms the production `AuditWriter`'s `force_next_write_failure()`
+//! hook via the `test-support`-gated env var
+//! `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1`, then exercises
+//! the wire. The next audit write — `tool_start` for the first
+//! `tools/call` — takes the real lock/append/error-mapping path
+//! and fails. The server must respond with an error envelope
+//! rather than silently proceeding.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use support::wire::harness::Harness;
+
+/// With the audit writer armed for one forced write failure,
+/// `tools/call use_account` must return an error envelope. Tests
+/// the real `AuditWriter` path (lock/append/error-mapping), not a
+/// swappable sink.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn audit_write_failure_fails_closed_for_tools_call() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = tempdir.path().join("config.toml");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path();
+    let config = format!(
+        r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+fail_open = false
+"#,
+        audit_path.display(),
+        allowed_base.display(),
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let mut harness = Harness::spawn_with_config(
+        &config_path,
+        tempdir,
+        &[("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE", "1")],
+    )
+    .await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "use_account",
+                "arguments": { "account": "nonexistent" },
+            }),
+        )
+        .await;
+
+    // The contract is "fails closed" — the server must NOT
+    // silently succeed when the audit write fails.
+    let is_envelope_error = response.get("error").is_some();
+    let is_tool_error = response["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        is_envelope_error || is_tool_error,
+        "tools/call with armed audit-write failure must fail closed, got {response}",
+    );
+}
+
+/// Initialize handshake must succeed (or fail cleanly) regardless
+/// of audit failure arming. `initialize` doesn't write an audit
+/// record by itself, so this test pins that the env-var hook
+/// doesn't accidentally break the handshake.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn audit_write_failure_does_not_block_initialize() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = tempdir.path().join("config.toml");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path();
+    let config = format!(
+        r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+fail_open = false
+"#,
+        audit_path.display(),
+        allowed_base.display(),
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let mut harness = Harness::spawn_with_config(
+        &config_path,
+        tempdir,
+        &[("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE", "1")],
+    )
+    .await;
+    let response = harness.initialize_handshake().await;
+    assert!(
+        response["result"].is_object(),
+        "initialize must succeed even with audit failure armed, got {response}",
+    );
+}

--- a/crates/rimap-server/tests/mcp_audit_failure.rs
+++ b/crates/rimap-server/tests/mcp_audit_failure.rs
@@ -7,24 +7,29 @@
 //! `tools/call` — takes the real lock/append/error-mapping path
 //! and fails. The server must respond with an error envelope
 //! rather than silently proceeding.
+//!
+//! The pair `list_accounts_succeeds_when_audit_healthy` (control)
+//! and `list_accounts_fails_closed_when_audit_armed` (armed) is
+//! the only way to prove the contract: if the env-var hook is
+//! never read, the armed test passes when it shouldn't; if the
+//! hook fires unconditionally, the control test fails. Both
+//! tests passing together is the proof. Phase 4 Codex review
+//! finding #1: a single test against a call that ALWAYS fails
+//! (e.g. `use_account` on a missing account) is vacuous because
+//! the assertion holds whether or not the hook fires.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
 
 #[path = "support/mod.rs"]
 mod support;
 
-use serde_json::json;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use support::wire::harness::Harness;
 
-/// With the audit writer armed for one forced write failure,
-/// `tools/call use_account` must return an error envelope. Tests
-/// the real `AuditWriter` path (lock/append/error-mapping), not a
-/// swappable sink.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn audit_write_failure_fails_closed_for_tools_call() {
-    let tempdir = TempDir::new().expect("tempdir");
+/// Build a zero-account config TOML with `fail_open = false`.
+fn write_zero_account_config(tempdir: &TempDir) -> std::path::PathBuf {
     let config_path = tempdir.path().join("config.toml");
     let audit_path = tempdir.path().join("audit.jsonl");
     let allowed_base = tempdir.path();
@@ -40,7 +45,71 @@ fail_open = false
         audit_path.display(),
         allowed_base.display(),
     );
-    std::fs::write(&config_path, config).expect("write config");
+    std::fs::write(&config_path, &config).expect("write config");
+    config_path
+}
+
+/// Drive `tools/call list_accounts` against the harness and return
+/// the response envelope. Caller asserts on the outcome.
+async fn call_list_accounts(harness: &mut Harness) -> Value {
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+    harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "list_accounts",
+                "arguments": {},
+            }),
+        )
+        .await
+}
+
+/// Control case: with the audit-failure hook UNARMED, `tools/call
+/// list_accounts` MUST succeed against `accounts = []`. The tool
+/// is universally available (it does not require a configured
+/// account) and returns an empty list in the zero-account config.
+///
+/// This case is the proof that the call we use in
+/// `list_accounts_fails_closed_when_audit_armed` is healthy by
+/// default — without it, that armed test could not distinguish
+/// "audit failure caused the rejection" from "the call was
+/// already going to fail."
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_accounts_succeeds_when_audit_healthy() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_zero_account_config(&tempdir);
+
+    // No env var: hook does NOT fire.
+    let mut harness = Harness::spawn_with_config(&config_path, tempdir, &[]).await;
+    let response = call_list_accounts(&mut harness).await;
+
+    assert!(
+        response.get("error").is_none(),
+        "control: list_accounts must not produce a JSON-RPC error envelope when audit is healthy, got {response}",
+    );
+    let is_tool_error = response["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        !is_tool_error,
+        "control: list_accounts must not return isError when audit is healthy, got {response}",
+    );
+}
+
+/// Armed case: with the audit-failure hook ARMED via
+/// `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1`, the same
+/// `tools/call list_accounts` MUST fail. The next audit write —
+/// `tool_start` for this call — takes the real `AuditWriter`
+/// lock/append/error-mapping path and surfaces an error to the
+/// dispatch envelope, which (with `fail_open = false`) must
+/// propagate as a wire-level rejection.
+///
+/// Paired with `list_accounts_succeeds_when_audit_healthy` above.
+/// Both tests must pass; if either fails, the audit-failure
+/// boundary is regressed or the hook is broken.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_accounts_fails_closed_when_audit_armed() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = write_zero_account_config(&tempdir);
 
     let mut harness = Harness::spawn_with_config(
         &config_path,
@@ -48,52 +117,24 @@ fail_open = false
         &[("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE", "1")],
     )
     .await;
-    let _ = harness.initialize_handshake().await;
-    harness.send_initialized().await;
+    let response = call_list_accounts(&mut harness).await;
 
-    let response = harness
-        .request(
-            "tools/call",
-            json!({
-                "name": "use_account",
-                "arguments": { "account": "nonexistent" },
-            }),
-        )
-        .await;
-
-    // The contract is "fails closed" — the server must NOT
-    // silently succeed when the audit write fails.
     let is_envelope_error = response.get("error").is_some();
     let is_tool_error = response["result"]["isError"].as_bool().unwrap_or(false);
     assert!(
         is_envelope_error || is_tool_error,
-        "tools/call with armed audit-write failure must fail closed, got {response}",
+        "armed: list_accounts must fail closed when audit-write is armed to fail, got {response}",
     );
 }
 
 /// Initialize handshake must succeed (or fail cleanly) regardless
-/// of audit failure arming. `initialize` doesn't write an audit
+/// of audit-failure arming. `initialize` doesn't write an audit
 /// record by itself, so this test pins that the env-var hook
 /// doesn't accidentally break the handshake.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn audit_write_failure_does_not_block_initialize() {
     let tempdir = TempDir::new().expect("tempdir");
-    let config_path = tempdir.path().join("config.toml");
-    let audit_path = tempdir.path().join("audit.jsonl");
-    let allowed_base = tempdir.path();
-    let config = format!(
-        r#"
-accounts = []
-
-[audit]
-path = "{}"
-allowed_base_dir = "{}"
-fail_open = false
-"#,
-        audit_path.display(),
-        allowed_base.display(),
-    );
-    std::fs::write(&config_path, config).expect("write config");
+    let config_path = write_zero_account_config(&tempdir);
 
     let mut harness = Harness::spawn_with_config(
         &config_path,

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -731,3 +731,48 @@ async fn initialize_with_known_older_version_is_rejected() {
         other => panic!("expected clean close, got {other:?}"),
     }
 }
+
+/// Edge case: `protocolVersion: ""` is valid JSON but a degenerate
+/// version string. Must be rejected with -32602. Pins the boundary
+/// against any future code that might special-case empty strings.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_with_empty_string_protocol_version() {
+    let mut harness = Harness::spawn().await;
+
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!("expected -32602 rejection for empty protocolVersion, got {other:?}"),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32602));
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!([PINNED_PROTOCOL_VERSION]),
+    );
+    let message = envelope["error"]["message"].as_str().unwrap_or_else(|| {
+        panic!("error.message must be a string, got {envelope}");
+    });
+    assert!(
+        message.contains("''"),
+        "empty peer version should appear as '' in the human-readable message, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -431,6 +431,37 @@ async fn tools_list_before_initialize_str_id() {
     }
 }
 
+/// Pre-initialize NOTIFICATION (no `id`) must NOT receive an error
+/// envelope — per JSON-RPC §4.1 notifications never get a response.
+/// Server closes cleanly and exits 0 with audit reason Eof.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_notification_silent_close() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Send a pre-initialize notification (not a request — no id).
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({"requestId": 1, "reason": "client decided not to initialize"}),
+        )
+        .await;
+
+    // No response should arrive; the server should close cleanly.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            panic!("pre-initialize notification must NOT produce an envelope, got {envelope}");
+        }
+        other => panic!("expected clean close, got {other:?}"),
+    }
+
+    // Audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+
 // ---------------------------------------------------------------------------
 // Test 9: two `tools/list` requests in flight simultaneously
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -1,0 +1,262 @@
+//! MCP wire-shape negative-path tests (issue #266, Phase 4).
+//!
+//! Targeted negative cases that complement the property-based
+//! coverage in `mcp_wire_proptest.rs`. Each test follows the
+//! probe-first contract documented in
+//! `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
+//! §4.1: every test asserts either a specific JSON-RPC error
+//! envelope shape OR a clean stdin shutdown — never just
+//! "didn't crash."
+//!
+//! `CloseOrResponse::Crashed` and `CloseOrResponse::Hung` always
+//! fail the test, regardless of which input produced them.
+
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use serde_json::{Value, json};
+
+use support::wire::harness::{CloseOrResponse, Harness, REQUEST_TIMEOUT};
+use support::wire::schema::assert_envelope_valid;
+
+/// Probe helper: parse a response line from `CloseOrResponse::Response`
+/// and assert it is a valid JSON-RPC envelope. Returns the parsed `Value`.
+fn parse_response_line(line: &str) -> Value {
+    serde_json::from_str(line.trim_end()).unwrap_or_else(|e| {
+        panic!("server emitted non-JSON line: {e}\nraw: {line:?}");
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: unparsable JSON
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unparsable_json_errors_or_closes() {
+    let mut harness = Harness::spawn().await;
+    harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    harness.send_line("this is not json at all").await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp closes stdin cleanly (CleanClose)
+    // rather than emitting a -32700 parse-error envelope. The server treats
+    // an unparsable line as a fatal framing error and shuts down the session
+    // instead of recovering per-message.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            // rmcp chose to emit an error envelope instead of closing.
+            // Encode the observed code so future rmcp changes are visible.
+            let envelope = parse_response_line(&line);
+            assert!(
+                envelope["error"].is_object(),
+                "expected error envelope for unparsable JSON, got {envelope}",
+            );
+            assert_eq!(
+                envelope["error"]["code"],
+                json!(-32700),
+                "expected -32700 (ParseError) for unparsable JSON, got {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Probed 2026-05-13: server elects clean close on parse failure.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on unparsable JSON input: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!("server hung (no response within {REQUEST_TIMEOUT:?}) on unparsable JSON input");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: valid JSON but not a JSON-RPC envelope → -32600
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn valid_json_invalid_envelope_returns_minus_32600() {
+    let mut harness = Harness::spawn().await;
+    harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // Valid JSON — not an object at all.
+    harness.send_line("[1, 2, 3]").await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp closes stdin cleanly (CleanClose)
+    // rather than emitting a -32600 invalid-request envelope. An array
+    // at the top level is not a valid JSON-RPC message framing, so rmcp
+    // treats it as a fatal framing error.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            assert!(
+                envelope["error"].is_object(),
+                "expected error envelope for invalid JSON-RPC envelope, got {envelope}",
+            );
+            assert_eq!(
+                envelope["error"]["code"],
+                json!(-32600),
+                "expected -32600 (InvalidRequest) for non-object JSON, got {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Probed 2026-05-13: server elects clean close on framing error.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on invalid JSON-RPC envelope: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on invalid JSON-RPC envelope"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: missing `method` field → -32600
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_method_field() {
+    let mut harness = Harness::spawn().await;
+    harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // A JSON object that looks superficially like a request but has no `method`.
+    let msg = json!({"jsonrpc": "2.0", "id": 99, "params": {}});
+    harness.send_line(&msg.to_string()).await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp closes stdin cleanly (CleanClose)
+    // rather than emitting a -32600 envelope. The missing `method` field
+    // causes a deserialization failure that rmcp treats as fatal framing.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            assert!(
+                envelope["error"].is_object(),
+                "expected error envelope for missing `method`, got {envelope}",
+            );
+            // -32600 InvalidRequest is the most appropriate code; accept
+            // -32700 ParseError if rmcp maps deserialization failures there.
+            let code = envelope["error"]["code"].as_i64().unwrap_or_else(|| {
+                panic!("error.code must be a number, got {envelope}");
+            });
+            assert!(
+                code == -32600 || code == -32700,
+                "expected -32600 or -32700 for missing `method`, got code {code} in {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Probed 2026-05-13: server elects clean close on missing `method`.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on missing `method` field: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on missing `method` field"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: `method` is wrong type (number instead of string) → -32600
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_type_method_field() {
+    let mut harness = Harness::spawn().await;
+    harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // `method` is a number, not a string — violates JSON-RPC 2.0 §4.
+    let msg = json!({"jsonrpc": "2.0", "id": 100, "method": 42, "params": {}});
+    harness.send_line(&msg.to_string()).await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp closes stdin cleanly (CleanClose)
+    // rather than emitting a -32600 envelope. A numeric `method` causes a
+    // deserialization failure that rmcp treats as fatal framing.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            assert!(
+                envelope["error"].is_object(),
+                "expected error envelope for wrong-type `method`, got {envelope}",
+            );
+            let code = envelope["error"]["code"].as_i64().unwrap_or_else(|| {
+                panic!("error.code must be a number, got {envelope}");
+            });
+            assert!(
+                code == -32600 || code == -32700,
+                "expected -32600 or -32700 for wrong-type `method`, got code {code} in {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Probed 2026-05-13: server elects clean close on wrong-type `method`.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on wrong-type `method` field: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on wrong-type `method` field"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: oversized params payload
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oversized_params_payload() {
+    let mut harness = Harness::spawn().await;
+    harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // 4 MiB of 'A' in a single params field — well above any reasonable
+    // MCP message size limit.
+    let huge_value = "A".repeat(4 * 1024 * 1024);
+    let msg = json!({
+        "jsonrpc": "2.0",
+        "id": 101,
+        "method": "tools/list",
+        "params": {"oversized": huge_value},
+    });
+    harness.send_line(&msg.to_string()).await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp returns a normal tools/list
+    // result (CloseOrResponse::Response) because it does not enforce a
+    // message-size limit. The oversized `params` field is ignored by
+    // `tools/list` which takes no params. Both a response and a clean
+    // close are spec-legal for an oversized payload; only Crashed/Hung fail.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            // Server processed the oversized payload and responded.
+            // Accept either a valid result or a valid error envelope.
+            let envelope = parse_response_line(&line);
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Server elected to close on oversized input — also acceptable.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on oversized params payload: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on oversized params payload"
+            );
+        }
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -368,6 +368,71 @@ async fn tools_list_before_initialize() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 9: two `tools/list` requests in flight simultaneously
+// ---------------------------------------------------------------------------
+
+/// Send two `tools/list` requests back-to-back without awaiting
+/// the first response. Both must return well-formed envelopes
+/// within `REQUEST_TIMEOUT`, with ids matching the requests. Tests
+/// that the server doesn't serialize stdout writes in a way that
+/// corrupts responses, and that the harness's id-buffering works.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_tools_list_two_inflight() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let id_a = harness.send_request_no_wait("tools/list", json!({})).await;
+    let id_b = harness.send_request_no_wait("tools/list", json!({})).await;
+
+    // Await in the OPPOSITE order from send to exercise the
+    // out-of-order buffering path in recv_until_id.
+    let response_b = harness.recv_until_id(id_b).await;
+    let response_a = harness.recv_until_id(id_a).await;
+
+    assert_eq!(response_a["id"], json!(id_a));
+    assert_eq!(response_b["id"], json!(id_b));
+    assert!(response_a["result"].is_object(), "id_a must succeed");
+    assert!(response_b["result"].is_object(), "id_b must succeed");
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: bidi-override character in a tool argument
+// ---------------------------------------------------------------------------
+
+/// Inject a Unicode bidi-override character (U+202E RIGHT-TO-LEFT
+/// OVERRIDE) into a tool argument. Server must either accept and
+/// process the call (returning an error envelope because no
+/// account named that exists in the zero-account config) or
+/// reject with a validation error. Either way: no panic in the
+/// argument-redactor or audit writer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bidi_override_in_tool_argument() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "use_account",
+                "arguments": { "account": "foo\u{202E}bar" },
+            }),
+        )
+        .await;
+
+    // The contract here is "server didn't panic and returned a
+    // well-formed envelope" — the schema validation inside
+    // `request` already enforces that. Additionally assert the
+    // call was rejected (no account exists with that name).
+    assert!(
+        response.get("error").is_some() || response["result"]["isError"].as_bool() == Some(true),
+        "use_account with non-existent account must fail, got {response}",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test 8: `initialize` with unsupported protocol version
 // ---------------------------------------------------------------------------
 

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -399,6 +399,38 @@ async fn tools_list_before_initialize() {
     );
 }
 
+/// Same contract as `tools_list_before_initialize`, but with a string
+/// id. Pins id-type preservation at the wire layer: numeric coercion
+/// of `id` in the synthesizer would surface here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize_str_id() {
+    let mut harness = Harness::spawn().await;
+
+    // Send a hand-crafted request with a STRING id rather than using
+    // send_request_no_wait (which auto-assigns a u64).
+    let raw = r#"{"jsonrpc":"2.0","id":"abc-123","method":"tools/list","params":{}}"#;
+    harness.send_line(raw).await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list w/ str id, got {other:?}"
+        ),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32002));
+    assert_eq!(
+        envelope["id"],
+        json!("abc-123"),
+        "string id must survive verbatim through the envelope synthesizer, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 9: two `tools/list` requests in flight simultaneously
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -600,19 +600,15 @@ async fn bidi_override_in_tool_argument() {
 // Test 8: `initialize` with unsupported protocol version
 // ---------------------------------------------------------------------------
 
-/// Client requests a protocol version the server doesn't support.
-/// Spec (per MCP): "If the server supports the requested protocol
-/// version, it MUST respond with the same version. Otherwise, the
-/// server MUST respond with a version it does support."
-///
-/// Probed 2026-05-13 (rmcp 1.5): rmcp accepts the unknown version
-/// and echoes it back. This is a bug filed as #276. The test
-/// below pins the spec-compliant behavior; it is `#[ignore]`'d
-/// until #276 lands.
+/// Client requests a protocol version the server doesn't support. Per
+/// spec §"Desired behavior" (#276), the server must reply with a
+/// JSON-RPC -32602 error envelope listing `supported_versions ==
+/// ["2025-11-25"]`, then close cleanly and exit 0 with audit reason
+/// Eof. Fixed by #276.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "blocked on #276: server echoes unsupported protocol versions"]
 async fn initialize_unsupported_protocol_version() {
     let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
 
     let _id = harness
         .send_request_no_wait(
@@ -628,41 +624,54 @@ async fn initialize_unsupported_protocol_version() {
         )
         .await;
 
+    // Phase 1: error envelope arrives with -32602.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => {
+            panic!("expected -32602 error envelope for unsupported protocol version, got {other:?}")
+        }
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32602),
+        "must be code -32602 (INVALID_PARAMS), got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!([PINNED_PROTOCOL_VERSION]),
+        "supported_versions must be exactly [PINNED_PROTOCOL_VERSION] — locks in LATEST-only \
+         posture and prevents older version names from sneaking onto the wire; got {envelope}",
+    );
+    let message = envelope["error"]["message"].as_str().unwrap_or_else(|| {
+        panic!("error.message must be a string, got {envelope}");
+    });
+    assert!(
+        message.contains("1999-01-01"),
+        "message must echo the peer version 1999-01-01, got {message:?}",
+    );
+    assert!(
+        message.contains(PINNED_PROTOCOL_VERSION),
+        "message must include the supported version PINNED_PROTOCOL_VERSION, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    // Phase 2: stdout closes and the server exits 0.
     match harness.response_or_close(REQUEST_TIMEOUT).await {
-        CloseOrResponse::Response(line) => {
-            let envelope = parse_response_line(&line);
-            if envelope.get("error").is_some() {
-                // Error path. Spec-legal: server rejected the version.
-                let code = &envelope["error"]["code"];
-                assert!(
-                    code.is_i64(),
-                    "error code must be an integer per JSON-RPC, got {envelope}",
-                );
-            } else {
-                // Counter-proposal path. The server's response must include
-                // a SUPPORTED version, NOT echo the client's bad input.
-                let version = envelope["result"]["protocolVersion"]
-                    .as_str()
-                    .unwrap_or_else(|| {
-                        panic!("protocolVersion must be a string, got {envelope}");
-                    });
-                assert_ne!(
-                    version, "1999-01-01",
-                    "server must not echo the unsupported version back (bug #276); got {envelope}",
-                );
-                assert_envelope_valid(&envelope);
-            }
-        }
-        CloseOrResponse::CleanClose => {
-            // Server elected clean close on unsupported version — also spec-legal.
-        }
-        CloseOrResponse::Crashed(diag) => {
-            panic!("server crashed on unsupported protocol version: {diag}");
-        }
-        CloseOrResponse::Hung => {
-            panic!(
-                "server hung (no response within {REQUEST_TIMEOUT:?}) on unsupported protocol version",
-            );
-        }
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on unsupported protocol version, got {other:?}"
+        ),
     }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on handled INVALID_PARAMS rejection",
+    );
 }

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -29,6 +29,24 @@ fn parse_response_line(line: &str) -> Value {
     })
 }
 
+/// Read the `process_end.reason` from the audit log produced by the
+/// harness. Panics if no `process_end` record is found.
+fn read_process_end_reason(path: &std::path::Path) -> rimap_audit::ProcessEndReason {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read audit log at {}: {e}", path.display()));
+    for line in contents.lines() {
+        let record: rimap_audit::AuditRecord = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("parse audit record {line:?}: {e}"));
+        if let rimap_audit::Payload::ProcessEnd(p) = record.payload {
+            return p.reason;
+        }
+    }
+    panic!(
+        "no process_end record found in audit log at {}",
+        path.display()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: unparsable JSON
 // ---------------------------------------------------------------------------
@@ -327,44 +345,58 @@ async fn initialize_after_already_initialized() {
 // Test 7: `tools/list` before `initialize`
 // ---------------------------------------------------------------------------
 
-/// `tools/list` before `initialize` must error or close the session
-/// cleanly. Server is in the "uninitialized" state and cannot answer
-/// protocol-level requests until handshake completes.
+/// `tools/list` before `initialize` must return a JSON-RPC error
+/// envelope with code -32002 (Server not initialized), echo the
+/// request id verbatim, then close stdin and exit `0`. Fixed by #275.
 ///
-/// Probed 2026-05-13 (rmcp 1.5): server CRASHES with exit code 1.
-/// This is a bug filed as #275. The test below pins the spec-
-/// compliant behavior (error envelope OR clean close); it is
-/// `#[ignore]`'d until the underlying bug is fixed. Un-ignore
-/// after #275 lands.
+/// Audit log MUST record `process_end.reason: Eof` on the success
+/// path — this is the contract the bug report flagged as broken.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "blocked on #275: server crashes on pre-initialize requests"]
 async fn tools_list_before_initialize() {
     let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
     // Deliberately skip initialize_handshake.
+    let id = harness.send_request_no_wait("tools/list", json!({})).await;
 
-    let _id = harness.send_request_no_wait("tools/list", json!({})).await;
+    // Phase 1: error envelope arrives with -32002.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => {
+            panic!("expected -32002 error envelope for pre-initialize tools/list, got {other:?}")
+        }
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32002),
+        "must be code -32002 (Server not initialized), got {envelope}",
+    );
+    assert_eq!(
+        envelope["id"],
+        json!(id),
+        "id must be echoed verbatim, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
 
+    // Phase 2: stdout closes and the server exits 0.
     match harness.response_or_close(REQUEST_TIMEOUT).await {
-        CloseOrResponse::Response(line) => {
-            let envelope = parse_response_line(&line);
-            assert!(
-                envelope["error"].is_object(),
-                "tools/list before initialize must return an error envelope, got {envelope}",
-            );
-            assert_envelope_valid(&envelope);
-        }
-        CloseOrResponse::CleanClose => {
-            // Spec-compliant: server closed cleanly.
-        }
-        CloseOrResponse::Crashed(diag) => {
-            panic!("server crashed on pre-initialize tools/list (bug #275): {diag}",);
-        }
-        CloseOrResponse::Hung => {
-            panic!(
-                "server hung (no response within {REQUEST_TIMEOUT:?}) on pre-initialize tools/list",
-            );
-        }
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on pre-initialize tools/list, got {other:?}"
+        ),
     }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on successful pre-initialize handling",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -327,50 +327,41 @@ async fn initialize_after_already_initialized() {
 // Test 7: `tools/list` before `initialize`
 // ---------------------------------------------------------------------------
 
-/// `tools/list` before `initialize` must error or close the session.
-/// Server is in the "uninitialized" state and cannot answer protocol-
-/// level requests until handshake completes.
+/// `tools/list` before `initialize` must error or close the session
+/// cleanly. Server is in the "uninitialized" state and cannot answer
+/// protocol-level requests until handshake completes.
 ///
-/// Probed 2026-05-13 (rmcp 1.5): rmcp exits with a non-zero status
-/// (exit code 1, `Crashed`) on a pre-initialize `tools/list`. It logs
-/// "expect initialized request, but received: Some(Request(...))" and
-/// terminates. Both `Crashed` and `CleanClose` are acceptable session-
-/// rejection outcomes; only Hung fails the test. A Response path is
-/// also handled: if rmcp emits a JSON-RPC error instead of crashing it
-/// must be a well-formed error envelope.
+/// Probed 2026-05-13 (rmcp 1.5): server CRASHES with exit code 1.
+/// This is a bug filed as #275. The test below pins the spec-
+/// compliant behavior (error envelope OR clean close); it is
+/// `#[ignore]`'d until the underlying bug is fixed. Un-ignore
+/// after #275 lands.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "blocked on #275: server crashes on pre-initialize requests"]
 async fn tools_list_before_initialize() {
     let mut harness = Harness::spawn().await;
     // Deliberately skip initialize_handshake.
 
-    // Use send_request_no_wait + response_or_close because rmcp closes
-    // (or crashes) the connection instead of emitting a JSON-RPC error
-    // envelope for pre-initialize requests.
     let _id = harness.send_request_no_wait("tools/list", json!({})).await;
 
-    // Probed 2026-05-13 (rmcp 1.5): server crashes (exit code 1) on
-    // tools/list before initialize. Crashed is the observed outcome.
     match harness.response_or_close(REQUEST_TIMEOUT).await {
         CloseOrResponse::Response(line) => {
-            // rmcp chose to emit a response instead of crashing. If it is
-            // an error envelope, accept it; if somehow a success, fail the test.
             let envelope = parse_response_line(&line);
             assert!(
                 envelope["error"].is_object(),
-                "tools/list before initialize must return an error if it responds, got {envelope}",
+                "tools/list before initialize must return an error envelope, got {envelope}",
             );
             assert_envelope_valid(&envelope);
         }
         CloseOrResponse::CleanClose => {
-            // Server shut down cleanly on pre-initialize request — acceptable.
+            // Spec-compliant: server closed cleanly.
         }
-        CloseOrResponse::Crashed(_diag) => {
-            // Probed 2026-05-13 (rmcp 1.5): server exits with code 1 on
-            // tools/list before initialize. This is the observed behavior.
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on pre-initialize tools/list (bug #275): {diag}",);
         }
         CloseOrResponse::Hung => {
             panic!(
-                "server hung (no response within {REQUEST_TIMEOUT:?}) on tools/list before initialize"
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on pre-initialize tools/list",
             );
         }
     }
@@ -381,22 +372,19 @@ async fn tools_list_before_initialize() {
 // ---------------------------------------------------------------------------
 
 /// Client requests a protocol version the server doesn't support.
-/// Spec allows two behaviors: server may counter-propose its own
-/// supported version, or return a JSON-RPC error.
+/// Spec (per MCP): "If the server supports the requested protocol
+/// version, it MUST respond with the same version. Otherwise, the
+/// server MUST respond with a version it does support."
 ///
-/// Probed 2026-05-13 (rmcp 1.5): rmcp takes the counter-proposal path
-/// and echoes back the client's version string verbatim (even for an
-/// obviously invalid version like "1999-01-01"). rmcp performs no
-/// version validation — any string is accepted. The test pins this:
-/// if rmcp responds, it must be a success result with a non-null
-/// protocolVersion string. The error path and clean-close path are
-/// also handled for forward compatibility.
+/// Probed 2026-05-13 (rmcp 1.5): rmcp accepts the unknown version
+/// and echoes it back. This is a bug filed as #276. The test
+/// below pins the spec-compliant behavior; it is `#[ignore]`'d
+/// until #276 lands.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "blocked on #276: server echoes unsupported protocol versions"]
 async fn initialize_unsupported_protocol_version() {
     let mut harness = Harness::spawn().await;
 
-    // Use send_request_no_wait + response_or_close in case rmcp closes
-    // the connection on an unsupported version, rather than responding.
     let _id = harness
         .send_request_no_wait(
             "initialize",
@@ -411,49 +399,40 @@ async fn initialize_unsupported_protocol_version() {
         )
         .await;
 
-    // Probed 2026-05-13 (rmcp 1.5): counter-proposal path fires. rmcp
-    // echoes the client's "1999-01-01" version back in the result.
     match harness.response_or_close(REQUEST_TIMEOUT).await {
         CloseOrResponse::Response(line) => {
             let envelope = parse_response_line(&line);
             if envelope.get("error").is_some() {
-                // Error path. rmcp emitted a JSON-RPC error — acceptable.
-                // Probed 2026-05-13: this branch did NOT fire; counter-proposal
-                // fired instead. If this branch fires in a future rmcp version,
-                // tighten to the actual error code.
+                // Error path. Spec-legal: server rejected the version.
                 let code = &envelope["error"]["code"];
                 assert!(
                     code.is_i64(),
                     "error code must be an integer per JSON-RPC, got {envelope}",
                 );
             } else {
-                // Counter-proposal path — observed rmcp 1.5 behavior.
-                // rmcp returns a success result. The protocolVersion in the
-                // result is whatever rmcp chose (may echo the client's string).
+                // Counter-proposal path. The server's response must include
+                // a SUPPORTED version, NOT echo the client's bad input.
                 let version = envelope["result"]["protocolVersion"]
                     .as_str()
                     .unwrap_or_else(|| {
                         panic!("protocolVersion must be a string, got {envelope}");
                     });
-                // Probed 2026-05-13 (rmcp 1.5): rmcp echoes "1999-01-01" back
-                // verbatim — no version enforcement. Assert the field is present
-                // and non-empty; the exact value is rmcp's choice.
-                assert!(
-                    !version.is_empty(),
-                    "protocolVersion in counter-proposal must be non-empty, got {envelope}",
+                assert_ne!(
+                    version, "1999-01-01",
+                    "server must not echo the unsupported version back (bug #276); got {envelope}",
                 );
                 assert_envelope_valid(&envelope);
             }
         }
         CloseOrResponse::CleanClose => {
-            // Server elected to close on unsupported protocol version — acceptable.
+            // Server elected clean close on unsupported version — also spec-legal.
         }
         CloseOrResponse::Crashed(diag) => {
             panic!("server crashed on unsupported protocol version: {diag}");
         }
         CloseOrResponse::Hung => {
             panic!(
-                "server hung (no response within {REQUEST_TIMEOUT:?}) on unsupported protocol version"
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on unsupported protocol version",
             );
         }
     }

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -18,7 +18,7 @@ mod support;
 
 use serde_json::{Value, json};
 
-use support::wire::harness::{CloseOrResponse, Harness, REQUEST_TIMEOUT};
+use support::wire::harness::{CloseOrResponse, Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT};
 use support::wire::schema::assert_envelope_valid;
 
 /// Probe helper: parse a response line from `CloseOrResponse::Response`
@@ -256,6 +256,204 @@ async fn oversized_params_payload() {
         CloseOrResponse::Hung => {
             panic!(
                 "server hung (no response within {REQUEST_TIMEOUT:?}) on oversized params payload"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: second `initialize` after handshake already completed
+// ---------------------------------------------------------------------------
+
+/// After a successful `initialize`, a second `initialize` request is
+/// sent. Probed 2026-05-13 (rmcp 1.5): rmcp accepts the second
+/// initialize and returns a fresh success result — it does not reject
+/// re-initialization. Both a success result and a JSON-RPC error are
+/// observed outcomes; only Crashed/Hung fail the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_after_already_initialized() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // Send a SECOND initialize via send_request_no_wait + response_or_close
+    // so that a connection-close outcome is handled gracefully alongside
+    // the success-response path that rmcp 1.5 actually takes.
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": PINNED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    // Probed 2026-05-13 (rmcp 1.5): rmcp returns a successful initialize
+    // result for the second request (re-initialization is accepted).
+    // A JSON-RPC error or clean close would also be spec-legal; only
+    // Crashed and Hung are failures.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            // Probed 2026-05-13 (rmcp 1.5): second initialize returns a
+            // success result with protocolVersion and serverInfo fields.
+            // Accept either a result (re-init allowed) or an error (rejected).
+            assert!(
+                envelope.get("result").is_some() || envelope.get("error").is_some(),
+                "second initialize response must have result or error, got {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Server elected clean close on second initialize — also acceptable.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on second initialize request: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on second initialize request"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: `tools/list` before `initialize`
+// ---------------------------------------------------------------------------
+
+/// `tools/list` before `initialize` must error or close the session.
+/// Server is in the "uninitialized" state and cannot answer protocol-
+/// level requests until handshake completes.
+///
+/// Probed 2026-05-13 (rmcp 1.5): rmcp exits with a non-zero status
+/// (exit code 1, `Crashed`) on a pre-initialize `tools/list`. It logs
+/// "expect initialized request, but received: Some(Request(...))" and
+/// terminates. Both `Crashed` and `CleanClose` are acceptable session-
+/// rejection outcomes; only Hung fails the test. A Response path is
+/// also handled: if rmcp emits a JSON-RPC error instead of crashing it
+/// must be a well-formed error envelope.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize() {
+    let mut harness = Harness::spawn().await;
+    // Deliberately skip initialize_handshake.
+
+    // Use send_request_no_wait + response_or_close because rmcp closes
+    // (or crashes) the connection instead of emitting a JSON-RPC error
+    // envelope for pre-initialize requests.
+    let _id = harness.send_request_no_wait("tools/list", json!({})).await;
+
+    // Probed 2026-05-13 (rmcp 1.5): server crashes (exit code 1) on
+    // tools/list before initialize. Crashed is the observed outcome.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            // rmcp chose to emit a response instead of crashing. If it is
+            // an error envelope, accept it; if somehow a success, fail the test.
+            let envelope = parse_response_line(&line);
+            assert!(
+                envelope["error"].is_object(),
+                "tools/list before initialize must return an error if it responds, got {envelope}",
+            );
+            assert_envelope_valid(&envelope);
+        }
+        CloseOrResponse::CleanClose => {
+            // Server shut down cleanly on pre-initialize request — acceptable.
+        }
+        CloseOrResponse::Crashed(_diag) => {
+            // Probed 2026-05-13 (rmcp 1.5): server exits with code 1 on
+            // tools/list before initialize. This is the observed behavior.
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on tools/list before initialize"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: `initialize` with unsupported protocol version
+// ---------------------------------------------------------------------------
+
+/// Client requests a protocol version the server doesn't support.
+/// Spec allows two behaviors: server may counter-propose its own
+/// supported version, or return a JSON-RPC error.
+///
+/// Probed 2026-05-13 (rmcp 1.5): rmcp takes the counter-proposal path
+/// and echoes back the client's version string verbatim (even for an
+/// obviously invalid version like "1999-01-01"). rmcp performs no
+/// version validation — any string is accepted. The test pins this:
+/// if rmcp responds, it must be a success result with a non-null
+/// protocolVersion string. The error path and clean-close path are
+/// also handled for forward compatibility.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_unsupported_protocol_version() {
+    let mut harness = Harness::spawn().await;
+
+    // Use send_request_no_wait + response_or_close in case rmcp closes
+    // the connection on an unsupported version, rather than responding.
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "1999-01-01",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    // Probed 2026-05-13 (rmcp 1.5): counter-proposal path fires. rmcp
+    // echoes the client's "1999-01-01" version back in the result.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            if envelope.get("error").is_some() {
+                // Error path. rmcp emitted a JSON-RPC error — acceptable.
+                // Probed 2026-05-13: this branch did NOT fire; counter-proposal
+                // fired instead. If this branch fires in a future rmcp version,
+                // tighten to the actual error code.
+                let code = &envelope["error"]["code"];
+                assert!(
+                    code.is_i64(),
+                    "error code must be an integer per JSON-RPC, got {envelope}",
+                );
+            } else {
+                // Counter-proposal path — observed rmcp 1.5 behavior.
+                // rmcp returns a success result. The protocolVersion in the
+                // result is whatever rmcp chose (may echo the client's string).
+                let version = envelope["result"]["protocolVersion"]
+                    .as_str()
+                    .unwrap_or_else(|| {
+                        panic!("protocolVersion must be a string, got {envelope}");
+                    });
+                // Probed 2026-05-13 (rmcp 1.5): rmcp echoes "1999-01-01" back
+                // verbatim — no version enforcement. Assert the field is present
+                // and non-empty; the exact value is rmcp's choice.
+                assert!(
+                    !version.is_empty(),
+                    "protocolVersion in counter-proposal must be non-empty, got {envelope}",
+                );
+                assert_envelope_valid(&envelope);
+            }
+        }
+        CloseOrResponse::CleanClose => {
+            // Server elected to close on unsupported protocol version — acceptable.
+        }
+        CloseOrResponse::Crashed(diag) => {
+            panic!("server crashed on unsupported protocol version: {diag}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung (no response within {REQUEST_TIMEOUT:?}) on unsupported protocol version"
             );
         }
     }

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -675,3 +675,59 @@ async fn initialize_unsupported_protocol_version() {
         "process_end.reason must be Eof on handled INVALID_PARAMS rejection",
     );
 }
+
+/// Strict-posture tripwire (#276 Codex adversarial-review Finding 1):
+/// known older MCP versions (`2024-11-05`, etc.) MUST also be rejected
+/// with -32602, even though they appear in `ProtocolVersion::KNOWN_VERSIONS`.
+/// rmcp 1.5 doesn't actually emit older wire shapes — accepting them
+/// would echo "2024-11-05" while serving 2025-11-25-shaped responses.
+/// This test fails if a future change ever broadens the acceptance set,
+/// forcing the relaxation to be a deliberate spec revision.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_with_known_older_version_is_rejected() {
+    let mut harness = Harness::spawn().await;
+
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => {
+            panic!("expected -32602 rejection for known older version 2024-11-05, got {other:?}")
+        }
+    };
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32602),
+        "known older version must be rejected, not silently accepted; got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!([PINNED_PROTOCOL_VERSION]),
+        "supported_versions must remain [PINNED_PROTOCOL_VERSION] even when peer asks for a known older version, got {envelope}",
+    );
+    let message = envelope["error"]["message"].as_str().unwrap_or_else(|| {
+        panic!("error.message must be a string, got {envelope}");
+    });
+    assert!(
+        message.contains("2024-11-05"),
+        "message must echo the rejected peer version 2024-11-05, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -12,6 +12,7 @@
 //! fail the test, regardless of which input produced them.
 
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
+#![expect(clippy::expect_used, reason = "integration tests")]
 
 #[path = "support/mod.rs"]
 mod support;
@@ -460,6 +461,74 @@ async fn pre_initialize_notification_silent_close() {
     // Audit log captured the success path as reason Eof.
     let reason = read_process_end_reason(&audit_path);
     assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+
+/// Codex review finding 2026-05-14 (medium): transport-level write
+/// failures while emitting the pre-initialize envelope must NOT be
+/// classified as clean EOF. Server's stdout read end is closed
+/// before the request arrives; the envelope write fails with
+/// `BrokenPipe`; the server exits non-zero and the audit log records
+/// `reason: Error`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_envelope_write_failure_records_error() {
+    use support::wire::harness::SHUTDOWN_TIMEOUT;
+    use tokio::io::AsyncWriteExt;
+    use tokio::time::timeout;
+
+    let mut detached = support::wire::harness::Harness::spawn_with_closed_stdout().await;
+
+    // Send a pre-initialize request. Server will read it, attempt to
+    // write the envelope, and fail with BrokenPipe because stdout's
+    // read end is already closed.
+    let line = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#.to_string() + "\n";
+    detached
+        .stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write request");
+    detached.stdin.flush().await.expect("flush request");
+
+    // Wait for the child to exit.
+    let status = timeout(SHUTDOWN_TIMEOUT, detached.child.wait())
+        .await
+        .expect("child exit within SHUTDOWN_TIMEOUT")
+        .expect("child wait");
+
+    // Server must NOT exit 0 on a broken-pipe write failure. It may
+    // exit with a non-zero status (anyhow propagated) or, if Rust's
+    // SIGPIPE handling regresses, be killed by signal 13 — both are
+    // failures we want to surface but only the first is the
+    // contract we lock in.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert!(
+            status.signal().is_none(),
+            "server must not be killed by SIGPIPE (regression in Rust runtime); got {status:?}\n--- captured stderr ---\n{}",
+            detached.captured_stderr(),
+        );
+    }
+    assert!(
+        !status.success(),
+        "server must exit non-zero when envelope write fails; got {status:?}\n--- captured stderr ---\n{}",
+        detached.captured_stderr(),
+    );
+
+    // Audit log must record reason Error, NOT Eof.
+    let reason = read_process_end_reason(detached.audit_path());
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Error,
+        "process_end.reason must be Error when envelope delivery fails, not Eof — \
+         masking transport failures as clean EOF defeats the audit-correctness goal",
+    );
+
+    // The propagated anyhow context must surface in stderr.
+    let stderr = detached.captured_stderr();
+    assert!(
+        stderr.contains("pre-init error envelope"),
+        "expected propagated 'pre-init error envelope' anyhow context in stderr, got:\n{stderr}",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
+++ b/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 4a4e8da2e4c2c5cc836b7910313991cd74a8bf708e383bba7687d110925d5e3b # shrinks to tool_name = "_5CqQ_5//_r-JQ25L_/AqJbNO2IkgQqNH2_", args = {"3Mqi_jnN_clP5SL": Number(-1189419463853538064), "IIcrKASC": Number(1307706573187548487)}

--- a/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
+++ b/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4a4e8da2e4c2c5cc836b7910313991cd74a8bf708e383bba7687d110925d5e3b # shrinks to tool_name = "_5CqQ_5//_r-JQ25L_/AqJbNO2IkgQqNH2_", args = {"3Mqi_jnN_clP5SL": Number(-1189419463853538064), "IIcrKASC": Number(1307706573187548487)}

--- a/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
+++ b/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e6e6f11c123dd9d50f094d49679036594530158355116c207c4d7c383115bf4b # shrinks to envelope = Object {"id": Number(0), "jsonrpc": String("2.0"), "method": String("tools/list"), "params": Number(0)}

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -1,0 +1,141 @@
+//! MCP wire-shape property tests (issue #266, Phase 4).
+//!
+//! Three proptest properties driving the production
+//! `rusty-imap-mcp` binary with arbitrary JSON-RPC envelopes and
+//! tool-call arguments. Default ≥1000 cases per property; nightly
+//! runs scale via `PROPTEST_CASES`.
+//!
+//! Session-isolation discipline (§3.2 of the design doc):
+//! - The harness is shared across cases for speed.
+//! - `with_live_harness` restarts the harness if a case closed the
+//!   connection, so cases never run against a poisoned session.
+//! - Property 1's strategy excludes the pinned state-mutating
+//!   method set so cases stay independent of MCP session state.
+//!
+//! Property strategy notes inline. See
+//! `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
+//! for the full design context.
+//!
+//! # Runtime architecture
+//!
+//! Proptest's `proptest!` macro expands to a synchronous function,
+//! so each case calls `block_on` to drive async work. Tokio I/O
+//! handles (`ChildStdin`, `BufReader<ChildStdout>`) are bound to
+//! the runtime that created them — using a fresh runtime per case
+//! would invalidate the shared harness. Instead, `RUNTIME` is a
+//! single process-lifetime `tokio::runtime::Runtime` stored in a
+//! `OnceLock`; every case reuses the same `block_on` target so
+//! harness I/O handles remain valid across cases.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::sync::{Mutex, OnceLock};
+
+use proptest::prelude::*;
+use serde_json::{Value, json};
+
+use support::wire::harness::Harness;
+
+/// Single tokio runtime shared across all proptest cases in this
+/// binary. All `Harness` I/O handles are bound to this runtime;
+/// creating a new runtime per-case would invalidate them.
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build shared tokio runtime")
+    })
+}
+
+/// Run `body` against a harness, restarting the harness if the
+/// previous case poisoned the session. After `body` runs, the
+/// helper checks `is_usable` and drops the harness if false.
+///
+/// Codex review finding #2 verified that a simple `try_wait`
+/// check could let a poisoned (stdout-closed but not-yet-reaped)
+/// harness leak across cases. `Harness::is_usable` consolidates
+/// the check.
+async fn with_live_harness<F, Fut>(mut h: Option<Harness>, body: F) -> Option<Harness>
+where
+    F: FnOnce(Harness) -> Fut,
+    Fut: std::future::Future<Output = Harness>,
+{
+    let needs_fresh = match h.as_mut() {
+        None => true,
+        Some(harness) => !harness.is_usable(),
+    };
+    if needs_fresh {
+        drop(h);
+        let mut fresh = Harness::spawn().await;
+        let _ = fresh.initialize_handshake().await;
+        fresh.send_initialized().await;
+        h = Some(fresh);
+    }
+    let mut after = body(h.expect("ensured Some above")).await;
+    if !after.is_usable() {
+        return None;
+    }
+    Some(after)
+}
+
+/// Process-lifetime harness shared across all proptest cases within
+/// one property invocation. Protected by a `std::sync::Mutex` so
+/// the synchronous proptest runner can lock it without requiring an
+/// async context; all actual I/O is performed inside `runtime().block_on`.
+static HARNESS: Mutex<Option<Harness>> = Mutex::new(None);
+
+// Property 2: arbitrary tool name with arbitrary JSON arguments
+// always produces a JSON-RPC error envelope. Stateless by
+// construction (every case is `tools/call <X>`; no method that
+// mutates MCP session state is ever sent).
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    fn prop_tools_call_unknown_tool(
+        tool_name in "[A-Za-z0-9_./-]{1,64}",
+        args in proptest::collection::hash_map(
+            "[A-Za-z0-9_]{1,16}",
+            proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+            0..6,
+        ),
+    ) {
+        runtime().block_on(async {
+            let harness = HARNESS.lock().expect("HARNESS lock").take();
+            let harness = with_live_harness(harness, |mut h| async move {
+                let arguments: serde_json::Map<String, Value> = args
+                    .into_iter()
+                    .collect();
+                let response = h
+                    .request(
+                        "tools/call",
+                        json!({
+                            "name": tool_name,
+                            "arguments": arguments,
+                        }),
+                    )
+                    .await;
+                let is_envelope_error = response.get("error").is_some();
+                let is_tool_error = response["result"]["isError"]
+                    .as_bool()
+                    .unwrap_or(false);
+                assert!(
+                    is_envelope_error || is_tool_error,
+                    "unknown tool {tool_name:?} must produce an error, got {response}",
+                );
+                h
+            }).await;
+            *HARNESS.lock().expect("HARNESS lock") = harness;
+        });
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -139,3 +139,69 @@ proptest! {
         });
     }
 }
+
+/// Build an arbitrary `arguments` map for `use_account`. Mixes:
+/// - Well-formed argument names (`account`, `name`, etc.) with
+///   wrong value types
+/// - Random argument names with random values
+/// - Empty maps
+fn arb_arguments() -> impl Strategy<Value = Value> {
+    let well_formed_keys = prop_oneof![
+        Just("account".to_string()),
+        Just("name".to_string()),
+        Just("id".to_string()),
+        "[a-z]{1,16}".prop_map(String::from),
+    ];
+    let any_value = prop_oneof![
+        Just(json!(null)),
+        proptest::arbitrary::any::<bool>().prop_map(|b| json!(b)),
+        proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+        "[\\PC]{0,64}".prop_map(|s| json!(s)),
+    ];
+    proptest::collection::hash_map(well_formed_keys, any_value, 0..6).prop_map(|m| {
+        let obj: serde_json::Map<String, Value> = m.into_iter().collect();
+        Value::Object(obj)
+    })
+}
+
+// Property 3: `use_account` with arbitrary argument shapes. With
+// zero accounts configured (the harness's default), every call
+// MUST fail. Stateless by construction.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    fn prop_tools_call_use_account_argument_shape(
+        arguments in arb_arguments(),
+    ) {
+        runtime().block_on(async move {
+            let harness = HARNESS.lock().expect("HARNESS lock").take();
+            let harness = with_live_harness(harness, |mut h| async move {
+                let response = h
+                    .request(
+                        "tools/call",
+                        json!({
+                            "name": "use_account",
+                            "arguments": arguments,
+                        }),
+                    )
+                    .await;
+                let is_envelope_error = response.get("error").is_some();
+                let is_tool_error = response["result"]["isError"]
+                    .as_bool()
+                    .unwrap_or(false);
+                assert!(
+                    is_envelope_error || is_tool_error,
+                    "use_account with arbitrary args must fail (no accounts configured), got {response}",
+                );
+                h
+            }).await;
+            *HARNESS.lock().expect("HARNESS lock") = harness;
+        });
+    }
+}

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -28,6 +28,7 @@
 //! harness I/O handles remain valid across cases.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "integration tests")]
 
 #[path = "support/mod.rs"]
 mod support;
@@ -37,7 +38,38 @@ use std::sync::{Mutex, OnceLock};
 use proptest::prelude::*;
 use serde_json::{Value, json};
 
-use support::wire::harness::Harness;
+use support::wire::harness::{CloseOrResponse, Harness, REQUEST_TIMEOUT};
+use support::wire::schema::assert_envelope_valid;
+
+/// Methods that mutate MCP session state. The property-1 strategy
+/// MUST NOT generate these as the `method` field, since they would
+/// couple subsequent cases to earlier ones (poisoning the shared
+/// harness). The set is pinned here AND asserted against rmcp's
+/// known stateful surface in `assert_exclusion_set_matches_rmcp`
+/// below — that assertion is the regression net that catches a
+/// future MCP spec addition introducing a new stateful method.
+const STATE_MUTATING_METHODS: &[&str] = &["initialize", "notifications/initialized"];
+
+#[test]
+fn assert_exclusion_set_matches_rmcp() {
+    // rmcp 1.5 documents stateful protocol methods at:
+    //   rmcp::model::ProtocolVersion docs + Initialize/Initialized
+    //   in rmcp::model::request.
+    //
+    // If a future rmcp version adds a new stateful method (e.g.
+    // `session/reset`), this assertion is the place to update — and
+    // STATE_MUTATING_METHODS above must be updated in lockstep, or
+    // property 1 starts coupling cases.
+    //
+    // This test is a sentinel — it doesn't introspect rmcp at runtime
+    // because rmcp's request enum is sealed. Instead, the maintainer
+    // updates BOTH sides of the pair (this constant and the rmcp dep)
+    // together. Bumping rmcp without inspecting this list trips a
+    // human review checkpoint via this comment.
+    let expected = ["initialize", "notifications/initialized"];
+    let actual: Vec<&str> = STATE_MUTATING_METHODS.to_vec();
+    assert_eq!(actual, expected.to_vec());
+}
 
 /// Single tokio runtime shared across all proptest cases in this
 /// binary. All `Harness` I/O handles are bound to this runtime;
@@ -164,6 +196,62 @@ fn arb_arguments() -> impl Strategy<Value = Value> {
     })
 }
 
+/// Build an arbitrary JSON-RPC-ish envelope. Each field is
+/// optionally present and may be of a wrong type. The `method`
+/// field, when present, is drawn from a set that EXCLUDES
+/// state-mutating methods to keep cases independent.
+fn arb_envelope() -> impl Strategy<Value = Value> {
+    let arb_method = prop_oneof![
+        // Known stateless methods
+        Just("tools/list".to_string()),
+        Just("tools/call".to_string()),
+        Just("resources/list".to_string()),
+        Just("ping".to_string()),
+        // Unknown methods (still stateless; the server returns
+        // method-not-found without touching session state)
+        "[a-z/]{1,32}".prop_map(String::from),
+    ]
+    .prop_filter("exclude state-mutating methods", |m: &String| {
+        !STATE_MUTATING_METHODS.contains(&m.as_str())
+    });
+
+    let arb_id = prop_oneof![
+        Just(json!(null)),
+        proptest::arbitrary::any::<u32>().prop_map(|n| json!(n)),
+        "[a-z0-9]{1,8}".prop_map(|s| json!(s)),
+    ];
+
+    let arb_params = prop_oneof![
+        Just(json!({})),
+        Just(json!(null)),
+        proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+        "[\\PC]{0,32}".prop_map(|s| json!(s)),
+    ];
+
+    (
+        prop::option::of(Just("2.0".to_string())),
+        prop::option::of(arb_id),
+        prop::option::of(arb_method),
+        prop::option::of(arb_params),
+    )
+        .prop_map(|(jsonrpc, id, method, params)| {
+            let mut obj = serde_json::Map::new();
+            if let Some(v) = jsonrpc {
+                obj.insert("jsonrpc".to_string(), json!(v));
+            }
+            if let Some(v) = id {
+                obj.insert("id".to_string(), v);
+            }
+            if let Some(v) = method {
+                obj.insert("method".to_string(), json!(v));
+            }
+            if let Some(v) = params {
+                obj.insert("params".to_string(), v);
+            }
+            Value::Object(obj)
+        })
+}
+
 // Property 3: `use_account` with arbitrary argument shapes. With
 // zero accounts configured (the harness's default), every call
 // MUST fail. Stateless by construction.
@@ -199,6 +287,58 @@ proptest! {
                     is_envelope_error || is_tool_error,
                     "use_account with arbitrary args must fail (no accounts configured), got {response}",
                 );
+                h
+            }).await;
+            *HARNESS.lock().expect("HARNESS lock") = harness;
+        });
+    }
+}
+
+// Property 1: arbitrary JSON-RPC-ish envelopes never panic the
+// server. Either the server emits a well-formed envelope (success
+// or error) or it cleanly closes the connection.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    #[ignore = "blocked on #277: server hangs on unknown-method envelopes missing \
+                jsonrpc/id fields; re-enable once rmcp responds or closes cleanly"]
+    fn prop_envelope_never_panics(envelope in arb_envelope()) {
+        runtime().block_on(async move {
+            let mut harness = HARNESS.lock().expect("HARNESS lock").take();
+            harness = with_live_harness(harness, |mut h| async move {
+                h.send_line(&envelope.to_string()).await;
+                let outcome = h.response_or_close(REQUEST_TIMEOUT).await;
+                match outcome {
+                    CloseOrResponse::Response(line) => {
+                        let env: Value = serde_json::from_str(line.trim_end())
+                            .expect("server response must be valid JSON");
+                        assert_envelope_valid(&env);
+                    }
+                    CloseOrResponse::CleanClose => {
+                        // Spec-legal: harness is now poisoned;
+                        // with_live_harness will drop it after the
+                        // case and spawn a fresh one for the next.
+                    }
+                    CloseOrResponse::Crashed(diagnostic) => {
+                        panic!(
+                            "server crashed during property 1 case — \
+                             file an issue and pin a regression seed before continuing: \
+                             envelope={envelope}\n{diagnostic}",
+                        );
+                    }
+                    CloseOrResponse::Hung => {
+                        panic!(
+                            "server hung during property 1 case (no response, no close \
+                             within {REQUEST_TIMEOUT:?}): envelope={envelope}",
+                        );
+                    }
+                }
                 h
             }).await;
             *HARNESS.lock().expect("HARNESS lock") = harness;

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -317,8 +317,6 @@ proptest! {
     ))]
 
     #[test]
-    #[ignore = "blocked on #277: server hangs on unknown-method envelopes missing \
-                jsonrpc/id fields; re-enable once rmcp responds or closes cleanly"]
     fn prop_envelope_never_panics(envelope in arb_envelope()) {
         runtime().block_on(async move {
             let mut harness = HARNESS.lock().expect("HARNESS lock").take();

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -250,6 +250,17 @@ fn arb_envelope() -> impl Strategy<Value = Value> {
             }
             Value::Object(obj)
         })
+        .prop_filter(
+            "exclude spec-legal notifications (jsonrpc==\"2.0\" + missing id + present method) — \
+             their silent-ignore is JSON-RPC §4.1 compliant and covered separately by \
+             valid_notification_does_not_hang_session",
+            |env| {
+                let is_notification = env.get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
+                    && env.get("id").is_none()
+                    && env.get("method").and_then(|v| v.as_str()).is_some();
+                !is_notification
+            },
+        )
 }
 
 // Property 3: `use_account` with arbitrary argument shapes. With

--- a/crates/rimap-server/tests/mcp_wire_proptest.rs
+++ b/crates/rimap-server/tests/mcp_wire_proptest.rs
@@ -253,7 +253,7 @@ fn arb_envelope() -> impl Strategy<Value = Value> {
         .prop_filter(
             "exclude spec-legal notifications (jsonrpc==\"2.0\" + missing id + present method) — \
              their silent-ignore is JSON-RPC §4.1 compliant and covered separately by \
-             valid_notification_does_not_hang_session",
+             wire_initialized_notification_elicits_no_response in mcp_wire_conformance.rs",
             |env| {
                 let is_notification = env.get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
                     && env.get("id").is_none()

--- a/crates/rimap-server/tests/support/dovecot/harness.rs
+++ b/crates/rimap-server/tests/support/dovecot/harness.rs
@@ -95,6 +95,26 @@ fn container_name(project: &str) -> String {
     format!("{project}-dovecot")
 }
 
+/// Mint a unique-on-host identifier for compose project naming.
+/// Combines `SystemTime` nanos with `process::id()` and a process-
+/// local `AtomicU64` counter so no two calls on the same host can
+/// produce the same string — even when two parallel threads call
+/// within the same coarse `SystemTime` tick (macOS resolution is
+/// not nanosecond), or when consecutive nextest binaries land on
+/// the same nanos value. Mirrors `rimap-imap::uuid_like` (PR #273).
+fn uuid_like() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos:x}-{pid:x}-{n:x}")
+}
+
 pub struct DovecotHarness {
     project: String,
     compose_dir: PathBuf,
@@ -117,13 +137,14 @@ impl DovecotHarness {
             .join("integration")
             .join("dovecot");
 
-        let project = format!(
-            "rimap-e2e-{:x}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        );
+        // Compose project name must be unique across (a) parallel
+        // threads within one cargo-test process and (b) consecutive
+        // nextest binary invocations on the same host. SystemTime
+        // nanos alone is insufficient — macOS resolution is not
+        // nanosecond and we have observed collisions in the wild
+        // (e.g. wire_e2e_readonly_posture_denial on parallel run).
+        // Same pattern as rimap-imap::uuid_like (PR #273, 422f564).
+        let project = format!("rimap-e2e-{}", uuid_like());
 
         let mut host_port = ReservedPort::acquire()
             .ok_or_else(|| HarnessError::PortReservationFailed("acquire returned None".into()))?;

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -47,7 +47,6 @@ pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// an orderly shutdown — the malformed-input contract demands
 /// that distinction, so this enum is required.
 #[derive(Debug)]
-#[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
 pub enum CloseOrResponse {
     /// The server produced a line of output (newline-terminated).
     Response(String),
@@ -100,6 +99,40 @@ pub struct Harness {
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
     _tempdir: TempDir,
+}
+
+/// Suppress per-binary dead-code warnings on items consumed by some but not all
+/// integration-test binaries. Each binary compiles this file independently; items
+/// used by `mcp_wire_negative.rs` appear dead in `mcp_wire_conformance.rs` and
+/// vice-versa. Referencing them here marks them as used in every compilation unit,
+/// eliminating the need for `#[expect(dead_code)]` annotations that would fire as
+/// "unfulfilled" in the binary that DOES call the item.
+///
+/// Mirrors the `force_use_for_dead_code_link` function in `schema.rs`.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary dead-code in binaries that don't call these items"
+)]
+fn force_use_for_dead_code_link() {
+    // CloseOrResponse and its associated methods: used by mcp_wire_negative,
+    // unused by mcp_wire_conformance / e2e_wire. The inner String fields of
+    // Response and Crashed must also be referenced to suppress the
+    // "field `0` is never read" lint in binaries that don't pattern-match
+    // on the enum.
+    if let CloseOrResponse::Response(s) | CloseOrResponse::Crashed(s) =
+        CloseOrResponse::Response(String::new())
+    {
+        let _ = s;
+    }
+    // Methods used by mcp_wire_negative, not by other binaries.
+    let _ = Harness::response_or_close;
+    let _ = Harness::send_line;
+    let _ = Harness::recv_line_within;
+    // Methods used by mcp_wire_conformance, not by mcp_wire_negative.
+    let _ = Harness::assert_no_response_within;
+    let _ = Harness::shutdown_and_wait;
+    // Constant used by mcp_wire_conformance / e2e_wire, not by mcp_wire_negative.
+    let _ = PINNED_PROTOCOL_VERSION;
 }
 
 impl Harness {
@@ -317,7 +350,6 @@ allowed_base_dir = "{}"
     /// Callers MUST `match` the result; `_` matches are a code-
     /// review failure because they re-introduce the original
     /// Option-shaped bug.
-    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn response_or_close(&mut self, request_dur: Duration) -> CloseOrResponse {
         let mut buf = String::new();
         let read = timeout(request_dur, self.stdout.read_line(&mut buf)).await;
@@ -390,7 +422,6 @@ allowed_base_dir = "{}"
     /// `line` itself MUST NOT contain a `\n` (MCP framing is one
     /// JSON envelope per line; embedded newlines would split the
     /// envelope across lines).
-    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn send_line(&mut self, line: &str) {
         assert!(
             !line.contains('\n'),
@@ -411,7 +442,6 @@ allowed_base_dir = "{}"
     /// The returned string retains the trailing `\n`. Callers that
     /// need to parse or compare the payload should strip it via
     /// `line.trim_end_matches('\n')` or `line.trim_end()`.
-    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn recv_line_within(&mut self, dur: Duration) -> Option<String> {
         let mut buf = String::new();
         match timeout(dur, self.stdout.read_line(&mut buf)).await {

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -136,6 +136,19 @@ fn force_use_for_dead_code_link() {
     // Method used by mcp_wire_negative (pre-initialize tests), not by
     // other binaries.
     let _ = Harness::audit_path;
+    // Method used by mcp_wire_negative (pre-initialize write-failure
+    // test), not by other binaries.
+    let _ = Harness::spawn_with_closed_stdout;
+    // DetachedStdoutHarness methods used by mcp_wire_negative, not by
+    // other binaries. The pub `child` / `stdin` fields are read by the
+    // pre-initialize write-failure test only; reference them here so
+    // every test-binary compilation sees them as used.
+    let _ = DetachedStdoutHarness::audit_path;
+    let _ = DetachedStdoutHarness::captured_stderr;
+    let _ = |h: &DetachedStdoutHarness| {
+        let _ = &h.child;
+        let _ = &h.stdin;
+    };
     // Methods used by mcp_wire_negative and e2e_wire_cancellation, not
     // by other binaries.
     let _ = Harness::send_request_no_wait;
@@ -219,6 +232,59 @@ allowed_base_dir = "{}"
             stderr_log,
             buffered_responses: std::collections::VecDeque::new(),
             poisoned: false,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Spawn the binary with the legacy zero-account config, then
+    /// immediately drop the `BufReader<ChildStdout>` read handle. The
+    /// child's stdout pipe write end is now connected to a closed
+    /// reader; the next write the server attempts will fail with
+    /// `BrokenPipe`. Used by `pre_initialize_envelope_write_failure`
+    /// to exercise the propagated-error path on transport failure.
+    #[expect(clippy::unused_async, reason = "uniform async surface")]
+    pub async fn spawn_with_closed_stdout() -> DetachedStdoutHarness {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let stderr_log = tempdir.path().join("rusty-imap-mcp.stderr.log");
+        let stderr_file = File::create(&stderr_log).expect("create stderr log file");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(stderr_file))
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        // Take the read end of the stdout pipe and drop it immediately.
+        // The child's write end is now connected to a closed reader.
+        let stdout = child.stdout.take().expect("stdout");
+        drop(stdout);
+
+        DetachedStdoutHarness {
+            child,
+            stdin,
+            stderr_log,
+            audit_path,
             _tempdir: tempdir,
         }
     }
@@ -567,5 +633,32 @@ allowed_base_dir = "{}"
             .expect("clean exit within timeout")
             .expect("wait");
         (status, tempdir)
+    }
+}
+
+/// Lightweight harness variant used by transport-failure regression
+/// tests that intentionally close the server's stdout read end before
+/// sending input. The server's pre-initialize envelope write will
+/// fail with `BrokenPipe`. This struct cannot read stdout responses;
+/// it exists only to drive stdin, wait for the child exit, and read
+/// the resulting audit log + captured stderr.
+pub struct DetachedStdoutHarness {
+    pub child: Child,
+    pub stdin: ChildStdin,
+    stderr_log: PathBuf,
+    audit_path: PathBuf,
+    // Held until drop so the audit log path stays valid.
+    _tempdir: TempDir,
+}
+
+impl DetachedStdoutHarness {
+    /// Path to the audit log produced by the spawned binary.
+    pub fn audit_path(&self) -> &std::path::Path {
+        &self.audit_path
+    }
+
+    /// Read the captured stderr file. Empty string on read failure.
+    pub fn captured_stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
     }
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -127,6 +127,7 @@ fn force_use_for_dead_code_link() {
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
+    let _ = Harness::send_request_no_wait;
     // No current callers — suppressed here for the same per-binary
     // dead-code reason; Task 5 will add callers via the concurrency
     // and adversarial-input tests.
@@ -296,7 +297,6 @@ allowed_base_dir = "{}"
     /// Send a JSON-RPC request and return the assigned id WITHOUT
     /// awaiting a response. Pair with `recv_until_id` to drive
     /// multiple in-flight requests deterministically.
-    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn send_request_no_wait(&mut self, method: &str, params: Value) -> u64 {
         self.next_id += 1;
         let id = self.next_id;

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -114,6 +114,10 @@ pub struct Harness {
     reason = "type-link to suppress per-binary dead-code in binaries that don't call these items"
 )]
 fn force_use_for_dead_code_link() {
+    // Harness::spawn: used by mcp_wire_conformance / e2e_wire / mcp_wire_negative /
+    // mcp_wire_proptest, but not by mcp_audit_failure (which always uses
+    // spawn_with_config to inject the env var).
+    let _ = Harness::spawn;
     // CloseOrResponse and its associated methods: used by mcp_wire_negative,
     // unused by mcp_wire_conformance / e2e_wire. The inner String fields of
     // Response and Crashed must also be referenced to suppress the

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -129,12 +129,15 @@ fn force_use_for_dead_code_link() {
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
+    // Methods used by mcp_wire_negative and e2e_wire_cancellation, not
+    // by other binaries.
     let _ = Harness::send_request_no_wait;
     let _ = Harness::recv_until_id;
     // No current callers in any binary — suppressed here for the same
     // per-binary dead-code reason.
     let _ = Harness::recv_line_within;
-    // Method used by mcp_wire_conformance, not by other binaries.
+    // Method used by mcp_wire_conformance and e2e_wire_cancellation,
+    // not by other binaries.
     let _ = Harness::assert_no_response_within;
     // Method used by mcp_wire_conformance and e2e_wire, not by
     // mcp_wire_negative.

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -124,6 +124,8 @@ fn force_use_for_dead_code_link() {
     {
         let _ = s;
     }
+    // Method used by mcp_wire_proptest, not by other binaries.
+    let _ = Harness::is_usable;
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
@@ -208,6 +210,36 @@ allowed_base_dir = "{}"
             buffered_responses: std::collections::VecDeque::new(),
             poisoned: false,
             _tempdir: tempdir,
+        }
+    }
+
+    /// Returns true if the harness can be used for another request:
+    /// the child process is still running AND the harness has not
+    /// observed an unrecoverable session state (EOF, crash, hang,
+    /// schema-validation failure on a parsed envelope). Codex
+    /// review finding #2 verified that `try_wait` alone is
+    /// insufficient — a child whose stdout closed but whose process
+    /// has not yet been reaped would otherwise pass the "alive"
+    /// check while subsequent reads return EOF immediately.
+    ///
+    /// Always check this before reusing a harness across cases.
+    /// The proptest restart-on-close discipline (this task)
+    /// consults it; if false, the helper drops the poisoned
+    /// harness and spawns a fresh one.
+    pub fn is_usable(&mut self) -> bool {
+        if self.poisoned {
+            return false;
+        }
+        match self.child.try_wait() {
+            Ok(None) => true,
+            Ok(Some(_status)) => {
+                self.poisoned = true;
+                false
+            }
+            Err(_) => {
+                self.poisoned = true;
+                false
+            }
         }
     }
 

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -251,6 +251,10 @@ allowed_base_dir = "{}"
     /// the child closed stdout. Unlike `request`, this does NOT parse
     /// or validate the line; fuzz tests use it to observe whatever
     /// the server actually emitted (which may be malformed by design).
+    ///
+    /// The returned string retains the trailing `\n`. Callers that
+    /// need to parse or compare the payload should strip it via
+    /// `line.trim_end_matches('\n')` or `line.trim_end()`.
     #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn recv_line_within(&mut self, dur: Duration) -> Option<String> {
         let mut buf = String::new();

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -127,9 +127,14 @@ fn force_use_for_dead_code_link() {
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
+    // No current callers — suppressed here for the same per-binary
+    // dead-code reason; Task 5 will add callers via the concurrency
+    // and adversarial-input tests.
     let _ = Harness::recv_line_within;
-    // Methods used by mcp_wire_conformance, not by mcp_wire_negative.
+    // Method used by mcp_wire_conformance, not by other binaries.
     let _ = Harness::assert_no_response_within;
+    // Method used by mcp_wire_conformance and e2e_wire, not by
+    // mcp_wire_negative.
     let _ = Harness::shutdown_and_wait;
     // Constant used by mcp_wire_conformance / e2e_wire, not by mcp_wire_negative.
     let _ = PINNED_PROTOCOL_VERSION;

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -221,6 +221,45 @@ allowed_base_dir = "{}"
         self.stdin.flush().await.expect("flush notification");
     }
 
+    /// Write arbitrary bytes to the child's stdin verbatim. No newline
+    /// is appended; the caller is responsible for framing. Used by
+    /// fuzz / malformed-input tests that need to send bytes the
+    /// normal `request` / `notify` API would reject.
+    pub async fn send_raw(&mut self, bytes: &[u8]) {
+        self.stdin.write_all(bytes).await.expect("write raw bytes");
+        self.stdin.flush().await.expect("flush raw bytes");
+    }
+
+    /// Convenience wrapper: write `line` followed by `\n`. The
+    /// `line` itself MUST NOT contain a `\n` (MCP framing is one
+    /// JSON envelope per line; embedded newlines would split the
+    /// envelope across lines).
+    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+    pub async fn send_line(&mut self, line: &str) {
+        assert!(
+            !line.contains('\n'),
+            "send_line: caller-supplied content must not contain a newline; got {line:?}",
+        );
+        let mut framed = String::with_capacity(line.len() + 1);
+        framed.push_str(line);
+        framed.push('\n');
+        self.send_raw(framed.as_bytes()).await;
+    }
+
+    /// Read one line of stdout under `dur`. Returns `Some(line)` on
+    /// success, `None` if `dur` elapsed before a newline arrived OR
+    /// the child closed stdout. Unlike `request`, this does NOT parse
+    /// or validate the line; fuzz tests use it to observe whatever
+    /// the server actually emitted (which may be malformed by design).
+    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+    pub async fn recv_line_within(&mut self, dur: Duration) -> Option<String> {
+        let mut buf = String::new();
+        match timeout(dur, self.stdout.read_line(&mut buf)).await {
+            Ok(Ok(0) | Err(_)) | Err(_) => None, // EOF, I/O error, or timeout
+            Ok(Ok(_)) => Some(buf),              // line read; buf ends with '\n'
+        }
+    }
+
     /// Assert no bytes arrive on stdout for the given duration.
     pub async fn assert_no_response_within(&mut self, dur: Duration) {
         let mut buf = String::new();

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -133,6 +133,9 @@ fn force_use_for_dead_code_link() {
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
+    // Method used by mcp_wire_negative (pre-initialize tests), not by
+    // other binaries.
+    let _ = Harness::audit_path;
     // Methods used by mcp_wire_negative and e2e_wire_cancellation, not
     // by other binaries.
     let _ = Harness::send_request_no_wait;
@@ -256,6 +259,18 @@ allowed_base_dir = "{}"
     /// panic messages.
     pub fn captured_stderr(&self) -> String {
         std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
+    }
+
+    /// Path to the audit log file for this harness. Used by tests
+    /// that need to read `process_end` records post-shutdown.
+    #[expect(
+        clippy::used_underscore_binding,
+        reason = "the leading underscore on `_tempdir` is a visual convention to flag that the \
+                  field is held purely for its drop guard; this accessor exposes its path on \
+                  purpose so audit-log assertions can read the file before the guard drops"
+    )]
+    pub fn audit_path(&self) -> std::path::PathBuf {
+        self._tempdir.path().join("audit.jsonl")
     }
 
     /// Read exactly one parsed envelope from stdout. Skips

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -128,9 +128,9 @@ fn force_use_for_dead_code_link() {
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
     let _ = Harness::send_request_no_wait;
-    // No current callers — suppressed here for the same per-binary
-    // dead-code reason; Task 5 will add callers via the concurrency
-    // and adversarial-input tests.
+    let _ = Harness::recv_until_id;
+    // No current callers in any binary — suppressed here for the same
+    // per-binary dead-code reason.
     let _ = Harness::recv_line_within;
     // Method used by mcp_wire_conformance, not by other binaries.
     let _ = Harness::assert_no_response_within;
@@ -320,7 +320,6 @@ allowed_base_dir = "{}"
     /// requests already in flight are buffered and can be retrieved by
     /// later `recv_until_id` calls. Panics if the response envelope
     /// fails schema validation.
-    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
     pub async fn recv_until_id(&mut self, target: u64) -> Value {
         // Fast path: target already buffered.
         if let Some(pos) = self

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -42,6 +42,31 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 // jitter when other tests are spawning binaries / parsers concurrently.
 pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Possible outcomes when probing the server for "either a
+/// response or a close." Codex review finding #1 verified that
+/// a simple `Option<String>` could not distinguish a panic
+/// (stdout closed but child exited with non-zero status) from
+/// an orderly shutdown — the malformed-input contract demands
+/// that distinction, so this enum is required.
+#[derive(Debug)]
+#[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+pub enum CloseOrResponse {
+    /// The server produced a line of output (newline-terminated).
+    Response(String),
+    /// EOF observed AND `child.wait()` returned exit code 0
+    /// within `SHUTDOWN_TIMEOUT`. The server shut down
+    /// cleanly. Harness is now poisoned (process reaped).
+    CleanClose,
+    /// EOF observed AND child exited with a non-zero status or
+    /// was killed by a signal. The server crashed. Includes the
+    /// raw exit-status string for diagnostics. Harness poisoned.
+    Crashed(String),
+    /// Stdout did NOT yield EOF AND no line arrived within
+    /// `request_dur`. The server is hung or unresponsive.
+    /// Harness poisoned.
+    Hung,
+}
+
 /// Owns the spawned child plus its piped stdio.
 pub struct Harness {
     child: Child,
@@ -55,6 +80,23 @@ pub struct Harness {
     /// contention that made the prior `Stdio::piped()` capture hang every
     /// wire test on the 2-second `REQUEST_TIMEOUT` (see commit 3a58304).
     stderr_log: PathBuf,
+    /// Out-of-order response envelopes parked here by `recv_until_id`
+    /// when a response for a not-yet-awaited id arrives ahead of the
+    /// one the caller is waiting for. Keyed by the JSON-RPC `id`
+    /// (always a u64 in this harness because `next_id` is u64).
+    buffered_responses: std::collections::VecDeque<(u64, Value)>,
+    /// Set to true once the harness has observed an unrecoverable
+    /// session state: stdout EOF, child exit (clean or crash),
+    /// timeout where stdout is still open but the server is
+    /// unresponsive, or schema validation failure on a parsed
+    /// envelope. Once poisoned the harness MUST NOT be used for
+    /// further requests — `is_usable` returns false for poisoned
+    /// harnesses regardless of process status, which is what the
+    /// proptest restart-on-close discipline (Task 6) consults.
+    /// Codex review finding #2 verified this is necessary because
+    /// a closed-stdout child may not yet be reaped, so `try_wait`
+    /// alone is insufficient.
+    poisoned: bool,
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
     _tempdir: TempDir,
@@ -124,6 +166,8 @@ allowed_base_dir = "{}"
             stdout,
             next_id: 0,
             stderr_log,
+            buffered_responses: std::collections::VecDeque::new(),
+            poisoned: false,
             _tempdir: tempdir,
         }
     }
@@ -134,6 +178,57 @@ allowed_base_dir = "{}"
     /// panic messages.
     pub fn captured_stderr(&self) -> String {
         std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
+    }
+
+    /// Read exactly one parsed envelope from stdout. Skips
+    /// notifications (which have a `method` and absent/null `id`) but
+    /// does NOT skip responses; returns the first response observed.
+    /// Panics on timeout, EOF, or parse failure with stderr included
+    /// in the diagnostic. Shared by `request` and `recv_until_id`.
+    async fn read_one_envelope(&mut self, caller: &str) -> Value {
+        loop {
+            let mut buf = String::new();
+            let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
+            let read = match read_result {
+                Ok(io_result) => io_result.unwrap_or_else(|e| {
+                    panic!(
+                        "read response error on {caller}: {e}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )
+                }),
+                Err(elapsed) => panic!(
+                    "response to {caller} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
+                     --- captured child stderr ---\n{}",
+                    self.captured_stderr(),
+                ),
+            };
+            assert!(
+                read > 0,
+                "stdout closed before responding to {caller}\n\
+                 --- captured child stderr ---\n{}",
+                self.captured_stderr(),
+            );
+            let envelope: Value = serde_json::from_str(buf.trim_end()).unwrap_or_else(|e| {
+                panic!(
+                    "failed to parse envelope JSON from server on {caller}: {e}\n\
+                         raw line: {buf:?}\n\
+                         --- captured child stderr ---\n{}",
+                    self.captured_stderr(),
+                )
+            });
+            let is_notification =
+                envelope.get("method").is_some() && envelope.get("id").is_none_or(Value::is_null);
+            if is_notification {
+                assert_eq!(
+                    envelope["jsonrpc"],
+                    json!("2.0"),
+                    "notification must declare jsonrpc=\"2.0\"; got {envelope}",
+                );
+                continue;
+            }
+            return envelope;
+        }
     }
 
     /// Send a JSON-RPC request and return the parsed response value.
@@ -154,55 +249,116 @@ allowed_base_dir = "{}"
             .expect("write request");
         self.stdin.flush().await.expect("flush request");
 
-        // MCP servers may interleave server-initiated notifications
-        // (e.g. `notifications/tools/list_changed` after a successful
-        // `use_account` — see crates/rimap-server/src/mcp/server.rs)
-        // ahead of the response to our request. Loop past notifications
-        // until we observe a response whose id matches our request.
+        let envelope = self.read_one_envelope(method).await;
+        assert_eq!(envelope["id"], json!(id), "response id must match request");
+        assert_envelope_valid(&envelope);
+        envelope
+    }
+
+    /// Send a JSON-RPC request and return the assigned id WITHOUT
+    /// awaiting a response. Pair with `recv_until_id` to drive
+    /// multiple in-flight requests deterministically.
+    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+    pub async fn send_request_no_wait(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+        id
+    }
+
+    /// Drain stdout (skipping notifications) until a response envelope
+    /// with `id == target` arrives. Out-of-order responses for other
+    /// requests already in flight are buffered and can be retrieved by
+    /// later `recv_until_id` calls. Panics if the response envelope
+    /// fails schema validation.
+    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+    pub async fn recv_until_id(&mut self, target: u64) -> Value {
+        // Fast path: target already buffered.
+        if let Some(pos) = self
+            .buffered_responses
+            .iter()
+            .position(|(id, _)| *id == target)
+        {
+            let (_, env) = self.buffered_responses.remove(pos).expect("indexed");
+            super::schema::assert_envelope_valid(&env);
+            return env;
+        }
+        // Slow path: read until we see target, parking other ids.
         loop {
-            let mut buf = String::new();
-            let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
-            let read = match read_result {
-                Ok(io_result) => io_result.unwrap_or_else(|e| {
-                    panic!(
-                        "read response error on {method}: {e}\n\
+            let envelope = self
+                .read_one_envelope(&format!("recv_until_id({target})"))
+                .await;
+            let id = envelope["id"].as_u64().unwrap_or_else(|| {
+                panic!("response envelope missing numeric id while awaiting {target}: {envelope}")
+            });
+            if id == target {
+                super::schema::assert_envelope_valid(&envelope);
+                return envelope;
+            }
+            self.buffered_responses.push_back((id, envelope));
+        }
+    }
+
+    /// Probe-based contract helper: within `request_dur`, observe
+    /// one of `Response`/`CleanClose`/`Crashed`/`Hung`. On any
+    /// non-`Response` outcome, the harness is marked `poisoned`
+    /// so the restart-on-close discipline (Task 6) won't reuse it.
+    /// Callers MUST `match` the result; `_` matches are a code-
+    /// review failure because they re-introduce the original
+    /// Option-shaped bug.
+    #[expect(dead_code, reason = "consumed by upcoming Phase 4 fuzz tests")]
+    pub async fn response_or_close(&mut self, request_dur: Duration) -> CloseOrResponse {
+        let mut buf = String::new();
+        let read = timeout(request_dur, self.stdout.read_line(&mut buf)).await;
+        match read {
+            Ok(Ok(0)) => {
+                // EOF. Verify the child exited cleanly within
+                // SHUTDOWN_TIMEOUT and distinguish CleanClose from Crashed.
+                self.poisoned = true;
+                let wait = timeout(SHUTDOWN_TIMEOUT, self.child.wait()).await;
+                match wait {
+                    Ok(Ok(status)) if status.success() => CloseOrResponse::CleanClose,
+                    Ok(Ok(status)) => CloseOrResponse::Crashed(format!(
+                        "{status:?}\n\
                          --- captured child stderr ---\n{}",
                         self.captured_stderr(),
-                    )
-                }),
-                Err(elapsed) => panic!(
-                    "response to {method} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
+                    )),
+                    Ok(Err(e)) => CloseOrResponse::Crashed(format!(
+                        "child.wait() error: {e}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )),
+                    Err(_elapsed) => CloseOrResponse::Crashed(format!(
+                        "child did not exit within {SHUTDOWN_TIMEOUT:?} after EOF\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )),
+                }
+            }
+            Ok(Ok(_)) => CloseOrResponse::Response(buf),
+            Ok(Err(e)) => {
+                self.poisoned = true;
+                CloseOrResponse::Crashed(format!(
+                    "read error while waiting for response-or-close: {e}\n\
                      --- captured child stderr ---\n{}",
                     self.captured_stderr(),
-                ),
-            };
-            assert!(
-                read > 0,
-                "stdout closed before responding to {method}\n\
-                 --- captured child stderr ---\n{}",
-                self.captured_stderr(),
-            );
-            let envelope: Value =
-                serde_json::from_str(buf.trim_end()).expect("parse envelope JSON");
-            // A notification is identified by the presence of `method` and
-            // an absent or null `id` field. `assert_envelope_valid` is
-            // response-only (it demands `result` or `error`), so we
-            // intentionally do not validate the notification envelope
-            // here — we just check `jsonrpc=2.0` so a malformed line
-            // does not silently slip past, and continue reading.
-            let is_notification =
-                envelope.get("method").is_some() && envelope.get("id").is_none_or(Value::is_null);
-            if is_notification {
-                assert_eq!(
-                    envelope["jsonrpc"],
-                    json!("2.0"),
-                    "notification must declare jsonrpc=\"2.0\"; got {envelope}",
-                );
-                continue;
+                ))
             }
-            assert_eq!(envelope["id"], json!(id), "response id must match request");
-            assert_envelope_valid(&envelope);
-            return envelope;
+            Err(_elapsed) => {
+                self.poisoned = true;
+                CloseOrResponse::Hung
+            }
         }
     }
 
@@ -313,6 +469,8 @@ allowed_base_dir = "{}"
             stdout: _,
             next_id: _,
             stderr_log: _,
+            buffered_responses: _,
+            poisoned: _,
             _tempdir: tempdir,
         } = self;
         drop(stdin);

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -21,8 +21,6 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::timeout;
 
-use super::schema::assert_envelope_valid;
-
 /// MCP protocol version pinned by this harness. Matches the
 /// directory under `tests/fixtures/mcp-spec/` and the `LATEST` value
 /// in `rmcp 1.5`. Update both when bumping.
@@ -57,9 +55,12 @@ pub enum CloseOrResponse {
     /// within `SHUTDOWN_TIMEOUT`. The server shut down
     /// cleanly. Harness is now poisoned (process reaped).
     CleanClose,
-    /// EOF observed AND child exited with a non-zero status or
-    /// was killed by a signal. The server crashed. Includes the
-    /// raw exit-status string for diagnostics. Harness poisoned.
+    /// EOF observed AND either: the child exited with a non-zero
+    /// status, was killed by a signal, `child.wait()` itself
+    /// errored, OR the child failed to exit within `SHUTDOWN_TIMEOUT`
+    /// after stdout closed. The server crashed or got stuck post-
+    /// EOF. Includes a diagnostic string with the precise sub-
+    /// reason and captured stderr. Harness poisoned.
     Crashed(String),
     /// Stdout did NOT yield EOF AND no line arrived within
     /// `request_dur`. The server is hung or unresponsive.
@@ -90,12 +91,11 @@ pub struct Harness {
     /// timeout where stdout is still open but the server is
     /// unresponsive, or schema validation failure on a parsed
     /// envelope. Once poisoned the harness MUST NOT be used for
-    /// further requests — `is_usable` returns false for poisoned
-    /// harnesses regardless of process status, which is what the
-    /// proptest restart-on-close discipline (Task 6) consults.
-    /// Codex review finding #2 verified this is necessary because
-    /// a closed-stdout child may not yet be reaped, so `try_wait`
-    /// alone is insufficient.
+    /// further requests. A future `is_usable` accessor (Task 6)
+    /// will consult this flag for the proptest restart-on-close
+    /// discipline. Codex review finding #2 verified the flag is
+    /// necessary because a closed-stdout child may not yet be
+    /// reaped, so `try_wait` alone is insufficient.
     poisoned: bool,
     // Hold the tempdir until the harness drops so the audit log path
     // remains valid for the lifetime of the spawned process.
@@ -251,7 +251,7 @@ allowed_base_dir = "{}"
 
         let envelope = self.read_one_envelope(method).await;
         assert_eq!(envelope["id"], json!(id), "response id must match request");
-        assert_envelope_valid(&envelope);
+        super::schema::assert_envelope_valid(&envelope);
         envelope
     }
 

--- a/crates/rimap-server/tests/support/wire/mod.rs
+++ b/crates/rimap-server/tests/support/wire/mod.rs
@@ -15,3 +15,21 @@ pub mod schema;
 
 pub use harness::{Harness, PINNED_PROTOCOL_VERSION};
 pub use schema::assert_valid;
+
+/// Suppress per-binary unused-import warnings on re-exports consumed by some
+/// but not all integration-test binaries. `mcp_wire_conformance.rs` imports
+/// `Harness`, `PINNED_PROTOCOL_VERSION`, and `assert_valid` via these re-exports;
+/// `mcp_wire_negative.rs` imports from sub-modules directly and does not consume
+/// these re-exports. Referencing the items here marks them as used in every
+/// binary compilation.
+///
+/// Mirrors the pattern in `schema.rs` and `harness.rs`.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary unused-import warnings"
+)]
+fn force_use_of_re_exports() {
+    let _ = std::mem::size_of::<Harness>();
+    let _ = PINNED_PROTOCOL_VERSION;
+    let _ = assert_valid as fn(_, _);
+}

--- a/docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md
+++ b/docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md
@@ -116,16 +116,16 @@ exchange arbitrary bytes. Prerequisite for #266 Phase 4."
 
 ---
 
-## Task 2: Harness — concurrent request API, `read_one_envelope` refactor, `assert_clean_shutdown_or_response`
+## Task 2: Harness — concurrent request API, `read_one_envelope` refactor, `response_or_close`
 
 **Files:**
 - Modify: `crates/rimap-server/tests/support/wire/harness.rs`
 
-Add `send_request_no_wait` (returns the assigned id without awaiting a response), `recv_until_id` (reads stdout until the matching id arrives, buffering out-of-order envelopes in a `VecDeque`), and `assert_clean_shutdown_or_response` (codifies the probe-first contract). Refactor the notification-skip loop inside `request` into a shared `read_one_envelope` helper.
+Add `send_request_no_wait` (returns the assigned id without awaiting a response), `recv_until_id` (reads stdout until the matching id arrives, buffering out-of-order envelopes in a `VecDeque`), and `response_or_close` (returns an explicit `CloseOrResponse` enum that distinguishes a clean close, a crash, and a hang on EOF — Codex review finding #1 verified this distinction is required). Refactor the notification-skip loop inside `request` into a shared `read_one_envelope` helper.
 
 - [ ] **Step 1: Add a per-Harness buffer field and pending-ids set**
 
-In the same file, modify the `Harness` struct (around line 46) to add a buffer:
+In the same file, modify the `Harness` struct (around line 46) to add a buffer AND a poisoned flag. The `poisoned` flag is set whenever the harness has observed an unrecoverable session state (stdout EOF, child exit, response-shape corruption) so subsequent reuse can be rejected — see Task 2 Step 5 for where it gets set, and Task 6 Step 2 for where it's consulted by the proptest restart-on-close discipline.
 
 ```rust
 pub struct Harness {
@@ -139,11 +139,23 @@ pub struct Harness {
     /// one the caller is waiting for. Keyed by the JSON-RPC `id`
     /// (always a u64 in this harness because `next_id` is u64).
     buffered_responses: std::collections::VecDeque<(u64, Value)>,
+    /// Set to true once the harness has observed an unrecoverable
+    /// session state: stdout EOF, child exit (clean or crash),
+    /// timeout where stdout is still open but the server is
+    /// unresponsive, or schema validation failure on a parsed
+    /// envelope. Once poisoned the harness MUST NOT be used for
+    /// further requests — `is_usable` returns false for poisoned
+    /// harnesses regardless of process status, which is what the
+    /// proptest restart-on-close discipline (Task 6) consults.
+    /// Codex review finding #2 verified this is necessary because
+    /// a closed-stdout child may not yet be reaped, so `try_wait`
+    /// alone is insufficient.
+    poisoned: bool,
     _tempdir: TempDir,
 }
 ```
 
-In `Harness::spawn_with_config` (around line 121), initialize the new field:
+In `Harness::spawn_with_config` (around line 121), initialize the new fields:
 
 ```rust
         Self {
@@ -153,11 +165,12 @@ In `Harness::spawn_with_config` (around line 121), initialize the new field:
             next_id: 0,
             stderr_log,
             buffered_responses: std::collections::VecDeque::new(),
+            poisoned: false,
             _tempdir: tempdir,
         }
 ```
 
-In `Harness::shutdown_and_wait` (around line 266), destructure the new field:
+In `Harness::shutdown_and_wait` (around line 266), destructure the new fields:
 
 ```rust
         let Self {
@@ -167,6 +180,7 @@ In `Harness::shutdown_and_wait` (around line 266), destructure the new field:
             next_id: _,
             stderr_log: _,
             buffered_responses: _,
+            poisoned: _,
             _tempdir: tempdir,
         } = self;
 ```
@@ -320,40 +334,91 @@ Right after `request`, add:
     }
 ```
 
-- [ ] **Step 5: Add `assert_clean_shutdown_or_response`**
+- [ ] **Step 5: Add the `Outcome` enum and `response_or_close`**
 
-Right after `recv_until_id`, add:
+Right after `recv_until_id`, define an explicit outcome type and the helper that returns it. This replaces the simple `Option<String>` shape from the original sketch — Codex review finding #1 verified that mapping EOF directly to "clean close" cannot distinguish an orderly server shutdown from a panic that closed stdout, so the helper MUST verify exit status on EOF and propagate that distinction back to callers.
 
 ```rust
-    /// Probe-based contract helper: assert that within `request_dur`
-    /// either a response line arrives OR the child cleanly closes
-    /// stdout (EOF). Returns the line if one arrived, or `None` if
-    /// the connection closed. Panics on any other outcome (timeout
-    /// with stdout still open, partial line, etc).
-    ///
-    /// Used by malformed-input tests where the server is allowed to
-    /// EITHER respond with a JSON-RPC error envelope OR close the
-    /// connection — both are spec-legal outcomes.
-    pub async fn assert_clean_shutdown_or_response(
-        &mut self,
-        request_dur: Duration,
-    ) -> Option<String> {
+    /// Possible outcomes when probing the server for "either a
+    /// response or a close." Codex review finding #1 verified that
+    /// a simple `Option<String>` could not distinguish a panic
+    /// (stdout closed but child exited with non-zero status) from
+    /// an orderly shutdown — the malformed-input contract demands
+    /// that distinction, so this enum is required.
+    #[derive(Debug)]
+    pub enum CloseOrResponse {
+        /// The server produced a line of output (newline-terminated).
+        Response(String),
+        /// EOF observed AND `child.wait()` returned exit code 0
+        /// within `SHUTDOWN_TIMEOUT`. The server shut down
+        /// cleanly. Harness is now poisoned (process reaped).
+        CleanClose,
+        /// EOF observed AND child exited with a non-zero status or
+        /// was killed by a signal. The server crashed. Includes the
+        /// raw exit-status string for diagnostics. Harness poisoned.
+        Crashed(String),
+        /// Stdout did NOT yield EOF AND no line arrived within
+        /// `request_dur`. The server is hung or unresponsive.
+        /// Harness poisoned.
+        Hung,
+    }
+
+    /// Probe-based contract helper: within `request_dur`, observe
+    /// one of `Response`/`CleanClose`/`Crashed`/`Hung`. On any
+    /// non-`Response` outcome, the harness is marked `poisoned`
+    /// so the restart-on-close discipline (Task 6) won't reuse it.
+    /// Callers MUST `match` the result; `_` matches are a code-
+    /// review failure because they re-introduce the original
+    /// Option-shaped bug.
+    pub async fn response_or_close(&mut self, request_dur: Duration) -> CloseOrResponse {
         let mut buf = String::new();
-        match timeout(request_dur, self.stdout.read_line(&mut buf)).await {
-            Ok(Ok(0)) => None, // EOF — clean close
-            Ok(Ok(_)) => Some(buf),
-            Ok(Err(e)) => panic!(
-                "read error while waiting for response-or-close: {e}\n\
-                 --- captured child stderr ---\n{}",
-                self.captured_stderr(),
-            ),
-            Err(_elapsed) => panic!(
-                "neither response nor close arrived within {request_dur:?}\n\
-                 --- captured child stderr ---\n{}",
-                self.captured_stderr(),
-            ),
+        let read = timeout(request_dur, self.stdout.read_line(&mut buf)).await;
+        match read {
+            Ok(Ok(0)) => {
+                // EOF. Verify the child exited cleanly within
+                // SHUTDOWN_TIMEOUT and distinguish CleanClose from Crashed.
+                self.poisoned = true;
+                let wait = timeout(SHUTDOWN_TIMEOUT, self.child.wait()).await;
+                match wait {
+                    Ok(Ok(status)) if status.success() => CloseOrResponse::CleanClose,
+                    Ok(Ok(status)) => CloseOrResponse::Crashed(format!(
+                        "{status:?}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )),
+                    Ok(Err(e)) => CloseOrResponse::Crashed(format!(
+                        "child.wait() error: {e}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )),
+                    Err(_elapsed) => CloseOrResponse::Crashed(format!(
+                        "child did not exit within {SHUTDOWN_TIMEOUT:?} after EOF\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )),
+                }
+            }
+            Ok(Ok(_)) => CloseOrResponse::Response(buf),
+            Ok(Err(e)) => {
+                self.poisoned = true;
+                CloseOrResponse::Crashed(format!(
+                    "read error while waiting for response-or-close: {e}\n\
+                     --- captured child stderr ---\n{}",
+                    self.captured_stderr(),
+                ))
+            }
+            Err(_elapsed) => {
+                self.poisoned = true;
+                CloseOrResponse::Hung
+            }
         }
     }
+```
+
+Re-export `CloseOrResponse` from `support/wire/mod.rs` alongside `Harness`:
+
+```rust
+pub use harness::{CloseOrResponse, Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
 ```
 
 - [ ] **Step 6: Run Phase 1 tests to confirm no regression**
@@ -372,9 +437,9 @@ git commit -m "test(rimap-server): add concurrent request API and shutdown-or-re
 
 send_request_no_wait + recv_until_id buffers out-of-order responses
 in a VecDeque so concurrent in-flight requests are observable
-deterministically. assert_clean_shutdown_or_response codifies the
-probe-first 'either valid envelope or clean close' contract for
-malformed-input tests. The notification-skip loop is extracted into
+deterministically. response_or_close returns an explicit
+CloseOrResponse enum that distinguishes a clean close from a crash
+or hang on EOF (Codex review finding #1). The notification-skip loop is extracted into
 a shared read_one_envelope helper. Prerequisite for #266 Phase 4."
 ```
 
@@ -399,6 +464,9 @@ Five tests that exercise the server with unparseable JSON, invalid JSON-RPC enve
 //! §4.1: every test asserts either a specific JSON-RPC error
 //! envelope shape OR a clean stdin shutdown — never just
 //! "didn't crash."
+//!
+//! `CloseOrResponse::Crashed` and `CloseOrResponse::Hung` always
+//! fail the test, regardless of which input produced them.
 
 #![expect(clippy::expect_used, reason = "integration tests")]
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
@@ -410,17 +478,17 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
-use support::wire::{Harness, REQUEST_TIMEOUT, assert_envelope_valid};
+use support::wire::{CloseOrResponse, Harness, REQUEST_TIMEOUT, assert_envelope_valid};
 ```
 
 Note: `REQUEST_TIMEOUT` and `assert_envelope_valid` may need re-exporting from `support/wire/mod.rs`. Check the current re-exports and add any missing ones.
 
-- [ ] **Step 2: Re-export `REQUEST_TIMEOUT` and `assert_envelope_valid` from the wire module**
+- [ ] **Step 2: Re-export `REQUEST_TIMEOUT`, `CloseOrResponse`, and `assert_envelope_valid` from the wire module**
 
-In `crates/rimap-server/tests/support/wire/mod.rs`, ensure both are public. The current file content is short; if either is missing from the re-exports, add it:
+In `crates/rimap-server/tests/support/wire/mod.rs`, ensure all three are public. The current file content is short; add any missing re-exports:
 
 ```rust
-pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
+pub use harness::{CloseOrResponse, Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
 pub use schema::{assert_envelope_valid, assert_valid, validator_for, validator_for_tool_response};
 ```
 
@@ -444,14 +512,13 @@ async fn unparsable_json_errors_or_closes() {
 
     harness.send_line("not json").await;
 
-    let outcome = harness
-        .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
-        .await;
+    let outcome = harness.response_or_close(REQUEST_TIMEOUT).await;
     match outcome {
         // Probed 2026-05-13 (rmcp 1.5): RECORD THE ACTUAL BEHAVIOR
         // HERE after running this test the first time. The test should
-        // then pin whichever branch fired and panic on the other.
-        Some(line) => {
+        // then pin whichever Response/CleanClose branch fired and
+        // panic on the other. Crashed and Hung ALWAYS fail.
+        CloseOrResponse::Response(line) => {
             let env: Value = serde_json::from_str(line.trim_end())
                 .expect("server response must be valid JSON");
             assert_envelope_valid(&env);
@@ -468,10 +535,20 @@ async fn unparsable_json_errors_or_closes() {
                 "expected parse error code -32700, got {env}",
             );
         }
-        None => {
-            // Clean close is also spec-legal. If the probe says the
-            // server closes here, replace the Some(...) branch above
+        CloseOrResponse::CleanClose => {
+            // Clean close is spec-legal. If the probe says this
+            // branch fires, replace the Response(...) branch above
             // with `panic!("expected clean close, got response: {line}")`.
+        }
+        CloseOrResponse::Crashed(diagnostic) => {
+            panic!(
+                "server crashed on unparseable input — Phase 4 must surface this as a bug: {diagnostic}",
+            );
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung on unparseable input (no response, no close within {REQUEST_TIMEOUT:?})",
+            );
         }
     }
 }
@@ -618,18 +695,27 @@ async fn oversized_params_payload() {
     });
     harness.send_line(&payload.to_string()).await;
 
-    let outcome = harness
-        .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
-        .await;
-    if let Some(line) = outcome {
-        let env: Value = serde_json::from_str(line.trim_end())
-            .expect("server response must be valid JSON");
-        assert_envelope_valid(&env);
-        // Either a successful tools/list response or an error
-        // envelope is acceptable; both are well-formed.
+    let outcome = harness.response_or_close(REQUEST_TIMEOUT).await;
+    match outcome {
+        CloseOrResponse::Response(line) => {
+            let env: Value = serde_json::from_str(line.trim_end())
+                .expect("server response must be valid JSON");
+            assert_envelope_valid(&env);
+            // Either a successful tools/list response or an error
+            // envelope is acceptable; both are well-formed.
+        }
+        CloseOrResponse::CleanClose => {
+            // Spec-legal: server elected to close rather than respond.
+        }
+        CloseOrResponse::Crashed(diagnostic) => {
+            panic!("server crashed on oversized payload: {diagnostic}");
+        }
+        CloseOrResponse::Hung => {
+            panic!(
+                "server hung on oversized payload (no response, no close within {REQUEST_TIMEOUT:?})",
+            );
+        }
     }
-    // None outcome (clean close) is also acceptable per the
-    // probe-first contract.
 }
 ```
 
@@ -1001,46 +1087,77 @@ use serde_json::{Value, json};
 use support::wire::{Harness, REQUEST_TIMEOUT, assert_envelope_valid};
 
 /// Run `body` against a harness, restarting the harness if the
-/// previous case closed the connection. Returns the (possibly new)
-/// harness so the caller can keep using it. The "is alive" check is
-/// done by sending a no-op `tools/list` and timing out fast; if it
-/// hangs or the child exited, a fresh harness is spawned.
-async fn with_live_harness<F, Fut>(mut h: Option<Harness>, body: F) -> Harness
+/// previous case poisoned the session (EOF observed, child exited,
+/// or `is_usable` reports false for any other reason). After
+/// `body` runs, the caller MUST check `is_usable` on the returned
+/// harness and drop it if false — `with_live_harness` only
+/// guarantees a usable harness at body-entry, not at body-exit,
+/// because the case itself may have poisoned it.
+///
+/// Codex review finding #2 verified that a simple `try_wait`
+/// check could let a poisoned (stdout-closed but not-yet-reaped)
+/// harness leak across cases. `Harness::is_usable` consolidates
+/// the check.
+async fn with_live_harness<F, Fut>(mut h: Option<Harness>, body: F) -> Option<Harness>
 where
     F: FnOnce(Harness) -> Fut,
     Fut: std::future::Future<Output = Harness>,
 {
-    if h.is_none() || !is_alive(h.as_mut().expect("checked is_none above")).await {
+    let needs_fresh = match h.as_mut() {
+        None => true,
+        Some(harness) => !harness.is_usable(),
+    };
+    if needs_fresh {
+        // Drop the poisoned harness if any.
+        drop(h);
         let mut fresh = Harness::spawn().await;
         let _ = fresh.initialize_handshake().await;
         fresh.send_initialized().await;
         h = Some(fresh);
     }
-    body(h.expect("ensured Some above")).await
-}
-
-/// Cheap liveness check: poll the child process. Returns true if the
-/// child is still running. False if it has exited or polling failed.
-async fn is_alive(h: &mut Harness) -> bool {
-    // This accessor is added below for visibility into child status.
-    h.child_is_running()
+    let mut after = body(h.expect("ensured Some above")).await;
+    // If the body poisoned the harness (e.g. property 1's case
+    // observed CleanClose/Crashed/Hung), drop it instead of
+    // returning it to the pool.
+    if !after.is_usable() {
+        return None;
+    }
+    Some(after)
 }
 ```
 
-- [ ] **Step 3: Add the `child_is_running` accessor on `Harness`**
+- [ ] **Step 3: Add the `is_usable` accessor on `Harness`**
 
 In `crates/rimap-server/tests/support/wire/harness.rs`, add this method right after `captured_stderr`:
 
 ```rust
-    /// Returns true if the child process is still running (i.e.
-    /// `try_wait` reports no exit yet). Used by the proptest
-    /// restart-on-close discipline to detect a poisoned session
-    /// cheaply, without sending a probing request.
-    pub fn child_is_running(&mut self) -> bool {
+    /// Returns true if the harness can be used for another request:
+    /// the child process is still running AND the harness has not
+    /// observed an unrecoverable session state (EOF, crash, hang,
+    /// schema-validation failure on a parsed envelope). Codex
+    /// review finding #2 verified that `try_wait` alone is
+    /// insufficient — a child whose stdout closed but whose process
+    /// has not yet been reaped would otherwise pass the "alive"
+    /// check while subsequent reads return EOF immediately.
+    ///
+    /// Always check this before reusing a harness across cases.
+    /// The proptest restart-on-close discipline (this task)
+    /// consults it; if false, the helper drops the poisoned
+    /// harness and spawns a fresh one.
+    pub fn is_usable(&mut self) -> bool {
+        if self.poisoned {
+            return false;
+        }
         match self.child.try_wait() {
             Ok(None) => true,
-            Ok(Some(_status)) => false,
-            Err(_) => false,
+            Ok(Some(_status)) => {
+                self.poisoned = true;
+                false
+            }
+            Err(_) => {
+                self.poisoned = true;
+                false
+            }
         }
     }
 ```
@@ -1083,7 +1200,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut harness = HARNESS.lock().await.take();
-            harness = Some(with_live_harness(harness, |mut h| async move {
+            harness = with_live_harness(harness, |mut h| async move {
                 let arguments: serde_json::Map<String, Value> = args
                     .into_iter()
                     .map(|(k, v)| (k, v))
@@ -1109,7 +1226,7 @@ proptest! {
                     "unknown tool {tool_name:?} must produce an error, got {response}",
                 );
                 h
-            }).await);
+            }).await;
             *HARNESS.lock().await = harness;
         });
     }
@@ -1155,7 +1272,7 @@ git add crates/rimap-server/tests/mcp_wire_proptest.rs \
 git commit -m "test(rimap-server): property 2 — unknown-tool fuzz (#266)
 
 Adds mcp_wire_proptest.rs with the restart-on-close discipline
-(child_is_running accessor + with_live_harness helper) and the
+(is_usable accessor + with_live_harness helper) and the
 simplest of the three properties: arbitrary tools/call invocations
 must always produce an error envelope. PROPTEST_CASES env var
 controls the case count. Phase 4 §4.2 property 2."
@@ -1202,7 +1319,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut harness = HARNESS.lock().await.take();
-            harness = Some(with_live_harness(harness, |mut h| async move {
+            harness = with_live_harness(harness, |mut h| async move {
                 let response = h
                     .request(
                         "tools/call",
@@ -1221,7 +1338,7 @@ proptest! {
                     "use_account with arbitrary args must fail (no accounts configured), got {response}",
                 );
                 h
-            }).await);
+            }).await;
             *HARNESS.lock().await = harness;
         });
     }
@@ -1408,21 +1525,36 @@ proptest! {
 
         runtime.block_on(async move {
             let mut harness = HARNESS.lock().await.take();
-            harness = Some(with_live_harness(harness, |mut h| async move {
+            harness = with_live_harness(harness, |mut h| async move {
                 h.send_line(&envelope.to_string()).await;
-                let outcome = h
-                    .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
-                    .await;
-                if let Some(line) = outcome {
-                    let env: Value = serde_json::from_str(line.trim_end())
-                        .expect("server response must be valid JSON");
-                    assert_envelope_valid(&env);
+                let outcome = h.response_or_close(REQUEST_TIMEOUT).await;
+                match outcome {
+                    CloseOrResponse::Response(line) => {
+                        let env: Value = serde_json::from_str(line.trim_end())
+                            .expect("server response must be valid JSON");
+                        assert_envelope_valid(&env);
+                    }
+                    CloseOrResponse::CleanClose => {
+                        // Spec-legal: harness is now poisoned;
+                        // `with_live_harness` will drop it after the
+                        // case and spawn a fresh one for the next.
+                    }
+                    CloseOrResponse::Crashed(diagnostic) => {
+                        panic!(
+                            "server crashed during property 1 case — \
+                             file an issue and pin a regression seed before continuing: \
+                             envelope={envelope}\n{diagnostic}",
+                        );
+                    }
+                    CloseOrResponse::Hung => {
+                        panic!(
+                            "server hung during property 1 case (no response, no close \
+                             within {REQUEST_TIMEOUT:?}): envelope={envelope}",
+                        );
+                    }
                 }
-                // None outcome (clean close) is also acceptable. The
-                // restart-on-close discipline will spawn a fresh
-                // harness for the next case.
                 h
-            }).await);
+            }).await;
             *HARNESS.lock().await = harness;
         });
     }
@@ -1435,7 +1567,7 @@ proptest! {
 PROPTEST_CASES=200 cargo test -p rimap-server --test mcp_wire_proptest -- prop_envelope_never_panics --nocapture
 ```
 
-Expected: 200 cases pass. The runtime here is dominated by the harness restart-on-close path; if `assert_clean_shutdown_or_response` is timing out, the test is much slower than the others. If runtime is excessive, profile and consider reducing REQUEST_TIMEOUT for this property only.
+Expected: 200 cases pass. The runtime here is dominated by the harness restart-on-close path; if `response_or_close` is timing out (i.e. many cases hit `Hung`), the test is much slower than the others. If runtime is excessive, profile and consider reducing REQUEST_TIMEOUT for this property only. A `Hung` outcome failing the test is also the right call here — if generated envelopes routinely hang the server, that's a server bug.
 
 If a case shrinks to a panic, STOP — this is exactly the bug-discovery scenario the spec anticipates. File a separate issue, fix on a sibling branch, commit the `proptest-regressions/` seed with this task.
 
@@ -1481,7 +1613,164 @@ cargo test -p rimap-server --lib audit_envelope::tests
 
 Expected: both `dropped_guard_enqueues_cancellation_record` and `disarmed_guard_does_not_enqueue` pass. If they don't, STOP — the project's invariant from #71/#99 is broken and must be fixed before Phase 4 lands.
 
-Note in your scratch notes: "Audit-layer Drop contract verified via existing tests; new file `drop_emits_cancelled.rs` is not added per spec §4.4.2 lookup."
+The existing tests cover the guard's Drop discipline at its tightest point (manually constructing an `AuditEnvelopeGuard`). Codex review finding #4 noted two legitimate gaps:
+- `dropped_guard_enqueues_cancellation_record` asserts `lines.len() >= 2`, which would not catch a regression that double-emits the cancellation record.
+- Neither test exercises `run_with_audit_envelope` end-to-end, so a regression that moved guard construction before `emit_tool_start` or forgot to disarm on the normal path would pass guard-level tests.
+
+Steps 1a and 1b address both gaps.
+
+- [ ] **Step 1a: Tighten the existing `dropped_guard_enqueues_cancellation_record` assertion**
+
+In `crates/rimap-server/src/mcp/audit_envelope.rs`, locate the assertion (around line 333):
+
+```rust
+        assert!(
+            lines.len() >= 2,
+            "expected >= 2 records (tool_start + cancellation tool_end), got: {contents}",
+        );
+```
+
+Replace with an exact-count assertion:
+
+```rust
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected exactly 2 records (tool_start + cancellation tool_end), got {} records:\n{contents}",
+            lines.len(),
+        );
+```
+
+Run `cargo test -p rimap-server --lib audit_envelope::tests::dropped_guard_enqueues_cancellation_record`. Expected: pass. If it fails because more than 2 records were written, investigate before continuing — that itself would be the regression Codex anticipated.
+
+- [ ] **Step 1b: Add a wrapper-level test that exercises `run_with_audit_envelope` end-to-end**
+
+The existing tests construct the guard manually. The wrapper-level test drives `run_with_audit_envelope` with a `std::future::pending()` body, polls once, then drops the outer future. The cancellation record must be emitted exactly once.
+
+`run_with_audit_envelope` is `pub(super)` on `impl ImapMcpServer`, so the test (which lives in `crates/rimap-server/src/mcp/audit_envelope.rs::tests`) can call it through an `ImapMcpServer` instance. The instance requires a small `#[cfg(test)] pub(crate) fn new_for_tests(...)` constructor that builds a minimal server with just the fields `run_with_audit_envelope` touches (`audit`, `redaction_salt`, `cancellation_sender`, plus whatever `redact_tool_args` and the dispatch path require).
+
+First, locate the `ImapMcpServer` struct definition:
+
+```bash
+grep -n "pub struct ImapMcpServer\|impl ImapMcpServer" crates/rimap-server/src/mcp/server.rs crates/rimap-server/src/mcp/mod.rs 2>/dev/null
+```
+
+Add the constructor in the file where `ImapMcpServer` is defined. Pattern:
+
+```rust
+#[cfg(test)]
+impl ImapMcpServer {
+    /// Minimal test constructor — instantiates an `ImapMcpServer`
+    /// with only the fields needed for `run_with_audit_envelope`
+    /// and its callees. Compiled only under `cfg(test)` so this
+    /// constructor never ships in the released binary. Callers
+    /// fill in additional fields as the test requires.
+    pub(crate) fn new_for_tests(
+        audit: std::sync::Arc<rimap_audit::AuditWriter>,
+        cancellation_sender: rimap_audit::CancelledToolEndSender,
+    ) -> Self {
+        // The exact fields here depend on the live ImapMcpServer
+        // shape. Inspect the struct and provide defaults
+        // (Default::default(), empty Vec, etc.) for everything
+        // that run_with_audit_envelope doesn't read. If a field
+        // is read but not trivially constructible, add it as
+        // another parameter to this function.
+        todo!("inspect ImapMcpServer fields and fill in defaults")
+    }
+}
+```
+
+The `todo!` is intentional — the implementer must look at the live struct rather than rely on a snapshot here. If the struct has many fields, prefer a builder pattern over a long positional argument list.
+
+Next, add the test inside `crates/rimap-server/src/mcp/audit_envelope.rs::tests`:
+
+```rust
+    /// Wrapper-level test: drives `run_with_audit_envelope` with a
+    /// body that never completes, polls once to allow
+    /// `emit_tool_start` to fire, then drops the outer future.
+    /// Expectation: exactly one `tool_start` and exactly one
+    /// `tool_end {status: cancelled}` record, in order. Catches
+    /// regressions where guard construction is reordered relative
+    /// to `tool_start` emission, or where the disarm call is
+    /// moved/removed on the normal path. Codex review finding #4.
+    #[tokio::test]
+    async fn dropped_run_with_audit_envelope_emits_exactly_one_cancellation() {
+        use std::sync::Arc;
+
+        use rimap_audit::cancellation_channel;
+        use rimap_audit::spawn_drainer;
+        use rimap_core::Posture;
+        use rimap_core::tool::ToolName;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = Arc::new(test_writer(path.clone()));
+        let (tx, rx) = cancellation_channel();
+        let drainer = spawn_drainer(rx, (*writer).clone());
+
+        let server = super::super::server::ImapMcpServer::new_for_tests(
+            Arc::clone(&writer),
+            tx.clone(),
+        );
+
+        // Construct a future that runs run_with_audit_envelope with
+        // a body that pends forever, poll it once to drive
+        // emit_tool_start, then drop it.
+        {
+            let args = serde_json::Map::new();
+            let fut = server.run_with_audit_envelope(
+                ToolName::Search,
+                Some("test".to_string()),
+                super::super::dispatch::PostureContext::from_explicit(Posture::Readonly),
+                &args,
+                |_ticket| async { std::future::pending::<_>().await },
+            );
+            tokio::pin!(fut);
+            // Poll once via timeout to ensure tool_start emits.
+            // 50ms is generous; emit_tool_start is a single
+            // spawn_blocking + file append.
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                &mut fut,
+            )
+            .await;
+            // Drop fut here — undisarmed guard fires cancellation.
+        }
+
+        drop(tx);
+        drainer.await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected exactly 2 records (tool_start + cancellation tool_end), got {} records:\n{contents}",
+            lines.len(),
+        );
+        assert!(
+            lines[0].contains(r#""payload":"tool_start""#)
+                || lines[0].contains(r#""tool_start""#),
+            "first record must be tool_start: {}",
+            lines[0],
+        );
+        assert!(
+            lines[1].contains(r#""status":"cancelled""#),
+            "second record must be cancellation tool_end: {}",
+            lines[1],
+        );
+    }
+```
+
+The `PostureContext::from_explicit` constructor is hypothetical — inspect the live `crate::mcp::dispatch::PostureContext` API and use whatever constructor exists. Same for any other type the test references.
+
+Run the test:
+
+```bash
+cargo test -p rimap-server --lib audit_envelope::tests::dropped_run_with_audit_envelope_emits_exactly_one_cancellation
+```
+
+Expected: pass. If it fails because guard construction is incorrectly ordered or disarm is missing, STOP — that is a real bug in `run_with_audit_envelope`; file an issue, fix on a sibling branch, then continue.
 
 - [ ] **Step 2: Create the wire-layer cancellation test file**
 
@@ -1512,26 +1801,45 @@ use serde_json::json;
 use support::wire::Harness;
 ```
 
-- [ ] **Step 3: Add the Dovecot-backed setup helper**
+- [ ] **Step 3: Add the Dovecot-backed setup helper with silent-skip discipline**
 
-The implementer must check `e2e_wire.rs` for the exact Dovecot harness invocation pattern. The pattern is approximately:
+Codex review finding #3 verified that this repo's contract is **silent skip on `HarnessError::DockerUnavailable`** unless `RIMAP_REQUIRE_DOCKER=1` is set. Both `e2e_wire.rs:95-98` and `e2e_wire.rs:548-550` use this pattern; the Phase 4 cancellation tests MUST follow it or they will fail on every CI runner without Docker/Podman.
+
+The helper returns `Option<Harness>` — `None` means "skip this test." Each test entry adds a `let Some(...) else { return; }` to honor the skip.
 
 ```rust
+use support::dovecot::{DovecotHarness, HarnessError, fixtures};
+
 /// Spawn the binary against a Dovecot-backed config and complete the
-/// MCP handshake. The harness returned has `use_account` already
-/// called against the `draftsafe` test account so subsequent
-/// `tools/call search` works.
-async fn spawn_with_dovecot() -> Harness {
-    let dovecot = support::dovecot::Harness::try_start()
-        .expect("Dovecot harness must start (Docker required)");
-    // ...build a config TOML referencing dovecot.port() and the
-    //    fingerprint; this is the same pattern as e2e_wire.rs.
-    //    Copy it verbatim if possible to minimize drift.
-    todo!("copy Dovecot config setup from e2e_wire.rs")
+/// MCP handshake. Returns `None` when the container runtime is
+/// unavailable (silent skip per the repo's existing contract; see
+/// crates/rimap-server/tests/support/dovecot/harness.rs for how
+/// RIMAP_REQUIRE_DOCKER=1 flips this to loud failure). Other
+/// harness errors panic with diagnostic so they surface loudly.
+///
+/// The harness has `use_account` already called against the
+/// `draftsafe` test account so subsequent `tools/call
+/// draftsafe.search` works.
+async fn spawn_with_dovecot() -> Option<Harness> {
+    let dovecot = match DovecotHarness::try_start() {
+        Ok(d) => d,
+        Err(HarnessError::DockerUnavailable) => return None,
+        Err(e) => panic!("Dovecot harness failed: {e}"),
+    };
+    // The rest of this helper mirrors the existing pattern in
+    // e2e_wire.rs: build a config TOML referencing dovecot.port()
+    // and the TLS fingerprint, write it to a tempdir, call
+    // Harness::spawn_with_config with the password env var, then
+    // drive use_account.
+    //
+    // Copy the live pattern from e2e_wire.rs verbatim. The Dovecot
+    // harness API may evolve between Phase 3 and Phase 4 landings;
+    // mirroring the latest pattern avoids drift.
+    todo!("copy the Dovecot config setup + use_account drive from e2e_wire.rs (look at the function around line 95)")
 }
 ```
 
-When implementing this, copy the exact pattern from `e2e_wire.rs` rather than reinventing it. The plan is intentionally not prescribing the exact bytes here because the Dovecot harness API may have evolved between Phase 3 and Phase 4; the implementer should mirror the latest pattern.
+When implementing this, copy the exact pattern from `e2e_wire.rs` rather than reinventing it. The `todo!` above is intentional — it forces the implementer to look at the live code rather than rely on a snapshot in this plan.
 
 - [ ] **Step 4: Write `cancel_during_inflight_tools_call_keeps_session_alive`**
 
@@ -1545,7 +1853,12 @@ Append:
 /// follow-up `tools/list`. No panic, no envelope corruption.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancel_during_inflight_tools_call_keeps_session_alive() {
-    let mut harness = spawn_with_dovecot().await;
+    let Some(mut harness) = spawn_with_dovecot().await else {
+        // Silent skip when Docker/Podman is unavailable; the
+        // existing repo contract (see e2e_wire.rs and
+        // support/dovecot/harness.rs).
+        return;
+    };
 
     let search_id = harness
         .send_request_no_wait(
@@ -1593,7 +1906,9 @@ Append:
 /// must accept silently, not respond, and remain responsive.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancel_unknown_request_id_is_noop() {
-    let mut harness = spawn_with_dovecot().await;
+    let Some(mut harness) = spawn_with_dovecot().await else {
+        return;
+    };
 
     harness
         .notify(
@@ -1628,15 +1943,25 @@ Expected: both tests pass. If the Dovecot harness fails to start (Docker not run
 - [ ] **Step 7: Commit**
 
 ```bash
-git add crates/rimap-server/tests/e2e_wire_cancellation.rs
-git commit -m "test(rimap-server): wire-layer cancellation acceptance (#266)
+git add crates/rimap-server/tests/e2e_wire_cancellation.rs \
+        crates/rimap-server/src/mcp/audit_envelope.rs \
+        crates/rimap-server/src/mcp/server.rs
+# Add any other files touched by the new_for_tests constructor.
+git commit -m "test(rimap-server): cancellation acceptance + wrapper-level audit test (#266)
 
-Two race-free tests: cancel an in-flight tools/call and verify the
-session remains responsive; cancel an unknown request id and verify
-the server treats it as a no-op. The audit-layer Drop contract from
-#71/#99 is already pinned by the in-process tests in
-mcp/audit_envelope.rs, so this file does not duplicate that
-coverage. Phase 4 §4.4."
+Three deliverables:
+- Wire-layer cancellation acceptance test in
+  tests/e2e_wire_cancellation.rs. Silent skip on
+  DockerUnavailable, matching e2e_wire.rs.
+- Tightened existing dropped_guard_enqueues_cancellation_record
+  assertion from lines.len() >= 2 to exactly 2.
+- New wrapper-level test
+  dropped_run_with_audit_envelope_emits_exactly_one_cancellation
+  that drives run_with_audit_envelope end-to-end. Catches
+  regressions in guard construction order or disarm discipline
+  that guard-level tests would miss. Adds a cfg(test) test
+  constructor on ImapMcpServer.
+Phase 4 §4.4 + Codex review findings #3, #4."
 ```
 
 ---
@@ -2074,5 +2399,5 @@ Note: the pre-push hook on this repo runs `just test` and `cargo deny`. The push
 
 - **Spec coverage:** Each of the four spec test categories has a corresponding task (3–5 for negative-path, 6–8 for proptest, 9 for cancellation, 10 for audit failure, 11 for CI). The "Drop test in `rimap-audit/tests/drop_emits_cancelled.rs`" the spec named is documented as already covered by existing in-crate tests in Task 9 step 1 — a deliberate departure from the spec backed by source-code lookup.
 - **Placeholder scan:** Task 9 Step 3 contains a `todo!("copy Dovecot config setup from e2e_wire.rs")` — this is intentional because the Dovecot harness API may have evolved and the implementer must mirror the live pattern rather than a snapshot. The plan flags this explicitly rather than pretending to have current bytes. All other code blocks are complete.
-- **Type consistency:** `Harness::send_request_no_wait`, `recv_until_id`, `send_line`, `recv_line_within`, `assert_clean_shutdown_or_response`, `child_is_running` are defined in Tasks 1, 2, 6 and used in Tasks 3, 4, 5, 6, 7, 8, 9, 10. Names match throughout.
+- **Type consistency:** `Harness::send_request_no_wait`, `recv_until_id`, `send_line`, `recv_line_within`, `response_or_close` (returns `CloseOrResponse`), and `is_usable` are defined in Tasks 1, 2, 6 and used in Tasks 3, 4, 5, 6, 7, 8, 9, 10. Names match throughout.
 - **Probe-first discipline:** Tasks 3 and 4 have explicit "Run the test to observe behavior, then encode the observed code" steps. The plan does not pretend to know the exact JSON-RPC error codes rmcp emits; it tells the implementer to find them and pin them.

--- a/docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md
+++ b/docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md
@@ -1,0 +1,2078 @@
+# MCP Protocol Fuzzing & Negative-Path Coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Phase 4 of the MCP test plan (issue #266): property-based and targeted negative-path tests for the MCP JSON-RPC wire, plus an audit fail-closed boundary test and a race-free wire-level cancellation acceptance test.
+
+**Architecture:** Five new test binaries across two crates, all reusing and extending the Phase 1 `support/wire/Harness`. The harness gains raw send/recv primitives, a buffered concurrent-request API, and an "assert clean shutdown OR response" helper. Proptest cases share a harness per property with a restart-on-close discipline; property 1's `method` strategy excludes the pinned MCP-stateful set. The audit-failure tests arm `AuditWriter::force_next_write_failure()` through a tiny `test-support`-gated CLI flag rather than a swappable sink. The cancellation contract is split: the existing in-process Drop tests at `crates/rimap-server/src/mcp/audit_envelope.rs::tests` already pin the `tool_end {status: cancelled}` invariant from #71/#99, so the new wire-layer test only asserts race-free invariants (server stays responsive, no envelope corruption).
+
+**Tech Stack:** Rust stable, tokio, `rmcp 1.5`, `proptest 1.6`, `jsonschema`, `tempfile`, `assert_cmd`, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
+
+---
+
+## Pre-flight
+
+The branch `feature/issue-266-mcp-fuzzing` is already checked out with the spec committed (commits `3948bf7` and `a032e98`). Verify before starting:
+
+```bash
+git rev-parse --abbrev-ref HEAD  # expect: feature/issue-266-mcp-fuzzing
+git status --short                # expect: clean
+```
+
+Pre-commit hooks are installed (the spec commits ran them). `prek install` if `git config core.hooksPath` is unset.
+
+The Phase 1 wire-test infrastructure lives at:
+- `crates/rimap-server/tests/support/wire/harness.rs` — `Harness` struct
+- `crates/rimap-server/tests/support/wire/schema.rs` — `assert_envelope_valid`, `validator_for`, `assert_valid`
+- `crates/rimap-server/tests/support/wire/mod.rs` — re-exports
+- `crates/rimap-server/tests/support/mod.rs` — adds `pub mod wire;`
+
+Read the existing wire conformance tests at `crates/rimap-server/tests/mcp_wire_conformance.rs` to understand the test pattern (`#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`, `Harness::spawn`, `initialize_handshake`, `send_initialized`).
+
+---
+
+## Task 1: Harness — raw send/recv primitives
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+- Modify: `crates/rimap-server/tests/mcp_wire_conformance.rs` (verify nothing breaks)
+
+Add `send_raw`, `send_line`, and `recv_line_within` to `Harness`. These bypass JSON-RPC envelope validation so fuzz tests can send arbitrary bytes and read whatever arrives without the existing `request()` method's id-match + schema-validate discipline getting in the way.
+
+- [ ] **Step 1: Add `send_raw` and `send_line`**
+
+In `crates/rimap-server/tests/support/wire/harness.rs`, add these methods to `impl Harness` right after `notify` (around line 222):
+
+```rust
+    /// Write arbitrary bytes to the child's stdin verbatim. No newline
+    /// is appended; the caller is responsible for framing. Used by
+    /// fuzz / malformed-input tests that need to send bytes the
+    /// normal `request` / `notify` API would reject.
+    pub async fn send_raw(&mut self, bytes: &[u8]) {
+        self.stdin
+            .write_all(bytes)
+            .await
+            .expect("write raw bytes");
+        self.stdin.flush().await.expect("flush raw bytes");
+    }
+
+    /// Convenience wrapper: write `line` followed by `\n`. The
+    /// `line` itself MUST NOT contain a `\n` (MCP framing is one
+    /// JSON envelope per line; embedded newlines would split the
+    /// envelope across lines).
+    pub async fn send_line(&mut self, line: &str) {
+        assert!(
+            !line.contains('\n'),
+            "send_line: caller-supplied content must not contain a newline; got {line:?}",
+        );
+        let mut framed = String::with_capacity(line.len() + 1);
+        framed.push_str(line);
+        framed.push('\n');
+        self.send_raw(framed.as_bytes()).await;
+    }
+```
+
+- [ ] **Step 2: Add `recv_line_within`**
+
+Right after `send_line`, add:
+
+```rust
+    /// Read one line of stdout under `dur`. Returns `Some(line)` on
+    /// success, `None` if `dur` elapsed before a newline arrived OR
+    /// the child closed stdout. Unlike `request`, this does NOT parse
+    /// or validate the line; fuzz tests use it to observe whatever
+    /// the server actually emitted (which may be malformed by design).
+    pub async fn recv_line_within(&mut self, dur: Duration) -> Option<String> {
+        let mut buf = String::new();
+        match timeout(dur, self.stdout.read_line(&mut buf)).await {
+            Ok(Ok(0)) => None,            // EOF
+            Ok(Ok(_)) => Some(buf),       // line read; buf ends with '\n'
+            Ok(Err(_)) => None,           // I/O error → treat as EOF
+            Err(_elapsed) => None,        // timeout
+        }
+    }
+```
+
+- [ ] **Step 3: Verify the Phase 1 tests still compile and pass**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance
+```
+
+Expected: all 9 existing wire conformance tests pass. The new methods are added, not modifying existing ones, so this should be a clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "test(rimap-server): add raw send/recv primitives to wire Harness
+
+send_raw, send_line, and recv_line_within bypass the JSON-RPC envelope
+validation in request/notify so fuzz and malformed-input tests can
+exchange arbitrary bytes. Prerequisite for #266 Phase 4."
+```
+
+---
+
+## Task 2: Harness — concurrent request API, `read_one_envelope` refactor, `assert_clean_shutdown_or_response`
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+
+Add `send_request_no_wait` (returns the assigned id without awaiting a response), `recv_until_id` (reads stdout until the matching id arrives, buffering out-of-order envelopes in a `VecDeque`), and `assert_clean_shutdown_or_response` (codifies the probe-first contract). Refactor the notification-skip loop inside `request` into a shared `read_one_envelope` helper.
+
+- [ ] **Step 1: Add a per-Harness buffer field and pending-ids set**
+
+In the same file, modify the `Harness` struct (around line 46) to add a buffer:
+
+```rust
+pub struct Harness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+    stderr_log: PathBuf,
+    /// Out-of-order response envelopes parked here by `recv_until_id`
+    /// when a response for a not-yet-awaited id arrives ahead of the
+    /// one the caller is waiting for. Keyed by the JSON-RPC `id`
+    /// (always a u64 in this harness because `next_id` is u64).
+    buffered_responses: std::collections::VecDeque<(u64, Value)>,
+    _tempdir: TempDir,
+}
+```
+
+In `Harness::spawn_with_config` (around line 121), initialize the new field:
+
+```rust
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+            stderr_log,
+            buffered_responses: std::collections::VecDeque::new(),
+            _tempdir: tempdir,
+        }
+```
+
+In `Harness::shutdown_and_wait` (around line 266), destructure the new field:
+
+```rust
+        let Self {
+            mut child,
+            stdin,
+            stdout: _,
+            next_id: _,
+            stderr_log: _,
+            buffered_responses: _,
+            _tempdir: tempdir,
+        } = self;
+```
+
+- [ ] **Step 2: Add `read_one_envelope` private helper**
+
+Right above the existing `request` method (around line 141), add:
+
+```rust
+    /// Read exactly one parsed envelope from stdout. Skips
+    /// notifications (which have a `method` and absent/null `id`) but
+    /// does NOT skip responses; returns the first response observed.
+    /// Panics on timeout, EOF, or parse failure with stderr included
+    /// in the diagnostic. Shared by `request` and `recv_until_id`.
+    async fn read_one_envelope(&mut self, caller: &str) -> Value {
+        loop {
+            let mut buf = String::new();
+            let read_result = timeout(REQUEST_TIMEOUT, self.stdout.read_line(&mut buf)).await;
+            let read = match read_result {
+                Ok(io_result) => io_result.unwrap_or_else(|e| {
+                    panic!(
+                        "read response error on {caller}: {e}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )
+                }),
+                Err(elapsed) => panic!(
+                    "response to {caller} did not arrive within {REQUEST_TIMEOUT:?} ({elapsed})\n\
+                     --- captured child stderr ---\n{}",
+                    self.captured_stderr(),
+                ),
+            };
+            assert!(
+                read > 0,
+                "stdout closed before responding to {caller}\n\
+                 --- captured child stderr ---\n{}",
+                self.captured_stderr(),
+            );
+            let envelope: Value = serde_json::from_str(buf.trim_end())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "failed to parse envelope JSON from server on {caller}: {e}\n\
+                         raw line: {buf:?}\n\
+                         --- captured child stderr ---\n{}",
+                        self.captured_stderr(),
+                    )
+                });
+            let is_notification = envelope.get("method").is_some()
+                && envelope.get("id").is_none_or(Value::is_null);
+            if is_notification {
+                assert_eq!(
+                    envelope["jsonrpc"],
+                    json!("2.0"),
+                    "notification must declare jsonrpc=\"2.0\"; got {envelope}",
+                );
+                continue;
+            }
+            return envelope;
+        }
+    }
+```
+
+- [ ] **Step 3: Refactor `request` to use `read_one_envelope`**
+
+Replace the body of `request` (lines 141–207) with:
+
+```rust
+    pub async fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+
+        let envelope = self.read_one_envelope(method).await;
+        assert_eq!(envelope["id"], json!(id), "response id must match request");
+        super::schema::assert_envelope_valid(&envelope);
+        envelope
+    }
+```
+
+Note: this is functionally identical to the old loop. The only change is that the notification-skip + parse + stderr-on-failure logic is now shared. Verify by running the Phase 1 tests after the next step.
+
+- [ ] **Step 4: Add `send_request_no_wait` and `recv_until_id`**
+
+Right after `request`, add:
+
+```rust
+    /// Send a JSON-RPC request and return the assigned id WITHOUT
+    /// awaiting a response. Pair with `recv_until_id` to drive
+    /// multiple in-flight requests deterministically.
+    pub async fn send_request_no_wait(&mut self, method: &str, params: Value) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        let envelope = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = format!("{envelope}\n");
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .expect("write request");
+        self.stdin.flush().await.expect("flush request");
+        id
+    }
+
+    /// Drain stdout (skipping notifications) until a response envelope
+    /// with `id == target` arrives. Out-of-order responses for other
+    /// requests already in flight are buffered and can be retrieved by
+    /// later `recv_until_id` calls. Panics if the response envelope
+    /// fails schema validation.
+    pub async fn recv_until_id(&mut self, target: u64) -> Value {
+        // Fast path: target already buffered.
+        if let Some(pos) = self
+            .buffered_responses
+            .iter()
+            .position(|(id, _)| *id == target)
+        {
+            let (_, env) = self.buffered_responses.remove(pos).expect("indexed");
+            super::schema::assert_envelope_valid(&env);
+            return env;
+        }
+        // Slow path: read until we see target, parking other ids.
+        loop {
+            let envelope = self
+                .read_one_envelope(&format!("recv_until_id({target})"))
+                .await;
+            let id = envelope["id"].as_u64().unwrap_or_else(|| {
+                panic!(
+                    "response envelope missing numeric id while awaiting {target}: {envelope}"
+                )
+            });
+            if id == target {
+                super::schema::assert_envelope_valid(&envelope);
+                return envelope;
+            }
+            self.buffered_responses.push_back((id, envelope));
+        }
+    }
+```
+
+- [ ] **Step 5: Add `assert_clean_shutdown_or_response`**
+
+Right after `recv_until_id`, add:
+
+```rust
+    /// Probe-based contract helper: assert that within `request_dur`
+    /// either a response line arrives OR the child cleanly closes
+    /// stdout (EOF). Returns the line if one arrived, or `None` if
+    /// the connection closed. Panics on any other outcome (timeout
+    /// with stdout still open, partial line, etc).
+    ///
+    /// Used by malformed-input tests where the server is allowed to
+    /// EITHER respond with a JSON-RPC error envelope OR close the
+    /// connection — both are spec-legal outcomes.
+    pub async fn assert_clean_shutdown_or_response(
+        &mut self,
+        request_dur: Duration,
+    ) -> Option<String> {
+        let mut buf = String::new();
+        match timeout(request_dur, self.stdout.read_line(&mut buf)).await {
+            Ok(Ok(0)) => None, // EOF — clean close
+            Ok(Ok(_)) => Some(buf),
+            Ok(Err(e)) => panic!(
+                "read error while waiting for response-or-close: {e}\n\
+                 --- captured child stderr ---\n{}",
+                self.captured_stderr(),
+            ),
+            Err(_elapsed) => panic!(
+                "neither response nor close arrived within {request_dur:?}\n\
+                 --- captured child stderr ---\n{}",
+                self.captured_stderr(),
+            ),
+        }
+    }
+```
+
+- [ ] **Step 6: Run Phase 1 tests to confirm no regression**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance
+```
+
+Expected: all 9 tests pass. The refactor in Step 3 is functionally identical to the original.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "test(rimap-server): add concurrent request API and shutdown-or-response helper
+
+send_request_no_wait + recv_until_id buffers out-of-order responses
+in a VecDeque so concurrent in-flight requests are observable
+deterministically. assert_clean_shutdown_or_response codifies the
+probe-first 'either valid envelope or clean close' contract for
+malformed-input tests. The notification-skip loop is extracted into
+a shared read_one_envelope helper. Prerequisite for #266 Phase 4."
+```
+
+---
+
+## Task 3: `mcp_wire_negative.rs` — malformed-input tests
+
+**Files:**
+- Create: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Five tests that exercise the server with unparseable JSON, invalid JSON-RPC envelopes, missing/wrong-type fields, and an oversized payload. Each test follows the probe-first pattern: run the test once with a placeholder assertion, observe the actual server behavior, then encode the observed behavior as the assertion with an inline comment documenting the probe date and rmcp version.
+
+- [ ] **Step 1: Create the file scaffold**
+
+```rust
+//! MCP wire-shape negative-path tests (issue #266, Phase 4).
+//!
+//! Targeted negative cases that complement the property-based
+//! coverage in `mcp_wire_proptest.rs`. Each test follows the
+//! probe-first contract documented in
+//! `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
+//! §4.1: every test asserts either a specific JSON-RPC error
+//! envelope shape OR a clean stdin shutdown — never just
+//! "didn't crash."
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use support::wire::{Harness, REQUEST_TIMEOUT, assert_envelope_valid};
+```
+
+Note: `REQUEST_TIMEOUT` and `assert_envelope_valid` may need re-exporting from `support/wire/mod.rs`. Check the current re-exports and add any missing ones.
+
+- [ ] **Step 2: Re-export `REQUEST_TIMEOUT` and `assert_envelope_valid` from the wire module**
+
+In `crates/rimap-server/tests/support/wire/mod.rs`, ensure both are public. The current file content is short; if either is missing from the re-exports, add it:
+
+```rust
+pub use harness::{Harness, PINNED_PROTOCOL_VERSION, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT};
+pub use schema::{assert_envelope_valid, assert_valid, validator_for, validator_for_tool_response};
+```
+
+Then run `cargo check -p rimap-server --tests` to confirm exports compile.
+
+- [ ] **Step 3: Write `unparsable_json_errors_or_closes`**
+
+Append to `mcp_wire_negative.rs`:
+
+```rust
+/// Send unparseable bytes. Server MUST either return a JSON-RPC
+/// parse error (-32700) or cleanly close stdin. Either is
+/// spec-legal; the test pins whichever behavior rmcp actually
+/// implements so a future regression to the third option (hang,
+/// panic, malformed line) trips the assertion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unparsable_json_errors_or_closes() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    harness.send_line("not json").await;
+
+    let outcome = harness
+        .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
+        .await;
+    match outcome {
+        // Probed 2026-05-13 (rmcp 1.5): RECORD THE ACTUAL BEHAVIOR
+        // HERE after running this test the first time. The test should
+        // then pin whichever branch fired and panic on the other.
+        Some(line) => {
+            let env: Value = serde_json::from_str(line.trim_end())
+                .expect("server response must be valid JSON");
+            assert_envelope_valid(&env);
+            assert!(
+                env.get("error").is_some(),
+                "expected error envelope for unparseable input, got {env}",
+            );
+            // -32700 is the JSON-RPC parse-error code. If rmcp emits
+            // something else (e.g. -32600 invalid-request), update
+            // this assertion and document why.
+            assert_eq!(
+                env["error"]["code"],
+                json!(-32700),
+                "expected parse error code -32700, got {env}",
+            );
+        }
+        None => {
+            // Clean close is also spec-legal. If the probe says the
+            // server closes here, replace the Some(...) branch above
+            // with `panic!("expected clean close, got response: {line}")`.
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to observe actual server behavior**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative -- unparsable_json_errors_or_closes --nocapture
+```
+
+Expected: one of three outcomes:
+- **Test passes** with the `Some` branch firing → the server emits an error envelope. Note this in the inline comment: "Probed 2026-05-13: rmcp returns -32700 with message ..."
+- **Test fails** in the `Some` branch because the code is different (e.g., -32600) → update the assertion to the observed code and document.
+- **Test passes** with the `None` branch firing → the server closed cleanly. Replace the `Some` branch body with a panic: this test now pins clean-close behavior.
+
+Document the choice with an inline comment. After updating, re-run to confirm the test passes deterministically.
+
+- [ ] **Step 5: Write `valid_json_invalid_envelope_returns_minus_32600`**
+
+Append:
+
+```rust
+/// Send a JSON object that parses but lacks JSON-RPC fields. Server
+/// MUST respond with -32600 invalid request. Tighter contract than
+/// the unparseable case because the input is syntactically valid
+/// JSON; the only reason to reject it is the JSON-RPC envelope
+/// shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn valid_json_invalid_envelope_returns_minus_32600() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    harness.send_line(r#"{"foo":"bar"}"#).await;
+
+    let line = harness
+        .recv_line_within(REQUEST_TIMEOUT)
+        .await
+        .expect("server must respond to syntactically-valid JSON");
+    let env: Value = serde_json::from_str(line.trim_end())
+        .expect("server response must be valid JSON");
+    assert_envelope_valid(&env);
+    assert!(
+        env.get("error").is_some(),
+        "expected error envelope for invalid JSON-RPC, got {env}",
+    );
+    // Probed 2026-05-13 (rmcp 1.5): rmcp emits -32600 for envelopes
+    // missing required fields. If this drifts (e.g. -32700 because
+    // the parser is permissive), update the assertion.
+    assert_eq!(
+        env["error"]["code"],
+        json!(-32600),
+        "expected invalid-request code -32600, got {env}",
+    );
+}
+```
+
+- [ ] **Step 6: Write `missing_method_field`**
+
+Append:
+
+```rust
+/// Envelope with `jsonrpc` and `id` but no `method`. Same expected
+/// outcome as the previous test (-32600).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_method_field() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    harness
+        .send_line(r#"{"jsonrpc":"2.0","id":1,"params":{}}"#)
+        .await;
+
+    let line = harness
+        .recv_line_within(REQUEST_TIMEOUT)
+        .await
+        .expect("server must respond to envelope missing method");
+    let env: Value = serde_json::from_str(line.trim_end())
+        .expect("server response must be valid JSON");
+    assert_envelope_valid(&env);
+    assert_eq!(
+        env["error"]["code"],
+        json!(-32600),
+        "missing method must produce invalid-request, got {env}",
+    );
+}
+```
+
+- [ ] **Step 7: Write `wrong_type_method_field`**
+
+Append:
+
+```rust
+/// Envelope with `method` set to an integer instead of a string.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_type_method_field() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    harness
+        .send_line(r#"{"jsonrpc":"2.0","id":1,"method":42,"params":{}}"#)
+        .await;
+
+    let line = harness
+        .recv_line_within(REQUEST_TIMEOUT)
+        .await
+        .expect("server must respond to method-of-wrong-type");
+    let env: Value = serde_json::from_str(line.trim_end())
+        .expect("server response must be valid JSON");
+    assert_envelope_valid(&env);
+    assert_eq!(
+        env["error"]["code"],
+        json!(-32600),
+        "wrong-type method must produce invalid-request, got {env}",
+    );
+}
+```
+
+- [ ] **Step 8: Write `oversized_params_payload`**
+
+Append:
+
+```rust
+/// Send `tools/list` with a 1 MiB `note` field in `params`. The
+/// payload is well-formed JSON-RPC but huge. Server must either
+/// answer with a valid envelope (success ignoring the unknown
+/// field, or error) or cleanly close — but it MUST NOT hang past
+/// REQUEST_TIMEOUT.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oversized_params_payload() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let big = "x".repeat(1024 * 1024);
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": 999,
+        "method": "tools/list",
+        "params": { "note": big },
+    });
+    harness.send_line(&payload.to_string()).await;
+
+    let outcome = harness
+        .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
+        .await;
+    if let Some(line) = outcome {
+        let env: Value = serde_json::from_str(line.trim_end())
+            .expect("server response must be valid JSON");
+        assert_envelope_valid(&env);
+        // Either a successful tools/list response or an error
+        // envelope is acceptable; both are well-formed.
+    }
+    // None outcome (clean close) is also acceptable per the
+    // probe-first contract.
+}
+```
+
+- [ ] **Step 9: Run all five tests**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative
+```
+
+Expected: all five pass after the probe-and-encode pass on Step 4. If any test reveals a real bug (panic in the server, hang, malformed line), STOP — file a separate issue, fix on a sibling branch, and only continue with this task after the fix lands. Per the spec §5 and the issue's acceptance criteria.
+
+- [ ] **Step 10: Run clippy on the new file**
+
+```bash
+cargo clippy -p rimap-server --tests -- -D warnings
+```
+
+Expected: no warnings. The file allows `expect_used` and `panic` at the top per the existing pattern; if clippy flags anything else, fix it in place.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs \
+        crates/rimap-server/tests/support/wire/mod.rs
+git commit -m "test(rimap-server): negative-path tests for malformed MCP envelopes (#266)
+
+Five tests covering unparseable JSON, invalid JSON-RPC envelopes,
+missing/wrong-type method field, and an oversized payload. Each test
+encodes the probed server behavior (rmcp 1.5) with an inline comment
+so future regressions are visible. Phase 4 §4.1 malformed-input row."
+```
+
+---
+
+## Task 4: `mcp_wire_negative.rs` — protocol-state tests
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Three tests that exercise MCP protocol-state errors: double-initialize, `tools/list` before initialize, and unsupported protocol version.
+
+- [ ] **Step 1: Write `initialize_after_already_initialized`**
+
+Append to `mcp_wire_negative.rs`:
+
+```rust
+/// After a successful `initialize`, a second `initialize` request
+/// must be rejected. Spec says only one initialize per session.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_after_already_initialized() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    // Send a SECOND initialize. The harness's `request` helper
+    // would auto-increment ids; we use it directly because the
+    // response is still a normal JSON-RPC error envelope.
+    let response = harness
+        .request(
+            "initialize",
+            json!({
+                "protocolVersion": support::wire::PINNED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    assert!(
+        response.get("error").is_some(),
+        "second initialize must error, got {response}",
+    );
+    // Probed 2026-05-13 (rmcp 1.5): RECORD ACTUAL CODE HERE on
+    // first run. Common candidates: -32600 (invalid request),
+    // -32603 (internal), or a rmcp-specific code. Update the
+    // assertion to whichever fires.
+    let code = &response["error"]["code"];
+    assert!(
+        code.is_i64(),
+        "error code must be an integer per JSON-RPC, got {response}",
+    );
+}
+```
+
+- [ ] **Step 2: Write `tools_list_before_initialize`**
+
+Append:
+
+```rust
+/// `tools/list` before `initialize` must error. Server is in the
+/// "uninitialized" state and cannot answer protocol-level requests
+/// until handshake completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize() {
+    let mut harness = Harness::spawn().await;
+    // Deliberately skip initialize_handshake.
+
+    let response = harness.request("tools/list", json!({})).await;
+
+    assert!(
+        response.get("error").is_some(),
+        "tools/list before initialize must error, got {response}",
+    );
+    // Probed 2026-05-13 (rmcp 1.5): RECORD ACTUAL CODE HERE.
+    let code = &response["error"]["code"];
+    assert!(
+        code.is_i64(),
+        "error code must be an integer per JSON-RPC, got {response}",
+    );
+}
+```
+
+- [ ] **Step 3: Write `initialize_unsupported_protocol_version`**
+
+Append:
+
+```rust
+/// Client requests a protocol version the server doesn't support.
+/// Spec allows TWO behaviors: server may echo its own supported
+/// version (counter-proposal), or server may return an error
+/// envelope. Both are spec-legal; the test pins whichever rmcp
+/// actually does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_unsupported_protocol_version() {
+    let mut harness = Harness::spawn().await;
+
+    let response = harness
+        .request(
+            "initialize",
+            json!({
+                "protocolVersion": "1999-01-01",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    if let Some(error) = response.get("error") {
+        // Error path. Pin to whatever code rmcp emits.
+        let code = &error["code"];
+        assert!(
+            code.is_i64(),
+            "error code must be an integer per JSON-RPC, got {response}",
+        );
+    } else {
+        // Counter-proposal path. The server's response must include
+        // the actual supported version, NOT echo the client's bad
+        // version.
+        let version = response["result"]["protocolVersion"]
+            .as_str()
+            .expect("protocolVersion must be a string");
+        assert_ne!(
+            version, "1999-01-01",
+            "server must not echo the unsupported version back",
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Probe and pin**
+
+Run each new test in isolation to observe behavior:
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative -- initialize_after_already_initialized --nocapture
+cargo test -p rimap-server --test mcp_wire_negative -- tools_list_before_initialize --nocapture
+cargo test -p rimap-server --test mcp_wire_negative -- initialize_unsupported_protocol_version --nocapture
+```
+
+For each test that passes with the integer-code assertion, tighten the assertion to the actual observed code. Document with an inline comment.
+
+- [ ] **Step 5: Run the full file**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative
+```
+
+Expected: all 8 tests (5 from Task 3 + 3 from this task) pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): protocol-state negative tests (#266)
+
+Three tests: double-initialize, tools/list before initialize, and
+unsupported-version negotiation. Each pins probed rmcp behavior with
+an inline comment. Phase 4 §4.1 protocol-state rows."
+```
+
+---
+
+## Task 5: `mcp_wire_negative.rs` — concurrency and adversarial-input
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Two tests: deterministic concurrent in-flight requests via `send_request_no_wait` + `recv_until_id`, and a bidi-override character injected into a tool argument.
+
+- [ ] **Step 1: Write `concurrent_tools_list_two_inflight`**
+
+Append:
+
+```rust
+/// Send two `tools/list` requests back-to-back without awaiting
+/// the first response. Both must return well-formed envelopes
+/// within REQUEST_TIMEOUT, with ids matching the requests. Tests
+/// that the server doesn't serialize stdout writes in a way that
+/// corrupts responses, and that the harness's id-buffering works.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_tools_list_two_inflight() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let id_a = harness
+        .send_request_no_wait("tools/list", json!({}))
+        .await;
+    let id_b = harness
+        .send_request_no_wait("tools/list", json!({}))
+        .await;
+
+    // Await in the OPPOSITE order from send to exercise the
+    // out-of-order buffering path in recv_until_id.
+    let response_b = harness.recv_until_id(id_b).await;
+    let response_a = harness.recv_until_id(id_a).await;
+
+    assert_eq!(response_a["id"], json!(id_a));
+    assert_eq!(response_b["id"], json!(id_b));
+    assert!(response_a["result"].is_object(), "id_a must succeed");
+    assert!(response_b["result"].is_object(), "id_b must succeed");
+}
+```
+
+- [ ] **Step 2: Write `bidi_override_in_tool_argument`**
+
+Append:
+
+```rust
+/// Inject a Unicode bidi-override character (U+202E RIGHT-TO-LEFT
+/// OVERRIDE) into a tool argument. Server must either accept and
+/// process the call (returning an error envelope because no
+/// account named that exists in the zero-account config) or
+/// reject with a validation error. Either way: no panic in the
+/// argument-redactor or audit writer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bidi_override_in_tool_argument() {
+    let mut harness = Harness::spawn().await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "use_account",
+                "arguments": { "account": "foo\u{202E}bar" },
+            }),
+        )
+        .await;
+
+    // The contract here is "server didn't panic and returned a
+    // well-formed envelope" — the schema validation inside
+    // `request` already enforces that. Additionally assert the
+    // call was rejected (no account exists with that name).
+    assert!(
+        response.get("error").is_some()
+            || response["result"]["isError"].as_bool() == Some(true),
+        "use_account with non-existent account must fail, got {response}",
+    );
+}
+```
+
+- [ ] **Step 3: Run and probe**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative -- concurrent_tools_list_two_inflight bidi_override_in_tool_argument --nocapture
+```
+
+Expected: both pass. If the bidi test reveals a panic in the audit writer's argument redaction path, STOP and file an issue per the spec's bug-discovery policy.
+
+- [ ] **Step 4: Run the full file**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative
+```
+
+Expected: all 10 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): concurrent and adversarial-input negative tests (#266)
+
+Two tests: two tools/list calls in flight at once (exercises the
+send_request_no_wait / recv_until_id buffering path), and a bidi-
+override character injected into a use_account argument (exercises
+the audit-redaction path against adversarial Unicode). Phase 4 §4.1
+concurrency + adversarial rows."
+```
+
+---
+
+## Task 6: `mcp_wire_proptest.rs` — restart-on-close helper + property 2 (unknown tool)
+
+**Files:**
+- Create: `crates/rimap-server/tests/mcp_wire_proptest.rs`
+- Modify: `crates/rimap-server/Cargo.toml` (add `proptest` to `[dev-dependencies]` if not already there)
+
+Property 2 is the simplest of the three: every case is `tools/call <random name>` with arbitrary arguments, and every response must be an error envelope. This task also establishes the shared infrastructure (restart-on-close helper) used by all three properties.
+
+- [ ] **Step 1: Verify proptest dev-dep wiring for `rimap-server`**
+
+Check `crates/rimap-server/Cargo.toml`:
+
+```bash
+grep -n "proptest" crates/rimap-server/Cargo.toml
+```
+
+If not present, add to `[dev-dependencies]`:
+
+```toml
+proptest = { workspace = true }
+```
+
+Run `cargo check -p rimap-server --tests` to confirm.
+
+- [ ] **Step 2: Create the file scaffold with the restart-on-close helper**
+
+Create `crates/rimap-server/tests/mcp_wire_proptest.rs`:
+
+```rust
+//! MCP wire-shape property tests (issue #266, Phase 4).
+//!
+//! Three proptest properties driving the production
+//! `rusty-imap-mcp` binary with arbitrary JSON-RPC envelopes and
+//! tool-call arguments. Default ≥1000 cases per property; nightly
+//! runs scale via `PROPTEST_CASES`.
+//!
+//! Session-isolation discipline (§3.2 of the design doc):
+//! - The harness is shared across cases for speed.
+//! - `with_live_harness` restarts the harness if a case closed the
+//!   connection, so cases never run against a poisoned session.
+//! - Property 1's strategy excludes the pinned state-mutating
+//!   method set so cases stay independent of MCP session state.
+//!
+//! Property strategy notes inline. See
+//! `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
+//! for the full design context.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+use serde_json::{Value, json};
+
+use support::wire::{Harness, REQUEST_TIMEOUT, assert_envelope_valid};
+
+/// Run `body` against a harness, restarting the harness if the
+/// previous case closed the connection. Returns the (possibly new)
+/// harness so the caller can keep using it. The "is alive" check is
+/// done by sending a no-op `tools/list` and timing out fast; if it
+/// hangs or the child exited, a fresh harness is spawned.
+async fn with_live_harness<F, Fut>(mut h: Option<Harness>, body: F) -> Harness
+where
+    F: FnOnce(Harness) -> Fut,
+    Fut: std::future::Future<Output = Harness>,
+{
+    if h.is_none() || !is_alive(h.as_mut().expect("checked is_none above")).await {
+        let mut fresh = Harness::spawn().await;
+        let _ = fresh.initialize_handshake().await;
+        fresh.send_initialized().await;
+        h = Some(fresh);
+    }
+    body(h.expect("ensured Some above")).await
+}
+
+/// Cheap liveness check: poll the child process. Returns true if the
+/// child is still running. False if it has exited or polling failed.
+async fn is_alive(h: &mut Harness) -> bool {
+    // This accessor is added below for visibility into child status.
+    h.child_is_running()
+}
+```
+
+- [ ] **Step 3: Add the `child_is_running` accessor on `Harness`**
+
+In `crates/rimap-server/tests/support/wire/harness.rs`, add this method right after `captured_stderr`:
+
+```rust
+    /// Returns true if the child process is still running (i.e.
+    /// `try_wait` reports no exit yet). Used by the proptest
+    /// restart-on-close discipline to detect a poisoned session
+    /// cheaply, without sending a probing request.
+    pub fn child_is_running(&mut self) -> bool {
+        match self.child.try_wait() {
+            Ok(None) => true,
+            Ok(Some(_status)) => false,
+            Err(_) => false,
+        }
+    }
+```
+
+Run `cargo check -p rimap-server --tests` to confirm.
+
+- [ ] **Step 4: Write property 2 — `prop_tools_call_unknown_tool`**
+
+Append to `mcp_wire_proptest.rs`:
+
+```rust
+/// Property 2: arbitrary tool name with arbitrary JSON arguments
+/// always produces a JSON-RPC error envelope. Stateless by
+/// construction (every case is `tools/call <X>`; no method that
+/// mutates MCP session state is ever sent).
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    fn prop_tools_call_unknown_tool(
+        tool_name in "[A-Za-z0-9_./-]{1,64}",
+        args in proptest::collection::hash_map(
+            "[A-Za-z0-9_]{1,16}",
+            proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+            0..6,
+        ),
+    ) {
+        // proptest does not natively support async test bodies, so
+        // we build a Tokio runtime per case. Cheap because the
+        // harness is reused inside RUNTIME-scoped state.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        runtime.block_on(async move {
+            let mut harness = HARNESS.lock().await.take();
+            harness = Some(with_live_harness(harness, |mut h| async move {
+                let arguments: serde_json::Map<String, Value> = args
+                    .into_iter()
+                    .map(|(k, v)| (k, v))
+                    .collect();
+                let response = h
+                    .request(
+                        "tools/call",
+                        json!({
+                            "name": tool_name,
+                            "arguments": arguments,
+                        }),
+                    )
+                    .await;
+                // The contract: either a JSON-RPC error envelope, or
+                // a result envelope whose `isError` field is true (the
+                // rmcp/MCP convention for tool-level errors).
+                let is_envelope_error = response.get("error").is_some();
+                let is_tool_error = response["result"]["isError"]
+                    .as_bool()
+                    .unwrap_or(false);
+                assert!(
+                    is_envelope_error || is_tool_error,
+                    "unknown tool {tool_name:?} must produce an error, got {response}",
+                );
+                h
+            }).await);
+            *HARNESS.lock().await = harness;
+        });
+    }
+}
+
+// Process-lifetime harness shared across all proptest cases within
+// one property invocation. Wrapped in tokio::sync::Mutex so cases
+// (which each block on their own runtime) can serialize access.
+// Tokio's Mutex is async; we use `blocking_lock` inside the runtime.
+//
+// NOTE: each property runs sequentially in the proptest macro
+// expansion, so sharing one mutex across properties is fine —
+// they don't overlap.
+static HARNESS: tokio::sync::Mutex<Option<Harness>> = tokio::sync::Mutex::const_new(None);
+```
+
+Note: the harness sharing pattern above is one approach. If the implementer finds a cleaner pattern during step 5 (e.g., a per-property `thread_local!` or a `once_cell::OnceCell`), prefer that. The contract is: cases share a harness, harness restarts if dead. The mechanism is flexible.
+
+- [ ] **Step 5: Run the property to verify it works**
+
+```bash
+PROPTEST_CASES=200 cargo test -p rimap-server --test mcp_wire_proptest -- prop_tools_call_unknown_tool --nocapture
+```
+
+Expected: 200 cases pass. If proptest finds a shrinking case (a specific tool name or args shape that breaks the contract), STOP. Either:
+- It's a real server bug — file separate issue, fix on sibling branch, then commit the `proptest-regressions/` seed with this task.
+- It's a test-strategy bug — adjust the strategy (e.g., the generator produces an arg shape the server interprets as a successful call). Pin the shrunk case with a comment.
+
+- [ ] **Step 6: Scale to 1000 cases for CI baseline**
+
+```bash
+PROPTEST_CASES=1000 cargo test -p rimap-server --test mcp_wire_proptest -- prop_tools_call_unknown_tool
+```
+
+Expected: 1000 cases pass within the CI budget (rough target: under 60s on a developer machine). If runtime is excessive, profile with a smaller case count (`--profile dev`) to see if the bottleneck is harness reuse vs. per-case roundtrip.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_proptest.rs \
+        crates/rimap-server/tests/support/wire/harness.rs \
+        crates/rimap-server/Cargo.toml
+git commit -m "test(rimap-server): property 2 — unknown-tool fuzz (#266)
+
+Adds mcp_wire_proptest.rs with the restart-on-close discipline
+(child_is_running accessor + with_live_harness helper) and the
+simplest of the three properties: arbitrary tools/call invocations
+must always produce an error envelope. PROPTEST_CASES env var
+controls the case count. Phase 4 §4.2 property 2."
+```
+
+---
+
+## Task 7: `mcp_wire_proptest.rs` — property 3 (`use_account` argument shape)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_proptest.rs`
+
+Property 3 reuses the same shared harness and restart-on-close discipline as property 2 but constrains the method to `tools/call use_account` with arbitrary argument shapes. With zero accounts configured, every call must fail; the strategy explores argument-shape edge cases (missing fields, wrong types, unicode).
+
+- [ ] **Step 1: Write the property**
+
+Append to `mcp_wire_proptest.rs`:
+
+```rust
+/// Property 3: `use_account` with arbitrary argument shapes. With
+/// zero accounts configured (the harness's default), every call
+/// MUST fail. Stateless by construction.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    fn prop_tools_call_use_account_argument_shape(
+        // Arbitrary JSON values for `arguments`. The strategy
+        // intentionally produces both well-formed-but-wrong shapes
+        // (e.g. `{"account": 42}`) and shapes that look right
+        // (e.g. `{"account": "foo"}`) — the server must reject all
+        // of them because no accounts are configured.
+        arguments in arb_arguments(),
+    ) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        runtime.block_on(async move {
+            let mut harness = HARNESS.lock().await.take();
+            harness = Some(with_live_harness(harness, |mut h| async move {
+                let response = h
+                    .request(
+                        "tools/call",
+                        json!({
+                            "name": "use_account",
+                            "arguments": arguments,
+                        }),
+                    )
+                    .await;
+                let is_envelope_error = response.get("error").is_some();
+                let is_tool_error = response["result"]["isError"]
+                    .as_bool()
+                    .unwrap_or(false);
+                assert!(
+                    is_envelope_error || is_tool_error,
+                    "use_account with arbitrary args must fail (no accounts configured), got {response}",
+                );
+                h
+            }).await);
+            *HARNESS.lock().await = harness;
+        });
+    }
+}
+
+/// Build an arbitrary `arguments` map. Mixes:
+/// - Well-formed argument names (`account`, `name`, etc.) with
+///   wrong value types
+/// - Random argument names with random values
+/// - Empty maps
+fn arb_arguments() -> impl Strategy<Value = Value> {
+    let well_formed_keys = prop_oneof![
+        Just("account".to_string()),
+        Just("name".to_string()),
+        Just("id".to_string()),
+        "[a-z]{1,16}".prop_map(String::from),
+    ];
+    let any_value = prop_oneof![
+        Just(json!(null)),
+        proptest::arbitrary::any::<bool>().prop_map(|b| json!(b)),
+        proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+        "[\\PC]{0,64}".prop_map(|s| json!(s)),  // arbitrary printable Unicode
+    ];
+    proptest::collection::hash_map(well_formed_keys, any_value, 0..6)
+        .prop_map(|m| {
+            let obj: serde_json::Map<String, Value> = m.into_iter().collect();
+            Value::Object(obj)
+        })
+}
+```
+
+- [ ] **Step 2: Run the property**
+
+```bash
+PROPTEST_CASES=200 cargo test -p rimap-server --test mcp_wire_proptest -- prop_tools_call_use_account_argument_shape --nocapture
+```
+
+Expected: 200 cases pass. If any case unexpectedly succeeds (e.g., the server has a code path that creates an account on the fly), investigate before committing.
+
+- [ ] **Step 3: Scale and commit**
+
+```bash
+PROPTEST_CASES=1000 cargo test -p rimap-server --test mcp_wire_proptest -- prop_tools_call_use_account_argument_shape
+git add crates/rimap-server/tests/mcp_wire_proptest.rs
+git commit -m "test(rimap-server): property 3 — use_account argument-shape fuzz (#266)
+
+Arbitrary JSON argument shapes for use_account against the zero-
+account config; every call must fail. Phase 4 §4.2 property 3."
+```
+
+---
+
+## Task 8: `mcp_wire_proptest.rs` — property 1 (envelope never panics)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_proptest.rs`
+
+Property 1 is the most aggressive: arbitrary JSON envelopes, including arbitrary `method` values, sent to the server. The strategy excludes the pinned state-mutating set so cases stay independent. Contract: server either emits a well-formed JSON-RPC envelope or cleanly closes the connection.
+
+- [ ] **Step 1: Define the state-mutating method exclusion set**
+
+Append to `mcp_wire_proptest.rs` near the top (before the property blocks):
+
+```rust
+/// Methods that mutate MCP session state. The property-1 strategy
+/// MUST NOT generate these as the `method` field, since they would
+/// couple subsequent cases to earlier ones (poisoning the shared
+/// harness). The set is pinned here AND asserted against rmcp's
+/// known stateful surface in `assert_exclusion_set_matches_rmcp`
+/// below — that assertion is the regression net that catches a
+/// future MCP spec addition introducing a new stateful method.
+const STATE_MUTATING_METHODS: &[&str] = &[
+    "initialize",
+    "notifications/initialized",
+];
+
+#[test]
+fn assert_exclusion_set_matches_rmcp() {
+    // rmcp 1.5 documents stateful protocol methods at:
+    //   rmcp::model::ProtocolVersion docs + Initialize/Initialized
+    //   in rmcp::model::request.
+    //
+    // If a future rmcp version adds a new stateful method (e.g.
+    // `session/reset`), this assertion is the place to update — and
+    // STATE_MUTATING_METHODS above must be updated in lockstep, or
+    // property 1 starts coupling cases.
+    //
+    // This test is a sentinel — it doesn't introspect rmcp at runtime
+    // because rmcp's request enum is sealed. Instead, the maintainer
+    // updates BOTH sides of the pair (this constant and the rmcp dep)
+    // together. Bumping rmcp without inspecting this list trips a
+    // human review checkpoint via this comment.
+    let expected = ["initialize", "notifications/initialized"];
+    let actual: Vec<&str> = STATE_MUTATING_METHODS.iter().copied().collect();
+    assert_eq!(actual, expected.to_vec());
+}
+```
+
+- [ ] **Step 2: Write the strategy generator**
+
+Append:
+
+```rust
+/// Build an arbitrary JSON-RPC-ish envelope. Each field is
+/// optionally present and may be of a wrong type. The `method`
+/// field, when present, is drawn from a set that EXCLUDES
+/// state-mutating methods to keep cases independent.
+fn arb_envelope() -> impl Strategy<Value = Value> {
+    let arb_method = prop_oneof![
+        // Known stateless methods
+        Just("tools/list".to_string()),
+        Just("tools/call".to_string()),
+        Just("resources/list".to_string()),
+        Just("ping".to_string()),
+        // Unknown methods (still stateless; the server returns
+        // method-not-found without touching session state)
+        "[a-z/]{1,32}".prop_map(String::from),
+    ]
+    .prop_filter(
+        "exclude state-mutating methods",
+        |m: &String| !STATE_MUTATING_METHODS.contains(&m.as_str()),
+    );
+
+    let arb_id = prop_oneof![
+        Just(json!(null)),
+        proptest::arbitrary::any::<u32>().prop_map(|n| json!(n)),
+        "[a-z0-9]{1,8}".prop_map(|s| json!(s)),  // string id — also legal JSON-RPC
+    ];
+
+    let arb_params = prop_oneof![
+        Just(json!({})),
+        Just(json!(null)),
+        proptest::arbitrary::any::<i64>().prop_map(|n| json!(n)),
+        "[\\PC]{0,32}".prop_map(|s| json!(s)),
+    ];
+
+    (
+        prop::option::of(Just("2.0".to_string())),
+        prop::option::of(arb_id),
+        prop::option::of(arb_method),
+        prop::option::of(arb_params),
+    )
+        .prop_map(|(jsonrpc, id, method, params)| {
+            let mut obj = serde_json::Map::new();
+            if let Some(v) = jsonrpc {
+                obj.insert("jsonrpc".to_string(), json!(v));
+            }
+            if let Some(v) = id {
+                obj.insert("id".to_string(), v);
+            }
+            if let Some(v) = method {
+                obj.insert("method".to_string(), json!(v));
+            }
+            if let Some(v) = params {
+                obj.insert("params".to_string(), v);
+            }
+            Value::Object(obj)
+        })
+}
+```
+
+- [ ] **Step 3: Write the property**
+
+Append:
+
+```rust
+/// Property 1: arbitrary JSON-RPC-ish envelopes never panic the
+/// server. Either the server emits a well-formed envelope (success
+/// or error) or it cleanly closes the connection.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(
+        std::env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000)
+    ))]
+
+    #[test]
+    fn prop_envelope_never_panics(envelope in arb_envelope()) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        runtime.block_on(async move {
+            let mut harness = HARNESS.lock().await.take();
+            harness = Some(with_live_harness(harness, |mut h| async move {
+                h.send_line(&envelope.to_string()).await;
+                let outcome = h
+                    .assert_clean_shutdown_or_response(REQUEST_TIMEOUT)
+                    .await;
+                if let Some(line) = outcome {
+                    let env: Value = serde_json::from_str(line.trim_end())
+                        .expect("server response must be valid JSON");
+                    assert_envelope_valid(&env);
+                }
+                // None outcome (clean close) is also acceptable. The
+                // restart-on-close discipline will spawn a fresh
+                // harness for the next case.
+                h
+            }).await);
+            *HARNESS.lock().await = harness;
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run the property**
+
+```bash
+PROPTEST_CASES=200 cargo test -p rimap-server --test mcp_wire_proptest -- prop_envelope_never_panics --nocapture
+```
+
+Expected: 200 cases pass. The runtime here is dominated by the harness restart-on-close path; if `assert_clean_shutdown_or_response` is timing out, the test is much slower than the others. If runtime is excessive, profile and consider reducing REQUEST_TIMEOUT for this property only.
+
+If a case shrinks to a panic, STOP — this is exactly the bug-discovery scenario the spec anticipates. File a separate issue, fix on a sibling branch, commit the `proptest-regressions/` seed with this task.
+
+- [ ] **Step 5: Run all three properties together**
+
+```bash
+PROPTEST_CASES=1000 cargo test -p rimap-server --test mcp_wire_proptest
+```
+
+Expected: all three properties pass at 1000 cases each. The `assert_exclusion_set_matches_rmcp` sentinel test also passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_proptest.rs
+# Also stage the regressions dir if any shrunk cases were committed:
+git add crates/rimap-server/tests/proptest-regressions/ 2>/dev/null || true
+git commit -m "test(rimap-server): property 1 — envelope never panics (#266)
+
+Arbitrary JSON-RPC-ish envelopes excluding the pinned state-mutating
+method set ({initialize, notifications/initialized}). Server must
+either emit a well-formed envelope or cleanly close the connection.
+A sentinel test pins the exclusion set against rmcp's stateful
+surface; bumping rmcp without updating the set trips a human review
+checkpoint. Phase 4 §4.2 property 1."
+```
+
+---
+
+## Task 9: Cancellation contract — verify Drop coverage, add wire-layer test
+
+**Files:**
+- Verify (no change): `crates/rimap-server/src/mcp/audit_envelope.rs` (existing tests)
+- Create: `crates/rimap-server/tests/e2e_wire_cancellation.rs`
+
+The audit-layer Drop contract is already pinned by the in-process tests at `crates/rimap-server/src/mcp/audit_envelope.rs:296-382` (`dropped_guard_enqueues_cancellation_record` and `disarmed_guard_does_not_enqueue`). These tests cover the exact contract that the spec's `drop_emits_cancelled.rs` test would have introduced, so we don't add a redundant test. The wire-layer test in `e2e_wire_cancellation.rs` asserts only race-free invariants.
+
+- [ ] **Step 1: Confirm existing audit Drop coverage**
+
+```bash
+cargo test -p rimap-server --lib audit_envelope::tests
+```
+
+Expected: both `dropped_guard_enqueues_cancellation_record` and `disarmed_guard_does_not_enqueue` pass. If they don't, STOP — the project's invariant from #71/#99 is broken and must be fixed before Phase 4 lands.
+
+Note in your scratch notes: "Audit-layer Drop contract verified via existing tests; new file `drop_emits_cancelled.rs` is not added per spec §4.4.2 lookup."
+
+- [ ] **Step 2: Create the wire-layer cancellation test file**
+
+Read the existing `crates/rimap-server/tests/e2e_wire.rs` to understand the Dovecot-harness pattern, including how it spawns the binary with a real account config, drives `use_account`, etc.
+
+Create `crates/rimap-server/tests/e2e_wire_cancellation.rs`:
+
+```rust
+//! Wire-layer cancellation acceptance (issue #266, Phase 4).
+//!
+//! Race-free assertions only. The audit-layer Drop contract from
+//! #71/#99 (tool_end {status: cancelled} on Drop) is pinned by the
+//! in-process tests at crates/rimap-server/src/mcp/audit_envelope.rs.
+//! This file only asserts that the server accepts
+//! `notifications/cancelled` without crashing and remains
+//! responsive afterwards.
+//!
+//! See docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md §4.4.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use serde_json::json;
+
+use support::wire::Harness;
+```
+
+- [ ] **Step 3: Add the Dovecot-backed setup helper**
+
+The implementer must check `e2e_wire.rs` for the exact Dovecot harness invocation pattern. The pattern is approximately:
+
+```rust
+/// Spawn the binary against a Dovecot-backed config and complete the
+/// MCP handshake. The harness returned has `use_account` already
+/// called against the `draftsafe` test account so subsequent
+/// `tools/call search` works.
+async fn spawn_with_dovecot() -> Harness {
+    let dovecot = support::dovecot::Harness::try_start()
+        .expect("Dovecot harness must start (Docker required)");
+    // ...build a config TOML referencing dovecot.port() and the
+    //    fingerprint; this is the same pattern as e2e_wire.rs.
+    //    Copy it verbatim if possible to minimize drift.
+    todo!("copy Dovecot config setup from e2e_wire.rs")
+}
+```
+
+When implementing this, copy the exact pattern from `e2e_wire.rs` rather than reinventing it. The plan is intentionally not prescribing the exact bytes here because the Dovecot harness API may have evolved between Phase 3 and Phase 4; the implementer should mirror the latest pattern.
+
+- [ ] **Step 4: Write `cancel_during_inflight_tools_call_keeps_session_alive`**
+
+Append:
+
+```rust
+/// Send a `tools/call search` then immediately a
+/// `notifications/cancelled` for that request id. The server must
+/// produce ONE response envelope for the cancelled id (race-
+/// dependent: result OR error) and remain responsive to a
+/// follow-up `tools/list`. No panic, no envelope corruption.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_during_inflight_tools_call_keeps_session_alive() {
+    let mut harness = spawn_with_dovecot().await;
+
+    let search_id = harness
+        .send_request_no_wait(
+            "tools/call",
+            json!({
+                "name": "draftsafe.search",
+                "arguments": { "folder": "INBOX", "criteria": "ALL" },
+            }),
+        )
+        .await;
+    // Send cancellation immediately. JSON-RPC notifications have no id.
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({ "requestId": search_id, "reason": "test cancel" }),
+        )
+        .await;
+
+    // Drain the response to the search id. Either a success result
+    // or an error envelope is acceptable — both are race-dependent
+    // and both prove the server didn't crash.
+    let response = harness.recv_until_id(search_id).await;
+    assert_eq!(response["id"], json!(search_id));
+    assert!(
+        response.get("result").is_some() || response.get("error").is_some(),
+        "expected result or error envelope, got {response}",
+    );
+
+    // Follow-up tools/list must still succeed — the server is
+    // responsive after handling the cancellation.
+    let list = harness.request("tools/list", json!({})).await;
+    assert!(
+        list["result"].is_object(),
+        "server must remain responsive after cancellation, got {list}",
+    );
+}
+```
+
+- [ ] **Step 5: Write `cancel_unknown_request_id_is_noop`**
+
+Append:
+
+```rust
+/// `notifications/cancelled` for an id that was never used. Server
+/// must accept silently, not respond, and remain responsive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_unknown_request_id_is_noop() {
+    let mut harness = spawn_with_dovecot().await;
+
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({ "requestId": 999_999, "reason": "test cancel unknown" }),
+        )
+        .await;
+
+    // Asserts no response within a tight window: the server must
+    // NOT echo or error on an unknown-id cancellation.
+    harness
+        .assert_no_response_within(std::time::Duration::from_millis(200))
+        .await;
+
+    // Server still responsive.
+    let list = harness.request("tools/list", json!({})).await;
+    assert!(
+        list["result"].is_object(),
+        "server must remain responsive after no-op cancellation, got {list}",
+    );
+}
+```
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+cargo test -p rimap-server --test e2e_wire_cancellation
+```
+
+Expected: both tests pass. If the Dovecot harness fails to start (Docker not running), the harness's `try_start` should produce a clear error; document the local-dev requirement.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/tests/e2e_wire_cancellation.rs
+git commit -m "test(rimap-server): wire-layer cancellation acceptance (#266)
+
+Two race-free tests: cancel an in-flight tools/call and verify the
+session remains responsive; cancel an unknown request id and verify
+the server treats it as a no-op. The audit-layer Drop contract from
+#71/#99 is already pinned by the in-process tests in
+mcp/audit_envelope.rs, so this file does not duplicate that
+coverage. Phase 4 §4.4."
+```
+
+---
+
+## Task 10: Test-support env-var hook + `mcp_audit_failure.rs`
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs` (add a `test-support`-gated env-var that calls `force_next_write_failure` at startup)
+- Create: `crates/rimap-server/tests/mcp_audit_failure.rs`
+
+The wire-level audit-failure tests need a way to arm `AuditWriter::force_next_write_failure()` from outside the server process. We add a tiny `test-support`-gated env-var that the binary reads at startup and, if set, calls `force_next_write_failure()` on its `AuditWriter` exactly once before serving any requests.
+
+- [ ] **Step 1: Locate the AuditWriter construction in `main.rs`**
+
+```bash
+grep -n "AuditWriter::open\|AuditWriter::new\|AuditWriter\\b" crates/rimap-server/src/main.rs crates/rimap-server/src/lib.rs 2>/dev/null
+```
+
+Identify the function where the `AuditWriter` is constructed. The test-support hook will live immediately after that construction. The exact location depends on the current code layout; the typical pattern is a `setup_audit()` or `build_server()` function called from `main`.
+
+- [ ] **Step 2: Add the env-var hook**
+
+In the file where the `AuditWriter` is constructed (likely `main.rs` or a helper module), immediately after construction add:
+
+```rust
+#[cfg(feature = "test-support")]
+{
+    // RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1 arms the
+    // production AuditWriter's force_next_write_failure() hook
+    // exactly once at startup. Used by mcp_audit_failure.rs to
+    // exercise the real lock/append/error-mapping path without
+    // adding a sentinel sink.
+    //
+    // The hook lives behind `test-support` per the existing
+    // convention (Cargo.toml comment: "code under
+    // cfg(feature = test-support) MUST NOT change wire shape").
+    // This hook changes the audit write OUTCOME, not the wire
+    // shape, so it complies with that constraint.
+    if std::env::var("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        audit_writer.force_next_write_failure();
+    }
+}
+```
+
+Adapt the variable name `audit_writer` to whatever the local binding is called. If the writer is wrapped in an `Arc`, you may need `Arc::as_ref` or similar.
+
+- [ ] **Step 3: Run the existing test suite to ensure no wire shape changed**
+
+```bash
+cargo test -p rimap-server --test mcp_wire_conformance
+```
+
+Expected: all 9 Phase 1 tests pass. The hook is dormant when the env var is unset, so wire shape is unaffected.
+
+- [ ] **Step 4: Create `mcp_audit_failure.rs`**
+
+```rust
+//! Audit fail-closed boundary tests (issue #266, Phase 4 §4.3).
+//!
+//! Arms the production `AuditWriter`'s `force_next_write_failure()`
+//! hook via the `test-support`-gated env var
+//! `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE=1`, then exercises
+//! the wire. The next audit write — `tool_start` for the first
+//! `tools/call` — takes the real lock/append/error-mapping path
+//! and fails. The server must respond with an error envelope
+//! rather than silently proceeding.
+
+#![expect(clippy::expect_used, reason = "integration tests")]
+#![expect(clippy::panic, reason = "test assertions render diagnostics")]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::path::Path;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use support::wire::Harness;
+```
+
+- [ ] **Step 5: Write `audit_write_failure_fails_closed_for_tools_call`**
+
+Append:
+
+```rust
+/// With the audit writer armed for one forced write failure,
+/// `tools/call use_account` must return an error envelope. Tests
+/// the real AuditWriter path (lock/append/error-mapping), not a
+/// swappable sink.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn audit_write_failure_fails_closed_for_tools_call() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = tempdir.path().join("config.toml");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path();
+    let config = format!(
+        r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+fail_open = false
+"#,
+        audit_path.display(),
+        allowed_base.display(),
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let mut harness = Harness::spawn_with_config(
+        &config_path,
+        tempdir,
+        &[("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE", "1")],
+    )
+    .await;
+    let _ = harness.initialize_handshake().await;
+    harness.send_initialized().await;
+
+    let response = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "use_account",
+                "arguments": { "account": "nonexistent" },
+            }),
+        )
+        .await;
+
+    // The contract is "fails closed" — the server must NOT
+    // silently succeed when the audit write fails. The exact
+    // shape (error envelope vs. result envelope with isError=true)
+    // is probed.
+    let is_envelope_error = response.get("error").is_some();
+    let is_tool_error = response["result"]["isError"]
+        .as_bool()
+        .unwrap_or(false);
+    assert!(
+        is_envelope_error || is_tool_error,
+        "tools/call with armed audit-write failure must fail closed, got {response}",
+    );
+}
+```
+
+- [ ] **Step 6: Write `audit_write_failure_does_not_block_initialize`**
+
+Append:
+
+```rust
+/// Initialize handshake must succeed (or fail cleanly) regardless
+/// of audit failure arming. `initialize` doesn't write an audit
+/// record by itself, so this test pins that the env-var hook
+/// doesn't accidentally break the handshake.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn audit_write_failure_does_not_block_initialize() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let config_path = tempdir.path().join("config.toml");
+    let audit_path = tempdir.path().join("audit.jsonl");
+    let allowed_base = tempdir.path();
+    let config = format!(
+        r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+fail_open = false
+"#,
+        audit_path.display(),
+        allowed_base.display(),
+    );
+    std::fs::write(&config_path, config).expect("write config");
+
+    let mut harness = Harness::spawn_with_config(
+        &config_path,
+        tempdir,
+        &[("RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE", "1")],
+    )
+    .await;
+    let response = harness.initialize_handshake().await;
+    // The handshake's result envelope must validate against the
+    // schema (initialize_handshake calls request, which validates).
+    // No additional assertion needed — getting here without a
+    // panic IS the test.
+    assert!(
+        response["result"].is_object(),
+        "initialize must succeed even with audit failure armed, got {response}",
+    );
+}
+```
+
+- [ ] **Step 7: Run both tests**
+
+```bash
+cargo test -p rimap-server --test mcp_audit_failure
+```
+
+Expected: both pass. If `audit_write_failure_fails_closed_for_tools_call` fails because the server silently succeeds, that's a real fail-closed bug in the production code — STOP, file an issue, fix on a sibling branch, return.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs \
+        crates/rimap-server/tests/mcp_audit_failure.rs
+git commit -m "test(rimap-server): audit fail-closed boundary tests (#266)
+
+Adds a test-support-gated env-var hook (RIMAP_TEST_FORCE_NEXT_AUDIT_
+WRITE_FAILURE) that arms AuditWriter::force_next_write_failure() at
+startup, and two tests that exercise the real lock/append/error-
+mapping path: tools/call must fail closed when the audit write
+fails, and initialize must remain unaffected. Phase 4 §4.3, §6.4."
+```
+
+---
+
+## Task 11: Nightly CI workflow + zero-test-run guard
+
+**Files:**
+- Create: `.github/workflows/mcp-fuzz-nightly.yml`
+
+GitHub Actions workflow that runs the proptest binary nightly at `PROPTEST_CASES=100000` and asserts a non-zero test count was actually executed.
+
+- [ ] **Step 1: Look up current pinned SHAs for required actions**
+
+```bash
+grep -rn "actions/checkout\|dtolnay/rust-toolchain\|Swatinem/rust-cache" .github/workflows/ | head -10
+```
+
+Note the current SHAs and version comments. The new workflow must use the same pinned-SHA convention.
+
+- [ ] **Step 2: Create the workflow file**
+
+Create `.github/workflows/mcp-fuzz-nightly.yml`. Use the SHAs from the existing workflows (do not invent new ones):
+
+```yaml
+name: MCP Fuzz Nightly
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak relative to other scheduled jobs.
+    - cron: '17 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: proptest 100k cases
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PROPTEST_CASES: '100000'
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@<PINNED_SHA>  # vN.M.K — replace with the SHA used by ci.yml
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@<PINNED_SHA>  # vN.M.K — replace with the SHA used by ci.yml
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@<PINNED_SHA>  # vN.M.K — replace with the SHA used by ci.yml
+        with:
+          shared-key: mcp-fuzz-nightly
+
+      - name: Run proptest binary at 100k cases
+        id: proptest
+        run: |
+          set -euo pipefail
+          # --test (singular) selects the integration-test binary by name.
+          # --tests (plural) is a "run all integration tests" flag that would
+          # turn 'mcp_wire_proptest' into a name filter and silently run zero
+          # property functions (which are named prop_*). Phase 4 §6.1.
+          OUTPUT=$(cargo test -p rimap-server --test mcp_wire_proptest -- --nocapture 2>&1 | tee /dev/stderr)
+          echo "$OUTPUT" > proptest-output.log
+          # Extract the "running N tests" lines and sum.
+          TESTS_RUN=$(echo "$OUTPUT" | grep -oE 'running [0-9]+ tests?' | awk '{s+=$2} END {print s+0}')
+          echo "tests_run=$TESTS_RUN" >> "$GITHUB_OUTPUT"
+          if [ "$TESTS_RUN" -eq 0 ]; then
+            echo "::error::Zero tests reported as executed. The --test selector likely missed the binary. Phase 4 §6.1 guard."
+            exit 1
+          fi
+          echo "Total tests executed: $TESTS_RUN"
+
+      - name: Upload proptest output on failure
+        if: failure()
+        uses: actions/upload-artifact@<PINNED_SHA>  # vN.M.K — replace with the SHA used by ci.yml
+        with:
+          name: proptest-output
+          path: proptest-output.log
+          retention-days: 7
+```
+
+After substituting the SHAs, verify with `zizmor`:
+
+```bash
+zizmor .github/workflows/mcp-fuzz-nightly.yml
+```
+
+Expected: no findings. If `zizmor` flags anything (e.g., missing `permissions`, dangling pull_request_target), fix in place.
+
+- [ ] **Step 3: Lint with actionlint**
+
+```bash
+actionlint .github/workflows/mcp-fuzz-nightly.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Smoke-test the test-execution count parser locally**
+
+```bash
+PROPTEST_CASES=10 cargo test -p rimap-server --test mcp_wire_proptest -- --nocapture 2>&1 | grep -oE 'running [0-9]+ tests?' | awk '{s+=$2} END {print s+0}'
+```
+
+Expected: a non-zero count (≥4 — the three properties plus the `assert_exclusion_set_matches_rmcp` sentinel). Confirm the awk pipeline matches what the workflow uses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/mcp-fuzz-nightly.yml
+git commit -m "ci: nightly proptest fuzz with zero-test-run guard (#266)
+
+Runs cargo test -p rimap-server --test mcp_wire_proptest at
+PROPTEST_CASES=100000 every night at 03:17 UTC. Includes a guard
+that fails the job if the test runner reports zero tests executed —
+this catches drift in the --test (singular) vs --tests (plural)
+selector that the spec's acceptance criteria depend on. Phase 4
+§6.1, §8."
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** none (verification only)
+
+Run the full suite, lints, and `cargo deny` to confirm nothing regressed.
+
+- [ ] **Step 1: Run the whole rimap-server test suite**
+
+```bash
+cargo test -p rimap-server
+```
+
+Expected: every test passes, including the new Phase 4 binaries and the pre-existing Phase 1/3 binaries. If anything fails, investigate before declaring done.
+
+- [ ] **Step 2: Run the whole workspace test suite**
+
+```bash
+cargo test --workspace
+```
+
+Expected: every test in every crate passes.
+
+- [ ] **Step 3: Run clippy with denied warnings**
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings. Fix anything that surfaces in the new files; never reach for `#[allow]` (per the workspace lints policy that denies `allow_attributes`).
+
+- [ ] **Step 4: Run `cargo fmt --check`**
+
+```bash
+cargo fmt --check
+```
+
+Expected: clean. If anything is unformatted, run `cargo fmt` and amend.
+
+- [ ] **Step 5: Run `cargo deny`**
+
+```bash
+cargo deny check
+```
+
+Expected: no advisories, no license problems, no banned crates. Phase 4 added zero production dependencies, so any new finding should be from a pre-existing transitive dep that drifted.
+
+- [ ] **Step 6: Verify acceptance criteria**
+
+Walk through `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md` §8 and check each box.
+
+Acceptance commands:
+
+```bash
+cargo test -p rimap-server --test mcp_wire_negative
+cargo test -p rimap-server --test mcp_wire_proptest
+cargo test -p rimap-server --test mcp_audit_failure
+cargo test -p rimap-server --test e2e_wire_cancellation
+# (no rimap-audit drop_emits_cancelled test — covered by existing in-crate tests)
+```
+
+Each must report PASS with a non-zero test count.
+
+- [ ] **Step 7: Push and open the PR**
+
+```bash
+git push -u origin feature/issue-266-mcp-fuzzing
+gh pr create --title "test(mcp): Phase 4 — protocol fuzzing and negative-path coverage (#266)" --body "$(cat <<'EOF'
+## Summary
+- Implements Phase 4 of the MCP test plan (#266): malformed-input negative tests, property-based envelope and tool-call fuzzing, wire-layer cancellation acceptance, and audit fail-closed boundary tests.
+- Five new test binaries plus a nightly CI workflow.
+- Design: `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`.
+- Adversarial review applied: `docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md` (this plan).
+
+## Test plan
+- [x] `cargo test -p rimap-server --test mcp_wire_negative`
+- [x] `cargo test -p rimap-server --test mcp_wire_proptest`
+- [x] `cargo test -p rimap-server --test mcp_audit_failure`
+- [x] `cargo test -p rimap-server --test e2e_wire_cancellation` (Dovecot required)
+- [x] `cargo test --workspace`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo deny check`
+- [x] `zizmor .github/workflows/mcp-fuzz-nightly.yml`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: the pre-push hook on this repo runs `just test` and `cargo deny`. The push may take several minutes; if the SSH connection idle-closes, configure `ServerAliveInterval` per the project's persistent guidance.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Each of the four spec test categories has a corresponding task (3–5 for negative-path, 6–8 for proptest, 9 for cancellation, 10 for audit failure, 11 for CI). The "Drop test in `rimap-audit/tests/drop_emits_cancelled.rs`" the spec named is documented as already covered by existing in-crate tests in Task 9 step 1 — a deliberate departure from the spec backed by source-code lookup.
+- **Placeholder scan:** Task 9 Step 3 contains a `todo!("copy Dovecot config setup from e2e_wire.rs")` — this is intentional because the Dovecot harness API may have evolved and the implementer must mirror the live pattern rather than a snapshot. The plan flags this explicitly rather than pretending to have current bytes. All other code blocks are complete.
+- **Type consistency:** `Harness::send_request_no_wait`, `recv_until_id`, `send_line`, `recv_line_within`, `assert_clean_shutdown_or_response`, `child_is_running` are defined in Tasks 1, 2, 6 and used in Tasks 3, 4, 5, 6, 7, 8, 9, 10. Names match throughout.
+- **Probe-first discipline:** Tasks 3 and 4 have explicit "Run the test to observe behavior, then encode the observed code" steps. The plan does not pretend to know the exact JSON-RPC error codes rmcp emits; it tells the implementer to find them and pin them.

--- a/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
+++ b/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
@@ -26,11 +26,11 @@
 
 ---
 
-## Task 0: Pre-flight — Verify dependency on #266 is satisfied
+## Task 0: Pre-flight — Sanity-check the working tree
 
 **Files:** none (verification only)
 
-**Context:** This plan exercises the wire-level negative-test harness from #266 / PR #278. As of the spec date (2026-05-14), that harness lived only on the `feature/issue-266-mcp-fuzzing` branch. Before starting any implementation, confirm the harness is present on the current branch — either because #266 merged to main and the implementer rebased, or because this branch is stacked on `feature/issue-266-mcp-fuzzing`. If absent, **stop and resolve the branching strategy with the user** per the spec's Dependencies section.
+**Context:** This branch is stacked on `feature/issue-266-mcp-fuzzing` so the wire harness from #266 (`mcp_wire_negative.rs` + `support/wire/harness.rs`) is present. The PR opened from this branch targets `feature/issue-266-mcp-fuzzing` as its base — see the spec's Dependencies section for why. This task confirms the working tree is in the expected shape before any code changes begin.
 
 - [ ] **Step 1: Confirm the harness files exist**
 
@@ -41,7 +41,7 @@ test -f crates/rimap-server/tests/support/wire/harness.rs && \
 echo "OK: harness present"
 ```
 
-Expected: `OK: harness present`. If either file is missing, halt and consult the spec's Dependencies section.
+Expected: `OK: harness present`. If either file is missing, the rebase onto `feature/issue-266-mcp-fuzzing` did not land — halt and consult the spec's Dependencies section.
 
 - [ ] **Step 2: Confirm the ignored test we plan to un-ignore is present and ignored**
 
@@ -1169,14 +1169,14 @@ EOF
 
 ```bash
 git push -u origin fix/issue-275-pre-initialize-handling
-gh pr create --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
+gh pr create --base feature/issue-266-mcp-fuzzing --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
 ## Summary
 
 - Pre-initialize Request → JSON-RPC `-32002` "Server not initialized" envelope (request id echoed verbatim), clean close, exit 0, audit `reason: Eof`.
 - Pre-initialize Notification / Response → silent clean close, exit 0, audit `reason: Eof`.
 - Envelope write failure → propagated `anyhow::Error`, non-zero exit, audit `reason: Error` (Codex adversarial-review finding 2026-05-14).
 
-Fixes #275.
+Fixes #275. One of three merge blockers (#275, #276, #277) for PR #278; targets `feature/issue-266-mcp-fuzzing` so the un-ignore commit travels with the fix.
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
+++ b/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
@@ -1,0 +1,1210 @@
+# Pre-Initialize Request Handling Implementation Plan (#275)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `exit 1` crash on pre-`initialize` requests with a JSON-RPC `-32002` error envelope (echoing the request id) followed by a clean exit `0`, while preserving non-zero exit + `process_end.reason: Error` on transport write failures.
+
+**Architecture:** New `mcp/preinit.rs` module owns one pure helper that converts an offending `ClientJsonRpcMessage::Request` into a newline-terminated JSON-RPC error line. `main.rs::run` matches on `rmcp::service::server::ServerInitializeError::ExpectedInitializeRequest`, writes the line through a fresh `tokio::io::stdout()`, and returns `Ok(())` on success or propagates the write error via `?`. Notifications and Responses are dropped silently with `Ok(())`.
+
+**Tech Stack:** Rust (workspace MSRV 1.88.0), tokio async I/O, rmcp 1.5, serde_json, anyhow, tracing. Wire-level integration tests use the `Harness` from `crates/rimap-server/tests/support/wire/`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md`](../specs/2026-05-14-issue-275-pre-initialize-handling-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `crates/rimap-server/src/mcp/preinit.rs` — pure helper + unit tests
+
+**Modify:**
+- `crates/rimap-server/src/mcp/mod.rs` — add `preinit` module declaration
+- `crates/rimap-server/src/mcp/error.rs` — add `NOT_INITIALIZED` constant
+- `crates/rimap-server/src/main.rs` — match arm in `run()` and import the helper
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — un-ignore one test, add three new tests, add audit-log assertions
+- `crates/rimap-server/tests/support/wire/harness.rs` — new `audit_path()` accessor and `DetachedStdoutHarness` + `spawn_with_closed_stdout()`
+
+---
+
+## Task 0: Pre-flight — Verify dependency on #266 is satisfied
+
+**Files:** none (verification only)
+
+**Context:** This plan exercises the wire-level negative-test harness from #266 / PR #278. As of the spec date (2026-05-14), that harness lived only on the `feature/issue-266-mcp-fuzzing` branch. Before starting any implementation, confirm the harness is present on the current branch — either because #266 merged to main and the implementer rebased, or because this branch is stacked on `feature/issue-266-mcp-fuzzing`. If absent, **stop and resolve the branching strategy with the user** per the spec's Dependencies section.
+
+- [ ] **Step 1: Confirm the harness files exist**
+
+Run:
+```bash
+test -f crates/rimap-server/tests/mcp_wire_negative.rs && \
+test -f crates/rimap-server/tests/support/wire/harness.rs && \
+echo "OK: harness present"
+```
+
+Expected: `OK: harness present`. If either file is missing, halt and consult the spec's Dependencies section.
+
+- [ ] **Step 2: Confirm the ignored test we plan to un-ignore is present and ignored**
+
+Run:
+```bash
+rg -n 'tools_list_before_initialize|blocked on #275' crates/rimap-server/tests/mcp_wire_negative.rs
+```
+
+Expected: a match showing `#[ignore = "blocked on #275: server crashes on pre-initialize requests"]` above an `async fn tools_list_before_initialize()`. If the line is absent or unignored, halt — the test harness has drifted from the spec and the test assertions in this plan need re-alignment.
+
+- [ ] **Step 3: Confirm the workspace builds clean before changes**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean exit, no errors. If errors, stop and address them first.
+
+- [ ] **Step 4: No commit. Move to Task 1.**
+
+---
+
+## Task 1: Add `NOT_INITIALIZED` error-code constant
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/error.rs`
+
+The wire code `-32002` is reserved for "Server not initialized" in the LSP/MCP ecosystem. Add it alongside the existing custom codes (`POSTURE_DENIED`, `RATE_LIMITED`, etc.). The constant is consumed by `preinit.rs` in Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test in `crates/rimap-server/src/mcp/error.rs` inside the existing `mod tests` block (find the existing `#[test] fn message_is_preserved()` and add after it):
+
+```rust
+    #[test]
+    fn not_initialized_code_value() {
+        assert_eq!(super::NOT_INITIALIZED, McpCode(-32002));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::error::tests::not_initialized_code_value
+```
+
+Expected: FAIL with `cannot find value 'NOT_INITIALIZED' in module 'super'`.
+
+- [ ] **Step 3: Add the constant**
+
+In `crates/rimap-server/src/mcp/error.rs`, add (after the existing `ATTACHMENT_TOO_LARGE` constant near line 23, before `pub fn to_mcp_error`):
+
+```rust
+/// Server has not yet received the MCP `initialize` request. The first
+/// message a client sends MUST be `initialize` (or `ping`). Any other
+/// pre-initialize request is rejected with this code and a clean
+/// session shutdown.
+pub const NOT_INITIALIZED: McpCode = McpCode(-32002);
+```
+
+Also update the module-level doc-comment listing custom codes (top of `error.rs`, lines 1-9). Replace the existing list with:
+
+```rust
+//! Map `RimapError` to rmcp `ErrorData` for MCP tool error responses.
+//!
+//! Custom error codes in the JSON-RPC "server error" range
+//! (-32000 to -32099):
+//! - -32001: posture denied
+//! - -32002: server not initialized (pre-initialize request)
+//! - -32003: rate limited
+//! - -32004: circuit breaker open
+//! - -32005: attachment too large
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::error::tests::not_initialized_code_value
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/error.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add NOT_INITIALIZED -32002 error code (#275)
+
+Reserve the JSON-RPC server-error code -32002 for the
+"server has not yet received the MCP initialize request"
+case, alongside the existing POSTURE_DENIED / RATE_LIMITED /
+CIRCUIT_OPEN / ATTACHMENT_TOO_LARGE codes. Consumed by the
+pre-initialize envelope synthesizer in a follow-up commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Create the `preinit` module with envelope synthesizer
+
+**Files:**
+- Create: `crates/rimap-server/src/mcp/preinit.rs`
+
+The helper is pure (no I/O, no transport access) so we can unit-test it directly against the rmcp types. `RequestId` is `rmcp::model::NumberOrString` — either an `i64` or an `Arc<str>` — so only those two id flavors are reachable. (JSON `null` ids would have failed rmcp's deserializer before reaching us; no test case needed for that.)
+
+- [ ] **Step 1: Write the failing test file with the synthesizer's contract pinned**
+
+Create `crates/rimap-server/src/mcp/preinit.rs` with the body below. The tests reference `synthesize_pre_init_error_envelope`, which does not yet exist — compilation will fail.
+
+```rust
+//! Pre-initialize request handler.
+//!
+//! Synthesizes the JSON-RPC error envelope that the MCP server sends
+//! when a client violates the lifecycle by issuing any non-`initialize`,
+//! non-`ping` request as its first message (#275). The helper is pure:
+//! it does no I/O and holds no state. The transport write happens in
+//! `main.rs::run`.
+//!
+//! Notifications and Responses pre-initialize return `None`: per
+//! JSON-RPC §4.1 notifications never receive a response, and a
+//! standalone Response is malformed (no matching server request).
+
+use rmcp::model::ClientJsonRpcMessage;
+use serde_json::json;
+
+use crate::mcp::error::NOT_INITIALIZED;
+
+/// Build the newline-terminated JSON-RPC error line to emit for an
+/// offending pre-initialize message. Returns `Some` only for the
+/// `Request` variant.
+pub(crate) fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String> {
+    match msg {
+        ClientJsonRpcMessage::Request(req) => {
+            let id = req.id.clone().into_json_value();
+            let envelope = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": NOT_INITIALIZED.0,
+                    "message": "Server not initialized: send `initialize` \
+                                before any other request",
+                },
+            });
+            Some(format!("{envelope}\n"))
+        }
+        ClientJsonRpcMessage::Notification(_)
+        | ClientJsonRpcMessage::Response(_)
+        | ClientJsonRpcMessage::Error(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::unwrap_used, reason = "tests")]
+
+    use std::sync::Arc;
+
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorData,
+        JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+        JsonRpcVersion2_0, ListToolsRequest, NumberOrString,
+        PaginatedRequestParamInner, ProgressNotification, ProgressNotificationParam,
+    };
+    use serde_json::{Value, json};
+
+    use super::synthesize_pre_init_error_envelope;
+
+    /// Build a Request variant carrying a `tools/list` request with the
+    /// supplied id.
+    fn request_msg(id: NumberOrString) -> ClientJsonRpcMessage {
+        let list_tools = ListToolsRequest {
+            method: Default::default(),
+            params: Some(PaginatedRequestParamInner { cursor: None }),
+            extensions: Default::default(),
+        };
+        ClientJsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            request: ClientRequest::ListToolsRequest(list_tools),
+        })
+    }
+
+    #[test]
+    fn request_with_numeric_id_produces_minus_32002_envelope() {
+        let msg = request_msg(NumberOrString::Number(42));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert!(line.ends_with('\n'), "must be newline-terminated");
+        let parsed: Value = serde_json::from_str(line.trim_end())
+            .expect("envelope is valid JSON");
+        assert_eq!(parsed["jsonrpc"], json!("2.0"));
+        assert_eq!(parsed["id"], json!(42));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+        assert!(parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Server not initialized"));
+    }
+
+    #[test]
+    fn request_with_string_id_preserves_string_id() {
+        let msg = request_msg(NumberOrString::String(Arc::from("abc-123")));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], json!("abc-123"));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+    }
+
+    #[test]
+    fn line_is_single_line_with_one_trailing_newline() {
+        let msg = request_msg(NumberOrString::Number(1));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert_eq!(line.matches('\n').count(), 1, "exactly one newline");
+        assert!(line.ends_with('\n'), "newline is trailing");
+        assert!(!line.trim_end().contains('\n'), "no embedded newlines");
+    }
+
+    #[test]
+    fn notification_returns_none() {
+        let progress = ProgressNotification {
+            method: Default::default(),
+            params: ProgressNotificationParam {
+                progress: 0,
+                total: None,
+                progress_token: NumberOrString::Number(1),
+                message: None,
+            },
+            extensions: Default::default(),
+        };
+        let msg = ClientJsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: JsonRpcVersion2_0,
+            notification: ClientNotification::ProgressNotification(progress),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn response_returns_none() {
+        let msg = ClientJsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            result: Default::default(),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn error_variant_returns_none() {
+        let msg = ClientJsonRpcMessage::Error(JsonRpcError {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            error: ErrorData::internal_error("synthetic".to_string(), None),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Verify the tests fail to compile**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::preinit 2>&1 | head -30
+```
+
+Expected: compile error — `unresolved import` for `crate::mcp::preinit` (the module is not declared in `mcp/mod.rs` yet). That's the next task.
+
+- [ ] **Step 3: No commit yet — proceed to Task 3 to wire the module in.**
+
+---
+
+## Task 3: Declare the `preinit` module
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/mod.rs`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `crates/rimap-server/src/mcp/mod.rs`, add `pub(crate) mod preinit;` alphabetically. After this change the top of the file reads:
+
+```rust
+//! MCP runtime: server handler, response/error types, content parsing.
+
+pub(crate) mod audit_envelope;
+pub mod content;
+pub(crate) mod dispatch;
+pub mod error;
+pub(crate) mod preinit;
+pub mod response;
+pub mod server;
+// `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod
+// mcp` in `lib.rs`) so the binary's test-support `dump-tool-catalog`
+// subcommand (#264) can reach `TOOL_DEFS`. Production callers route through
+// `dispatch` and `server` and do not import this module directly.
+pub mod tool_catalog;
+pub(crate) mod tool_name;
+```
+
+- [ ] **Step 2: Run the preinit tests**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::preinit
+```
+
+Expected: all six tests pass:
+- `request_with_numeric_id_produces_minus_32002_envelope`
+- `request_with_string_id_preserves_string_id`
+- `line_is_single_line_with_one_trailing_newline`
+- `notification_returns_none`
+- `response_returns_none`
+- `error_variant_returns_none`
+
+If any test fails to compile because an rmcp type name differs in your local rmcp 1.5 (e.g. `ProgressNotificationParam` vs `ProgressNotificationParams`), fix the test to match the actual rmcp type — the helper's contract is what matters, not the exact constructor shape.
+
+- [ ] **Step 3: Run clippy on the new module**
+
+Run:
+```bash
+cargo clippy -p rimap-server --lib --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/preinit.rs crates/rimap-server/src/mcp/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add pre-initialize envelope synthesizer (#275)
+
+New `mcp/preinit.rs` module exposes a pure helper that converts an
+offending pre-initialize ClientJsonRpcMessage into a newline-terminated
+JSON-RPC error line with code -32002 and the request id echoed
+verbatim. Notifications, Responses, and Error variants return None
+(no envelope, silent close at the call site).
+
+Includes unit tests for numeric id, string id, framing (single line,
+trailing newline), and all None-returning variants. Not yet wired into
+the server entrypoint — that's the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire the helper into `main.rs::run`
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+This is the behavior-change commit. Lines 136-140 currently wrap any `rmcp::serve_server` error in `anyhow!` and exit 1. We split that into three cases: `Ok` (normal run), `ExpectedInitializeRequest(Some(msg))` (synthesize envelope, return `Ok(())`), and everything else (preserve today's behavior).
+
+- [ ] **Step 1: Add the imports near the top of `main.rs`**
+
+Find the existing `use` block (lines 7-29 approximately). Add these imports alphabetically with the other module-level uses:
+
+```rust
+use rmcp::service::server::ServerInitializeError;
+use tokio::io::AsyncWriteExt;
+```
+
+`anyhow::Context` is already imported via line 16 (`use anyhow::Context;`) — no change there.
+
+- [ ] **Step 2: Replace the serve_server call block**
+
+In `crates/rimap-server/src/main.rs`, locate the existing block (currently `main.rs:136-147`):
+
+```rust
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
+        let transport = rmcp::transport::io::stdio();
+        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        // waiting() takes ownership of service, consuming it and dropping the
+        // ImapMcpServer (including all cancellation sender clones) when it
+        // returns. The drainer task exits once all senders have dropped.
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+```
+
+Replace with:
+
+```rust
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
+        let transport = rmcp::transport::io::stdio();
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                if let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(&msg) {
+                    let mut out = tokio::io::stdout();
+                    out.write_all(line.as_bytes())
+                        .await
+                        .context("writing pre-init error envelope to stdout")?;
+                    out.flush()
+                        .await
+                        .context("flushing pre-init error envelope")?;
+                    tracing::info!(
+                        "rejected pre-initialize request with -32002 envelope",
+                    );
+                }
+                return Ok(());
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
+        // waiting() takes ownership of service, consuming it and dropping the
+        // ImapMcpServer (including all cancellation sender clones) when it
+        // returns. The drainer task exits once all senders have dropped.
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+```
+
+Note the path: `rimap_server::mcp::preinit::synthesize_pre_init_error_envelope`. `main.rs` is the binary crate's entry point and reaches into the library crate `rimap_server` (see existing line 7-8). The function is `pub(crate)` in `mcp/preinit.rs`, so the path needs adjustment.
+
+- [ ] **Step 3: Adjust the function visibility**
+
+Because `main.rs` calls the helper through the library crate boundary, change the visibility in `crates/rimap-server/src/mcp/preinit.rs` from `pub(crate)` to `pub`:
+
+```rust
+pub fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String> {
+```
+
+Also export it from the `mcp` module hierarchy. In `crates/rimap-server/src/mcp/mod.rs`, change the line you added in Task 3 from:
+
+```rust
+pub(crate) mod preinit;
+```
+
+to:
+
+```rust
+pub mod preinit;
+```
+
+The `mcp` module itself is `#[doc(hidden)] pub` (see `crates/rimap-server/src/lib.rs`) so this widens reachability only across the same workspace, not for external consumers.
+
+- [ ] **Step 4: Build the workspace and verify the binary still compiles**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean. If errors mention `rmcp::service::server::ServerInitializeError` not being in scope, your rmcp version may re-export it from a different path — check `rg "pub use.*ServerInitializeError" ~/.cargo/registry/src/index.crates.io-*/rmcp-*/src/lib.rs` and adjust the use statement.
+
+- [ ] **Step 5: Run lints**
+
+Run:
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs crates/rimap-server/src/mcp/mod.rs crates/rimap-server/src/mcp/preinit.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)
+
+Match on ServerInitializeError::ExpectedInitializeRequest in main.rs::run
+and reply with a JSON-RPC -32002 error envelope (request id echoed
+verbatim) instead of exiting 1. Write errors are propagated via `?` so
+broken-pipe / closed-reader cases still record process_end.reason: Error
+and exit non-zero. Notification / Response variants are dropped silently
+with a clean exit 0.
+
+Widens synthesize_pre_init_error_envelope visibility to pub so main.rs
+can reach it through the rimap_server library crate.
+
+Wire-level regression tests follow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Un-ignore `tools_list_before_initialize` and tighten assertions
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs` (add `audit_path()` accessor)
+
+This is the first wire-level verification of the Task 4 change.
+
+- [ ] **Step 1: Add `audit_path()` accessor on `Harness`**
+
+In `crates/rimap-server/tests/support/wire/harness.rs`, find the `impl Harness {` block and add this method near the other accessors (e.g., next to `captured_stderr`). The audit log path is `{_tempdir}/audit.jsonl` per `spawn()`'s config template.
+
+```rust
+    /// Path to the audit log file for this harness. Used by tests
+    /// that need to read `process_end` records post-shutdown.
+    pub fn audit_path(&self) -> std::path::PathBuf {
+        self._tempdir.path().join("audit.jsonl")
+    }
+```
+
+The `_tempdir` field has a leading underscore to indicate "held only for lifetime"; accessing it through `self._tempdir.path()` is still legal — the underscore convention is purely visual.
+
+Also add a reference to this accessor in the `force_use_for_dead_code_link` function near the top of the file so it isn't flagged as unused in test binaries that don't call it:
+
+```rust
+    // Method used by mcp_wire_negative (pre-initialize tests), not by
+    // other binaries.
+    let _ = Harness::audit_path;
+```
+
+Add this line alongside the other `let _ = Harness::...` lines in that function.
+
+- [ ] **Step 2: Replace the un-ignored test**
+
+In `crates/rimap-server/tests/mcp_wire_negative.rs`, locate the existing `tools_list_before_initialize` test (around line 326-368). Replace the entire test (docstring + attributes + body) with:
+
+```rust
+// ---------------------------------------------------------------------------
+// Test 7: `tools/list` before `initialize`
+// ---------------------------------------------------------------------------
+
+/// `tools/list` before `initialize` must return a JSON-RPC error
+/// envelope with code -32002 (Server not initialized), echo the
+/// request id verbatim, then close stdin and exit `0`. Fixed by #275.
+///
+/// Audit log MUST record `process_end.reason: Eof` on the success
+/// path — this is the contract the bug report flagged as broken.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Deliberately skip initialize_handshake.
+    let id = harness.send_request_no_wait("tools/list", json!({})).await;
+
+    // Phase 1: error envelope arrives with -32002.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list, got {other:?}"
+        ),
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32002),
+        "must be code -32002 (Server not initialized), got {envelope}",
+    );
+    assert_eq!(
+        envelope["id"],
+        json!(id),
+        "id must be echoed verbatim, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    // Phase 2: stdout closes and the server exits 0.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on pre-initialize tools/list, got {other:?}"
+        ),
+    }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on successful pre-initialize handling",
+    );
+}
+```
+
+- [ ] **Step 3: Add the audit-reading helper at the top of `mcp_wire_negative.rs`**
+
+Below the existing `parse_response_line` helper (around line 26-30), add:
+
+```rust
+/// Read the `process_end.reason` from the audit log produced by the
+/// harness. Panics if no `process_end` record is found.
+fn read_process_end_reason(path: &std::path::Path) -> rimap_audit::ProcessEndReason {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read audit log at {}: {e}", path.display()));
+    for line in contents.lines() {
+        let record: rimap_audit::AuditRecord = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("parse audit record {line:?}: {e}"));
+        if let rimap_audit::Payload::ProcessEnd(p) = record.payload {
+            return p.reason;
+        }
+    }
+    panic!("no process_end record found in audit log at {}", path.display());
+}
+```
+
+- [ ] **Step 4: Confirm `rimap-audit` is a dev-dependency of `rimap-server`**
+
+Run:
+```bash
+rg -n 'rimap-audit\|rimap_audit' crates/rimap-server/Cargo.toml
+```
+
+If `rimap-audit` is only listed under `[dependencies]` and not `[dev-dependencies]`, add it under `[dev-dependencies]` too. Typically the entry exists in both — confirm before adding.
+
+- [ ] **Step 5: Run the un-ignored test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative tools_list_before_initialize -- --nocapture
+```
+
+Expected: PASS. If it fails:
+- Crashed (non-zero exit): Task 4 didn't land — check `main.rs` for the match arm.
+- Wrong error code: check the constant in `error.rs` (Task 1) and the synthesizer in `preinit.rs` (Task 2).
+- `no process_end record found`: the audit log may not be flushed; check the existing `log_process_end` block in `main.rs:168-171` is still on the early-return path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs crates/rimap-server/tests/support/wire/harness.rs crates/rimap-server/Cargo.toml
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin -32002 contract for pre-init tools/list (#275)
+
+Un-ignore tools_list_before_initialize with strict assertions:
+- response envelope must be code -32002 with the request id echoed
+- server must close stdin cleanly with exit 0
+- audit log must record process_end.reason: Eof
+
+Adds the audit_path() accessor on Harness and a read_process_end_reason
+helper in the test file so subsequent audit-reason assertions can reuse
+the pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `tools_list_before_initialize_str_id` test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the string-id roundtrip at the wire layer. Catches future regressions where the helper accidentally coerces ids through `as_u64()`.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `tools_list_before_initialize`:
+
+```rust
+/// Same contract as `tools_list_before_initialize`, but with a string
+/// id. Pins id-type preservation at the wire layer: numeric coercion
+/// of `id` in the synthesizer would surface here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize_str_id() {
+    let mut harness = Harness::spawn().await;
+
+    // Send a hand-crafted request with a STRING id rather than using
+    // send_request_no_wait (which auto-assigns a u64).
+    let raw = r#"{"jsonrpc":"2.0","id":"abc-123","method":"tools/list","params":{}}"#;
+    harness.send_line(raw).await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list w/ str id, got {other:?}"
+        ),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32002));
+    assert_eq!(
+        envelope["id"],
+        json!("abc-123"),
+        "string id must survive verbatim through the envelope synthesizer, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative tools_list_before_initialize_str_id -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin string-id roundtrip for pre-init reject (#275)
+
+Hand-crafts a pre-initialize tools/list request with a string id and
+verifies the -32002 envelope echoes the same string. Guards against
+future regressions where the synthesizer might coerce ids through
+as_u64() or similar.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add `pre_initialize_notification_silent_close` test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the Notification-path contract: no envelope, clean close, audit reason Eof.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `tools_list_before_initialize_str_id`:
+
+```rust
+/// Pre-initialize NOTIFICATION (no `id`) must NOT receive an error
+/// envelope — per JSON-RPC §4.1 notifications never get a response.
+/// Server closes cleanly and exits 0 with audit reason Eof.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_notification_silent_close() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Send a pre-initialize notification (not a request — no id).
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({"requestId": 1, "reason": "client decided not to initialize"}),
+        )
+        .await;
+
+    // No response should arrive; the server should close cleanly.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            panic!(
+                "pre-initialize notification must NOT produce an envelope, got {envelope}"
+            );
+        }
+        other => panic!("expected clean close, got {other:?}"),
+    }
+
+    // Audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative pre_initialize_notification_silent_close -- --nocapture
+```
+
+Expected: PASS. The server's match arm in `main.rs` returns `Ok(())` because `synthesize_pre_init_error_envelope` returned `None` for the Notification variant.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin silent-close for pre-init notifications (#275)
+
+Asserts notifications/cancelled before initialize produces NO wire
+response and the server exits 0 with audit reason Eof. Per JSON-RPC
+§4.1, notifications never receive a response.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add the closed-stdout harness variant
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+
+Adds a separate spawn helper that closes the stdout read end before the child writes, so the broken-pipe test in Task 9 has scaffolding. We introduce a small sister struct (`DetachedStdoutHarness`) rather than refactoring `Harness::stdout` to `Option<BufReader<...>>` — that refactor would touch every existing harness call site for one new test.
+
+- [ ] **Step 1: Define the sister struct and its accessors**
+
+Add to `crates/rimap-server/tests/support/wire/harness.rs`, after the `Harness` struct definition (and after any existing `impl Harness {` blocks — keep the file's existing structure intact):
+
+```rust
+/// Lightweight harness variant used by transport-failure regression
+/// tests that intentionally close the server's stdout read end before
+/// sending input. The server's pre-initialize envelope write will
+/// fail with `BrokenPipe`. This struct cannot read stdout responses;
+/// it exists only to drive stdin, wait for the child exit, and read
+/// the resulting audit log + captured stderr.
+pub struct DetachedStdoutHarness {
+    pub child: Child,
+    pub stdin: ChildStdin,
+    stderr_log: PathBuf,
+    audit_path: PathBuf,
+    // Held until drop so the audit log path stays valid.
+    _tempdir: TempDir,
+}
+
+impl DetachedStdoutHarness {
+    /// Path to the audit log produced by the spawned binary.
+    pub fn audit_path(&self) -> &std::path::Path {
+        &self.audit_path
+    }
+
+    /// Read the captured stderr file. Empty string on read failure.
+    pub fn captured_stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
+    }
+}
+```
+
+- [ ] **Step 2: Add the spawn helper**
+
+Add this method inside the existing `impl Harness { ... }` block (the one that contains `spawn()` and `spawn_with_config()`):
+
+```rust
+    /// Spawn the binary with the legacy zero-account config, then
+    /// immediately drop the BufReader<ChildStdout> read handle. The
+    /// child's stdout pipe write end is now connected to a closed
+    /// reader; the next write the server attempts will fail with
+    /// `BrokenPipe`. Used by `pre_initialize_envelope_write_failure`
+    /// to exercise the propagated-error path on transport failure.
+    pub async fn spawn_with_closed_stdout() -> DetachedStdoutHarness {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let stderr_log = tempdir.path().join("rusty-imap-mcp.stderr.log");
+        let stderr_file = File::create(&stderr_log).expect("create stderr log file");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(stderr_file))
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        // Take the read end of the stdout pipe and drop it immediately.
+        // The child's write end is now connected to a closed reader.
+        let stdout = child.stdout.take().expect("stdout");
+        drop(stdout);
+
+        DetachedStdoutHarness {
+            child,
+            stdin,
+            stderr_log,
+            audit_path,
+            _tempdir: tempdir,
+        }
+    }
+```
+
+- [ ] **Step 3: Suppress per-binary dead-code on the new symbol**
+
+Add to the `force_use_for_dead_code_link` function near the top of the file (this prevents the new method from being flagged as unused in test binaries that don't use it):
+
+```rust
+    // Method used by mcp_wire_negative (pre-initialize write-failure
+    // test), not by other binaries.
+    let _ = Harness::spawn_with_closed_stdout;
+```
+
+Same for `DetachedStdoutHarness`'s methods if needed — if clippy complains in CI, add `let _ = DetachedStdoutHarness::audit_path;` and `let _ = DetachedStdoutHarness::captured_stderr;` lines.
+
+- [ ] **Step 4: Build the harness**
+
+Run:
+```bash
+cargo check -p rimap-server --tests
+```
+
+Expected: clean. If unused-import warnings fire on `File`, `Command`, etc. — they're already imported by `spawn_with_config()`, no new imports should be needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): add closed-stdout harness variant (#275)
+
+Adds Harness::spawn_with_closed_stdout() and a sister
+DetachedStdoutHarness struct for the upcoming pre-initialize
+write-failure regression test. The spawn helper drops the
+BufReader<ChildStdout> immediately so the child's stdout-write end
+is connected to a closed reader; the server's next write fails with
+BrokenPipe.
+
+Scaffolding only — no behavior change. Used in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Add the write-failure regression test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the Codex finding #2 contract: write failures while emitting the envelope must record `process_end.reason: Error` and exit non-zero.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `pre_initialize_notification_silent_close`:
+
+```rust
+/// Codex review finding 2026-05-14 (medium): transport-level write
+/// failures while emitting the pre-initialize envelope must NOT be
+/// classified as clean EOF. Server's stdout read end is closed
+/// before the request arrives; the envelope write fails with
+/// BrokenPipe; the server exits non-zero and the audit log records
+/// `reason: Error`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_envelope_write_failure_records_error() {
+    use support::wire::harness::SHUTDOWN_TIMEOUT;
+    use tokio::time::timeout;
+
+    let mut detached =
+        support::wire::harness::Harness::spawn_with_closed_stdout().await;
+
+    // Send a pre-initialize request. Server will read it, attempt to
+    // write the envelope, and fail with BrokenPipe because stdout's
+    // read end is already closed.
+    let line = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#.to_string()
+        + "\n";
+    use tokio::io::AsyncWriteExt;
+    detached
+        .stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write request");
+    detached.stdin.flush().await.expect("flush request");
+
+    // Wait for the child to exit.
+    let status = timeout(SHUTDOWN_TIMEOUT, detached.child.wait())
+        .await
+        .expect("child exit within SHUTDOWN_TIMEOUT")
+        .expect("child wait");
+
+    // Server must NOT exit 0 on a broken-pipe write failure. It may
+    // exit with a non-zero status (anyhow propagated) or, if Rust's
+    // SIGPIPE handling regresses, be killed by signal 13 — both are
+    // failures we want to surface but only the first is the
+    // contract we lock in.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert!(
+            status.signal().is_none(),
+            "server must not be killed by SIGPIPE (regression in Rust runtime); got {status:?}\n--- captured stderr ---\n{}",
+            detached.captured_stderr(),
+        );
+    }
+    assert!(
+        !status.success(),
+        "server must exit non-zero when envelope write fails; got {status:?}\n--- captured stderr ---\n{}",
+        detached.captured_stderr(),
+    );
+
+    // Audit log must record reason Error, NOT Eof.
+    let reason = read_process_end_reason(detached.audit_path());
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Error,
+        "process_end.reason must be Error when envelope delivery fails, not Eof — \
+         masking transport failures as clean EOF defeats the audit-correctness goal",
+    );
+
+    // The propagated anyhow context must surface in stderr.
+    let stderr = detached.captured_stderr();
+    assert!(
+        stderr.contains("pre-init error envelope"),
+        "expected propagated 'pre-init error envelope' anyhow context in stderr, got:\n{stderr}",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative pre_initialize_envelope_write_failure_records_error -- --nocapture
+```
+
+Expected: PASS.
+
+Common failure modes:
+- **Killed by signal 13**: Rust's SIGPIPE handler regression — the cargo-built binary inherited a SIGPIPE handler that terminates the process. Check that nothing in `main.rs::main()` calls `signal_hook::register` or similar before `init()`.
+- **`process_end.reason == Eof`**: the `?` propagation in `main.rs` was lost — re-check Task 4.
+- **`no process_end record found`**: the binary panicked before `audit_for_shutdown.log_process_end(...)` fired. Check `main.rs:158-171` is still reachable on the early-return path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin Error reason on pre-init envelope write fail (#275)
+
+Closes the harness's stdout read end before sending a pre-initialize
+tools/list request, then asserts:
+- server exits non-zero (not killed by SIGPIPE)
+- process_end.reason: Error (not Eof — would mask the failure)
+- propagated anyhow context surfaces in stderr
+
+Addresses Codex adversarial-review finding 2026-05-14 (medium).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Full local-CI sweep and final commit (if needed)
+
+**Files:** none expected; this task verifies everything composes.
+
+- [ ] **Step 1: Run `just ci`**
+
+Run:
+```bash
+just ci
+```
+
+Expected: PASS. This runs fmt-check, clippy with `-D warnings`, the workspace test suite, and `cargo deny`.
+
+Common late-stage failures:
+- **Clippy `unused_imports` in `mcp_wire_negative.rs`**: the test file gained `use tokio::time::timeout` / `use tokio::io::AsyncWriteExt` inside one test function. If a sibling test binary compiles the same `support/` module and doesn't use them, no warning fires. If it does, lift the `use` statements to the top of `mcp_wire_negative.rs` so they're shared.
+- **`AuditRecord` / `Payload` / `ProcessEndReason` not in scope**: confirm the `rimap-audit` dev-dependency in `crates/rimap-server/Cargo.toml` is present.
+- **`audit_path` field is private on `DetachedStdoutHarness`**: confirm the accessor method exists and returns `&Path`.
+- **`stderr_log` field also private**: the `captured_stderr` accessor must be `pub` on `DetachedStdoutHarness`.
+
+- [ ] **Step 2: Verify no `#[ignore]` remains pinned to #275**
+
+Run:
+```bash
+rg -n '#\[ignore.*#275' crates/
+```
+
+Expected: no matches. If a match appears, un-ignore it (it was missed during Task 5) and re-run tests.
+
+- [ ] **Step 3: Verify the issue-closing references are accurate**
+
+Run:
+```bash
+rg -n '#275' crates/ docs/superpowers/
+```
+
+Expected: references in the spec file, the plan file, and any commit messages. No stale "blocked on #275" comments.
+
+- [ ] **Step 4: Final commit (only if any cleanup happened)**
+
+Only commit if there were fixups in Steps 1-3. If nothing was changed:
+
+```bash
+git status
+# (should report nothing to commit)
+```
+
+Otherwise:
+
+```bash
+git add -p   # stage cleanup hunks
+git commit -m "$(cat <<'EOF'
+chore(rimap-server): tidy after #275 implementation
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin fix/issue-275-pre-initialize-handling
+gh pr create --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
+## Summary
+
+- Pre-initialize Request → JSON-RPC `-32002` "Server not initialized" envelope (request id echoed verbatim), clean close, exit 0, audit `reason: Eof`.
+- Pre-initialize Notification / Response → silent clean close, exit 0, audit `reason: Eof`.
+- Envelope write failure → propagated `anyhow::Error`, non-zero exit, audit `reason: Error` (Codex adversarial-review finding 2026-05-14).
+
+Fixes #275.
+
+## Test plan
+
+- [ ] `cargo test -p rimap-server --test mcp_wire_negative` passes — four pre-initialize cases covered (numeric id, string id, notification silent close, write-failure).
+- [ ] `cargo test -p rimap-server --lib mcp::preinit` passes — six unit tests on the envelope synthesizer.
+- [ ] `just ci` passes locally.
+
+Spec: `docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md`
+Plan: `docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done
+
+All tasks complete. Verify with one final read-through of `git log fix/issue-275-pre-initialize-handling ^main` — should show:
+
+1. `docs(spec): pre-initialize request handling design (#275)` (already present)
+2. `docs(spec): address Codex adversarial-review findings (#275)` (already present)
+3. `feat(rimap-server): add NOT_INITIALIZED -32002 error code (#275)` (Task 1)
+4. `feat(rimap-server): add pre-initialize envelope synthesizer (#275)` (Task 3)
+5. `fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)` (Task 4)
+6. `test(rimap-server): pin -32002 contract for pre-init tools/list (#275)` (Task 5)
+7. `test(rimap-server): pin string-id roundtrip for pre-init reject (#275)` (Task 6)
+8. `test(rimap-server): pin silent-close for pre-init notifications (#275)` (Task 7)
+9. `test(rimap-server): add closed-stdout harness variant (#275)` (Task 8)
+10. `test(rimap-server): pin Error reason on pre-init envelope write fail (#275)` (Task 9)

--- a/docs/superpowers/plans/2026-05-14-issue-276-protocol-version-negotiation.md
+++ b/docs/superpowers/plans/2026-05-14-issue-276-protocol-version-negotiation.md
@@ -1,0 +1,1048 @@
+# Protocol-Version Negotiation Implementation Plan (#276)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject any `initialize` request whose `protocolVersion` is not exactly `ProtocolVersion::LATEST` with a JSON-RPC `-32602` error envelope, then exit cleanly; classify `InitializeFailed` outcomes by error code so server-faults stay observable.
+
+**Architecture:** Override `ServerHandler::initialize` on `ImapMcpServer` to validate the peer's version against `ProtocolVersion::LATEST`. A pure helper builds the `-32602` `ErrorData` listing the one supported version. `main.rs::run` adds a code-gated `InitializeFailed` arm that routes `INVALID_PARAMS` to clean exit (audit `Eof`) and other codes to propagated `anyhow::Error` (audit `Error`).
+
+**Tech Stack:** Rust (MSRV 1.88.0), tokio async I/O, rmcp 1.5, serde_json, anyhow, tracing. Wire-level tests use the harness from `crates/rimap-server/tests/support/wire/`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md`](../specs/2026-05-14-issue-276-protocol-version-negotiation-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `crates/rimap-server/src/mcp/server.rs` — add `InitializeRequestParams`, `InitializeResult`, `ProtocolVersion` to imports; add `async fn initialize` override inside `impl ServerHandler for ImapMcpServer`; add private free function `unsupported_protocol_version_error` near the bottom; add `#[cfg(test)] mod tests` block with helper unit tests
+- `crates/rimap-server/src/main.rs` — add `rmcp::model::ErrorCode` import; add private free function `initialize_failure_is_handled_rejection`; insert two new code-gated `InitializeFailed` match arms into `run()`; extend the existing `#[cfg(all(test, unix))] mod resolve_download_dir_tests` (or add a sibling test module) with classifier unit tests
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — un-ignore `initialize_unsupported_protocol_version` with strict assertions; add two new tests
+
+---
+
+## Task 0: Pre-flight — Sanity-check the working tree
+
+**Files:** none (verification only)
+
+**Context:** This branch is stacked on `fix/issue-275-pre-initialize-handling`. The wire-test harness from #266 is present (via the same stack), and #275's pre-initialize match arm (`ExpectedInitializeRequest`) is the structural neighbor of the new `InitializeFailed` arms we're adding. The ignored test we'll un-ignore is `initialize_unsupported_protocol_version` at `crates/rimap-server/tests/mcp_wire_negative.rs:612-668`.
+
+- [ ] **Step 1: Confirm the working tree is clean**
+
+Run:
+```bash
+git status --short && git rev-parse --abbrev-ref HEAD
+```
+
+Expected: empty status; `fix/issue-276-protocol-version-negotiation` (or a stacked descendant).
+
+- [ ] **Step 2: Confirm the harness, the ignored test, and #275's helper are all present**
+
+Run:
+```bash
+test -f crates/rimap-server/tests/mcp_wire_negative.rs && \
+test -f crates/rimap-server/tests/support/wire/harness.rs && \
+test -f crates/rimap-server/src/mcp/preinit.rs && \
+rg -q 'blocked on #276: server echoes unsupported protocol versions' crates/rimap-server/tests/mcp_wire_negative.rs && \
+echo "OK: prerequisites present"
+```
+
+Expected: `OK: prerequisites present`. If any check fails, the rebase onto `fix/issue-275-pre-initialize-handling` (or its merged base) did not land — halt and consult the spec's Dependencies section.
+
+- [ ] **Step 3: Confirm the workspace builds clean before changes**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean exit, no errors.
+
+- [ ] **Step 4: No commit. Move to Task 1.**
+
+---
+
+## Task 1: Add the `unsupported_protocol_version_error` helper with unit tests
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/server.rs`
+
+The helper is pure (no I/O, no state) so we TDD it directly. It produces the `ErrorData` payload that the override in Task 2 returns when the peer's version isn't `ProtocolVersion::LATEST`.
+
+- [ ] **Step 1: Add the new types to the rmcp model import**
+
+In `crates/rimap-server/src/mcp/server.rs`, find the existing `use rmcp::model::{ ... };` block at lines 19-24. Replace it with the expanded form below (adds `InitializeRequestParams`, `InitializeResult`, `ProtocolVersion`):
+
+```rust
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ErrorCode as McpCode, ErrorData, Implementation,
+    InitializeRequestParams, InitializeResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, ProtocolVersion, RawResource, ReadResourceRequestParams,
+    ReadResourceResult, Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
+};
+```
+
+- [ ] **Step 2: Write the failing helper-shape test**
+
+At the very bottom of `crates/rimap-server/src/mcp/server.rs`, after the closing brace of `impl ServerHandler for ImapMcpServer { ... }`, add this `#[cfg(test)]` module. Mark all tests; they'll fail until Step 3 adds the helper. (If a `#[cfg(test)] mod tests` block already exists at the file bottom, merge these tests into it instead of creating a duplicate module.)
+
+```rust
+#[cfg(test)]
+mod protocol_version_tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::unwrap_used, reason = "tests")]
+
+    use rmcp::model::{ErrorCode as McpCode, ProtocolVersion};
+    use serde_json::{Value, json};
+
+    use super::unsupported_protocol_version_error;
+
+    /// Build a `ProtocolVersion` carrying an arbitrary version string.
+    /// The rmcp deserializer accepts any string and produces a
+    /// `ProtocolVersion(Cow::Owned(s))` for unknown values, so this is
+    /// the cleanest way to construct one for tests.
+    fn version_from_str(s: &str) -> ProtocolVersion {
+        serde_json::from_value(json!(s)).expect("deserialize ProtocolVersion")
+    }
+
+    #[test]
+    fn shape_matches_spec() {
+        let v = version_from_str("1999-01-01");
+        let err = unsupported_protocol_version_error(&v);
+
+        assert_eq!(err.code, McpCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("1999-01-01"),
+            "message must echo the peer version, got {:?}",
+            err.message,
+        );
+        assert!(
+            err.message.contains("2025-11-25"),
+            "message must include the supported version, got {:?}",
+            err.message,
+        );
+
+        let data = err.data.as_ref().expect("data field present");
+        assert_eq!(
+            data["supported_versions"],
+            json!(["2025-11-25"]),
+            "supported_versions must be a single-element array of LATEST, got {data}",
+        );
+    }
+
+    #[test]
+    fn uses_runtime_latest() {
+        // Pins the contract that `supported_versions[0]` is built from
+        // `ProtocolVersion::LATEST.as_str()` at runtime, not a hard-
+        // coded literal. If a future rmcp bump shifts LATEST, this
+        // test stays green; the literal-pinning `shape_matches_spec`
+        // test will then surface the change visibly.
+        let v = version_from_str("anything-goes");
+        let err = unsupported_protocol_version_error(&v);
+        let data = err.data.as_ref().expect("data field present");
+        let arr = data["supported_versions"]
+            .as_array()
+            .expect("supported_versions is an array");
+        assert_eq!(arr.len(), 1, "single-element array");
+        assert_eq!(
+            arr[0].as_str().expect("string"),
+            ProtocolVersion::LATEST.as_str(),
+        );
+    }
+
+    #[test]
+    fn empty_peer_version_still_produces_envelope() {
+        let v = version_from_str("");
+        let err = unsupported_protocol_version_error(&v);
+        assert_eq!(err.code, McpCode::INVALID_PARAMS);
+        // Single-quoted empty string in the message: "...'%s'..."
+        assert!(
+            err.message.contains("''"),
+            "empty peer version should appear as '' in message, got {:?}",
+            err.message,
+        );
+    }
+
+    #[test]
+    fn data_field_is_present() {
+        // Guards against accidentally constructing the error without
+        // the data payload (would break machine-readable retry).
+        let v = version_from_str("1999-01-01");
+        let err = unsupported_protocol_version_error(&v);
+        assert!(err.data.is_some(), "data field must be present");
+    }
+
+    // Suppress unused-binding warning when the bound is not consumed
+    // in every test under conditional compilation.
+    #[expect(dead_code, reason = "shared test fixture")]
+    fn _ensure_value_used(_: Value) {}
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::server::protocol_version_tests 2>&1 | head -30
+```
+
+Expected: compile error — `cannot find function 'unsupported_protocol_version_error' in module 'super'`.
+
+- [ ] **Step 4: Add the helper at the bottom of `mcp/server.rs`**
+
+Add this private free function immediately BEFORE the `#[cfg(test)] mod protocol_version_tests` block you just added (so it's in module scope, reachable via `super::`):
+
+```rust
+/// Build the `ErrorData` payload returned by `ImapMcpServer::initialize`
+/// when the peer's `protocolVersion` is not exactly
+/// `ProtocolVersion::LATEST`. The envelope's `data` field carries
+/// `supported_versions` as a single-element array so clients have a
+/// machine-readable retry hint, and the message echoes the offending
+/// version in single quotes for log readability. (#276)
+fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorData {
+    let supported = [ProtocolVersion::LATEST.as_str()];
+    let message = format!(
+        "Unsupported protocol version: '{}'. Server supports: {}.",
+        peer_version.as_str(),
+        supported.join(", "),
+    );
+    let data = serde_json::json!({ "supported_versions": supported });
+    ErrorData::invalid_params(message, Some(data))
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::server::protocol_version_tests
+```
+
+Expected: 4 tests pass:
+- `shape_matches_spec`
+- `uses_runtime_latest`
+- `empty_peer_version_still_produces_envelope`
+- `data_field_is_present`
+
+- [ ] **Step 6: Run clippy on the modified file**
+
+Run:
+```bash
+cargo clippy -p rimap-server --lib --all-features -- -D warnings
+```
+
+Expected: clean. If clippy reports `dead_code` on the helper (because no call site exists yet — the `initialize` override is in Task 2), add a one-line `#[cfg_attr(not(test), expect(dead_code, reason = "wired into ImapMcpServer::initialize in the next commit (#276 task 2)"))]` attribute immediately above the function. The `#[expect]` form is mandated by the workspace's `allow_attributes = "deny"` clippy rule; Task 2 will remove the attribute as a natural consequence of adding the call site.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/server.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add unsupported_protocol_version_error helper (#276)
+
+Pure helper that builds the JSON-RPC -32602 ErrorData payload for
+peers whose protocolVersion isn't ProtocolVersion::LATEST. Message
+echoes the peer version in single quotes; data field carries
+supported_versions as a single-element array so clients have a
+machine-readable retry hint.
+
+Not yet wired into ImapMcpServer::initialize — that's the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Override `ImapMcpServer::initialize` to validate the protocol version
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/server.rs`
+
+This is the behavior-change commit. The override delegates to default behavior when the peer's version matches `LATEST`, and short-circuits with `Err(unsupported_protocol_version_error(...))` otherwise. rmcp at `service/server.rs:222` converts the Err into a wire `-32602` envelope and returns `Err(ServerInitializeError::InitializeFailed(...))` from `serve_server`; Task 4 will classify that as a handled rejection.
+
+- [ ] **Step 1: Add the `initialize` override**
+
+In `crates/rimap-server/src/mcp/server.rs`, find the `impl ServerHandler for ImapMcpServer { ... }` block (starts around line 254). The first method is `fn get_info(&self) -> ServerInfo`. Insert the new `async fn initialize` IMMEDIATELY AFTER `get_info` and BEFORE `async fn list_tools`. The exact placement keeps the trait methods in the same order rmcp's trait declaration uses (initialize-related first, then list/call methods).
+
+```rust
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, ErrorData> {
+        // LATEST-only acceptance per spec §"Why LATEST-only" (#276):
+        // rmcp 1.5 emits LATEST wire shapes regardless of negotiated
+        // version, so accepting older known versions would echo the
+        // peer's version string while serving 2025-11-25 capabilities.
+        // The exact-equality check is the only honest option.
+        if request.protocol_version != ProtocolVersion::LATEST {
+            return Err(unsupported_protocol_version_error(&request.protocol_version));
+        }
+        // Preserve the default-impl behavior for the happy path so the
+        // peer's ClientInfo is captured for subsequent dispatch.
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        Ok(self.get_info())
+    }
+```
+
+- [ ] **Step 2: Remove the dead_code suppression from Task 1 (if you added it)**
+
+If Step 6 of Task 1 added `#[cfg_attr(not(test), expect(dead_code, reason = "..."))]` above `unsupported_protocol_version_error`, delete those lines now. The `initialize` override is the call site that makes the helper live. The `#[expect]` form would now fail compilation because the underlying `dead_code` lint no longer fires.
+
+- [ ] **Step 3: Build the workspace**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean. If errors mention `InitializeRequestParams`, `InitializeResult`, or `ProtocolVersion` not in scope, verify that Task 1 Step 1's expanded `use rmcp::model::{ ... };` block landed.
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: clean. If clippy complains about `must_use_candidate` on the helper (now that it has a caller and might be a future public surface), add `#[must_use]` immediately above the helper declaration — same pattern as #275's `synthesize_pre_init_error_envelope`.
+
+- [ ] **Step 5: Run the existing test suite to confirm no regressions**
+
+Run:
+```bash
+cargo test -p rimap-server --lib
+```
+
+Expected: all tests pass, including the 4 new helper tests from Task 1 and the existing #275 `mcp::preinit::tests::*`. Do NOT run the ignored wire test `initialize_unsupported_protocol_version` — that's Task 5's job.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/server.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): reject non-LATEST protocolVersion in initialize (#276)
+
+Override ServerHandler::initialize on ImapMcpServer to return
+Err(unsupported_protocol_version_error(...)) when the peer's
+protocolVersion is not exactly ProtocolVersion::LATEST. rmcp converts
+the Err into a JSON-RPC -32602 wire envelope and short-circuits with
+ServerInitializeError::InitializeFailed; main.rs's match arm (next
+commit) classifies that as a handled rejection (clean exit 0, audit
+Eof).
+
+The strict LATEST-only narrowing matches what rmcp 1.5 actually
+emits — its serde types target LATEST exclusively. Accepting older
+versions would echo the peer's version string while serving
+2025-11-25 capabilities, recreating the unproven-semantics bug class
+#276 is fixing. See spec §"Why LATEST-only".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add the `initialize_failure_is_handled_rejection` classifier with unit tests
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+The classifier is a one-line `matches!` on `ErrorCode`. We unit-test it directly so the boundary between handled-client-rejection (INVALID_PARAMS) and server-fault (INTERNAL_ERROR and others) is pinned without needing a full integration test with a test-support hook.
+
+- [ ] **Step 1: Add the `ErrorCode` import**
+
+In `crates/rimap-server/src/main.rs`, find the existing `use rmcp::service::ServerInitializeError;` at line 27. Add a sibling import directly above or below it:
+
+```rust
+use rmcp::model::ErrorCode as McpErrorCode;
+```
+
+The local alias `McpErrorCode` matches the pattern `mcp/error.rs` uses (`ErrorCode as McpCode`); it avoids a name collision with `rimap_core::ErrorCode` if that ever surfaces in main.rs.
+
+- [ ] **Step 2: Write the failing classifier test**
+
+In `crates/rimap-server/src/main.rs`, find the `#[cfg(all(test, unix))] mod resolve_download_dir_tests { ... }` block at the bottom of the file (around line 428). After its closing brace, add a NEW sibling test module:
+
+```rust
+#[cfg(test)]
+mod initialize_failure_classifier_tests {
+    use rmcp::model::ErrorCode as McpErrorCode;
+
+    use super::initialize_failure_is_handled_rejection;
+
+    #[test]
+    fn invalid_params_is_handled_rejection() {
+        assert!(initialize_failure_is_handled_rejection(McpErrorCode::INVALID_PARAMS));
+    }
+
+    #[test]
+    fn internal_error_is_not_handled_rejection() {
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode::INTERNAL_ERROR));
+    }
+
+    #[test]
+    fn method_not_found_is_not_handled_rejection() {
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode::METHOD_NOT_FOUND));
+    }
+
+    #[test]
+    fn unknown_codes_are_not_handled_rejection() {
+        // Future-proofing: any code we haven't explicitly allow-listed
+        // must propagate as a server fault.
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(-32099)));
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(-32603 - 1)));
+        assert!(!initialize_failure_is_handled_rejection(McpErrorCode(-32700)));
+    }
+}
+```
+
+This test module uses `#[cfg(test)]` (not the platform-gated `#[cfg(all(test, unix))]` of its neighbor) because the classifier has no platform-specific behavior.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+```bash
+cargo test -p rimap-server --bin rusty-imap-mcp initialize_failure_classifier 2>&1 | head -20
+```
+
+Expected: compile error — `cannot find function 'initialize_failure_is_handled_rejection' in module 'super'`.
+
+- [ ] **Step 4: Add the classifier helper**
+
+In `crates/rimap-server/src/main.rs`, find a clear location for a small helper function — a good spot is immediately AFTER `emit_pre_init_error_envelope` (the #275 helper currently at lines 188-203). Add:
+
+```rust
+/// Classify a `ServerInitializeError::InitializeFailed` outcome by its
+/// inner `ErrorData.code`. Returns `true` for client-side bad-input
+/// codes that the wire envelope already communicated cleanly; the
+/// caller treats these as handled rejections (exit 0, audit `Eof`).
+/// Returns `false` for server-fault classes (`INTERNAL_ERROR` and
+/// anything else) so they propagate as non-zero exit with audit
+/// `Error`, keeping initialize-time outages observable. (#276)
+fn initialize_failure_is_handled_rejection(code: McpErrorCode) -> bool {
+    matches!(code, McpErrorCode::INVALID_PARAMS)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```bash
+cargo test -p rimap-server --bin rusty-imap-mcp initialize_failure_classifier
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Run clippy**
+
+Run:
+```bash
+cargo clippy -p rimap-server --bin rusty-imap-mcp --all-features -- -D warnings
+```
+
+Expected: clean. If clippy fires `dead_code` on `initialize_failure_is_handled_rejection` (because the call site in `main.rs::run` comes in Task 4), add a one-line `#[cfg_attr(not(test), expect(dead_code, reason = "wired into main.rs::run in the next commit (#276 task 4)"))]` attribute above the function. Task 4 removes it as a natural consequence of adding the call site.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add initialize_failure_is_handled_rejection helper (#276)
+
+One-line matches! on rmcp::model::ErrorCode that distinguishes
+client-side bad-input (INVALID_PARAMS) from server-fault classes
+(INTERNAL_ERROR, METHOD_NOT_FOUND, anything else). Unit tests pin the
+boundary directly without needing a wire-level test-support hook.
+
+Not yet wired into main.rs::run — that's the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire the code-gated `InitializeFailed` arms into `main.rs::run`
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+This is the second behavior-change commit. The new arms sit between #275's existing `ExpectedInitializeRequest` arm and the fallback `Err(other) => return Err(...)` catch-all. INVALID_PARAMS routes to clean exit; everything else propagates as today.
+
+- [ ] **Step 1: Update the `serve_server` match block**
+
+In `crates/rimap-server/src/main.rs`, locate the existing match block in `run()` (currently lines 140-147):
+
+```rust
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                emit_pre_init_error_envelope(&msg).await?;
+                return Ok(());
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
+```
+
+Replace with the expanded version below, inserting TWO new arms between the existing pre-init arm and the catch-all:
+
+```rust
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                emit_pre_init_error_envelope(&msg).await?;
+                return Ok(());
+            }
+            Err(ServerInitializeError::InitializeFailed(error_data))
+                if initialize_failure_is_handled_rejection(error_data.code) =>
+            {
+                // rmcp already sent the error envelope to the client.
+                // INVALID_PARAMS at the initialize boundary is a handled
+                // client rejection (e.g. unsupported protocol version per
+                // #276), not a server fault — clean exit 0, audit Eof.
+                tracing::info!(
+                    code = error_data.code.0,
+                    "rejected initialize with error envelope",
+                );
+                return Ok(());
+            }
+            Err(ServerInitializeError::InitializeFailed(error_data)) => {
+                // Server-fault classes (INTERNAL_ERROR and others) must
+                // surface as non-zero exit with process_end.reason: Error
+                // so initialize-time outages stay observable in the audit
+                // trail. (Codex adversarial-review finding 2026-05-14)
+                return Err(anyhow::anyhow!(
+                    "MCP server init failed: code {}: {}",
+                    error_data.code.0,
+                    error_data.message,
+                ));
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
+```
+
+Match-arm ordering matters: the guarded arm MUST come before the unguarded one with the same pattern, otherwise the unguarded arm will absorb every `InitializeFailed`.
+
+- [ ] **Step 2: Remove the dead_code suppression from Task 3 (if you added it)**
+
+If Step 6 of Task 3 added `#[cfg_attr(not(test), expect(dead_code, reason = "..."))]` above `initialize_failure_is_handled_rejection`, delete it now. The match arm is the call site that makes the helper live.
+
+- [ ] **Step 3: Build the workspace**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean. If errors mention `error_data.code.0`, the rmcp `ErrorCode` type may have a different inner-field name in your local rmcp 1.5 — verify with `grep "pub struct ErrorCode" ~/.cargo/registry/src/index.crates.io-*/rmcp-1.5*/src/model.rs`. The inner field is `0` because `ErrorCode(i32)` is a single-field tuple struct (per earlier exploration, `pub struct ErrorCode(pub i32)`).
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Run lib + binary test suites to confirm no regressions**
+
+Run:
+```bash
+cargo test -p rimap-server --lib
+```
+
+Expected: all pass, including:
+- 4 new `mcp::server::protocol_version_tests::*` from Task 1
+- 6 existing `mcp::preinit::tests::*` from #275
+
+Run:
+```bash
+cargo test -p rimap-server --bin rusty-imap-mcp
+```
+
+Expected: all pass, including:
+- 4 new `initialize_failure_classifier_tests::*` from Task 3
+- existing `resolve_download_dir_tests::*`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): code-gate InitializeFailed handling in main::run (#276)
+
+Adds two match arms to the serve_server result:
+
+- InitializeFailed with INVALID_PARAMS: rmcp already sent the wire
+  envelope (e.g. for unsupported protocol version per #276); exit 0
+  with process_end.reason: Eof. Same audit semantics as #275's
+  pre-init handled path.
+- InitializeFailed with anything else (INTERNAL_ERROR, etc.):
+  propagate as anyhow::Error so process_end.reason: Error and the
+  process exits non-zero. Keeps initialize-time outages observable
+  in the audit trail.
+
+Closes Codex adversarial-review finding 2026-05-14 (medium).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Un-ignore `initialize_unsupported_protocol_version` with strict assertions
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+This is the first wire-level verification of Tasks 1-4. The test already exists at lines 612-668 with `#[ignore = "blocked on #276: ..."]`; we un-ignore and tighten.
+
+- [ ] **Step 1: Replace the existing test body**
+
+In `crates/rimap-server/tests/mcp_wire_negative.rs`, locate the existing `initialize_unsupported_protocol_version` test (around lines 600-668, beginning with the `// Test 8: \`initialize\` with unsupported protocol version` banner). Replace the entire test region (docstring + attributes + body) with:
+
+```rust
+// ---------------------------------------------------------------------------
+// Test 8: `initialize` with unsupported protocol version
+// ---------------------------------------------------------------------------
+
+/// Client requests a protocol version the server doesn't support. Per
+/// spec §"Desired behavior" (#276), the server must reply with a
+/// JSON-RPC -32602 error envelope listing `supported_versions ==
+/// ["2025-11-25"]`, then close cleanly and exit 0 with audit reason
+/// Eof. Fixed by #276.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_unsupported_protocol_version() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "1999-01-01",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    // Phase 1: error envelope arrives with -32602.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32602 error envelope for unsupported protocol version, got {other:?}"
+        ),
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32602),
+        "must be code -32602 (INVALID_PARAMS), got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!(["2025-11-25"]),
+        "supported_versions must be exactly [\"2025-11-25\"] — locks in LATEST-only \
+         posture and prevents older version names from sneaking onto the wire; got {envelope}",
+    );
+    let message = envelope["error"]["message"]
+        .as_str()
+        .expect("error.message is a string");
+    assert!(
+        message.contains("1999-01-01"),
+        "message must echo the peer version 1999-01-01, got {message:?}",
+    );
+    assert!(
+        message.contains("2025-11-25"),
+        "message must include the supported version 2025-11-25, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    // Phase 2: stdout closes and the server exits 0.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on unsupported protocol version, got {other:?}"
+        ),
+    }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on handled INVALID_PARAMS rejection",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative initialize_unsupported_protocol_version -- --nocapture
+```
+
+Expected: PASS. The test:
+- Receives a `-32602` envelope with `supported_versions == ["2025-11-25"]`
+- Sees the server close stdin cleanly (exit 0)
+- Reads `process_end.reason == Eof` from the audit log
+
+If it fails:
+- Got a success response with `protocolVersion: "1999-01-01"` echoed back: Task 2 didn't land — check `mcp/server.rs` for the `initialize` override.
+- Got crashed / non-zero exit: Task 4 didn't land — check `main.rs::run` for the two new arms.
+- `supported_versions` mismatch: check Task 1's helper produces a single-element array.
+- `no process_end record found`: see Task 5 of the #275 plan; same root cause if it surfaces here.
+
+- [ ] **Step 3: Run clippy on the test binary**
+
+Run:
+```bash
+cargo clippy -p rimap-server --test mcp_wire_negative -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin -32602 contract for unsupported version (#276)
+
+Un-ignore initialize_unsupported_protocol_version with strict
+assertions matching the LATEST-only posture:
+- response envelope must be code -32602 with the peer version echoed
+- supported_versions must equal ["2025-11-25"] exactly
+- server must close stdin cleanly with exit 0
+- audit log must record process_end.reason: Eof
+
+The exact-array assertion on supported_versions is the tripwire
+against any future relaxation that would re-add older version names.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `initialize_with_known_older_version_is_rejected`
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the strict LATEST-only posture against any future permissive relaxation. Sends a known older version (`"2024-11-05"`) — which would silently succeed under the original buggy rmcp behavior — and verifies the same `-32602` rejection.
+
+- [ ] **Step 1: Write the test**
+
+In `crates/rimap-server/tests/mcp_wire_negative.rs`, add this test immediately after `initialize_unsupported_protocol_version`:
+
+```rust
+/// Strict-posture tripwire (#276 Codex adversarial-review Finding 1):
+/// known older MCP versions (`2024-11-05`, etc.) MUST also be rejected
+/// with -32602, even though they appear in `ProtocolVersion::KNOWN_VERSIONS`.
+/// rmcp 1.5 doesn't actually emit older wire shapes — accepting them
+/// would echo "2024-11-05" while serving 2025-11-25-shaped responses.
+/// This test fails if a future change ever broadens the acceptance set,
+/// forcing the relaxation to be a deliberate spec revision.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_with_known_older_version_is_rejected() {
+    let mut harness = Harness::spawn().await;
+
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32602 rejection for known older version 2024-11-05, got {other:?}"
+        ),
+    };
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32602),
+        "known older version must be rejected, not silently accepted; got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!(["2025-11-25"]),
+        "supported_versions must remain [\"2025-11-25\"] even when peer asks for a known older version, got {envelope}",
+    );
+    let message = envelope["error"]["message"]
+        .as_str()
+        .expect("error.message is a string");
+    assert!(
+        message.contains("2024-11-05"),
+        "message must echo the rejected peer version 2024-11-05, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative initialize_with_known_older_version_is_rejected -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin LATEST-only posture against known older versions (#276)
+
+Adds a tripwire test that sends a KNOWN_VERSIONS member (2024-11-05)
+and asserts it gets the same -32602 rejection as unknown garbage.
+Locks in the Codex Finding 1 resolution: rmcp 1.5 doesn't actually
+emit older wire shapes, so the server must not advertise compatibility
+with versions it cannot serve.
+
+This test BLOCKS any future change that relaxes the protocol-version
+acceptance set without first adding per-version conformance.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add `initialize_with_empty_string_protocol_version`
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the edge case: an empty `protocolVersion` string is valid JSON but a degenerate value. Must be rejected.
+
+- [ ] **Step 1: Write the test**
+
+In `crates/rimap-server/tests/mcp_wire_negative.rs`, add this test immediately after `initialize_with_known_older_version_is_rejected`:
+
+```rust
+/// Edge case: `protocolVersion: ""` is valid JSON but a degenerate
+/// version string. Must be rejected with -32602. Pins the boundary
+/// against any future code that might special-case empty strings.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_with_empty_string_protocol_version() {
+    let mut harness = Harness::spawn().await;
+
+    let _id = harness
+        .send_request_no_wait(
+            "initialize",
+            json!({
+                "protocolVersion": "",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "rusty-imap-mcp-phase4-test",
+                    "version": "0.0.0",
+                },
+            }),
+        )
+        .await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32602 rejection for empty protocolVersion, got {other:?}"
+        ),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32602));
+    assert_eq!(
+        envelope["error"]["data"]["supported_versions"],
+        json!(["2025-11-25"]),
+    );
+    let message = envelope["error"]["message"]
+        .as_str()
+        .expect("error.message is a string");
+    assert!(
+        message.contains("''"),
+        "empty peer version should appear as '' in the human-readable message, got {message:?}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative initialize_with_empty_string_protocol_version -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin empty-string protocolVersion rejection (#276)
+
+Edge case: protocolVersion: "" is valid JSON but degenerate. Must be
+rejected with the same -32602 contract as any non-LATEST version.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full local-CI sweep and PR creation
+
+**Files:** none expected; this task verifies everything composes.
+
+- [ ] **Step 1: Run the full mcp_wire_negative binary to confirm no regressions across the suite**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative
+```
+
+Expected: all tests pass (no `#[ignore]`'d tests blocking on #276 remain; the one blocked on #277, `prop_envelope_never_panics`, is in a different binary).
+
+- [ ] **Step 2: Run `just ci`**
+
+Run:
+```bash
+just ci
+```
+
+Expected: PASS. This runs fmt-check, clippy with `-D warnings`, the workspace test suite via nextest, and `cargo deny`.
+
+Common late-stage failures:
+- **`cargo deny` advisory failure for lettre or another crate**: the #275 PR (#279) already bumped lettre. If a new advisory has landed since then, address it in a sibling commit on this branch and re-run.
+- **Clippy `dead_code` on either helper**: confirm Task 2 Step 2 and Task 4 Step 2 removed the placeholder `#[cfg_attr]` attributes.
+- **Test failure on `tools_list_before_initialize` (or another #275 test)**: this plan should NOT have affected #275 paths. If it did, the new `InitializeFailed` arms in `main.rs::run` are absorbing a case they shouldn't — re-check the match-arm ordering (guarded INVALID_PARAMS arm comes BEFORE the unguarded `InitializeFailed` catch-all).
+
+- [ ] **Step 3: Verify no stale `#[ignore]` referencing #276 remains**
+
+Run:
+```bash
+rg -n '#\[ignore.*#276' crates/
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Verify the commit log matches the plan**
+
+Run:
+```bash
+git log --oneline HEAD ^fix/issue-275-pre-initialize-handling
+```
+
+Expected:
+1. `feat(rimap-server): add unsupported_protocol_version_error helper (#276)` (Task 1)
+2. `fix(rimap-server): reject non-LATEST protocolVersion in initialize (#276)` (Task 2)
+3. `feat(rimap-server): add initialize_failure_is_handled_rejection helper (#276)` (Task 3)
+4. `fix(rimap-server): code-gate InitializeFailed handling in main::run (#276)` (Task 4)
+5. `test(rimap-server): pin -32602 contract for unsupported version (#276)` (Task 5)
+6. `test(rimap-server): pin LATEST-only posture against known older versions (#276)` (Task 6)
+7. `test(rimap-server): pin empty-string protocolVersion rejection (#276)` (Task 7)
+8. (Plus the two earlier docs commits from the brainstorming/Codex-review phase, depending on what's in `^fix/issue-275-pre-initialize-handling`)
+
+- [ ] **Step 5: Push and open the PR**
+
+The branch target depends on whether PR #279 (the #275 PR) has merged yet. Pick the matching command:
+
+**If PR #279 is still open** (this PR stacks on #275):
+
+```bash
+GIT_SSH_COMMAND='ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=10' git push -u origin fix/issue-276-protocol-version-negotiation
+gh pr create --base fix/issue-275-pre-initialize-handling --title "fix(rimap-server): reject non-LATEST protocolVersion in initialize (#276)" --body "$(cat <<'EOF'
+## Summary
+
+- Override `ServerHandler::initialize` to reject any `protocolVersion` other than `ProtocolVersion::LATEST` (currently `"2025-11-25"`) with a JSON-RPC `-32602` error envelope listing `supported_versions == ["2025-11-25"]`.
+- Code-gate `ServerInitializeError::InitializeFailed` handling in `main.rs::run`: `INVALID_PARAMS` → clean exit (audit `Eof`); `INTERNAL_ERROR` and other server-fault codes → propagated `anyhow::Error` (audit `Error`).
+- Per Codex adversarial-review Finding 1, posture is strict LATEST-only (not permissive `KNOWN_VERSIONS`) — rmcp 1.5 has no per-version serialization, so accepting older versions would echo the peer's version while serving 2025-11-25-shaped responses.
+
+Fixes #276. Stacked on PR #279 (#275). Targets `fix/issue-275-pre-initialize-handling` while #279 is open; rebase onto `feature/issue-266-mcp-fuzzing` once #279 merges.
+
+## Test plan
+
+- [ ] `cargo test -p rimap-server --test mcp_wire_negative` — 3 new wire tests pass (`initialize_unsupported_protocol_version` un-ignored, plus `initialize_with_known_older_version_is_rejected` and `initialize_with_empty_string_protocol_version` added)
+- [ ] `cargo test -p rimap-server --lib mcp::server::protocol_version_tests` — 4 helper unit tests pass
+- [ ] `cargo test -p rimap-server --bin rusty-imap-mcp initialize_failure_classifier_tests` — 4 classifier unit tests pass
+- [ ] `just ci` passes locally
+
+Spec: `docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md`
+Plan: `docs/superpowers/plans/2026-05-14-issue-276-protocol-version-negotiation.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**If PR #279 has merged into `feature/issue-266-mcp-fuzzing`** (rebase first, then target the feature branch):
+
+```bash
+git fetch origin
+git rebase origin/feature/issue-266-mcp-fuzzing
+GIT_SSH_COMMAND='ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=10' git push -u origin fix/issue-276-protocol-version-negotiation
+gh pr create --base feature/issue-266-mcp-fuzzing --title "fix(rimap-server): reject non-LATEST protocolVersion in initialize (#276)" --body "$(cat <<'EOF'
+## Summary
+
+(same body as above)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+The `GIT_SSH_COMMAND` keepalive override is required on this repo per the auto-memory note (`project_push_ssh_keepalive.md`); without it, the pre-push hook's long `just test` + `cargo deny` run lets GitHub idle-close the SSH connection and the push exits 0 with no ref transfer.
+
+After push, verify the remote ref landed:
+
+```bash
+git ls-remote origin fix/issue-276-protocol-version-negotiation
+```
+
+Expected: the local HEAD SHA matches the remote ref.
+
+---
+
+## Done
+
+All tasks complete. Verify with one final read-through of `git log fix/issue-276-protocol-version-negotiation ^fix/issue-275-pre-initialize-handling` — should show the 7 implementation/test commits plus the two docs commits from the brainstorming phase (the design spec + Codex-review revisions).

--- a/docs/superpowers/plans/2026-05-15-issue-277-envelope-validator.md
+++ b/docs/superpowers/plans/2026-05-15-issue-277-envelope-validator.md
@@ -1,0 +1,2245 @@
+# JSON-RPC Envelope Validator Implementation Plan (#277)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap rmcp's stdio transport with a JSON-RPC 2.0 envelope validator that rejects malformed envelopes with `-32600` / `-32700` instead of letting rmcp's `try_parse_with_compatibility` silently drop them. Un-ignore `prop_envelope_never_panics`. Add a bridge-task supervisor with two-phase shutdown so write failures surface to `process_end.reason: Error` on every failure path.
+
+**Architecture:** A new `mcp/wire_validator.rs` module owns: a pure `validate()` function recognizing all four JSON-RPC envelope shapes (Request, Notification, Response, Error); two async bridge tasks (`validate_inbound`, `passthrough_outbound`) that sandwich rmcp's transport via `tokio::io::duplex`; a `ValidatorSupervisor` with `watch_for_error` / `drain` / `shutdown_after_failure`; a `stdio_with_validation()` entry point returning `ValidatedStdio { transport, stdout, supervisor }`. `main.rs::run` races both init and post-init against the supervisor (`tokio::select! { biased; ... }`) and uses `shutdown_after_failure` on every error path so clients holding stdin open don't cause shutdown to hang.
+
+**Tech Stack:** Rust (workspace MSRV 1.88.0), tokio (`io::duplex`, `select!`, async Mutex, `JoinHandle::abort()`), rmcp 1.5 (`IntoTransport<RoleServer, _, _>` over a `(DuplexStream, DuplexStream)` pair), serde_json, anyhow, tracing. Wire-level integration tests use the `Harness` from `crates/rimap-server/tests/support/wire/`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md`](../specs/2026-05-15-issue-277-envelope-validator-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `crates/rimap-server/src/mcp/wire_validator.rs` — validator module + `ValidatedStdio` / `ValidatorSupervisor` types + unit tests
+
+**Modify:**
+- `crates/rimap-server/src/mcp/mod.rs` — `pub mod wire_validator;`
+- `crates/rimap-server/src/main.rs` — transport swap, `emit_pre_init_error_envelope` signature thread-through, init-phase race, post-init two-phase shutdown
+- `crates/rimap-server/tests/support/wire/harness.rs` — new closed-stdout-with-open-stdin harness variant
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — 25 new wire-pinned tests
+- `crates/rimap-server/tests/mcp_wire_proptest.rs` — `prop_filter` on `arb_envelope`, un-ignore `prop_envelope_never_panics`
+
+---
+
+## Task 0: Pre-flight — sanity-check the working tree
+
+**Files:** none (verification only)
+
+**Context:** The branch is `feature/issue-266-mcp-fuzzing`. The #275 and #276 fixes have already merged here. The harness (`tests/support/wire/harness.rs`) is present with the closed-stdout variants added for #275. The pinned ignored test `prop_envelope_never_panics` is at `tests/mcp_wire_proptest.rs:311`. This task confirms the tree shape before any changes.
+
+- [ ] **Step 1: Confirm branch and tree are clean**
+
+Run:
+```bash
+git rev-parse --abbrev-ref HEAD && git status --short
+```
+
+Expected: `feature/issue-266-mcp-fuzzing` on the first line; empty `git status` on the second. If not on this branch, halt — the plan assumes #275 and #276 are merged into the current HEAD.
+
+- [ ] **Step 2: Confirm the prop test we will un-ignore is present and ignored**
+
+Run:
+```bash
+rg -n 'prop_envelope_never_panics|blocked on #277' crates/rimap-server/tests/mcp_wire_proptest.rs
+```
+
+Expected: a match showing `#[ignore = "blocked on #277: server hangs on unknown-method envelopes missing jsonrpc/id fields; re-enable once rmcp responds or closes cleanly"]` above an `fn prop_envelope_never_panics(...)`. If the line is absent or already un-ignored, halt.
+
+- [ ] **Step 3: Confirm the closed-stdout harness variant from #275 is present**
+
+Run:
+```bash
+rg -n 'spawn_with_closed_stdout|DetachedStdoutHarness' crates/rimap-server/tests/support/wire/harness.rs
+```
+
+Expected: at least two matches. This variant gets reused for tests 12-14 of this plan, and a new sibling variant gets added in Task 4.1.
+
+- [ ] **Step 4: Confirm the workspace builds clean before changes**
+
+Run:
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean exit, no errors.
+
+- [ ] **Step 5: No commit. Move to Task 1.1.**
+
+---
+
+## Task 1.1: Create `wire_validator.rs` skeleton with types
+
+**Files:**
+- Create: `crates/rimap-server/src/mcp/wire_validator.rs`
+- Modify: `crates/rimap-server/src/mcp/mod.rs`
+
+This task creates the module file with the core data types and stubs for the public surface. No implementations yet; later tasks fill them in. Compiling this task confirms the module declaration and type signatures are correct before TDD on `validate()` begins.
+
+- [ ] **Step 1: Create the module file with type stubs**
+
+Create `crates/rimap-server/src/mcp/wire_validator.rs`:
+
+```rust
+//! JSON-RPC 2.0 envelope validator (#277).
+//!
+//! Wraps rmcp's stdio transport: reads stdin, validates each line as a
+//! JSON-RPC 2.0 envelope, forwards valid envelopes to rmcp via an
+//! in-memory duplex stream, and synthesizes `-32600 Invalid Request` /
+//! `-32700 Parse error` envelopes for malformed input. Without this
+//! layer rmcp 1.5's `JsonRpcMessageCodec` silently drops envelopes
+//! that fail its compatibility shim — see
+//! `docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md`.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::io::{DuplexStream, Stdout};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Bridge-task duplex buffer. Large enough that one well-formed
+/// envelope fits in a single write; both directions are independent
+/// tasks so inbound stalls cannot cause outbound deadlock.
+const BUF_SIZE: usize = 64 * 1024;
+
+/// What the validator decides for a given line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValidationOutcome {
+    /// Forward the line byte-for-byte to rmcp.
+    Forward,
+    /// Empty or whitespace-only line — drop silently.
+    Skip,
+    /// Reject with the synthesized error envelope.
+    Reject(ErrorEnvelope),
+}
+
+/// A synthesized JSON-RPC error response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ErrorEnvelope {
+    pub code: i32,
+    pub message: &'static str,
+    pub id: Value, // `Value::Null` if absent or invalid; otherwise echoed string/number.
+}
+
+/// Public bundle handed back to `main.rs::run`. `transport` plugs into
+/// `rmcp::serve_server(server, validated.transport)`; `stdout` is the
+/// shared writer that all synchronized output paths (validator
+/// rejections, passthrough frames, AND `emit_pre_init_error_envelope`)
+/// lock; `supervisor` exposes the bridge-task lifecycle.
+pub struct ValidatedStdio {
+    pub transport: (DuplexStream, DuplexStream),
+    pub stdout: Arc<Mutex<Stdout>>,
+    pub supervisor: ValidatorSupervisor,
+}
+
+/// Supervises the two bridge tasks (`validate_inbound` and
+/// `passthrough_outbound`). See the spec for the three-method lifecycle
+/// contract: race-phase fail-fast (`watch_for_error`), success-path
+/// drain (`drain`), and failure-path abort+drain (`shutdown_after_failure`).
+pub struct ValidatorSupervisor {
+    pub(crate) inbound: JoinHandle<std::io::Result<()>>,
+    pub(crate) outbound: JoinHandle<std::io::Result<()>>,
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+Open `crates/rimap-server/src/mcp/mod.rs` and add the line `pub mod wire_validator;` alongside the other `pub mod` declarations. Place it alphabetically (after `tool_catalog` if present, before `server` if not — verify by reading the file first):
+
+```bash
+cat crates/rimap-server/src/mcp/mod.rs
+```
+
+Make the addition with `Edit` so the alphabetical ordering is preserved.
+
+- [ ] **Step 3: Verify the workspace still compiles**
+
+Run:
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean. The new types are pub(crate) or pub but unused; cargo will not warn at this stage because unused items in lib crates flow through to bin without warning unless `-W dead_code` is set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs crates/rimap-server/src/mcp/mod.rs
+git commit -m "feat(rimap-server): wire_validator module skeleton + types (#277)"
+```
+
+---
+
+## Task 1.2: Implement `validate()` with unit tests
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+This is the heart of the validator. Pure function, no I/O — every JSON-RPC 2.0 shape check goes here. The spec defines the decision logic in detail (see `### validate() decision logic` section). Write the unit tests first; the implementation is mechanical once the test cases are in place.
+
+- [ ] **Step 1: Add the unit-test scaffold**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs`:
+
+```rust
+// ============================================================
+// Pure validator (no I/O — unit-testable in isolation).
+// ============================================================
+
+/// `id` accepted by rmcp's `RxJsonRpcMessage`. Null is excluded
+/// because rmcp 1.5's `RequestId = NumberOrString` rejects null.
+pub(crate) fn is_forwardable_id(v: &Value) -> bool {
+    v.is_string() || v.is_number()
+}
+
+/// `error` body matches JSON-RPC §5.1: an object with numeric
+/// `code` and string `message`. `data` is optional.
+pub(crate) fn is_well_formed_error(v: &Value) -> bool {
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    obj.get("code").is_some_and(Value::is_number)
+        && obj.get("message").is_some_and(Value::is_string)
+}
+
+/// Read the top-level `id` field for echo on a rejection envelope.
+/// Returns `Value::Null` if `id` is missing or of a disallowed type;
+/// otherwise echoes the original value verbatim. JSON-RPC §5 says
+/// the id on a synthesized error response MUST be null when the
+/// original could not be detected.
+pub(crate) fn extract_id(obj: &serde_json::Map<String, Value>) -> Value {
+    match obj.get("id") {
+        Some(v) if v.is_string() || v.is_number() || v.is_null() => v.clone(),
+        _ => Value::Null,
+    }
+}
+
+pub(crate) fn parse_error() -> ErrorEnvelope {
+    ErrorEnvelope {
+        code: -32700,
+        message: "Parse error",
+        id: Value::Null,
+    }
+}
+
+pub(crate) fn invalid_request(id: Value) -> ErrorEnvelope {
+    ErrorEnvelope {
+        code: -32600,
+        message: "Invalid Request",
+        id,
+    }
+}
+
+/// Validate one line of input and decide what to do with it.
+pub(crate) fn validate(line: &str) -> ValidationOutcome {
+    if line.trim().is_empty() {
+        return ValidationOutcome::Skip;
+    }
+    let parsed: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return ValidationOutcome::Reject(parse_error()),
+    };
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return ValidationOutcome::Reject(invalid_request(Value::Null)),
+    };
+    if obj.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return ValidationOutcome::Reject(invalid_request(extract_id(obj)));
+    }
+
+    // id (if present) must be string|number — null is rejected here
+    // because rmcp's RequestId = NumberOrString won't deserialize null.
+    let id_present_and_valid = match obj.get("id") {
+        None => false,
+        Some(v) if is_forwardable_id(v) => true,
+        Some(_) => return ValidationOutcome::Reject(invalid_request(Value::Null)),
+    };
+
+    let method = obj.get("method");
+    let result = obj.get("result");
+    let error = obj.get("error");
+
+    match (method, result, error) {
+        // Request: method+id, no result, no error
+        (Some(m), None, None) if m.is_string() && id_present_and_valid => {
+            ValidationOutcome::Forward
+        }
+        // Notification: method, no id, no result, no error
+        (Some(m), None, None) if m.is_string() && !id_present_and_valid => {
+            ValidationOutcome::Forward
+        }
+        // Non-string method
+        (Some(_), None, None) => {
+            ValidationOutcome::Reject(invalid_request(extract_id(obj)))
+        }
+        // Response: id+result, no method, no error
+        (None, Some(_), None) if id_present_and_valid => ValidationOutcome::Forward,
+        // Error response: id+error, no method, no result, error well-formed
+        (None, None, Some(err)) if id_present_and_valid && is_well_formed_error(err) => {
+            ValidationOutcome::Forward
+        }
+        // Catch-all: empty object, response/error without id, malformed error,
+        // both result+error, method mixed with result/error.
+        _ => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn reject(code: i32, id: Value) -> ValidationOutcome {
+        ValidationOutcome::Reject(ErrorEnvelope {
+            code,
+            message: if code == -32700 { "Parse error" } else { "Invalid Request" },
+            id,
+        })
+    }
+
+    #[test]
+    fn empty_line_skips() {
+        assert_eq!(validate(""), ValidationOutcome::Skip);
+        assert_eq!(validate("   "), ValidationOutcome::Skip);
+        assert_eq!(validate("\r"), ValidationOutcome::Skip);
+    }
+
+    #[test]
+    fn invalid_json_returns_parse_error() {
+        assert_eq!(validate("not valid json"), reject(-32700, Value::Null));
+    }
+
+    #[test]
+    fn non_object_returns_invalid_request() {
+        assert_eq!(validate("[1, 2, 3]"), reject(-32600, Value::Null));
+        assert_eq!(validate("\"a string\""), reject(-32600, Value::Null));
+        assert_eq!(validate("42"), reject(-32600, Value::Null));
+        assert_eq!(validate("null"), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn missing_jsonrpc_returns_invalid_request() {
+        assert_eq!(validate(r#"{"method":"a"}"#), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn wrong_jsonrpc_value_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"1.0","method":"x","id":1}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn valid_request_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#),
+            ValidationOutcome::Forward
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"tools/list","id":"abc"}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn valid_notification_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"notifications/cancelled"}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn null_id_returns_invalid_request() {
+        // Even though JSON-RPC §5 allows null id on responses, rmcp's
+        // RequestId = NumberOrString rejects it on the wire; we match
+        // that grammar.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":null}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn array_or_object_id_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":[1,2]}"#),
+            reject(-32600, Value::Null)
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":{"k":"v"}}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn non_string_method_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":42,"id":1}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn valid_response_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":99,"result":{"x":1}}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn valid_error_response_forwards() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"not found"}}"#),
+            ValidationOutcome::Forward
+        );
+    }
+
+    #[test]
+    fn response_without_id_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","result":{}}"#),
+            reject(-32600, Value::Null)
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","error":{"code":1,"message":"x"}}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn both_result_and_error_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":1,"message":"x"}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn malformed_error_body_returns_invalid_request() {
+        // error must be object with numeric code + string message
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":"x","message":"y"}}"#),
+            reject(-32600, json!(1))
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"message":"only message"}}"#),
+            reject(-32600, json!(1))
+        );
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":"not even an object"}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn empty_object_returns_invalid_request() {
+        assert_eq!(validate(r#"{}"#), reject(-32600, Value::Null));
+    }
+
+    #[test]
+    fn mixed_method_and_result_returns_invalid_request() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1,"result":{}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the unit tests**
+
+Run:
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: all 16 tests in `mcp::wire_validator::tests` PASS. The lib already has many unrelated tests; the `--lib wire_validator` filter narrows the run.
+
+If anything fails, the implementation has a logic error — re-check the match arms against the spec's "Validation rules" table.
+
+- [ ] **Step 3: Run clippy on the new module**
+
+Run:
+```bash
+cargo clippy -p rimap-server --lib --all-targets --locked -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): pure JSON-RPC envelope validator (#277)"
+```
+
+---
+
+## Task 1.3: Synthesize error envelope as a wire string
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+The `ErrorEnvelope` value type from Task 1.1 carries the structured rejection. This task adds a helper that serializes it to the exact JSON-RPC wire shape (single line, terminating `\n`, flushed). The async tasks in Phase 2 use this helper when writing rejections.
+
+- [ ] **Step 1: Add the helper and its tests**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs`, BEFORE the `#[cfg(test)] mod tests` block:
+
+```rust
+/// Serialize a rejection envelope to a single wire line, terminated
+/// with `\n`. The shape matches JSON-RPC §5: `{jsonrpc, id, error}`
+/// with `error.{code, message}` and no `data`.
+pub(crate) fn synthesize_error_line(env: &ErrorEnvelope) -> String {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": env.id,
+        "error": {
+            "code": env.code,
+            "message": env.message,
+        },
+    });
+    // Use to_string (not pretty) so it's exactly one line.
+    let mut line = body.to_string();
+    line.push('\n');
+    line
+}
+```
+
+Add corresponding tests inside the existing `#[cfg(test)] mod tests` block:
+
+```rust
+    #[test]
+    fn synthesize_invalid_request_with_null_id() {
+        let env = ErrorEnvelope {
+            code: -32600,
+            message: "Invalid Request",
+            id: Value::Null,
+        };
+        let line = synthesize_error_line(&env);
+        assert!(line.ends_with('\n'));
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], Value::Null);
+        assert_eq!(parsed["error"]["code"], -32600);
+        assert_eq!(parsed["error"]["message"], "Invalid Request");
+        // No data field.
+        assert!(parsed["error"].get("data").is_none());
+    }
+
+    #[test]
+    fn synthesize_parse_error_has_correct_code() {
+        let line = synthesize_error_line(&parse_error());
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["error"]["code"], -32700);
+        assert_eq!(parsed["error"]["message"], "Parse error");
+    }
+
+    #[test]
+    fn synthesize_echoes_numeric_id() {
+        let env = invalid_request(json!(42));
+        let line = synthesize_error_line(&env);
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], 42);
+    }
+
+    #[test]
+    fn synthesize_echoes_string_id() {
+        let env = invalid_request(json!("abc"));
+        let line = synthesize_error_line(&env);
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], "abc");
+    }
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: all tests (16 from Task 1.2 + 4 new) PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): synthesize_error_line wire serializer (#277)"
+```
+
+---
+
+## Task 2.1: Implement `validate_inbound` bridge task
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+The inbound bridge reads lines from real stdin, runs `validate()`, and either forwards the line byte-for-byte to its duplex end or synthesizes a rejection through the shared stdout mutex. Reading uses `AsyncBufReadExt::read_until(b'\n', ...)` so the trailing newline is preserved verbatim (matches rmcp's framing).
+
+- [ ] **Step 1: Add the function**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs` (after `synthesize_error_line`, before the test module):
+
+```rust
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+/// Inbound bridge task. Reads from real stdin one line at a time
+/// (preserving the trailing `\n`), validates each line, and forwards
+/// or rejects.
+///
+/// Returns `Ok(())` on stdin EOF. Returns `Err(io::Error)` if a write
+/// to either the inbound duplex (forwarding) or shared stdout
+/// (rejection) fails — `BrokenPipe` on stdout is the most common
+/// failure mode and surfaces to `main.rs::run` via the supervisor so
+/// `process_end.reason: Error` is recorded.
+pub(crate) async fn validate_inbound<R>(
+    stdin: R,
+    mut to_rmcp: DuplexStream,
+    stdout: Arc<Mutex<Stdout>>,
+) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stdin);
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await?;
+        if n == 0 {
+            return Ok(()); // stdin EOF — clean shutdown.
+        }
+
+        // Strip trailing \n and optional \r for the validation view.
+        // rmcp's codec also strips \r; matching its grammar.
+        let trimmed: &[u8] = match buf.last() {
+            Some(&b'\n') => &buf[..buf.len() - 1],
+            _ => &buf[..],
+        };
+        let trimmed: &[u8] = match trimmed.last() {
+            Some(&b'\r') => &trimmed[..trimmed.len() - 1],
+            _ => trimmed,
+        };
+        let line_for_validation = std::str::from_utf8(trimmed).unwrap_or("");
+
+        match validate(line_for_validation) {
+            ValidationOutcome::Skip => continue,
+            ValidationOutcome::Forward => {
+                // Forward the buffer including its trailing \n so
+                // rmcp's framed reader sees the complete envelope.
+                if buf.last() != Some(&b'\n') {
+                    buf.push(b'\n');
+                }
+                to_rmcp.write_all(&buf).await?;
+                to_rmcp.flush().await?;
+            }
+            ValidationOutcome::Reject(env) => {
+                let line = synthesize_error_line(&env);
+                let mut sout = stdout.lock().await;
+                sout.write_all(line.as_bytes()).await?;
+                sout.flush().await?;
+                // Lock released here; loop continues.
+            }
+        }
+    }
+}
+```
+
+Note: the `use` statements may already exist higher in the file (`AsyncRead`, etc.). Consolidate so each item is imported exactly once.
+
+- [ ] **Step 2: Add a unit test**
+
+Inside the existing `#[cfg(test)] mod tests` block, add:
+
+```rust
+    use tokio::io::AsyncReadExt as _;
+
+    #[tokio::test]
+    async fn validate_inbound_forwards_valid_envelope() {
+        let stdin = std::io::Cursor::new(b"{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}\n".to_vec());
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        // Spawn the validator and consume rmcp's side concurrently.
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        let s = std::str::from_utf8(&forwarded).unwrap();
+        assert!(s.contains("\"method\":\"tools/list\""), "expected forwarded line, got {s:?}");
+        assert!(s.ends_with('\n'));
+    }
+
+    #[tokio::test]
+    async fn validate_inbound_skips_empty_lines() {
+        let stdin = std::io::Cursor::new(b"\n\n{\"jsonrpc\":\"2.0\",\"method\":\"x\",\"id\":1}\n".to_vec());
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        // Only the third (valid) line should reach rmcp.
+        let s = std::str::from_utf8(&forwarded).unwrap();
+        assert_eq!(s.lines().count(), 1);
+    }
+```
+
+Reject-path testing uses real stdout, which is not capturable in a unit test — defer to the integration tests in Phase 5.
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: all tests pass (Task 1.2 + 1.3 + 2 new = 22).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): validate_inbound bridge task (#277)"
+```
+
+---
+
+## Task 2.2: Implement `passthrough_outbound` bridge task
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+The outbound bridge reads complete frames from rmcp's duplex (line-framed because rmcp's framed writer terminates each envelope with `\n`) and writes each frame through the shared stdout mutex. Line-framed rather than `tokio::io::copy` so the lock is acquired per envelope, never held across an await on rmcp's writer.
+
+- [ ] **Step 1: Add the function**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs`:
+
+```rust
+/// Outbound bridge task. Reads frames from the outbound duplex
+/// (rmcp's writes land here) and writes each frame through the
+/// shared stdout mutex.
+///
+/// Returns `Ok(())` when rmcp drops its outbound duplex end (EOF).
+/// Returns `Err(io::Error)` if writing to real stdout fails — typically
+/// `BrokenPipe`, which surfaces to `main.rs::run` via the supervisor.
+pub(crate) async fn passthrough_outbound(
+    from_rmcp: DuplexStream,
+    stdout: Arc<Mutex<Stdout>>,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(from_rmcp);
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await?;
+        if n == 0 {
+            return Ok(()); // rmcp dropped outbound — clean shutdown.
+        }
+        let mut sout = stdout.lock().await;
+        sout.write_all(&buf).await?;
+        sout.flush().await?;
+        // Lock released; loop.
+    }
+}
+```
+
+- [ ] **Step 2: Add a unit test**
+
+Append inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn passthrough_outbound_drops_on_eof() {
+        let (rmcp_end, our_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        // Drop the rmcp side immediately — passthrough should see EOF
+        // and return Ok cleanly.
+        drop(rmcp_end);
+        let result = passthrough_outbound(our_end, stdout).await;
+        assert!(result.is_ok(), "expected Ok on EOF, got {result:?}");
+    }
+```
+
+A "writes are actually forwarded" test would need to redirect real stdout; defer to integration.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): passthrough_outbound bridge task (#277)"
+```
+
+---
+
+## Task 2.3: Implement `ValidatorSupervisor` with three methods
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+The supervisor owns the two `JoinHandle`s and exposes three lifecycle methods: `watch_for_error` (non-consuming, fail-fast during racing), `drain` (consuming, success-path post-init shutdown), and `shutdown_after_failure` (consuming, failure-path shutdown that aborts inbound first).
+
+- [ ] **Step 1: Implement the methods**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs`:
+
+```rust
+impl ValidatorSupervisor {
+    /// Non-consuming. Resolves with the first bridge-task error
+    /// encountered, OR `Ok(())` once both bridges exit `Ok` cleanly
+    /// (exotic mid-service condition — usually one side stays alive
+    /// until the service ends). Used for fail-fast during the
+    /// `service.waiting()` / `serve_server` race.
+    pub async fn watch_for_error(&mut self) -> std::io::Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                r = &mut self.inbound, if !self.inbound.is_finished() => {
+                    match Self::flatten(r) {
+                        Ok(()) if self.outbound.is_finished() => return Ok(()),
+                        Ok(()) => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+                r = &mut self.outbound, if !self.outbound.is_finished() => {
+                    match Self::flatten(r) {
+                        Ok(()) if self.inbound.is_finished() => return Ok(()),
+                        Ok(()) => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Success-path shutdown. Awaits both bridge tasks; returns the
+    /// first error encountered, else `Ok(())`. Use when
+    /// `service.waiting()` resolved `Ok` (which implies rmcp saw EOF
+    /// on its read, which implies inbound already exited — drain is
+    /// then essentially instant on inbound and bounded on outbound).
+    pub async fn drain(self) -> std::io::Result<()> {
+        let (in_r, out_r) = tokio::join!(self.inbound, self.outbound);
+        let in_r = Self::flatten(in_r);
+        let out_r = Self::flatten(out_r);
+        in_r.and(out_r)
+    }
+
+    /// Failure-path shutdown. Aborts the inbound bridge (the client
+    /// may keep stdin open while waiting for an error response;
+    /// without abort, we'd block forever in `read_until` on real
+    /// stdin), then awaits the outbound bridge to drain rmcp's
+    /// queued error envelope plus any validator-synthesized
+    /// rejections. Returns the first error from the outbound path;
+    /// inbound cancellation is expected and ignored.
+    pub async fn shutdown_after_failure(self) -> std::io::Result<()> {
+        self.inbound.abort();
+        // We don't care about the inbound result on this path —
+        // either it raced to EOF (Ok) or got aborted (JoinError).
+        let _ = self.inbound.await;
+        Self::flatten(self.outbound.await)
+    }
+
+    fn flatten(
+        r: Result<std::io::Result<()>, tokio::task::JoinError>,
+    ) -> std::io::Result<()> {
+        match r {
+            Ok(inner) => inner,
+            Err(je) if je.is_cancelled() => Ok(()),
+            Err(je) => Err(std::io::Error::other(format!("bridge task panic: {je}"))),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add unit tests**
+
+Append inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn drain_returns_ok_when_both_bridges_exit_ok() {
+        let inbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+        assert!(supervisor.drain().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn drain_surfaces_first_error() {
+        let inbound = tokio::spawn(async {
+            Err::<(), std::io::Error>(std::io::Error::other("inbound boom"))
+        });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+        let r = supervisor.drain().await;
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("inbound boom"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_after_failure_aborts_inbound() {
+        // Inbound never completes on its own — simulates a client
+        // holding stdin open.
+        let inbound = tokio::spawn(async {
+            std::future::pending::<std::io::Result<()>>().await
+        });
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let supervisor = ValidatorSupervisor { inbound, outbound };
+
+        // Should return promptly (within a few ms) thanks to abort.
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.shutdown_after_failure(),
+        )
+        .await;
+        assert!(r.is_ok(), "shutdown_after_failure did not abort inbound");
+        assert!(r.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn watch_for_error_returns_on_first_error() {
+        let inbound = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            Err::<(), std::io::Error>(std::io::Error::other("inbound failed"))
+        });
+        let outbound = tokio::spawn(async {
+            std::future::pending::<std::io::Result<()>>().await
+        });
+        let mut supervisor = ValidatorSupervisor { inbound, outbound };
+
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.watch_for_error(),
+        )
+        .await;
+        assert!(r.is_ok());
+        let inner = r.unwrap();
+        assert!(inner.is_err());
+        assert!(inner.unwrap_err().to_string().contains("inbound failed"));
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): ValidatorSupervisor lifecycle (#277)"
+```
+
+---
+
+## Task 2.4: Implement `stdio_with_validation()` entry point
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+Wire the pieces together. This is the public entry point `main.rs` calls.
+
+- [ ] **Step 1: Add the function**
+
+Append to `crates/rimap-server/src/mcp/wire_validator.rs`:
+
+```rust
+/// Build the validated stdio transport. The two bridge tasks are
+/// spawned immediately; their lifecycle is exposed via `supervisor`.
+/// The returned `transport` plugs into `rmcp::serve_server(server, transport)`.
+pub fn stdio_with_validation() -> ValidatedStdio {
+    let (inbound_our_end, inbound_rmcp_end) = tokio::io::duplex(BUF_SIZE);
+    let (outbound_rmcp_end, outbound_our_end) = tokio::io::duplex(BUF_SIZE);
+
+    let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+    let inbound = tokio::spawn(validate_inbound(
+        tokio::io::stdin(),
+        inbound_our_end,
+        Arc::clone(&stdout),
+    ));
+    let outbound = tokio::spawn(passthrough_outbound(
+        outbound_our_end,
+        Arc::clone(&stdout),
+    ));
+
+    ValidatedStdio {
+        transport: (inbound_rmcp_end, outbound_rmcp_end),
+        stdout,
+        supervisor: ValidatorSupervisor { inbound, outbound },
+    }
+}
+```
+
+- [ ] **Step 2: Smoke-test that it constructs**
+
+Add inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn stdio_with_validation_constructs_cleanly() {
+        let validated = stdio_with_validation();
+        // Verify the supervisor is present and we can drop everything.
+        drop(validated.transport);
+        // After dropping the duplex ends, both bridges should exit cleanly
+        // (stdin EOF or read 0 bytes from a dropped duplex).
+        let r = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            validated.supervisor.drain(),
+        )
+        .await;
+        // Either Ok (drained cleanly) OR Err (stdin returned an error
+        // on the test runner) is acceptable — we mainly want to confirm
+        // no panic and no hang.
+        assert!(r.is_ok(), "drain hung after dropping transport");
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "feat(rimap-server): stdio_with_validation entry point (#277)"
+```
+
+---
+
+## Task 3.1: Thread `Arc<Mutex<Stdout>>` into `emit_pre_init_error_envelope`
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+`emit_pre_init_error_envelope` currently writes directly to `tokio::io::stdout()` (`main.rs:199-211`). After the transport swap in Task 3.2, that would race the bridge tasks. Thread the shared mutex through the signature so pre-init envelopes lock the same writer.
+
+- [ ] **Step 1: Update the function signature**
+
+Open `crates/rimap-server/src/main.rs`. Locate `emit_pre_init_error_envelope` (currently starts around line 199). Change its signature and body:
+
+```rust
+async fn emit_pre_init_error_envelope(
+    msg: &rmcp::model::ClientJsonRpcMessage,
+    stdout: &std::sync::Arc<tokio::sync::Mutex<tokio::io::Stdout>>,
+) -> anyhow::Result<()> {
+    let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(msg) else {
+        return Ok(());
+    };
+    let mut out = stdout.lock().await;
+    out.write_all(line.as_bytes())
+        .await
+        .context("writing pre-init error envelope to stdout")?;
+    out.flush()
+        .await
+        .context("flushing pre-init error envelope")?;
+    Ok(())
+}
+```
+
+Add the necessary `use` for `tokio::io::AsyncWriteExt` at the top if not already imported.
+
+- [ ] **Step 2: Update the call site to compile (placeholder — will be reworked in Task 3.3)**
+
+The call site in `run()` currently passes no extra arg. To keep the file compiling between this task and Task 3.2, temporarily construct a local `Arc::new(Mutex::new(stdout()))` at the call site:
+
+```rust
+// In run(), where ExpectedInitializeRequest is matched:
+let _temp_stdout = std::sync::Arc::new(tokio::sync::Mutex::new(tokio::io::stdout()));
+emit_pre_init_error_envelope(&msg, &_temp_stdout).await?;
+```
+
+This is intentionally ugly — Task 3.3 replaces it with `validated.stdout`.
+
+- [ ] **Step 3: Verify the workspace compiles**
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run the existing pre-init tests to confirm no regression**
+
+```bash
+cargo nextest run -p rimap-server pre_init
+```
+
+Expected: all existing #275 pre-init wire tests still pass — the I/O behavior is the same (one mutex-acquisition per write), just routed through a local mutex for now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "refactor(rimap-server): emit_pre_init_error_envelope takes shared stdout (#277)"
+```
+
+---
+
+## Task 3.2: Swap the transport constructor
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+Replace `rmcp::transport::io::stdio()` with `wire_validator::stdio_with_validation()`. Update the `ExpectedInitializeRequest` arm to use the now-real `validated.stdout` instead of the temporary mutex from Task 3.1.
+
+- [ ] **Step 1: Construct `ValidatedStdio` once**
+
+Near the top of the `rt.block_on` block in `run()`, before the `rmcp::serve_server` call, add:
+
+```rust
+let validated = rimap_server::mcp::wire_validator::stdio_with_validation();
+let stdout_for_preinit = std::sync::Arc::clone(&validated.stdout);
+```
+
+Then replace:
+
+```rust
+let transport = rmcp::transport::io::stdio();
+```
+
+with:
+
+```rust
+let transport = validated.transport;
+```
+
+If `let transport` doesn't appear and `rmcp::transport::io::stdio()` is inlined, modify the inlined call site to use `validated.transport` instead.
+
+- [ ] **Step 2: Replace the temp mutex in `ExpectedInitializeRequest` with the real one**
+
+In the `Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg)))` arm, remove the `_temp_stdout` placeholder added in Task 3.1 and pass `&stdout_for_preinit` instead:
+
+```rust
+Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+    emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
+    return Ok(()); // shutdown handling added in Task 3.4
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean. There will be an unused-variable warning for `validated.supervisor` until Task 3.4 — that's OK for now; the linter denies warnings only on `clippy -- -D warnings`, not `cargo check`. Don't run clippy here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "feat(rimap-server): swap rmcp stdio for wire_validator (#277)"
+```
+
+---
+
+## Task 3.3: Init-phase race against the supervisor
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+Race `rmcp::serve_server(...).await` against `supervisor.watch_for_error()` so a bridge `BrokenPipe` during the pre-init phase doesn't leave the supervisor unobserved. Local `InitOutcome` enum disambiguates the failure sources.
+
+- [ ] **Step 1: Add the `InitOutcome` enum and rewrite the init block**
+
+Define a local enum at the start of the `rt.block_on` body (before constructing `validated`):
+
+```rust
+// Local enum to disambiguate init-phase failure sources for the
+// tokio::select! arms below.
+enum InitOutcome {
+    Bridge(std::io::Result<()>),
+    Rmcp(rmcp::service::ServerInitializeError),
+}
+```
+
+Then replace the existing `let service = match Box::pin(rmcp::serve_server(...)).await { ... };` block with the race-and-dispatch logic:
+
+```rust
+type InitResult = Result<rmcp::service::RunningService<rmcp::RoleServer, ImapMcpServer>, InitOutcome>;
+
+let init_result: InitResult = tokio::select! {
+    biased;
+    bridge = supervisor.watch_for_error() => Err(InitOutcome::Bridge(bridge)),
+    result = &mut init_fut => match result {
+        Ok(svc) => Ok(svc),
+        Err(e) => Err(InitOutcome::Rmcp(e)),
+    },
+};
+drop(init_fut);
+
+let service = match init_result {
+    Ok(svc) => svc,
+    Err(InitOutcome::Bridge(bridge_result)) => {
+        let primary = bridge_result.err().map_or_else(
+            || anyhow::anyhow!("validator bridges exited before init completed"),
+            |e| anyhow::anyhow!("validator bridge during init: {e}"),
+        );
+        let _ = supervisor.shutdown_after_failure().await;
+        return Err(primary);
+    }
+    Err(InitOutcome::Rmcp(ServerInitializeError::ExpectedInitializeRequest(Some(msg)))) => {
+        emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
+        return match supervisor.shutdown_after_failure().await {
+            Ok(()) => Ok(()),
+            Err(e) => Err(anyhow::anyhow!("validator bridge after pre-init: {e}")),
+        };
+    }
+    Err(InitOutcome::Rmcp(ServerInitializeError::InitializeFailed(error_data))) => {
+        let handled = handle_initialize_failed(&error_data);
+        return match supervisor.shutdown_after_failure().await {
+            Ok(()) => handled,
+            Err(e) => Err(anyhow::anyhow!("validator bridge after init failure: {e}")),
+        };
+    }
+    Err(InitOutcome::Rmcp(other)) => {
+        let _ = supervisor.shutdown_after_failure().await;
+        return Err(anyhow::anyhow!("MCP server init: {other}"));
+    }
+};
+```
+
+The exact `RunningService<...>` generic may need adjustment depending on rmcp 1.5's type — verify with `cargo check` and tweak the `InitResult` type alias if rustc complains.
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean. If rustc complains about the `RunningService<...>` type alias, copy the exact type from the error message into the alias.
+
+- [ ] **Step 3: Run all existing pre-init wire tests**
+
+```bash
+cargo nextest run -p rimap-server pre_init
+```
+
+Expected: pass. The init-phase race doesn't change observable behavior for the existing #275 / #276 paths; it only adds the new Bridge arm.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "feat(rimap-server): race init against validator supervisor (#277)"
+```
+
+---
+
+## Task 3.4: Post-init two-phase shutdown
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+Add the post-init race-then-drain logic that replaces the current plain `service.waiting().await?`. On `service.waiting() == Ok`, use `drain()` (inbound already exited). On any failure, use `shutdown_after_failure()` (inbound may be blocked on real stdin).
+
+- [ ] **Step 1: Rewrite the post-init block**
+
+After `let service = ... ;` (from Task 3.3), replace whatever currently follows the service binding (`service.waiting().await...`) with:
+
+```rust
+let mut service_fut = Box::pin(service.waiting());
+
+// Phase 1: race service against bridge errors.
+let service_outcome: anyhow::Result<()> = tokio::select! {
+    biased;
+    bridge = supervisor.watch_for_error() => match bridge {
+        Err(e) => Err(anyhow::anyhow!("validator bridge: {e}")),
+        Ok(()) => {
+            // Both bridges exited cleanly while service still running
+            // (exotic). Let service finish — it'll see EOF.
+            (&mut service_fut)
+                .await
+                .map_err(|e| anyhow::anyhow!("rmcp: {e}"))
+        }
+    },
+    result = &mut service_fut => result.map_err(|e| anyhow::anyhow!("rmcp: {e}")),
+};
+
+// Phase 2: drop service future to release rmcp's transport ends,
+// then shutdown supervisor.
+drop(service_fut);
+let shutdown_outcome = match &service_outcome {
+    Ok(()) => supervisor.drain().await,
+    Err(_) => supervisor.shutdown_after_failure().await,
+}
+.map_err(|e| anyhow::anyhow!("validator bridge shutdown: {e}"));
+
+let mcp_result: anyhow::Result<()> = match (service_outcome, shutdown_outcome) {
+    (Err(e), _) => Err(e),
+    (Ok(()), Err(e)) => Err(e),
+    (Ok(()), Ok(())) => Ok(()),
+};
+
+// Existing drainer_handle.await stays as-is below this block.
+```
+
+Make sure the existing `drainer_handle.await` and `emit_process_end(&audit, &mcp_result)` continue to run after this block.
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Run the workspace tests (post-init paths)**
+
+```bash
+cargo nextest run -p rimap-server --locked
+```
+
+Expected: existing wire tests pass. The new shutdown logic preserves observable behavior on success and on the existing failure paths (because today's `service.waiting()?` Err equivalently propagates to `mcp_result`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs
+git commit -m "feat(rimap-server): two-phase post-init shutdown via supervisor (#277)"
+```
+
+---
+
+## Task 4.1: Add harness variant — closed-stdout + open-stdin
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+
+Tests 20-22 need a harness that closes stdout (to force write failures) but keeps stdin open (to exercise the failure-path shutdown that aborts inbound). The existing `spawn_with_closed_stdout` from #275 closes both; we need a sibling.
+
+- [ ] **Step 1: Add the variant**
+
+Open `crates/rimap-server/tests/support/wire/harness.rs`. Locate `spawn_with_closed_stdout` (added for #275). Add an adjacent constructor:
+
+```rust
+/// Spawn the server with stdout redirected to a closed pipe (forcing
+/// write failures) but keep stdin open under our control. Tests
+/// 20-22 of #277 use this to verify bounded shutdown when a client
+/// holds stdin open after the server hits an error.
+pub async fn spawn_with_closed_stdout_open_stdin() -> Self {
+    // Copy the construction logic from spawn_with_closed_stdout, but
+    // keep stdin under our control instead of closing it. See
+    // spawn_with_closed_stdout for the closed-stdout setup pattern.
+    todo!("see spawn_with_closed_stdout — keep self.stdin as ChildStdin instead of closing it")
+}
+```
+
+Then fill in the implementation by copying the body of `spawn_with_closed_stdout` and removing only the lines that close stdin (or equivalent — read the existing function to see the exact pattern). The key invariant: after construction, `self.stdin` must still be `Some(ChildStdin)` (writable) and `self.stdout` must be on a closed pipe.
+
+- [ ] **Step 2: Add a self-test for the harness variant**
+
+In the same file, in an existing `#[cfg(test)] mod tests` if present (or a new one at the bottom):
+
+```rust
+    #[tokio::test]
+    async fn closed_stdout_open_stdin_keeps_stdin_writable() {
+        let mut h = Harness::spawn_with_closed_stdout_open_stdin().await;
+        // We should be able to write at least one line to stdin without error.
+        h.send_line(r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}"#).await;
+        // Don't assert on the response — stdout is closed.
+        // Drop will tear the harness down.
+    }
+```
+
+- [ ] **Step 3: Run the harness self-test**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative closed_stdout
+```
+
+Expected: the test passes (or compiles if it requires waiting for the next task's coverage). At minimum, no compile errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "test(rimap-server): closed-stdout + open-stdin harness variant (#277)"
+```
+
+---
+
+## Task 5.1: Wire-pinned tests 1-10 (validation rules)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+The ten validation-rule tests from the spec. Each test sends a single envelope and asserts the validator's wire response (code + id). Same shape; one test per row.
+
+- [ ] **Step 1: Add the test functions**
+
+Append to `crates/rimap-server/tests/mcp_wire_negative.rs`:
+
+```rust
+// ============================================================
+// #277 — validation rules (tests 1-10).
+// Each test sends one malformed envelope and asserts the
+// validator's wire response shape.
+// ============================================================
+
+async fn assert_invalid_request_response(
+    h: &mut Harness,
+    line: &str,
+    expected_id: serde_json::Value,
+    expected_code: i32,
+) {
+    h.send_line(line).await;
+    let outcome = h.response_or_close(REQUEST_TIMEOUT).await;
+    match outcome {
+        CloseOrResponse::Response(resp_line) => {
+            let env: serde_json::Value = serde_json::from_str(resp_line.trim_end())
+                .expect("validator response must be valid JSON");
+            assert_eq!(env["jsonrpc"], "2.0");
+            assert_eq!(env["id"], expected_id, "id mismatch on {line:?}");
+            assert_eq!(env["error"]["code"], expected_code, "code mismatch on {line:?}");
+        }
+        other => panic!("expected validator response, got {other:?} for {line:?}"),
+    }
+}
+
+#[tokio::test]
+async fn envelope_missing_jsonrpc_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"method":"a"}"#, serde_json::Value::Null, -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_missing_jsonrpc_with_numeric_id_echoes_id() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"method":"a","id":42}"#, serde_json::json!(42), -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_missing_jsonrpc_with_string_id_echoes_id() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"method":"a","id":"abc"}"#, serde_json::json!("abc"), -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_missing_jsonrpc_with_malformed_id_uses_null() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"method":"a","id":[1,2]}"#, serde_json::Value::Null, -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_with_wrong_jsonrpc_value_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"jsonrpc":"1.0","method":"x","id":1}"#, serde_json::json!(1), -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_with_non_string_method_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, r#"{"jsonrpc":"2.0","method":42,"id":1}"#, serde_json::json!(1), -32600).await;
+}
+
+#[tokio::test]
+async fn envelope_batch_array_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"[{"jsonrpc":"2.0","method":"x","id":1}]"#,
+        serde_json::Value::Null,
+        -32600,
+    ).await;
+}
+
+#[tokio::test]
+async fn envelope_invalid_json_returns_parse_error() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(&mut h, "not valid json", serde_json::Value::Null, -32700).await;
+}
+
+#[tokio::test]
+async fn envelope_empty_line_is_skipped() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    // Empty line then a valid request. Validator should skip the empty
+    // line silently; the next line on stdout should be the tools/list
+    // response (not a -32600 envelope).
+    h.send_line("").await;
+    let resp = h.request("tools/list", serde_json::json!({})).await;
+    let body: serde_json::Value = serde_json::from_str(resp.trim_end())
+        .expect("tools/list response must be valid JSON");
+    assert!(
+        body.get("result").is_some(),
+        "tools/list after empty line must respond with a result, got {body}",
+    );
+    assert!(
+        body.get("error").is_none(),
+        "tools/list after empty line must not carry an error envelope, got {body}",
+    );
+}
+
+#[tokio::test]
+async fn session_survives_invalid_envelope() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    // Send an invalid envelope first.
+    h.send_line(r#"{"method":"garbage"}"#).await;
+    let _ = h.response_or_close(REQUEST_TIMEOUT).await; // consume the -32600
+    // Then a valid request — must succeed.
+    let resp = h.request("tools/list", serde_json::json!({})).await;
+    let body: serde_json::Value = serde_json::from_str(resp.trim_end()).expect("valid JSON");
+    assert!(body.get("result").is_some(), "session should be alive: {body}");
+}
+```
+
+The exact existing `Harness::request` / `initialize_handshake` / `send_initialized` API names should be verified against the harness file before submitting — adjust if the actual method names differ.
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative envelope_ session_survives
+```
+
+Expected: all ten new tests PASS. If `envelope_empty_line_is_skipped` fails because the assertion shape is awkward, simplify to "assert the response was a `result` envelope with no preceding error line — there's a helper for that on Harness if present."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): validation-rule wire tests 1-10 (#277)"
+```
+
+---
+
+## Task 5.2: Wire-pinned test 11 (pre-init ordering)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Test 11 pins the shared-stdout invariant: send a pre-init `ping` (rmcp may answer it) immediately followed by a pre-init `tools/list` (which `emit_pre_init_error_envelope` rejects with `-32002`). Both stdout lines must parse as well-formed, distinct JSON-RPC envelopes with the expected id mapping — proves no mid-line interleaving.
+
+- [ ] **Step 1: Add the test**
+
+Append to `crates/rimap-server/tests/mcp_wire_negative.rs`:
+
+```rust
+#[tokio::test]
+async fn preinit_envelope_does_not_interleave_with_rmcp_frame() {
+    let mut h = Harness::spawn().await;
+    // Do NOT call initialize_handshake — both messages below are pre-init.
+
+    // Send ping (rmcp may respond on the standard MCP method) then
+    // tools/list (rmcp rejects pre-init → server emits -32002 via the
+    // shared stdout mutex).
+    h.send_line(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#).await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"tools/list","id":2}"#).await;
+
+    // Read up to two response lines and verify both parse cleanly.
+    let first = h.response_or_close(REQUEST_TIMEOUT).await;
+    let second = h.response_or_close(REQUEST_TIMEOUT).await;
+
+    let extract_line = |o: CloseOrResponse| -> Option<String> {
+        match o {
+            CloseOrResponse::Response(s) => Some(s),
+            _ => None,
+        }
+    };
+    let lines: Vec<String> = [first, second].into_iter().filter_map(extract_line).collect();
+
+    // We expect at least the pre-init -32002 envelope; ping handling is
+    // implementation-defined for pre-init.
+    let any_preinit_reject = lines.iter().any(|line| {
+        let env: serde_json::Value = serde_json::from_str(line.trim_end()).expect("valid JSON");
+        env["error"]["code"] == -32002
+    });
+    assert!(any_preinit_reject, "expected -32002 envelope, got {lines:?}");
+
+    // Every emitted line must parse as a complete JSON-RPC envelope
+    // (no mid-line interleaving).
+    for line in &lines {
+        let env: serde_json::Value = serde_json::from_str(line.trim_end())
+            .unwrap_or_else(|e| panic!("malformed line {line:?}: {e}"));
+        assert_eq!(env["jsonrpc"], "2.0");
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative preinit_envelope_does_not_interleave
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): pre-init/rmcp-frame ordering test (#277)"
+```
+
+---
+
+## Task 5.3: Wire-pinned tests 12-14 (closed-stdout audit semantics)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Three tests on closed-stdout: validator rejection write failure (12), rmcp response write failure during race phase (13), drain-phase write failure (14). All must record `process_end.reason: Error` and exit non-zero.
+
+- [ ] **Step 1: Add the three tests**
+
+Append to `crates/rimap-server/tests/mcp_wire_negative.rs`:
+
+```rust
+#[tokio::test]
+async fn process_end_on_validator_rejection_write_failure() {
+    // Closed stdout: validator can't write its -32600 rejection.
+    let mut h = Harness::spawn_with_closed_stdout().await;
+    // Don't bother with init; just send a malformed line.
+    h.send_line(r#"{"method":"a"}"#).await;
+    // Wait for the child to exit (it will, because the supervisor
+    // surfaces the write error).
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(5)).await;
+    assert!(!status.success(), "expected non-zero exit, got {status:?}");
+    // Audit log assertion: process_end record reason is Error.
+    let audit = h.read_audit_log().await;
+    assert!(
+        audit.contains("\"reason\":\"Error\""),
+        "expected process_end.reason=Error, audit was {audit}"
+    );
+}
+
+#[tokio::test]
+async fn process_end_on_rmcp_response_write_failure() {
+    // Closed stdout, race-phase: client completes init and sends a
+    // valid tools/list while stdout is closed. rmcp's response write
+    // into the passthrough fails downstream.
+    let mut h = Harness::spawn_with_closed_stdout().await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}"#).await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"tools/list","id":2}"#).await;
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(5)).await;
+    assert!(!status.success());
+    let audit = h.read_audit_log().await;
+    assert!(audit.contains("\"reason\":\"Error\""), "audit: {audit}");
+}
+
+#[tokio::test]
+async fn process_end_on_drain_phase_write_failure() {
+    // Drain-phase: client completes init, sends tools/list, then
+    // closes stdin so service.waiting() resolves Ok. The queued
+    // response cannot flush through closed stdout; drain catches
+    // the BrokenPipe.
+    let mut h = Harness::spawn_with_closed_stdout().await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}"#).await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"tools/list","id":2}"#).await;
+    h.close_stdin().await; // forces service.waiting() to resolve
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(5)).await;
+    assert!(!status.success());
+    let audit = h.read_audit_log().await;
+    assert!(audit.contains("\"reason\":\"Error\""), "audit: {audit}");
+}
+```
+
+The exact `close_stdin`, `wait_with_timeout`, `read_audit_log` methods may need to be added to `Harness` if not already present. Check the harness file first; if missing, add small helpers using existing primitives (`self.child.wait()` with `timeout`, etc.). The audit log path is stored on `Harness` per the #275 work; use the existing accessor.
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative process_end_on
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "test(rimap-server): closed-stdout audit semantics 12-14 (#277)"
+```
+
+---
+
+## Task 5.4: Wire-pinned test 15 (fixed-case notification)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Replaces the property-strategy notification coverage. Send a standard MCP notification (`notifications/cancelled`), then a `tools/list` request, and assert `tools/list` responds. Proves notifications don't poison or hang the session.
+
+- [ ] **Step 1: Add the test**
+
+```rust
+#[tokio::test]
+async fn valid_notification_does_not_hang_session() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    // Send a standard MCP notification (rmcp dispatches it; no response).
+    h.send_line(r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":0}}"#).await;
+    // Immediately follow with a request that MUST respond.
+    let resp = h.request("tools/list", serde_json::json!({})).await;
+    let body: serde_json::Value = serde_json::from_str(resp.trim_end()).expect("valid JSON");
+    assert!(body.get("result").is_some(), "tools/list after notification failed: {body}");
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative valid_notification_does_not_hang
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): valid notification keeps session alive (#277)"
+```
+
+---
+
+## Task 5.5: Wire-pinned tests 16-19 (Response/Error envelope handling)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Tests 16-17 verify the validator forwards valid client-side Response/Error envelopes (MCP server-initiated flow). Tests 18-19 verify it rejects malformed ones.
+
+- [ ] **Step 1: Add the four tests**
+
+```rust
+#[tokio::test]
+async fn valid_response_envelope_forwards() {
+    // Send a client-shaped Response envelope after init. The validator
+    // must NOT reject. rmcp probably ignores it (no pending server
+    // request to match), but we just verify no -32600 response appears
+    // and the session is still alive afterward.
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    h.send_line(r#"{"jsonrpc":"2.0","id":99,"result":{"x":1}}"#).await;
+    // Wait briefly to confirm no spurious validator rejection.
+    if let CloseOrResponse::Response(line) = h.response_or_close(std::time::Duration::from_millis(250)).await {
+        let env: serde_json::Value = serde_json::from_str(line.trim_end()).expect("valid JSON");
+        assert!(env["error"]["code"].as_i64() != Some(-32600),
+                "validator wrongly rejected a valid response envelope: {env}");
+    }
+    // Then a normal request must succeed.
+    let resp = h.request("tools/list", serde_json::json!({})).await;
+    let body: serde_json::Value = serde_json::from_str(resp.trim_end()).expect("valid JSON");
+    assert!(body.get("result").is_some(), "session should be alive after forwarded response: {body}");
+}
+
+#[tokio::test]
+async fn valid_error_envelope_forwards() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    h.send_line(r#"{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"not found"}}"#).await;
+    if let CloseOrResponse::Response(line) = h.response_or_close(std::time::Duration::from_millis(250)).await {
+        let env: serde_json::Value = serde_json::from_str(line.trim_end()).expect("valid JSON");
+        assert!(env["error"]["code"].as_i64() != Some(-32600),
+                "validator wrongly rejected a valid error envelope: {env}");
+    }
+    let resp = h.request("tools/list", serde_json::json!({})).await;
+    let body: serde_json::Value = serde_json::from_str(resp.trim_end()).expect("valid JSON");
+    assert!(body.get("result").is_some(), "session should be alive after forwarded error: {body}");
+}
+
+#[tokio::test]
+async fn envelope_with_both_result_and_error_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":1,"message":"x"}}"#,
+        serde_json::json!(1),
+        -32600,
+    ).await;
+}
+
+#[tokio::test]
+async fn envelope_response_without_id_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"{"jsonrpc":"2.0","result":{}}"#,
+        serde_json::Value::Null,
+        -32600,
+    ).await;
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative valid_response valid_error envelope_with_both envelope_response_without
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): Response/Error envelope forwarding 16-19 (#277)"
+```
+
+---
+
+## Task 5.6: Wire-pinned tests 20-22 (bounded shutdown on open stdin)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Tests 20-22 use `spawn_with_closed_stdout_open_stdin` (from Task 4.1) to verify that init-failure paths, post-init failure paths, and init-phase bridge errors all exit within bounded time even when the client holds stdin open.
+
+- [ ] **Step 1: Add the three tests**
+
+```rust
+#[tokio::test]
+async fn init_failure_with_open_stdin_returns_promptly() {
+    // Client sends initialize with unsupported protocolVersion → rmcp
+    // emits -32602; does NOT close stdin.
+    let mut h = Harness::spawn().await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"1999-01-01","capabilities":{}}}"#).await;
+    // Hold stdin open (don't call close_stdin); rely on the server
+    // to shutdown_after_failure within bounded time.
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(2)).await;
+    // shutdown_after_failure should classify InitializeFailed (INVALID_PARAMS)
+    // as a handled rejection → exit 0.
+    assert!(status.success(), "init failure should exit 0, got {status:?}");
+}
+
+#[tokio::test]
+async fn process_end_on_post_init_service_error_with_open_stdin() {
+    // Closed stdout + open stdin: client completes init, sends
+    // tools/list, but never closes stdin. The supervisor must
+    // shutdown_after_failure and exit within bounded time.
+    let mut h = Harness::spawn_with_closed_stdout_open_stdin().await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}"#).await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"tools/list","id":2}"#).await;
+    // Hold stdin open — do NOT call close_stdin.
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(2)).await;
+    assert!(!status.success(), "expected non-zero exit, got {status:?}");
+    let audit = h.read_audit_log().await;
+    assert!(audit.contains("\"reason\":\"Error\""), "audit: {audit}");
+}
+
+#[tokio::test]
+async fn process_end_on_pre_init_bridge_error_with_open_stdin() {
+    // Closed stdout + open stdin: client sends a pre-init ping
+    // (rmcp queues a response). Passthrough fails on the closed
+    // stdout while rmcp is still waiting for initialize. Client
+    // never closes stdin.
+    let mut h = Harness::spawn_with_closed_stdout_open_stdin().await;
+    h.send_line(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#).await;
+    let status = h.wait_with_timeout(std::time::Duration::from_secs(2)).await;
+    assert!(!status.success(), "expected non-zero exit, got {status:?}");
+    let audit = h.read_audit_log().await;
+    assert!(audit.contains("\"reason\":\"Error\""), "audit: {audit}");
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative init_failure_with_open_stdin process_end_on_post_init_service_error process_end_on_pre_init_bridge_error
+```
+
+Expected: all three PASS within their bounded timeouts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): bounded shutdown on open stdin 20-22 (#277)"
+```
+
+---
+
+## Task 5.7: Wire-pinned tests 23-25 (rmcp grammar matching)
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Tests 23-25 pin the rmcp-grammar tightenings: null id rejected, malformed error body rejected.
+
+- [ ] **Step 1: Add the three tests**
+
+```rust
+#[tokio::test]
+async fn envelope_request_with_null_id_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"{"jsonrpc":"2.0","method":"tools/list","id":null}"#,
+        serde_json::Value::Null,
+        -32600,
+    ).await;
+}
+
+#[tokio::test]
+async fn envelope_error_response_with_malformed_body_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"{"jsonrpc":"2.0","id":1,"error":{"code":"not-a-number","message":"x"}}"#,
+        serde_json::json!(1),
+        -32600,
+    ).await;
+}
+
+#[tokio::test]
+async fn envelope_error_response_without_code_returns_invalid_request() {
+    let mut h = Harness::spawn().await;
+    h.initialize_handshake().await.expect("init");
+    h.send_initialized().await;
+    assert_invalid_request_response(
+        &mut h,
+        r#"{"jsonrpc":"2.0","id":1,"error":{"message":"oops"}}"#,
+        serde_json::json!(1),
+        -32600,
+    ).await;
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p rimap-server --test mcp_wire_negative envelope_request_with_null envelope_error_response
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "test(rimap-server): rmcp grammar matching 23-25 (#277)"
+```
+
+---
+
+## Task 6.1: Filter spec-legal notifications out of `arb_envelope`
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_proptest.rs`
+
+Adds `prop_filter` to `arb_envelope()` so the property no longer generates valid JSON-RPC notifications (which would produce no response and false-positive as `Hung`).
+
+- [ ] **Step 1: Modify the strategy**
+
+Locate `fn arb_envelope() -> impl Strategy<Value = Value>` (around line 217 of the current file). At the end of the `.prop_map(...)` chain, add:
+
+```rust
+        .prop_filter(
+            "exclude spec-legal notifications (jsonrpc==\"2.0\" + missing id + present method) — \
+             their silent-ignore is JSON-RPC §4.1 compliant and covered separately by \
+             valid_notification_does_not_hang_session",
+            |env| {
+                let is_notification = env.get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
+                    && env.get("id").is_none()
+                    && env.get("method").and_then(|v| v.as_str()).is_some();
+                !is_notification
+            },
+        )
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo check -p rimap-server --tests --locked
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_proptest.rs
+git commit -m "test(rimap-server): filter notifications out of arb_envelope (#277)"
+```
+
+---
+
+## Task 6.2: Un-ignore `prop_envelope_never_panics`
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_proptest.rs`
+
+With the validator in place and notifications filtered, the property should pass at the default 1000 cases.
+
+- [ ] **Step 1: Remove the `#[ignore]` attribute**
+
+Locate the `#[ignore = "blocked on #277: ..."]` line above `fn prop_envelope_never_panics` (around line 309-310). Delete the line entirely.
+
+- [ ] **Step 2: Run the property**
+
+```bash
+PROPTEST_CASES=1000 cargo nextest run -p rimap-server --test mcp_wire_proptest prop_envelope_never_panics
+```
+
+Expected: PASS at 1000 cases. If a panic occurs, the validator missed a case — capture the shrunk envelope, add a fixed-case test for it, and either tighten `validate()` or document why the case is non-fatal.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_proptest.rs
+git commit -m "test(rimap-server): un-ignore prop_envelope_never_panics (#277)"
+```
+
+---
+
+## Task 7.1: Tighten `is_forwardable_id` to rmcp's `i64` grammar
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+Round-6 follow-up. rmcp's `RequestId::Number` is `i64`. Fractional and out-of-i64-range JSON numbers fail rmcp's deserialization; the validator should reject them too.
+
+- [ ] **Step 1: Tighten the helper**
+
+In `crates/rimap-server/src/mcp/wire_validator.rs`, replace:
+
+```rust
+pub(crate) fn is_forwardable_id(v: &Value) -> bool {
+    v.is_string() || v.is_number()
+}
+```
+
+with:
+
+```rust
+pub(crate) fn is_forwardable_id(v: &Value) -> bool {
+    // rmcp 1.5's RequestId = NumberOrString. Strings are unrestricted;
+    // numbers must be i64-representable (rejects fractional values and
+    // numbers outside i64 range — serde_json parses very large ints as
+    // f64 which `as_i64` also rejects).
+    if v.is_string() {
+        return true;
+    }
+    v.as_i64().is_some()
+}
+```
+
+- [ ] **Step 2: Add unit tests**
+
+Inside the existing `mod tests` block in `wire_validator.rs`:
+
+```rust
+    #[test]
+    fn fractional_id_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":1.5}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+
+    #[test]
+    fn out_of_i64_range_id_rejects() {
+        // serde_json may parse very large integers as f64; either way
+        // as_i64() returns None and we reject.
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","method":"x","id":9223372036854775808}"#),
+            reject(-32600, Value::Null)
+        );
+    }
+```
+
+- [ ] **Step 3: Run**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: all tests PASS, including the two new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "fix(rimap-server): is_forwardable_id matches rmcp i64 range (#277)"
+```
+
+---
+
+## Task 7.2: Tighten `is_well_formed_error.code` to rmcp's `i32`
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/wire_validator.rs`
+
+Same shape as 7.1 but for the error envelope's `code` field. rmcp's `ErrorCode = i32`.
+
+- [ ] **Step 1: Tighten the helper**
+
+Replace:
+
+```rust
+pub(crate) fn is_well_formed_error(v: &Value) -> bool {
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    obj.get("code").is_some_and(Value::is_number)
+        && obj.get("message").is_some_and(Value::is_string)
+}
+```
+
+with:
+
+```rust
+pub(crate) fn is_well_formed_error(v: &Value) -> bool {
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    let code_ok = obj
+        .get("code")
+        .and_then(Value::as_i64)
+        .is_some_and(|n| i32::try_from(n).is_ok());
+    let message_ok = obj.get("message").is_some_and(Value::is_string);
+    code_ok && message_ok
+}
+```
+
+- [ ] **Step 2: Add unit tests**
+
+```rust
+    #[test]
+    fn fractional_error_code_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":1.5,"message":"x"}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+
+    #[test]
+    fn out_of_i32_range_error_code_rejects() {
+        assert_eq!(
+            validate(r#"{"jsonrpc":"2.0","id":1,"error":{"code":2147483648,"message":"x"}}"#),
+            reject(-32600, json!(1))
+        );
+    }
+```
+
+- [ ] **Step 3: Run**
+
+```bash
+cargo nextest run -p rimap-server --lib wire_validator
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/wire_validator.rs
+git commit -m "fix(rimap-server): is_well_formed_error.code matches rmcp i32 range (#277)"
+```
+
+---
+
+## Task 8: Full local CI sweep
+
+**Files:** none
+
+**Context:** Final gate — run `just ci` and verify everything green before opening PR #278 out of draft.
+
+- [ ] **Step 1: Run the full local CI sweep**
+
+```bash
+just ci
+```
+
+Expected: all stages green (nextest workspace, cargo deny, mcp-conformance, typos, etc.). If any failure surfaces, attribute it to one of the prior tasks and fix in a focused follow-up commit.
+
+- [ ] **Step 2: Verify `prop_envelope_never_panics` runs at a higher case count**
+
+```bash
+PROPTEST_CASES=10000 cargo nextest run -p rimap-server --test mcp_wire_proptest prop_envelope_never_panics
+```
+
+Expected: PASS at 10k cases. (Nightly runs 100k via the existing `mcp-fuzz-nightly.yml`.) If a panic surfaces at 10k that didn't at 1k, capture the shrunk envelope and add a fixed-case test before merging.
+
+- [ ] **Step 3: No commit — just CI confirmation.**
+
+---
+
+## Spec coverage check
+
+- **Problem / Root cause** (spec §Problem, §Root cause) → addressed by Tasks 1.2 + 2.1 (validator + inbound bridge); see also task assertions in Task 5.1.
+- **Two cases collapsed** (spec §Two cases collapsed) → case 1 = Task 1.2 + 5.1; case 2 = Task 6.1 strategy filter + Task 5.4 fixed-case.
+- **Desired behavior** (5 numbered behaviors) → 1: Tasks 1.2/2.1/2.2; 2: Task 1.2 empty-line test; 3: Task 1.2 parse-error test + 5.1 test 8; 4: Task 1.2 invalid-request tests + 5.1 tests 1-7; 5: Task 5.1 `session_survives_invalid_envelope`.
+- **Approach: validator architecture diagram** (spec §Approach) → Tasks 2.1-2.4 implement the diagram.
+- **Validator entry point + struct** (spec §Validator entry point) → Task 2.4.
+- **Bridge-task supervisor** (spec §Bridge-task supervisor, all three methods + the two-phase shutdown rationale) → Task 2.3 (methods) + Tasks 3.3/3.4 (usage in main.rs) + Tasks 5.3/5.6 (closed-stdout audit tests).
+- **Pre-init shares the validator stdout** (spec §Pre-init shares the validator stdout) → Task 3.1 + Task 5.2 (interleave test).
+- **Validation rules table + decision logic** (spec §Validation rules, §validate() decision logic) → Task 1.2 (all rule rows have matching unit tests) + Task 5.1 (wire-pinned tests 1-10).
+- **`id`-echo policy** (spec §id-echo policy) → Task 1.2 `extract_id` + assertions in Task 5.1 (numeric/string/null echo cases).
+- **Error envelope shapes** (spec §Error envelope shapes) → Task 1.3 `synthesize_error_line` + unit tests.
+- **File layout** (spec §File layout) → matches plan's File Structure section.
+- **Property strategy adjustment** (spec §Property strategy adjustment) → Task 6.1.
+- **Fixed-case notification coverage** (spec §Fixed-case notification coverage) → Task 5.4.
+- **Testing — all 25 tests** → Tasks 5.1 (10) + 5.2 (1) + 5.3 (3) + 5.4 (1) + 5.5 (4) + 5.6 (3) + 5.7 (3) = 25. ✓
+- **Risks / mitigations** — covered by the test plan (each risk has a pinning test in Task 5.*).
+- **Implementation follow-ups (round 6)** → Tasks 7.1 + 7.2.
+- **Dependencies and merge plan** → final task list (1.1 → 8) lands all six items in the spec's merge-plan numbering.
+
+No spec gaps.

--- a/docs/superpowers/plans/2026-05-15-pre-push-hook-trim.md
+++ b/docs/superpowers/plans/2026-05-15-pre-push-hook-trim.md
@@ -1,0 +1,493 @@
+# Pre-push Hook Trim Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the slow `just test` step in the `pre-push` stage of `.pre-commit-config.yaml` with `cargo check --workspace --all-targets --locked`, so `git push` completes under github.com's ~30s SSH idle window and stops silently dropping ref transfers.
+
+**Architecture:** Single-file edit to `.pre-commit-config.yaml`. The existing `cargo-nextest` hook becomes a `cargo-check` hook with the same `pre-push` stage, no Rust-type filter (`always_run: true`) so dependency-only / lockfile-only pushes also get gated. `cargo-deny check advisories bans` stays unchanged. No new files; no `just` target changes.
+
+**Tech Stack:** prek (pre-commit-in-Rust), `.pre-commit-config.yaml`, cargo. Manual verification only — no automated regression tests for the hook itself.
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-pre-push-hook-trim-design.md`](../specs/2026-05-15-pre-push-hook-trim-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `.pre-commit-config.yaml` — swap one hook entry (line ~127-133 in the current file)
+
+**No other repo changes.** The `project-push-ssh-keepalive` auto-memory gets a session-local "Resolved by" update *after* the commit lands; that lives outside the repo.
+
+---
+
+## Task 0: Pre-flight — Confirm current hook shape
+
+**Files:** none (verification only)
+
+**Context:** The plan touches one block of `.pre-commit-config.yaml`. This task pins the current contents so the edit in Task 1 targets exactly what the spec describes; if the file has drifted, halt rather than guess.
+
+- [ ] **Step 1: Confirm the cargo-nextest hook is on the `pre-push` stage today**
+
+Run:
+```bash
+grep -n -B1 -A6 "id: cargo-nextest" .pre-commit-config.yaml
+```
+
+Expected output (the exact bytes the edit replaces):
+
+```
+      - id: cargo-nextest
+        name: just test (prune stale containers + cargo nextest)
+        entry: just test
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+If any of those seven lines differ, halt. The spec assumes this block; an edited or moved hook breaks the assumption.
+
+- [ ] **Step 2: Confirm the cargo-deny hook is also on `pre-push` and unchanged by this plan**
+
+Run:
+```bash
+grep -n -B1 -A4 "id: cargo-deny" .pre-commit-config.yaml
+```
+
+Expected: the existing `cargo-deny` hook entry. This task will NOT modify it; the grep is just a snapshot.
+
+- [ ] **Step 3: Confirm prek is installed and the working tree is clean**
+
+Run:
+```bash
+prek --version && git status --short
+```
+
+Expected: a prek version line, and an empty git status (no uncommitted changes in the working tree). If `prek` is not found, install it per the project setup notes (`brew install prek` on macOS, or `cargo install --locked prek`). If the working tree has uncommitted changes, commit or stash them before starting Task 1.
+
+- [ ] **Step 4: No commit. Move to Task 1.**
+
+---
+
+## Task 1: Replace the cargo-nextest pre-push hook with cargo-check
+
+**Files:**
+- Modify: `.pre-commit-config.yaml` (one block, ~7 lines)
+
+The edit swaps `just test` for `cargo check --workspace --all-targets --locked` and replaces the `types: [rust]` file filter with `always_run: true` so dependency-only and lockfile-only pushes still trigger the hook (this is the regression Codex caught in adversarial review — `Cargo.toml` and `Cargo.lock` are not prek's `rust` type, so the `--locked` stale-lockfile check would otherwise be silently skipped).
+
+- [ ] **Step 1: Make the edit**
+
+Find this block in `.pre-commit-config.yaml`:
+
+```yaml
+      - id: cargo-nextest
+        name: just test (prune stale containers + cargo nextest)
+        entry: just test
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Replace it with:
+
+```yaml
+      - id: cargo-check
+        name: cargo check --workspace --all-targets --locked
+        entry: cargo check --workspace --all-targets --locked
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+The four lines that changed: `id`, `name`, `entry`, and `types: [rust]` → `always_run: true`. `language`, `pass_filenames`, and `stages` are unchanged.
+
+- [ ] **Step 2: Verify the YAML still parses**
+
+Run:
+```bash
+prek run --hook-stage pre-push --help >/dev/null 2>&1 && echo "OK: prek parsed config"
+```
+
+Expected: `OK: prek parsed config`. If prek errors with a YAML or schema complaint, re-check the edit for indentation drift (this file uses 2-space indents under `hooks:`).
+
+- [ ] **Step 3: Run the new hook on the current branch's HEAD to prove it executes**
+
+Run:
+```bash
+prek run cargo-check --hook-stage pre-push --all-files
+```
+
+Expected: `cargo check --workspace --all-targets --locked` runs and exits 0 (the workspace is clean at HEAD). Wall-time should be roughly the cargo-check duration (~5s on warm cache).
+
+If the hook id `cargo-check` isn't found, prek may have cached the old hooks list — run `prek clean` and retry.
+
+- [ ] **Step 4: Run the unchanged cargo-deny hook for comparison**
+
+Run:
+```bash
+prek run cargo-deny --hook-stage pre-push --all-files
+```
+
+Expected: `cargo deny check advisories bans` runs and exits 0. This confirms the cargo-deny entry was not disturbed by the YAML edit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "$(cat <<'EOF'
+chore(prek): trim pre-push hook from nextest to cargo check
+
+Replaces `just test` (cargo-nextest workspace ~25-60s) with
+`cargo check --workspace --all-targets --locked` (~5s) at the
+pre-push stage so git push completes under github.com's ~30s
+SSH idle window. Tests move entirely to CI; pre-push retains a
+fast compile+lockfile gate plus the existing cargo-deny
+advisory check.
+
+`always_run: true` (instead of `types: [rust]`) ensures
+Cargo.toml / Cargo.lock-only pushes still trigger the
+--locked check.
+EOF
+)"
+```
+
+Verify the commit landed:
+
+```bash
+git log --oneline -1
+```
+
+Expected: the commit subject above shows on the latest line.
+
+---
+
+## Task 2: Manual verification — happy path (compile-clean push)
+
+**Files:** none (live verification)
+
+**Context:** The hook itself is the test. Task 2 verifies the everyday case: a trivial commit pushes through without the `GIT_SSH_COMMAND` keepalive workaround.
+
+- [ ] **Step 1: Create a trivial probe commit on a throwaway branch**
+
+```bash
+git checkout -b verify/pre-push-trim
+echo "# Pre-push trim verification probe ($(date -u +%FT%TZ))" >> .gitignore
+# (.gitignore is a low-risk file; we'll revert this branch entirely after)
+git add .gitignore
+git commit -m "test: pre-push trim verification probe (will be deleted)"
+```
+
+- [ ] **Step 2: Push WITHOUT the keepalive workaround**
+
+```bash
+git push -u origin verify/pre-push-trim
+```
+
+Expected:
+- pre-push hook runs and prints `cargo check` + `cargo deny` lines, both Passed
+- the push completes with a real ref-transfer summary, e.g. `To github.com:randomparity/rusty-imap-mcp.git ... verify/pre-push-trim -> verify/pre-push-trim`
+- total wall-time well under 30s
+
+Verify the ref reached origin (per the `project-push-ssh-keepalive` memory: exit-0 is not sufficient evidence):
+
+```bash
+git ls-remote --heads origin verify/pre-push-trim
+```
+
+Expected: one line with the probe commit's SHA. If this returns empty, the push silently dropped the ref — Task 1's fix did not solve the problem (or your network/SSH conditions are exceptional). Halt and investigate before continuing.
+
+- [ ] **Step 3: Clean up the probe branch**
+
+```bash
+git checkout feature/issue-266-mcp-fuzzing
+git branch -D verify/pre-push-trim
+git push origin --delete verify/pre-push-trim
+```
+
+Expected: branch removed locally and on origin. No commit; the probe branch was throwaway.
+
+---
+
+## Task 3: Manual verification — compile-fail rejection
+
+**Files:** none (live verification — uses a temporary local edit, never committed)
+
+**Context:** Prove that the new hook actually catches compile-fail. This is what makes pre-push a meaningful gate.
+
+- [ ] **Step 1: Introduce a deliberate compile error in a throwaway file**
+
+Edit `crates/rimap-server/src/lib.rs` (or whichever file is open):
+
+Add a single line near the top after the existing imports:
+
+```rust
+const DELIBERATE_ERROR: u32 = "not a number";
+```
+
+This is a type-mismatch error that `cargo check` will reject.
+
+- [ ] **Step 2: Stage the change but DO NOT commit**
+
+```bash
+git add crates/rimap-server/src/lib.rs
+```
+
+- [ ] **Step 3: Run the hook directly to confirm rejection**
+
+```bash
+prek run cargo-check --hook-stage pre-push --all-files
+```
+
+Expected: the hook fails with non-zero exit; the output includes a Rust compile-error referencing `expected u32, found &str`. The push (if attempted) would be blocked.
+
+- [ ] **Step 4: Revert the edit**
+
+```bash
+git restore --staged --worktree crates/rimap-server/src/lib.rs
+```
+
+Verify:
+
+```bash
+git status --short crates/rimap-server/src/lib.rs
+```
+
+Expected: empty (file is back to the committed state).
+
+- [ ] **Step 5: No commit.**
+
+---
+
+## Task 4: Manual verification — stale-lockfile rejection
+
+**Files:** none (live verification — uses a temporary local edit, never committed)
+
+**Context:** Pin that the `--locked` flag catches `Cargo.lock` drift. This is the gate the old `just test` arguably had (nextest also uses `--locked`); we want to make sure we didn't lose it.
+
+- [ ] **Step 1: Hand-edit `Cargo.lock` to introduce a fake mismatch**
+
+The simplest reproducible drift: find a `version = "x.y.z"` line for a dep that's not used in this workspace and bump its patch number. Pick any third-party crate that appears in `Cargo.lock`. For example:
+
+```bash
+# Find the current line
+grep -n -m 1 "^version = " Cargo.lock | head -1
+```
+
+Then edit `Cargo.lock` by hand (the file is normally generated, so just bump a digit in any non-workspace `version = "..."` field — e.g., change `version = "1.0.0"` to `version = "1.0.999"`). Save.
+
+- [ ] **Step 2: Run the hook**
+
+```bash
+prek run cargo-check --hook-stage pre-push --all-files
+```
+
+Expected: the hook fails. The error message includes "the lock file ... needs to be updated but --locked was passed to prevent this" (exact wording varies by cargo version).
+
+- [ ] **Step 3: Restore Cargo.lock from the repo**
+
+```bash
+git restore Cargo.lock
+```
+
+Verify:
+
+```bash
+git diff Cargo.lock
+```
+
+Expected: empty (no diff). Cargo.lock matches HEAD.
+
+- [ ] **Step 4: No commit.**
+
+---
+
+## Task 5: Manual verification — dependency-only push still triggers the hook
+
+**Files:** none (live verification — pins the `always_run: true` regression Codex caught)
+
+**Context:** This is the regression case from adversarial review. With `types: [rust]`, a push containing only `Cargo.toml` / `Cargo.lock` changes (e.g. a dep bump) would bypass the hook entirely. With `always_run: true`, the hook fires regardless. Task 5 proves the new behavior live.
+
+- [ ] **Step 1: Create a throwaway branch with a Cargo.toml-only change**
+
+```bash
+git checkout -b verify/pre-push-dep-only
+```
+
+Pick a non-essential dep that already appears in a workspace `Cargo.toml`. For example, find a workspace member's `Cargo.toml` and add a harmless comment to bump it without changing semantics. Easiest: add a trailing newline.
+
+```bash
+# Find any workspace Cargo.toml and append a comment line
+echo "# verify/pre-push-dep-only probe" >> crates/rimap-server/Cargo.toml
+```
+
+This touches a `Cargo.toml` without touching any `.rs` file — exactly the scenario where the old `types: [rust]` filter would skip the hook.
+
+- [ ] **Step 2: Commit the change**
+
+```bash
+git add crates/rimap-server/Cargo.toml
+git commit -m "test: pre-push always_run verification probe (will be deleted)"
+```
+
+- [ ] **Step 3: Push without the keepalive workaround**
+
+```bash
+git push -u origin verify/pre-push-dep-only
+```
+
+Expected: the pre-push hook output INCLUDES the `cargo-check` line (Passed). If `cargo-check` is missing or shown as `Skipped`, the `always_run: true` change did not take effect — halt and re-check the Task 1 edit.
+
+The push itself should succeed; verify with:
+
+```bash
+git ls-remote --heads origin verify/pre-push-dep-only
+```
+
+Expected: one line with the probe commit's SHA.
+
+- [ ] **Step 4: Clean up the probe branch and revert the local Cargo.toml change**
+
+```bash
+git checkout feature/issue-266-mcp-fuzzing
+git branch -D verify/pre-push-dep-only
+git push origin --delete verify/pre-push-dep-only
+```
+
+Verify the local Cargo.toml is back to its committed state:
+
+```bash
+git diff crates/rimap-server/Cargo.toml
+```
+
+Expected: empty.
+
+---
+
+## Task 6: Manual verification — cargo-deny still gates the push
+
+**Files:** none (live verification — pins that the YAML edit didn't accidentally disturb the cargo-deny hook)
+
+**Context:** Cargo-deny is the other half of the pre-push stage. Task 6 confirms it still runs and still rejects on the kind of violation it's meant to catch.
+
+- [ ] **Step 1: Introduce a deny rule that flags an existing dep**
+
+The simplest reproducible failure: temporarily add an explicit `[bans]` entry to `deny.toml` for a crate that's already in the dependency tree. Pick any indirect crate from `Cargo.lock` (e.g. `serde` would be excessive — use something like `cfg-if` if present).
+
+```bash
+# Find a likely candidate
+grep -m1 "^name = \"cfg-if\"" Cargo.lock || echo "cfg-if not in tree; pick another"
+```
+
+If `cfg-if` is in tree, edit `deny.toml` to add (under whichever `[bans]` section exists, or create one):
+
+```toml
+[bans]
+deny = [
+    { name = "cfg-if" },
+]
+```
+
+(Adjust the exact TOML structure to match the existing `deny.toml` schema — see the existing file before editing.)
+
+- [ ] **Step 2: Run the hook**
+
+```bash
+prek run cargo-deny --hook-stage pre-push --all-files
+```
+
+Expected: the hook fails; output includes `cfg-if` (or whichever crate you chose) being explicitly banned.
+
+- [ ] **Step 3: Revert deny.toml**
+
+```bash
+git restore deny.toml
+```
+
+Verify:
+
+```bash
+git diff deny.toml
+```
+
+Expected: empty.
+
+- [ ] **Step 4: No commit.**
+
+---
+
+## Task 7: Update session memory and final verification
+
+**Files:** none (memory update + final sanity check)
+
+**Context:** The `project-push-ssh-keepalive` auto-memory becomes outdated once Task 1 lands. Update it to reference the fix so future Claude sessions know the `GIT_SSH_COMMAND` workaround is no longer the default path.
+
+- [ ] **Step 1: Update the auto-memory file**
+
+Edit `/Users/dave/.claude/projects/-Users-dave-src-rusty-imap-mcp/memory/project_push_ssh_keepalive.md` and add a stanza at the end:
+
+```markdown
+**Resolved by:** Commit landing this plan's Task 1 change to `.pre-commit-config.yaml` (see `docs/superpowers/specs/2026-05-15-pre-push-hook-trim-design.md` and the corresponding plan). Pre-push hook runtime now ≤10s on a warm cache; SSH keepalive no longer required for the everyday case. The `GIT_SSH_COMMAND` workaround stays documented for cold-cache edge cases (fresh clone, post-`cargo clean`, major dep bump) where worst-case cargo-check timing can still exceed the SSH idle window.
+```
+
+This is a local-only edit (auto-memory lives under `~/.claude/`, not in the repo). No git commit.
+
+- [ ] **Step 2: Sanity-check the full pre-push flow one more time**
+
+Create one more throwaway probe to confirm Tasks 1+2 stick:
+
+```bash
+git checkout -b verify/pre-push-final
+echo "" >> README.md
+git add README.md
+git commit -m "test: final pre-push sanity probe (will be deleted)"
+git push -u origin verify/pre-push-final
+```
+
+Expected:
+- pre-push hook output shows `cargo-check ... Passed` and `cargo-deny ... Passed`
+- the push prints a real ref-transfer summary
+- `git ls-remote --heads origin verify/pre-push-final` returns one line
+
+- [ ] **Step 3: Clean up**
+
+```bash
+git checkout feature/issue-266-mcp-fuzzing
+git branch -D verify/pre-push-final
+git push origin --delete verify/pre-push-final
+git restore README.md
+```
+
+Verify clean state:
+
+```bash
+git status --short
+git log --oneline -3
+```
+
+Expected:
+- empty `git status` (no working-tree drift from the verification tasks)
+- the Task 1 commit is on the latest line; the two preceding lines are whatever was on this branch before
+
+---
+
+## Spec coverage check
+
+Mapping each spec section to a task:
+
+- **Problem statement & SSH timeout** (spec lines 9-30) → addressed by Task 1, verified by Tasks 2 and 5
+- **Root cause** (spec lines 32-49) → addressed by Task 1 (replacing the slow step)
+- **Desired behavior** (spec lines 51-63) — `git push` works without keepalive (Tasks 2, 5, 7), compile/type-error gate (Task 3), cargo-deny still gates (Task 6), test-failure detection moves to CI (acceptance, not a task)
+- **Approach: hook config change** (spec lines 65-85) → Task 1
+- **Why `always_run`** (spec lines 87-99) → Task 1 explicit note + Task 5 live verification
+- **Why `cargo check`, not nothing / clippy / all-features** (spec rationale sections) → captured in Task 1's commit message
+- **`--locked` rationale** (spec section) → Task 4 verification
+- **File layout** (spec — single config file) → matches plan's File Structure
+- **Memory update** (spec section) → Task 7
+- **Testing plan** (spec section) → Tasks 2-6
+- **Risks: cold cache** (spec risk section) → not addressed by code; the spec acknowledges the workaround stays valid. Task 7's memory note captures this.
+
+No spec gaps.

--- a/docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md
+++ b/docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md
@@ -1,0 +1,290 @@
+# MCP Protocol Fuzzing & Negative-Path Coverage — Design
+
+**Status:** Draft 2026-05-13
+**Issue:** #266 (Phase 4 of 4)
+**Depends on:** #263 (Phase 1 wire harness, closed), #265 (Phase 3 Dovecot fixture, closed)
+**Scope:** Property-based and targeted negative-path tests for the MCP
+JSON-RPC wire: malformed envelopes, protocol-state errors, oversized
+payloads, concurrent requests, cancellation mid-call, audit fail-closed
+boundary. Builds on the wire-driving `Harness` shipped in Phase 1.
+
+## 1. Motivation
+
+Phases 1–3 cover happy-path conformance against three different
+validators (vendored MCP spec schema in #263, official Node SDK in
+#264, Dovecot behavioral conformance in #265). They do not cover what
+happens when a misbehaving or malicious client sends garbage. The
+server must respond with well-formed JSON-RPC error envelopes (per
+spec) — or cleanly close the connection — rather than crash, hang, or
+leak partial state. The most security-relevant tests live here, and
+this phase locks in the negative-path contract before any new tool or
+config surface is added.
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- Cover the negative-path categories the issue enumerates: malformed
+  input, method-level errors, protocol-state errors, concurrency,
+  cancellation, property-based envelope fuzzing, audit fail-closed.
+- Every test asserts a concrete contract — no test that only checks
+  "didn't crash."
+- Deterministic concurrency (no clock-based races); deterministic
+  proptest reproducibility (`proptest-regressions/` committed).
+- ≥1000 cases per property in CI; overnight runs scale via
+  `PROPTEST_CASES`.
+- Zero new production crate dependencies. Reuse the Phase 1 harness
+  and the existing workspace `proptest`.
+
+### Non-Goals
+
+- IMAP-server-side fuzzing — covered by `rimap-content` ammonia
+  property tests and the mail-parser adversarial corpus.
+- Coverage-guided fuzzing infrastructure — `.clusterfuzzlite/`
+  already exists.
+- Tool-output schema fuzzing — Phase 4 targets the wire/envelope
+  layer; output schemas are validated in Phase 1 and Phase 3.
+- New tools, new config surface, new production code paths. Phase 4
+  is testing only, except for the small `test-support` knob noted in
+  §6.4 if `chmod`-based audit failure injection turns out to be
+  unreliable in CI.
+
+## 3. Architecture
+
+Four new test binaries, all reusing the existing `support/wire/`
+module from Phase 1. The harness is extended in place — no new
+struct, no forked spawn path.
+
+| File | Purpose | Spawn config |
+| --- | --- | --- |
+| `crates/rimap-server/tests/mcp_wire_negative.rs` | Malformed JSON, protocol-state errors, version negotiation failures, concurrent in-flight requests. | Zero-account (`Harness::spawn`). |
+| `crates/rimap-server/tests/mcp_wire_proptest.rs` | `proptest`-driven envelope and `tools/call` argument fuzzing. ≥1000 cases per property by default. | Zero-account, harness reused across cases per property block. |
+| `crates/rimap-server/tests/mcp_audit_failure.rs` | Audit fail-closed boundary tests. | Zero-account, audit path on a write-failing target. |
+| `crates/rimap-server/tests/e2e_wire_cancellation.rs` | `notifications/cancelled` mid-`tools/call`, assert `tool_end { status: cancelled }` audit record. | Phase 3 Dovecot fixture (`support/dovecot/harness.rs`). |
+
+### 3.1 Harness extensions
+
+`crates/rimap-server/tests/support/wire/harness.rs` gains these methods.
+The existing `request` / `notify` / `shutdown_and_wait` surface is
+unchanged so Phases 1 and 3 continue to validate envelopes by default.
+
+```rust
+async fn send_raw(&mut self, bytes: &[u8]);
+async fn send_line(&mut self, line: &str);                     // appends \n
+async fn recv_line_within(&mut self, dur: Duration) -> Option<String>;
+async fn send_request_no_wait(&mut self, method: &str, params: Value) -> u64;
+async fn recv_until_id(&mut self, id: u64) -> Value;
+async fn assert_clean_shutdown_or_response(&mut self, request_dur: Duration);
+```
+
+The notification-skip loop currently inlined in `request` is refactored
+into a private `read_one_envelope` helper so `request` and
+`recv_until_id` share parsing and the stderr-on-failure diagnostics.
+`recv_until_id` buffers out-of-order responses in a small `VecDeque`
+keyed by id — when a later call asks for a buffered id, it is returned
+without touching stdout.
+
+### 3.2 Determinism primitives
+
+- **Concurrency** — `send_request_no_wait` + `recv_until_id` is a
+  single-task design; no `tokio::spawn`, no shared `Mutex` over
+  stdout. The harness drains stdout linearly; out-of-order responses
+  are buffered. Deterministic under nextest load.
+- **Cancellation timing** — the Dovecot-backed test polls the audit
+  log for `tool_start` (100 ms cap, 10 ms granularity) before issuing
+  `notifications/cancelled`. No `sleep()`-and-hope ordering.
+- **Proptest seeds** — `proptest-regressions/` is committed (same
+  pattern `rimap-content` already uses). Each shrink reproduces from
+  the committed seed.
+
+## 4. Test inventory & contracts
+
+Every test asserts a concrete contract. Probe-based contracts ("either
+envelope-X or clean close") record the probed behavior inline so
+future readers can tell why the assertion is shaped that way.
+
+### 4.1 `mcp_wire_negative.rs` (≈8–10 tests, zero-account)
+
+| Test | Input | Contract |
+| --- | --- | --- |
+| `unparsable_json_errors_or_closes` | `not json\n` | Envelope `code: -32700` OR child exits 0 within `SHUTDOWN_TIMEOUT`. |
+| `valid_json_invalid_envelope_returns_minus_32600` | `{"foo":"bar"}` | `-32600` invalid request, `jsonrpc == "2.0"`. |
+| `missing_method_field` | envelope without `method` | `-32600`. |
+| `wrong_type_method_field` | `"method": 42` | `-32600`. |
+| `oversized_params_payload` | `params.note` = 1 MiB string | Valid envelope (success or error) or clean close; never hang past `REQUEST_TIMEOUT`. |
+| `initialize_after_already_initialized` | Two `initialize` calls | Second returns an error envelope; exact code recorded inline. |
+| `tools_list_before_initialize` | `tools/list` without prior `initialize` | Error envelope; code recorded. |
+| `initialize_unsupported_protocol_version` | `protocolVersion: "1999-01-01"` | Echo of supported version OR error envelope (spec allows either). |
+| `concurrent_tools_list_two_inflight` | Two `tools/list` via `send_request_no_wait`, both awaited via `recv_until_id` | Both responses received within `REQUEST_TIMEOUT`, ids match, no corruption. |
+| `bidi_override_in_tool_argument` | `tools/call use_account` with bidi-override in `account_id` | Accepted or rejected with valid error envelope; no panic in audit writer. |
+
+### 4.2 `mcp_wire_proptest.rs` (3 properties, zero-account)
+
+```rust
+#![proptest_config(ProptestConfig::with_cases(1000))]
+```
+
+`PROPTEST_CASES` overrides the case count. Overnight runs use 100 000.
+Each property block spawns one `Harness` and replays N envelopes
+through it — re-spawning per case would push the suite past minutes
+without adding coverage.
+
+1. **`prop_envelope_never_panics`** — strategy generates arbitrary
+   JSON values with optional `jsonrpc`, `id`, `method`, `params`
+   fields of randomized types. Assert: every input either produces a
+   well-formed JSON-RPC envelope validating against
+   `JSONRPCResponse`/`JSONRPCError`, or the server cleanly closes the
+   connection. No panic, no hang past `REQUEST_TIMEOUT`, no
+   malformed line.
+2. **`prop_tools_call_unknown_tool`** — arbitrary string tool names
+   plus arbitrary JSON `arguments`. Assert: every response validates
+   as `JSONRPCErrorResponse`; `code` is one of a documented small
+   set.
+3. **`prop_tools_call_use_account_argument_shape`** — `use_account`
+   called with arbitrary argument shapes. Assert: server returns a
+   valid error envelope (no account configured ⇒ rejection); never
+   a result envelope. (`list_accounts` is also advertised in the
+   zero-account config but takes no arguments, so it is not a
+   useful fuzz target for argument-shape properties; envelope-level
+   coverage for it lives in property 1.)
+
+### 4.3 `mcp_audit_failure.rs` (2–3 tests, zero-account)
+
+| Test | Setup | Contract |
+| --- | --- | --- |
+| `audit_write_failure_fails_closed_for_tools_call` | Audit path on a read-only directory (preferred) or a sentinel-rejecting `AuditSink` behind `test-support` feature (fallback, §6.4). | `tools/call use_account` returns an error envelope; server does NOT silently succeed. |
+| `audit_write_failure_does_not_block_initialize` | Same setup. | `initialize` either succeeds or fails with a clear error; exact behavior asserted from probe. |
+
+### 4.4 `e2e_wire_cancellation.rs` (2 tests, Dovecot-backed)
+
+| Test | Flow | Contract |
+| --- | --- | --- |
+| `cancel_search_emits_tool_end_cancelled` | `use_account` → start `tools/call search` over a large folder → poll audit log for `tool_start` (≤ 100 ms) → send `notifications/cancelled` with the request id → drain stdout. | Exactly one `tool_end` audit record for the cancelled request with `status: cancelled` (issues #71, #99). No `tool_end {status: ok}`. No panic. |
+| `cancel_unknown_request_id_is_noop` | Send `notifications/cancelled` for an id that was never used. | No response, no panic, server still responsive to subsequent `tools/list`. |
+
+## 5. Error handling
+
+Every assertion failure includes captured child stderr via the
+existing `Harness::captured_stderr` helper. Test diagnostics quote the
+captured stream so a CI failure surfaces the binary's
+`tracing::error!` output, not just the test panic line.
+
+For probe-based contracts, the probed behavior is documented inline:
+
+```rust
+// Probed 2026-05-13 (rmcp 1.5): server responds with -32700.
+// If this changes, the parse-error path either tightened (stricter
+// envelope rejection) or the framing changed — investigate before
+// updating the assertion.
+```
+
+Bugs found during probing — server panics on malformed input, hangs,
+leaks partial state, emits malformed envelopes — are filed as
+separate issues per the issue's acceptance criteria and fixed before
+Phase 4 merges. Each such bug gets a regression test that lands with
+the fix.
+
+## 6. CI, dependencies, decomposition
+
+### 6.1 CI integration
+
+- Default `cargo test -p rimap-server` runs the 1000-case proptest
+  properties under a per-property budget that keeps the suite under
+  the existing `rimap-server` test wall-clock. No CI matrix changes.
+- Overnight runs: GitHub Actions cron workflow at
+  `.github/workflows/mcp-fuzz-nightly.yml` sets
+  `PROPTEST_CASES=100000` and runs
+  `cargo test -p rimap-server --tests mcp_wire_proptest -- --nocapture`.
+  Pinned to a SHA per the repo's existing convention; `zizmor`
+  passes before merge.
+- Nextest classification: proptest tests use
+  `slow-timeout` overrides so a stuck case fails fast instead of
+  hitting the full CI timeout.
+- Dovecot-backed cancellation tests reuse the existing
+  `dovecot` gating mechanism from `e2e_wire.rs`.
+
+### 6.2 Dependencies
+
+No new crate. The fuzzing layer reuses `proptest` 1.6 (already a
+workspace dep), `jsonschema`, `tempfile`, `tokio`, `serde_json`,
+`assert_cmd`. `rmcp` 1.5 unchanged; the existing version-drift
+detector in
+`wire_protocol_version_negotiation_matches_vendored_schema` will
+catch any bump that invalidates a fuzz assertion.
+
+### 6.3 Decomposition
+
+Phase 4 lands as a single PR but the work decomposes into sequenced
+commits so probing-phase fallout does not block earlier commits:
+
+1. **Harness extensions** (`support/wire/harness.rs`). Exercised
+   transitively by the first test in `mcp_wire_negative.rs` that
+   uses each new method — no separate unit-test module is added to
+   `harness.rs` (the file currently has none and the integration
+   tests are the natural call site).
+2. **`mcp_wire_negative.rs`** — all probed contracts. Bugs found
+   during probing are fixed on sibling branches before this commit
+   lands.
+3. **`mcp_wire_proptest.rs`** — three properties at 1000 cases.
+   `proptest-regressions/` directory committed.
+4. **`mcp_audit_failure.rs`** — fail-closed boundary tests. May
+   reveal a small accessor need in `rimap-audit` (e.g., a way to
+   observe writer failure from a test); scope-flagged in the PR if
+   needed.
+5. **`e2e_wire_cancellation.rs`** — Dovecot-backed cancel tests.
+   Lands last; depends on Phase 3 harness + #99 Drop-emits-cancelled
+   discipline.
+6. **Nightly CI workflow** — same PR, reviewed separately.
+
+### 6.4 Audit failure injection — primary and fallback
+
+Primary mechanism: write the audit path to a `chmod 0o500` directory
+(`tempfile::TempDir` followed by a `std::fs::set_permissions` to
+revoke write). This is hermetic, requires no production-code change,
+and tests the real `AuditSink` against a real `EACCES`.
+
+Fallback (if `chmod` is unreliable as root in some CI runners): a
+`SentinelRejectingAuditSink` behind a `test-support` feature on
+`rimap-audit` that returns `Err` from every write. The test enables
+the feature and configures the sink via a `test-support`-gated config
+hook. Adds a permanent test-only branch in `rimap-audit`; choose
+during implementation based on whether the `chmod` path actually
+works on Linux + macOS CI.
+
+## 7. Risk register
+
+| Risk | Mitigation |
+| --- | --- |
+| Probing reveals a panic in the server on malformed input. | File issue, fix on sibling branch, regression test lands in Phase 4. Expected outcome, not blocker. |
+| Proptest finds a minimal-shrunk case hard to reproduce. | `proptest-regressions/` committed; each property's regressions reviewed in the PR. |
+| Concurrent-request test flaky under nextest. | Determinism comes from `send_request_no_wait` + `recv_until_id` (no clock races). If the binary serializes responses, the test still passes — just less interesting. |
+| `chmod 0o500` audit-fail trick doesn't work as root in CI. | Fall back to `SentinelRejectingAuditSink` (§6.4). |
+| Dovecot cancel test races `tool_start` audit landing. | Poll audit file 100 ms cap, 10 ms granularity rather than sleep-and-hope. |
+| Proptest at 100 000 cases overruns the nightly job's runner budget. | `slow-timeout` per property; nightly runs publish duration as part of the failure summary so we can split a single property into smaller ones if needed. |
+
+## 8. Acceptance criteria mapping
+
+Each acceptance criterion from issue #266 maps to a concrete artifact:
+
+- [ ] `cargo test -p rimap-server --tests mcp_wire_*` exercises every
+      category — covered by §4.1–§4.4 across four files.
+- [ ] Property tests run for ≥1000 cases per property in CI, gated by
+      env flag — `ProptestConfig::with_cases(1000)` + `PROPTEST_CASES`
+      override, §4.2 and §6.1.
+- [ ] Every negative case has an explicit assertion about correct
+      behavior — every row in §4.1–§4.4 has a contract column; "didn't
+      crash" alone is never an assertion (§5).
+- [ ] No new flakiness — determinism primitives in §3.2.
+- [ ] Bugs found during implementation filed as separate issues and
+      fixed before merge — §6.3 step 2 and §5.
+- [ ] Design doc in `docs/superpowers/specs/` — this file.
+
+## 9. Out of scope (explicit)
+
+- Coverage-guided fuzzing (`.clusterfuzzlite/` already exists).
+- IMAP-server-side fuzzing.
+- Tool-output schema fuzzing.
+- New tools, new config surface.
+- Schema drift detection — already covered by
+  `wire_protocol_version_negotiation_matches_vendored_schema` from
+  Phase 1.

--- a/docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md
+++ b/docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md
@@ -45,22 +45,26 @@ config surface is added.
 - Tool-output schema fuzzing — Phase 4 targets the wire/envelope
   layer; output schemas are validated in Phase 1 and Phase 3.
 - New tools, new config surface, new production code paths. Phase 4
-  is testing only, except for the small `test-support` knob noted in
-  §6.4 if `chmod`-based audit failure injection turns out to be
-  unreliable in CI.
+  is testing only. The audit-failure tests reuse the existing
+  `AuditWriter::force_next_write_failure()` hook (§6.4) rather than
+  introducing any new sink, feature flag, or filesystem trickery.
 
 ## 3. Architecture
 
-Four new test binaries, all reusing the existing `support/wire/`
-module from Phase 1. The harness is extended in place — no new
-struct, no forked spawn path.
+Five new test binaries across two crates, all reusing the existing
+`support/wire/` module from Phase 1 where they cross the wire. The
+harness is extended in place — no new struct, no forked spawn
+path. Four binaries live under `rimap-server/tests/`; the audit-
+layer Drop test lives under `rimap-audit/tests/` (see §4.4.2 for
+the rationale).
 
 | File | Purpose | Spawn config |
 | --- | --- | --- |
 | `crates/rimap-server/tests/mcp_wire_negative.rs` | Malformed JSON, protocol-state errors, version negotiation failures, concurrent in-flight requests. | Zero-account (`Harness::spawn`). |
-| `crates/rimap-server/tests/mcp_wire_proptest.rs` | `proptest`-driven envelope and `tools/call` argument fuzzing. ≥1000 cases per property by default. | Zero-account, harness reused across cases per property block. |
+| `crates/rimap-server/tests/mcp_wire_proptest.rs` | `proptest`-driven envelope and `tools/call` argument fuzzing. ≥1000 cases per property by default. | Zero-account, harness reused across cases with restart-on-close discipline (§3.2). |
 | `crates/rimap-server/tests/mcp_audit_failure.rs` | Audit fail-closed boundary tests. | Zero-account, audit path on a write-failing target. |
-| `crates/rimap-server/tests/e2e_wire_cancellation.rs` | `notifications/cancelled` mid-`tools/call`, assert `tool_end { status: cancelled }` audit record. | Phase 3 Dovecot fixture (`support/dovecot/harness.rs`). |
+| `crates/rimap-server/tests/e2e_wire_cancellation.rs` | Wire-layer cancellation: server accepts `notifications/cancelled` and stays responsive. Race-free assertions only (no `tool_end {status: cancelled}` here — see audit-layer test). | Phase 3 Dovecot fixture (`support/dovecot/harness.rs`). |
+| `crates/rimap-audit/tests/drop_emits_cancelled.rs` (new) | Audit-layer Drop discipline (#99): construct a `run_with_audit_envelope` future, poll once, drop it, assert exactly one `tool_end {status: cancelled}` record was written. Deterministic, no Dovecot, no race. | In-process unit test, no spawned binary. |
 
 ### 3.1 Harness extensions
 
@@ -96,6 +100,30 @@ without touching stdout.
 - **Proptest seeds** — `proptest-regressions/` is committed (same
   pattern `rimap-content` already uses). Each shrink reproduces from
   the committed seed.
+- **Proptest session isolation** — properties share a harness across
+  cases for speed (re-spawning the binary per case would push 1000
+  cases per property past the CI budget). Two disciplines keep
+  cases from poisoning each other:
+  - **Restart-on-close**: after every case, the harness checks
+    whether the connection is still alive (child process running,
+    stdout not at EOF). If not, the case records "connection closed
+    cleanly" as its result and the next case spawns a fresh
+    harness. No case ever runs against a poisoned session.
+  - **State-mutating-method exclusion** (property 1 only): the
+    strategy explicitly avoids generating `method` values that
+    mutate MCP session state. Pinned exclusion set:
+    `{"initialize", "notifications/initialized"}`. A pinned
+    assertion in the test cross-references this set against
+    `rmcp`'s known stateful methods so a future MCP spec addition
+    that introduces a new stateful method trips the assertion
+    rather than silently coupling cases. Properties 2 and 3 are
+    stateless by construction (`method` is fixed to
+    `tools/call <X>`) so they need no exclusion.
+  - **Shrinking caveat**: a shrunk regression assumes a freshly
+    initialized session. If a committed seed in
+    `proptest-regressions/` fails to reproduce against a fresh
+    harness, that is evidence of state-coupling — investigate as a
+    bug, do not delete the seed.
 
 ## 4. Test inventory & contracts
 
@@ -125,17 +153,29 @@ future readers can tell why the assertion is shaped that way.
 ```
 
 `PROPTEST_CASES` overrides the case count. Overnight runs use 100 000.
-Each property block spawns one `Harness` and replays N envelopes
-through it — re-spawning per case would push the suite past minutes
-without adding coverage.
+Each property block starts with one `Harness` and replays N
+envelopes through it. The restart-on-close discipline from §3.2
+spawns a fresh harness whenever a case closes the connection, so a
+case that legitimately ends the session never poisons the next
+case. Re-spawning unconditionally per case would push the suite
+past minutes without adding coverage, since properties 2 and 3 are
+stateless by construction and property 1 excludes the pinned
+state-mutating method set.
 
 1. **`prop_envelope_never_panics`** — strategy generates arbitrary
    JSON values with optional `jsonrpc`, `id`, `method`, `params`
-   fields of randomized types. Assert: every input either produces a
-   well-formed JSON-RPC envelope validating against
-   `JSONRPCResponse`/`JSONRPCError`, or the server cleanly closes the
-   connection. No panic, no hang past `REQUEST_TIMEOUT`, no
-   malformed line.
+   fields of randomized types. The `method` strategy excludes the
+   pinned state-mutating set `{"initialize", "notifications/initialized"}`
+   (see §3.2 Proptest session isolation) so cases stay independent
+   of session state. The test asserts at compile time / startup
+   that the exclusion set matches the methods rmcp documents as
+   stateful; a future spec addition that introduces a new stateful
+   method trips this assertion before silently coupling cases.
+   Assert per case: the input either produces a well-formed
+   JSON-RPC envelope validating against
+   `JSONRPCResponse`/`JSONRPCError`, or the server cleanly closes
+   the connection (restart-on-close discipline handles the latter).
+   No panic, no hang past `REQUEST_TIMEOUT`, no malformed line.
 2. **`prop_tools_call_unknown_tool`** — arbitrary string tool names
    plus arbitrary JSON `arguments`. Assert: every response validates
    as `JSONRPCErrorResponse`; `code` is one of a documented small
@@ -152,15 +192,42 @@ without adding coverage.
 
 | Test | Setup | Contract |
 | --- | --- | --- |
-| `audit_write_failure_fails_closed_for_tools_call` | Audit path on a read-only directory (preferred) or a sentinel-rejecting `AuditSink` behind `test-support` feature (fallback, §6.4). | `tools/call use_account` returns an error envelope; server does NOT silently succeed. |
-| `audit_write_failure_does_not_block_initialize` | Same setup. | `initialize` either succeeds or fails with a clear error; exact behavior asserted from probe. |
+| `audit_write_failure_fails_closed_for_tools_call` | Arm the in-process `AuditWriter` via `force_next_write_failure()` (see §6.4), then send `tools/call use_account` over the wire. | `tools/call use_account` returns an error envelope; server does NOT silently succeed. Exercises the real writer's lock / append / error-mapping path. |
+| `audit_write_failure_does_not_block_initialize` | Same setup, but the failure is armed before `initialize`. | `initialize` either succeeds or fails with a clear error; exact behavior asserted from probe. |
 
-### 4.4 `e2e_wire_cancellation.rs` (2 tests, Dovecot-backed)
+### 4.4 Cancellation — split across two layers
+
+The contract has two parts and they belong in two places. The wire
+layer's job is to accept the cancel envelope without crashing or
+breaking the session; the audit layer's job is to emit
+`tool_end {status: cancelled}` on Drop. Testing both ends in a
+single Dovecot-backed wire test forces a race (was the call still
+in flight when the cancel arrived?). The Codex adversarial review
+flagged this; the fix is to split.
+
+#### 4.4.1 `e2e_wire_cancellation.rs` (2 tests, Dovecot-backed)
+
+Race-free assertions only — these tests do *not* try to prove that
+the in-flight call was cancelled mid-execution.
 
 | Test | Flow | Contract |
 | --- | --- | --- |
-| `cancel_search_emits_tool_end_cancelled` | `use_account` → start `tools/call search` over a large folder → poll audit log for `tool_start` (≤ 100 ms) → send `notifications/cancelled` with the request id → drain stdout. | Exactly one `tool_end` audit record for the cancelled request with `status: cancelled` (issues #71, #99). No `tool_end {status: ok}`. No panic. |
+| `cancel_during_inflight_tools_call_keeps_session_alive` | `use_account` → start `tools/call search` → immediately send `notifications/cancelled` with the request id (no audit-log polling) → drain stdout. | Server emits exactly one response envelope for the cancelled request id (either result or error, race-dependent), then accepts a subsequent `tools/list` without restart. No panic, no malformed envelope, no orphaned stdout bytes. |
 | `cancel_unknown_request_id_is_noop` | Send `notifications/cancelled` for an id that was never used. | No response, no panic, server still responsive to subsequent `tools/list`. |
+
+#### 4.4.2 `crates/rimap-audit/tests/drop_emits_cancelled.rs` (new, 1–2 tests)
+
+In-process tests that drive the Drop discipline directly. No
+spawned binary, no Dovecot, no timing dependency.
+
+| Test | Flow | Contract |
+| --- | --- | --- |
+| `drop_after_tool_start_emits_cancelled_end` | Construct an `AuditWriter` writing to a tempdir. Wrap a never-completing future in `run_with_audit_envelope`. Poll once (drives the `tool_start` write). Drop. Read the audit log. | Exactly one `tool_start` followed by exactly one `tool_end` with `status: cancelled`. Issues #71, #99. |
+| `drop_before_tool_start_emits_nothing` | Construct the future but never poll it. Drop. | Audit log is empty. (Documents that the Drop guard only fires once `tool_start` has been written, which is the contract that #71 fixed.) |
+
+If `run_with_audit_envelope` is private to `rimap-server`, a
+crate-internal `#[cfg(test)]` accessor is added to expose it for
+the new test — flagged in §7 risk register.
 
 ## 5. Error handling
 
@@ -194,9 +261,15 @@ the fix.
 - Overnight runs: GitHub Actions cron workflow at
   `.github/workflows/mcp-fuzz-nightly.yml` sets
   `PROPTEST_CASES=100000` and runs
-  `cargo test -p rimap-server --tests mcp_wire_proptest -- --nocapture`.
-  Pinned to a SHA per the repo's existing convention; `zizmor`
-  passes before merge.
+  `cargo test -p rimap-server --test mcp_wire_proptest -- --nocapture`
+  (singular `--test`, selects the integration-test binary by name;
+  the plural `--tests` form would have turned `mcp_wire_proptest`
+  into a substring filter on test function names and silently run
+  zero properties). A subsequent step parses the test output and
+  fails the workflow if the runner reports zero tests executed —
+  this is the guard that catches any future drift in the selector
+  syntax. Pinned to a SHA per the repo's existing convention;
+  `zizmor` passes before merge.
 - Nextest classification: proptest tests use
   `slow-timeout` overrides so a stuck case fails fast instead of
   hitting the full CI timeout.
@@ -227,29 +300,44 @@ commits so probing-phase fallout does not block earlier commits:
    lands.
 3. **`mcp_wire_proptest.rs`** — three properties at 1000 cases.
    `proptest-regressions/` directory committed.
-4. **`mcp_audit_failure.rs`** — fail-closed boundary tests. May
-   reveal a small accessor need in `rimap-audit` (e.g., a way to
-   observe writer failure from a test); scope-flagged in the PR if
-   needed.
-5. **`e2e_wire_cancellation.rs`** — Dovecot-backed cancel tests.
-   Lands last; depends on Phase 3 harness + #99 Drop-emits-cancelled
-   discipline.
-6. **Nightly CI workflow** — same PR, reviewed separately.
+4. **`mcp_audit_failure.rs`** — fail-closed boundary tests via
+   `AuditWriter::force_next_write_failure()` (§6.4).
+5. **`drop_emits_cancelled.rs` in `rimap-audit/tests/`** —
+   audit-layer Drop discipline (#99). In-process, deterministic, no
+   wire. Lands before the wire-layer cancel test so the source-of-
+   truth contract is pinned first.
+6. **`e2e_wire_cancellation.rs`** — Dovecot-backed wire-layer
+   cancel acceptance test. Race-free assertions only (§4.4.1).
+   Lands last; depends on Phase 3 harness.
+7. **Nightly CI workflow** — same PR, reviewed separately.
 
-### 6.4 Audit failure injection — primary and fallback
+### 6.4 Audit failure injection
 
-Primary mechanism: write the audit path to a `chmod 0o500` directory
-(`tempfile::TempDir` followed by a `std::fs::set_permissions` to
-revoke write). This is hermetic, requires no production-code change,
-and tests the real `AuditSink` against a real `EACCES`.
+`rimap-audit::AuditWriter` already exposes a real test-injection
+hook used by `crates/rimap-server/tests/audit_fail_open.rs`:
 
-Fallback (if `chmod` is unreliable as root in some CI runners): a
-`SentinelRejectingAuditSink` behind a `test-support` feature on
-`rimap-audit` that returns `Err` from every write. The test enables
-the feature and configures the sink via a `test-support`-gated config
-hook. Adds a permanent test-only branch in `rimap-audit`; choose
-during implementation based on whether the `chmod` path actually
-works on Linux + macOS CI.
+```rust
+writer.force_next_write_failure();
+```
+
+This forces the *real* `AuditWriter`'s next `log_*` call to take
+the write-failure path through the real lock / append / error-
+mapping logic — it is not a swappable sink. Phase 4's audit tests
+reuse this hook rather than relying on filesystem permissions
+(`chmod 0o500` is unreliable as root on some CI runners) or a
+sentinel sink (which would bypass the very path the tests need to
+exercise, and add a permanent non-production branch). The Codex
+adversarial review flagged the sentinel-sink approach for exactly
+this reason.
+
+The audit-failure tests in `mcp_audit_failure.rs` drive the wire
+from the outside but use `force_next_write_failure()` on the
+in-process `AuditWriter` via the binary's existing test-support
+surface. If the surface needs a small extension (e.g., to call
+`force_next_write_failure()` from outside the process), that
+extension lives behind the existing `test-support` feature flag on
+`rimap-server` rather than `rimap-audit`, since the hook itself is
+already public on `AuditWriter`.
 
 ## 7. Risk register
 
@@ -258,16 +346,20 @@ works on Linux + macOS CI.
 | Probing reveals a panic in the server on malformed input. | File issue, fix on sibling branch, regression test lands in Phase 4. Expected outcome, not blocker. |
 | Proptest finds a minimal-shrunk case hard to reproduce. | `proptest-regressions/` committed; each property's regressions reviewed in the PR. |
 | Concurrent-request test flaky under nextest. | Determinism comes from `send_request_no_wait` + `recv_until_id` (no clock races). If the binary serializes responses, the test still passes — just less interesting. |
-| `chmod 0o500` audit-fail trick doesn't work as root in CI. | Fall back to `SentinelRejectingAuditSink` (§6.4). |
-| Dovecot cancel test races `tool_start` audit landing. | Poll audit file 100 ms cap, 10 ms granularity rather than sleep-and-hope. |
+| `run_with_audit_envelope` is private to `rimap-server`, so the audit-layer Drop test in `rimap-audit/tests/drop_emits_cancelled.rs` can't reach it. | Add a crate-internal `#[cfg(test)]` accessor on `rimap-server`, or move the test under `rimap-server/tests/` if the future is wholly server-internal. Decided during implementation; flagged here so the choice is visible. |
+| Wire-layer cancel test asserts race-dependent outcomes. | Tests only race-free invariants (server stays responsive, response envelope is well-formed). Cancellation-status assertion lives in the audit-layer Drop test, not here. |
 | Proptest at 100 000 cases overruns the nightly job's runner budget. | `slow-timeout` per property; nightly runs publish duration as part of the failure summary so we can split a single property into smaller ones if needed. |
 
 ## 8. Acceptance criteria mapping
 
 Each acceptance criterion from issue #266 maps to a concrete artifact:
 
-- [ ] `cargo test -p rimap-server --tests mcp_wire_*` exercises every
-      category — covered by §4.1–§4.4 across four files.
+- [ ] Every category exercised by an explicit per-binary
+      invocation (no glob): `cargo test -p rimap-server --test mcp_wire_negative`,
+      `--test mcp_wire_proptest`, `--test mcp_audit_failure`,
+      `--test e2e_wire_cancellation`, and
+      `cargo test -p rimap-audit --test drop_emits_cancelled`.
+      Covered by §4.1–§4.4.
 - [ ] Property tests run for ≥1000 cases per property in CI, gated by
       env flag — `ProptestConfig::with_cases(1000)` + `PROPTEST_CASES`
       override, §4.2 and §6.1.

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -38,7 +38,10 @@ The originating test —
 2. **Pre-initialize Notification or Response**: drop silently, close cleanly,
    exit `0`. (Per JSON-RPC §4.1, notifications never receive a response;
    a response without a matching server request is malformed.)
-3. **Audit log**: `process_end` emits with `reason: Eof`, not `Error`.
+3. **Audit log**: `process_end` emits with `reason: Eof` (not `Error`)
+   on the success path. Transport-level write failures while emitting
+   the envelope remain classified as `reason: Error` and exit non-zero
+   — those are real server faults, not misbehaving-client input.
 
 ## Approach
 
@@ -63,8 +66,13 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
     Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
         if let Some(line) = synthesize_pre_init_error_envelope(&msg) {
             let mut out = tokio::io::stdout();
-            let _ = out.write_all(line.as_bytes()).await;
-            let _ = out.flush().await;
+            out.write_all(line.as_bytes())
+                .await
+                .context("writing pre-init error envelope to stdout")?;
+            out.flush()
+                .await
+                .context("flushing pre-init error envelope")?;
+            tracing::info!("rejected pre-initialize request with -32002 envelope");
         }
         return Ok(());
     }
@@ -72,9 +80,18 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
 };
 ```
 
-Returning `Ok(())` causes the outer `mcp_result` to be `Ok`, which the
-existing `process_end` block at `main.rs:158-171` records as `reason: Eof`
-and the process exits `0`.
+Returning `Ok(())` on the success path causes the outer `mcp_result` to
+be `Ok`, which the existing `process_end` block at `main.rs:158-171`
+records as `reason: Eof` and the process exits `0`.
+
+Write/flush failures are propagated with `?`. A failed stdout write is
+a genuine server fault: the client never received the envelope and we
+have no other transport to recover. The `?` returns `Err` to
+`mcp_result`, which records `reason: Error` and exits non-zero —
+correct for that case. The bug we are fixing was misclassifying a
+successful handling of a misbehaving client as an error; propagating
+real transport faults to the same shutdown machinery preserves that
+audit-correctness goal at the failure boundary.
 
 Because rmcp has already consumed its `tokio::io::Stdout` by the time the
 error returns, the helper writes through a freshly acquired
@@ -83,6 +100,34 @@ process stdout file descriptor.
 
 The cancellation channel + drainer (`main.rs:133-134`) only matter for
 mid-dispatch cancellation; the early-return path skips them entirely.
+
+## Dependencies
+
+This spec assumes the wire-level negative-test harness from #266 / PR
+#278. As of 2026-05-14, that PR is still in DRAFT and the harness lives
+only on the `feature/issue-266-mcp-fuzzing` branch:
+
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — file under
+  which `tools_list_before_initialize` is `#[ignore]`'d
+- `crates/rimap-server/tests/support/wire/harness.rs` — the
+  `Harness` / `CloseOrResponse` / `response_or_close` plumbing the
+  test plan below references
+
+Implementation of #275 is therefore gated on #266 landing. Branching
+strategy is decided at implementation kickoff, not here:
+
+1. **Preferred: rebase onto `main` after #266 merges.** Clean history,
+   independent PR review.
+2. **Fallback: stack `fix/issue-275-pre-initialize-handling` on
+   `feature/issue-266-mcp-fuzzing`** and mark the PR as merge-after-#266.
+   Use this only if both PRs need to be in flight simultaneously.
+
+If #266's harness shape changes during its review (e.g. `CloseOrResponse`
+gains variants, `response_or_close` signature shifts), the test
+assertions in this spec are re-aligned to the merged shape before
+implementation begins. Adopting #266's harness wholesale into #275 is
+explicitly rejected: it would duplicate ~600 lines of #266's
+contribution and guarantee a merge conflict.
 
 ## Envelope shape
 
@@ -148,10 +193,38 @@ mid-dispatch cancellation; the early-return path skips them entirely.
 
 ### Audit log
 
-One assertion in either the un-ignored test or a sibling test that
-reads the audit log post-shutdown and verifies `process_end.reason
-== Eof`. The pattern follows existing audit-tail tests under
-`crates/rimap-server/tests/`.
+Two cases, both reading the audit log post-shutdown via the pattern
+established by existing audit-tail tests under
+`crates/rimap-server/tests/`:
+
+1. **Success path.** `tools_list_before_initialize` (and the string-id
+   variant) asserts `process_end.reason == Eof` after the envelope is
+   written and the server exits `0`. This is the case the bug report
+   is asking us to fix.
+2. **Write-failure path.** A new wire test
+   `pre_initialize_envelope_write_failure_records_error` closes the
+   harness's child-stdout read end before the server attempts to write
+   the envelope (Codex review finding 2026-05-14, medium). Asserts:
+   - server exits non-zero
+   - `process_end.reason == Error`
+   - the rejected envelope is observable in stderr or via the
+     `tracing::error!` machinery (no silent audit success on
+     transport failure)
+
+   This test requires a new harness helper —
+   `Harness::drop_stdout_reader()` or equivalent — that drops the
+   `BufReader<ChildStdout>` while keeping `child` alive so its exit
+   status can still be observed. Adding this helper is in scope for
+   #275 (small, ~10 lines in `support/wire/harness.rs`).
+
+### SIGPIPE handling
+
+The broken-stdout test relies on Rust's default SIGPIPE behavior
+(`SIG_IGN` since 1.0): writes to a closed pipe return `Err(BrokenPipe)`
+rather than terminating the process. This is checked by the test
+itself — if the assertion that the server exits non-zero (rather than
+being killed by SIGPIPE with `status.signal() == Some(13)`) ever
+fails, the test surfaces a SIGPIPE regression.
 
 ### Out of scope
 
@@ -168,11 +241,16 @@ reads the audit log post-shutdown and verifies `process_end.reason
    `Err(other) =>` arm preserves today's behavior for every other
    initialization failure (transport errors, unsupported protocol
    version, etc.) so we do not silently swallow real bugs.
-2. **stderr behavior.** The early-return path no longer emits
-   `tracing::error!`. A single `tracing::info!` log entry is added
-   at envelope-write time so audit operators can correlate the
-   wire event — kept at `info` because this is a normal handled
-   case, not a fault.
+2. **stderr behavior.** Two distinct outcomes:
+   - **Success** (envelope written, exit 0, `reason: Eof`): one
+     `tracing::info!` entry so audit operators can correlate the
+     wire event. Kept at `info` because this is a normal handled
+     case, not a fault.
+   - **Write failure** (envelope could not be delivered, exit
+     non-zero, `reason: Error`): the existing `tracing::error!("{e:#}")`
+     in `main.rs:49` fires from the propagated `anyhow::Error`,
+     same as today's behavior for other transport faults. No silent
+     classification of write failures as clean EOF.
 3. **stdout fd reuse.** Acquiring a fresh `tokio::io::stdout()` after
    rmcp drops its handle is safe because both wrap the same OS file
    descriptor. Anything rmcp wrote on this path (e.g. a ping response
@@ -202,7 +280,17 @@ Mirrors the issue:
 - Pre-initialize Request results in a JSON-RPC error envelope with
   `code == -32002`; pre-initialize Notification / Response is dropped
   silently.
-- `tools_list_before_initialize` and the two new wire tests pass with
+- `tools_list_before_initialize` (un-ignored) plus the three new wire
+  tests (`tools_list_before_initialize_str_id`,
+  `pre_initialize_notification_silent_close`,
+  `pre_initialize_envelope_write_failure_records_error`) pass with
   strict assertions on the chosen behavior.
-- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input.
-- `process_end` audit record reports `reason: Eof`.
+- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input
+  when the envelope is delivered successfully.
+- `process_end` audit record reports `reason: Eof` on the success
+  path.
+- Pre-initialize handling does **not** mask transport-level write
+  failures: if the server cannot deliver the envelope, exit
+  non-zero and audit `reason: Error`. The new
+  `pre_initialize_envelope_write_failure_records_error` wire test
+  pins this contract.

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -1,0 +1,208 @@
+# Pre-Initialize Request Handling (#275)
+
+**Date:** 2026-05-14
+**Issue:** [#275](https://github.com/randomparity/rusty-imap-mcp/issues/275)
+**Discovered by:** Phase 4 negative-path testing (#266)
+**Status:** Design approved; implementation pending
+
+## Problem
+
+A JSON-RPC client that sends any non-`initialize`, non-`ping` request as its
+first message causes `rusty-imap-mcp` to exit with code `1` and a stderr log:
+
+```
+expect initialized request, but received: Some(Request(ListToolsRequest(...)))
+```
+
+The crash corrupts audit trails (the `process_end` record is emitted with
+`reason: Error`) and gives misbehaving clients no actionable wire-level signal.
+
+## Root cause
+
+The rmcp 1.5 service loop
+([`rmcp-1.5.0/src/service/server.rs:172-204`](https://docs.rs/rmcp/1.5.0/src/rmcp/service/server.rs.html))
+accepts only `PingRequest` or `InitializeRequest` as the first message; anything
+else short-circuits to
+`ServerInitializeError::ExpectedInitializeRequest(Some(msg))`. The server
+entrypoint at `crates/rimap-server/src/main.rs:138-140` wraps that error with
+`anyhow!`, which propagates to `main()` and triggers `ExitCode::FAILURE`.
+
+The originating test —
+`crates/rimap-server/tests/mcp_wire_negative.rs:339-368`
+(`tools_list_before_initialize`) — is currently `#[ignore]`'d pending this fix.
+
+## Desired behavior
+
+1. **Pre-initialize Request** (e.g. `tools/list`): reply with a JSON-RPC error
+   envelope echoing the request's `id`, then close cleanly and exit `0`.
+2. **Pre-initialize Notification or Response**: drop silently, close cleanly,
+   exit `0`. (Per JSON-RPC §4.1, notifications never receive a response;
+   a response without a matching server request is malformed.)
+3. **Audit log**: `process_end` emits with `reason: Eof`, not `Error`.
+
+## Approach
+
+A new `crates/rimap-server/src/mcp/preinit.rs` module exposes one pure helper:
+
+```rust
+pub(crate) fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String>
+```
+
+The helper returns `Some(<newline-terminated JSON line>)` for the `Request`
+variant and `None` for `Notification` / `Response` / other variants. No I/O,
+no transport access — it is trivially unit-testable against
+`serde_json::Value` snapshots.
+
+The call site in `main.rs::run` matches on the specific rmcp error variant:
+
+```rust
+let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+    Ok(svc) => svc,
+    Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+        if let Some(line) = synthesize_pre_init_error_envelope(&msg) {
+            let mut out = tokio::io::stdout();
+            let _ = out.write_all(line.as_bytes()).await;
+            let _ = out.flush().await;
+        }
+        return Ok(());
+    }
+    Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+};
+```
+
+Returning `Ok(())` causes the outer `mcp_result` to be `Ok`, which the
+existing `process_end` block at `main.rs:158-171` records as `reason: Eof`
+and the process exits `0`.
+
+Because rmcp has already consumed its `tokio::io::Stdout` by the time the
+error returns, the helper writes through a freshly acquired
+`tokio::io::stdout()` handle. This is safe: both handles wrap the same
+process stdout file descriptor.
+
+The cancellation channel + drainer (`main.rs:133-134`) only matter for
+mid-dispatch cancellation; the early-return path skips them entirely.
+
+## Envelope shape
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <echoed verbatim>,
+  "error": {
+    "code": -32002,
+    "message": "Server not initialized: send `initialize` before any other request"
+  }
+}
+```
+
+- **Code `-32002`** lives in the JSON-RPC server-error band (`-32000..=-32099`)
+  and is the conventional "Server not initialized" code in the LSP / MCP
+  ecosystem. It does not collide with existing codes in
+  `crates/rimap-server/src/mcp/error.rs`: `-32001` posture-denied,
+  `-32003` rate-limited, `-32004` breaker, `-32005` attachment-too-large.
+  A new `pub const NOT_INITIALIZED: McpCode = McpCode(-32002);` is added
+  to that file so the code registry remains in one place; `preinit.rs`
+  references it from there.
+- **`id` echoing**: numbers, strings, and `null` pass through unchanged
+  via `serde_json::Value`. No `as_u64()` coercion.
+- **Message text**: a fixed string. No echo of the offending method name
+  or any client-supplied content (matches the opaque-message pattern
+  already used for `ProtectedFolder` / `ExpungeDenied` at
+  `crates/rimap-server/src/mcp/error.rs:41-44`).
+- **No `data` field**.
+
+## Test plan
+
+### Unit (`crates/rimap-server/src/mcp/preinit.rs`)
+
+1. `Request` with numeric id → envelope with same numeric id,
+   `error.code == -32002`, valid JSON-RPC framing.
+2. `Request` with string id → envelope with same string id.
+3. `Request` with `null` id → envelope with `id: null`.
+4. `Notification` → returns `None`.
+5. `Response` → returns `None`.
+6. Output ends with exactly one `\n`, is single-line, parses round-trip
+   via `serde_json::from_str`.
+
+### Integration
+
+**Un-ignore `tools_list_before_initialize`** at
+`crates/rimap-server/tests/mcp_wire_negative.rs:339-368`:
+
+- Remove `#[ignore]`.
+- Replace the accept-either-envelope-or-close branch with a strict
+  envelope assertion (`error.code == -32002`, `id` matches the id the
+  harness sent).
+- Add a follow-up `response_or_close` call that asserts `CleanClose`
+  (proves the server exited `0` after the envelope was written).
+- Update the docstring to reference #275 as fixed.
+
+**New wire tests in `mcp_wire_negative.rs`:**
+
+- `pre_initialize_notification_silent_close`: first message is
+  `notifications/cancelled`; assert `CleanClose` only (no envelope).
+- `tools_list_before_initialize_str_id`: same as the un-ignored test
+  but with a string id; pins id-type preservation at the wire layer.
+
+### Audit log
+
+One assertion in either the un-ignored test or a sibling test that
+reads the audit log post-shutdown and verifies `process_end.reason
+== Eof`. The pattern follows existing audit-tail tests under
+`crates/rimap-server/tests/`.
+
+### Out of scope
+
+- `mcp_wire_proptest.rs` already runs `initialize` first; no proptest
+  changes.
+- No e2e (Dovecot) test changes — this is a wire-level behavior.
+
+## Risks
+
+1. **rmcp upstream variant rename.** `ServerInitializeError` is
+   `#[non_exhaustive]`. If rmcp renames `ExpectedInitializeRequest`
+   or splits Request / Notification cases, the explicit match arm
+   becomes a compile error — the desired failure mode. The fallback
+   `Err(other) =>` arm preserves today's behavior for every other
+   initialization failure (transport errors, unsupported protocol
+   version, etc.) so we do not silently swallow real bugs.
+2. **stderr behavior.** The early-return path no longer emits
+   `tracing::error!`. A single `tracing::info!` log entry is added
+   at envelope-write time so audit operators can correlate the
+   wire event — kept at `info` because this is a normal handled
+   case, not a fault.
+3. **stdout fd reuse.** Acquiring a fresh `tokio::io::stdout()` after
+   rmcp drops its handle is safe because both wrap the same OS file
+   descriptor. Anything rmcp wrote on this path (e.g. a ping response
+   if the client sent `ping` before the offending request) is a
+   well-formed JSON-RPC line; our envelope simply follows it on a new
+   line. No partial writes or interleaving.
+
+## What does not change
+
+- Tool dispatch after `initialize` completes.
+- Audit-envelope guarantees for in-flight tool calls.
+- Other negative-path tests in `mcp_wire_negative.rs`.
+- The `RimapError` / `ErrorCode` taxonomy in `crates/rimap-core`
+  (the pre-init code lives only in the wire-level `McpCode` registry).
+
+## Explicitly out of scope
+
+- Issue #276 (protocol-version negotiation echoes unsupported versions).
+- Reorganizing `main.rs::run` (currently ~119 lines, over the 100-line
+  cap; flagged but addressed only if it becomes load-bearing).
+- Adding a new `ErrorCode` variant to `rimap_core::ErrorCode`.
+
+## Acceptance
+
+Mirrors the issue:
+
+- Pre-initialize Request results in a JSON-RPC error envelope with
+  `code == -32002`; pre-initialize Notification / Response is dropped
+  silently.
+- `tools_list_before_initialize` and the two new wire tests pass with
+  strict assertions on the chosen behavior.
+- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input.
+- `process_end` audit record reports `reason: Eof`.

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -103,31 +103,42 @@ mid-dispatch cancellation; the early-return path skips them entirely.
 
 ## Dependencies
 
-This spec assumes the wire-level negative-test harness from #266 / PR
-#278. As of 2026-05-14, that PR is still in DRAFT and the harness lives
-only on the `feature/issue-266-mcp-fuzzing` branch:
+This spec exercises the wire-level negative-test harness introduced in
+#266 / PR #278:
 
 - `crates/rimap-server/tests/mcp_wire_negative.rs` — file under
-  which `tools_list_before_initialize` is `#[ignore]`'d
+  which `tools_list_before_initialize` is `#[ignore]`'d, plus the
+  three new pre-initialize tests added by this fix
 - `crates/rimap-server/tests/support/wire/harness.rs` — the
   `Harness` / `CloseOrResponse` / `response_or_close` plumbing the
   test plan below references
 
-Implementation of #275 is therefore gated on #266 landing. Branching
-strategy is decided at implementation kickoff, not here:
+#275 is one of three merge blockers (#275, #276, #277) explicitly
+listed on PR #278. The blocker policy from #266's plan §5 — "bugs
+found during implementation are fixed before this phase merges" —
+keeps it literally true: by the time PR #278 reaches `main`, no
+`#[ignore]`'d Phase 4 tests remain in history.
 
-1. **Preferred: rebase onto `main` after #266 merges.** Clean history,
-   independent PR review.
-2. **Fallback: stack `fix/issue-275-pre-initialize-handling` on
-   `feature/issue-266-mcp-fuzzing`** and mark the PR as merge-after-#266.
-   Use this only if both PRs need to be in flight simultaneously.
+**Branching strategy.** The fix PR targets `feature/issue-266-mcp-fuzzing`
+as its merge base:
 
-If #266's harness shape changes during its review (e.g. `CloseOrResponse`
-gains variants, `response_or_close` signature shifts), the test
-assertions in this spec are re-aligned to the merged shape before
-implementation begins. Adopting #266's harness wholesale into #275 is
-explicitly rejected: it would duplicate ~600 lines of #266's
-contribution and guarantee a merge conflict.
+- It un-ignores `tools_list_before_initialize` and adds the three new
+  pre-initialize tests in the same PR as the production fix.
+  Reviewers see "this server change makes this previously-ignored test
+  pass" in one diff.
+- Once #275, #276, and #277 have all landed on
+  `feature/issue-266-mcp-fuzzing`, PR #278 is marked ready for review
+  and merges to `main` carrying all three fixes + un-ignores together.
+
+Note: targeting the feature branch is a *workflow* decision that keeps
+the un-ignore commit attached to the fix. The fix itself can be
+verified against the harness in a working copy regardless of which
+branch the PR ultimately targets. The constraint is only on PR base,
+not on local development.
+
+Cherry-picking the negative harness from #266 into a standalone #275
+PR off `main` is explicitly rejected: it duplicates ~600 lines of
+#266's contribution and guarantees a merge conflict.
 
 ## Envelope shape
 

--- a/docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md
@@ -1,0 +1,339 @@
+# Initialize Protocol-Version Negotiation (#276)
+
+**Date:** 2026-05-14
+**Issue:** [#276](https://github.com/randomparity/rusty-imap-mcp/issues/276)
+**Discovered by:** Phase 4 negative-path testing (#266)
+**Status:** Design approved; implementation pending
+**Depends on:** [#275](https://github.com/randomparity/rusty-imap-mcp/issues/275) (pre-initialize handling)
+
+## Problem
+
+A client sending `initialize` with `protocolVersion: "1999-01-01"` (or any
+unknown string) receives a success response with `protocolVersion: "1999-01-01"`
+echoed back. The server silently advertises support for any version the
+client names. Clients cannot detect version-negotiation failure, and a client
+speaking an MCP version we cannot handle proceeds with mismatched semantics.
+
+## Root cause
+
+rmcp 1.5's `serve_server_with_ct_inner`
+([`rmcp-1.5.0/src/service/server.rs:230-238`](https://docs.rs/rmcp/1.5.0/src/rmcp/service/server.rs.html))
+computes the wire response's `protocol_version` as:
+
+```rust
+let protocol_version = match peer_protocol_version
+    .partial_cmp(&init_response.protocol_version)
+    .ok_or(ServerInitializeError::UnsupportedProtocolVersion(...))?
+{
+    std::cmp::Ordering::Less => peer_info.params.protocol_version.clone(),
+    _ => init_response.protocol_version,
+};
+init_response.protocol_version = protocol_version;
+```
+
+`ProtocolVersion` (`rmcp/model.rs:140`) derives `PartialOrd` on a single
+`Cow<'static, str>` field, so `partial_cmp` performs lexicographic string
+comparison. For peer `"1999-01-01"` vs server `"2025-11-25"`,
+`"1999-01-01".cmp("2025-11-25") == Less` → rmcp's downgrade branch picks
+the peer's version and overwrites our response. `ProtocolVersion::KNOWN_VERSIONS`
+exists in rmcp (`model.rs:162-167`) but the negotiation logic never
+consults it.
+
+Consequence: even if we override `ServerHandler::initialize` to set a
+specific `protocol_version` on the response, rmcp's post-handler overwrite
+still echoes any peer string that lex-sorts lower than `LATEST`.
+
+The originating test —
+`crates/rimap-server/tests/mcp_wire_negative.rs:612-668`
+(`initialize_unsupported_protocol_version`) — is currently `#[ignore]`'d
+pending this fix.
+
+## Desired behavior
+
+1. **Peer's `protocolVersion` is in `ProtocolVersion::KNOWN_VERSIONS`**
+   (one of `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`):
+   accept and complete the handshake normally. rmcp's downgrade logic
+   produces a spec-compliant response (echo the peer's version when
+   older, return our `LATEST` when newer).
+2. **Peer's `protocolVersion` is anything else** (unknown string,
+   empty string, garbage): reply with a JSON-RPC `-32602` error
+   envelope that lists the supported versions, then close cleanly
+   and exit `0`.
+3. **Audit log:** `process_end.reason: Eof` on the rejection path
+   (rmcp emitted the envelope; this is a clean handled rejection,
+   not a server fault).
+
+## Approach
+
+Override `ServerHandler::initialize` on `ImapMcpServer`
+(`crates/rimap-server/src/mcp/server.rs`):
+
+```rust
+async fn initialize(
+    &self,
+    request: InitializeRequestParams,
+    context: RequestContext<RoleServer>,
+) -> Result<InitializeResult, ErrorData> {
+    if !ProtocolVersion::KNOWN_VERSIONS.contains(&request.protocol_version) {
+        return Err(unsupported_protocol_version_error(&request.protocol_version));
+    }
+    if context.peer.peer_info().is_none() {
+        context.peer.set_peer_info(request);
+    }
+    Ok(self.get_info())
+}
+```
+
+The check uses `rmcp::model::ProtocolVersion::KNOWN_VERSIONS` directly —
+single source of truth, automatically tracks rmcp version-list bumps.
+
+A small private helper `unsupported_protocol_version_error` lives near
+the bottom of `mcp/server.rs`:
+
+```rust
+fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorData {
+    let supported: Vec<&str> = ProtocolVersion::KNOWN_VERSIONS
+        .iter()
+        .map(ProtocolVersion::as_str)
+        .collect();
+    let message = format!(
+        "Unsupported protocol version: '{}'. Server supports: {}.",
+        peer_version.as_str(),
+        supported.join(", "),
+    );
+    let data = serde_json::json!({ "supported_versions": supported });
+    ErrorData::invalid_params(message, Some(data))
+}
+```
+
+When the handler returns `Err`, rmcp at `service/server.rs:222` calls
+`transport.send(ServerJsonRpcMessage::error(...))` to write the envelope,
+then returns `Err(ServerInitializeError::InitializeFailed(error_data))`
+from `serve_server`. Our `main.rs::run` adds a third match arm symmetric
+to the #275 `ExpectedInitializeRequest` arm:
+
+```rust
+Err(ServerInitializeError::InitializeFailed(_)) => {
+    // rmcp already sent the error envelope; this is a clean rejection
+    // of an invalid initialize request (unsupported protocol version,
+    // future bad-params cases), not a server fault.
+    tracing::info!("rejected initialize request with error envelope");
+    return Ok(());
+}
+```
+
+Returning `Ok(())` causes `process_end` to record `reason: Eof` and the
+process to exit `0` — the same audit semantics as #275's pre-init handled
+path.
+
+### Why counter-proposal isn't viable through rmcp
+
+The MCP spec's preferred path is "respond with a version we support":
+
+> "If the server supports the requested protocol version, it MUST respond
+> with the same version. Otherwise, the server MUST respond with a version
+> it does support."
+
+Setting `init_response.protocol_version = ProtocolVersion::LATEST` in our
+override does not work — rmcp's downgrade logic overwrites it with
+`min(peer, server)` lexicographically. The only paths that produce a
+spec-legal wire outcome without an upstream rmcp patch are:
+
+1. Return `Err` from `initialize` → wire error envelope (this design).
+2. Wrap rmcp's transport to intercept and rewrite the InitializeResult.
+
+Option 2 costs significantly more code and is explicitly out of scope.
+The spec's bug report accepts either "success result with a server-
+supported version OR a JSON-RPC error"; option 1 satisfies the latter.
+
+## Dependencies
+
+This branch is stacked on
+[`fix/issue-275-pre-initialize-handling`](https://github.com/randomparity/rusty-imap-mcp/pull/279).
+#276's match-arm addition to `main.rs::run` sits right next to #275's
+`ExpectedInitializeRequest` arm; the two changes touch adjacent lines.
+
+Like #275, this is a merge blocker for PR #278 — the test
+`initialize_unsupported_protocol_version` is `#[ignore]`'d on
+`feature/issue-266-mcp-fuzzing` pending this fix.
+
+**Branching strategy.** Fix PR targets either:
+
+1. `fix/issue-275-pre-initialize-handling` directly while #279 is open;
+   merging this PR rolls #275 + #276 into #275's branch. Practical
+   choice while #279 is in review.
+2. `feature/issue-266-mcp-fuzzing` once #279 merges; rebase
+   `fix/issue-276-protocol-version-negotiation` onto the merged base
+   and re-point the PR.
+
+Either path lands the un-ignore commit alongside the production fix in
+one diff, matching the #266 merge-blocker policy.
+
+## Error envelope shape
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <echoed verbatim>,
+  "error": {
+    "code": -32602,
+    "message": "Unsupported protocol version: '<peer-version>'. Server supports: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25.",
+    "data": {
+      "supported_versions": ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+    }
+  }
+}
+```
+
+- **Code `-32602` (`INVALID_PARAMS`)**: the protocol version is structured
+  data inside `params`. The standard JSON-RPC code for bad `params` is
+  -32602. Reusing `ErrorData::invalid_params` keeps the envelope
+  consistent with the rest of the dispatch path (`ErrorCode::InvalidInput`
+  in `crates/rimap-server/src/mcp/error.rs:37` already maps here). Avoids
+  burning a custom `-3200X` code for a single semantically-standard case.
+- **Message text**: echoes the peer's bad version in single quotes for
+  actionability. The peer-supplied protocol version is a client-asserted
+  protocol string, not adversarial content like email body — reflection
+  here doesn't carry the leakage risk #275 guards against. The supported
+  list is built at compile time from `ProtocolVersion::KNOWN_VERSIONS`,
+  so a future rmcp bump auto-updates the message without code changes.
+- **`data` field**: machine-readable `{"supported_versions": [...]}` so
+  a smart client can pick a version it speaks and retry. JSON-RPC §5.1
+  allows the field; MCP doesn't require it but doesn't forbid it.
+
+**No new `McpCode` constant.** `INVALID_PARAMS` is already in
+`rmcp::model::ErrorCode`; the `NOT_INITIALIZED: McpCode(-32002)` added
+in #275 stays.
+
+## Test plan
+
+### Integration
+
+**Un-ignore `initialize_unsupported_protocol_version`** at
+`crates/rimap-server/tests/mcp_wire_negative.rs:612-668`:
+
+- Remove `#[ignore]`.
+- Replace the accept-either-branch with strict assertions on the error
+  envelope path:
+  - `envelope["error"]["code"] == -32602`
+  - `envelope["error"]["data"]["supported_versions"]` is a JSON array
+    containing `"2025-11-25"` and non-empty
+  - `envelope["error"]["message"]` contains `"1999-01-01"` (the
+    peer's version, echoed back per the message-text rule above)
+- Add a follow-up `response_or_close` call asserting `CleanClose`
+  (proves the server exited `0` after rmcp sent the envelope).
+- Add an audit-log assertion: `read_process_end_reason(...) == Eof`.
+- Update the docstring to reference #276 as fixed.
+
+**New wire test — `initialize_with_known_older_version_succeeds`**:
+
+- Send `initialize` with `protocolVersion: "2024-11-05"`.
+- Assert success envelope (no `error` field).
+- Assert `envelope["result"]["protocolVersion"]` is a string in
+  `KNOWN_VERSIONS` (rmcp's downgrade will produce `"2024-11-05"`,
+  which is spec-legal — peer asked for an older version we accept).
+- Pins the permissive-posture decision: older known versions are
+  NOT rejected.
+
+**New wire test — `initialize_with_empty_string_protocol_version`**:
+
+- Send `protocolVersion: ""` — edge case where the client sends valid
+  JSON but a degenerate version string.
+- Assert error envelope with `code == -32602` (`""` is not in
+  `KNOWN_VERSIONS`).
+- Pins the boundary so future code that special-cases empty strings
+  is caught.
+
+### Unit
+
+**`mcp/server.rs::tests` — `unsupported_protocol_version_error_shape`**:
+
+- Construct a `ProtocolVersion` from `"1999-01-01"` (the rmcp
+  deserializer's fallback path produces an arbitrary string).
+- Call `unsupported_protocol_version_error(&version)`.
+- Assert: returned `ErrorData.code == INVALID_PARAMS`,
+  message contains `"1999-01-01"`, `data["supported_versions"]` is
+  a JSON array equal to the stringified `KNOWN_VERSIONS`.
+- Lives at the bottom of `mcp/server.rs` next to the helper. No I/O,
+  fast.
+
+**Optional: `unsupported_protocol_version_error_lists_all_known_versions`**:
+
+- Same helper, any peer version.
+- Assert `data["supported_versions"].len() == KNOWN_VERSIONS.len()`
+  and each value matches an entry in `KNOWN_VERSIONS`.
+- Pins the contract that the list is constructed from `KNOWN_VERSIONS`
+  (not hard-coded). Catches future drift if someone hand-edits the
+  list.
+
+### Out of scope
+
+- `mcp_wire_proptest.rs` — proptest harness uses
+  `PINNED_PROTOCOL_VERSION` so this code path is never hit fuzzily.
+  No proptest changes.
+- No e2e (Dovecot) test changes — this is a wire-level concern.
+
+## Risks
+
+1. **`KNOWN_VERSIONS` is rmcp-1.5-specific.** If we bump rmcp later, the
+   list may change shape. Mitigation: we reference
+   `ProtocolVersion::KNOWN_VERSIONS` live — bumping rmcp adjusts the
+   acceptance set automatically. The unit test that asserts the
+   stringified format flags the change visibly.
+
+2. **Permissive posture overstates compatibility.** Accepting
+   `"2024-11-05"` through `"2025-11-25"` is a claim that we speak all
+   four. Our schema fixtures and validation pin `"2025-11-25"`. A
+   client speaking an older version completes `initialize` but may
+   hit wire-shape mismatches in subsequent tool calls. Mitigation:
+   rmcp's downgrade logic claims to handle the wire differences.
+   Acknowledged limitation; explicitly accepted by the user during
+   design; out of scope for #276 to verify cross-version compat.
+
+3. **`InitializeFailed` arm catches all initialize-handler failures,
+   not just version mismatches.** If a future change adds new
+   `initialize` validation (e.g., `capabilities` field constraints),
+   it also gets classified as clean exit. That's the correct
+   behavior — rmcp will have sent the wire envelope, so exit 0 with
+   audit Eof is the right semantics for any handled rejection at the
+   initialize layer. No change needed.
+
+4. **rmcp upstream lex-comparison fix.** If rmcp ever fixes the
+   downgrade logic to consult `KNOWN_VERSIONS` directly, our override
+   becomes a no-op (the peer's bad version would already be rejected
+   upstream). That's fine — the override is defensive, costs nothing
+   when redundant.
+
+## What does not change
+
+- `synthesize_pre_init_error_envelope` and #275's pre-initialize
+  handling.
+- `get_info()` continues to advertise `ProtocolVersion::LATEST` as
+  the server's preferred version.
+- Tool dispatch, audit envelopes, other negative-path tests.
+- The `RimapError` / `ErrorCode` taxonomy in `crates/rimap-core`.
+
+## Explicitly out of scope
+
+- Counter-proposal via transport wrapper (requires significantly more
+  code; rmcp's lex-min logic blocks the direct path).
+- Cross-version wire compatibility (we accept older known versions
+  but don't actively translate wire shapes).
+- Patching rmcp upstream to use `KNOWN_VERSIONS` instead of lex
+  comparison (worth filing but separate from #276).
+- #277 (hung-on-unknown-method) — separate bug, separate plan.
+
+## Acceptance
+
+Mirrors the issue:
+
+- `initialize` with an unknown version returns a JSON-RPC `-32602`
+  error envelope listing the supported versions; the server exits
+  `0` and the audit log records `process_end.reason: Eof`.
+- `initialize` with a known older version (e.g., `"2024-11-05"`)
+  succeeds; the response's `protocolVersion` is the peer's version
+  (per rmcp's downgrade logic).
+- `initialize_unsupported_protocol_version` and the new wire tests
+  pass with strict assertions on the chosen behavior.
+- No crash, no `Crashed(...)` outcome from the harness on
+  unsupported-version input.

--- a/docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-276-protocol-version-negotiation-design.md
@@ -50,18 +50,36 @@ pending this fix.
 
 ## Desired behavior
 
-1. **Peer's `protocolVersion` is in `ProtocolVersion::KNOWN_VERSIONS`**
-   (one of `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`):
-   accept and complete the handshake normally. rmcp's downgrade logic
-   produces a spec-compliant response (echo the peer's version when
-   older, return our `LATEST` when newer).
-2. **Peer's `protocolVersion` is anything else** (unknown string,
-   empty string, garbage): reply with a JSON-RPC `-32602` error
-   envelope that lists the supported versions, then close cleanly
-   and exit `0`.
+1. **Peer's `protocolVersion` is exactly `ProtocolVersion::LATEST`**
+   (`"2025-11-25"`): accept and complete the handshake normally.
+2. **Peer's `protocolVersion` is anything else** — including known
+   older versions (`2024-11-05`, `2025-03-26`, `2025-06-18`), unknown
+   strings, empty strings, garbage: reply with a JSON-RPC `-32602`
+   error envelope listing the one supported version, then close
+   cleanly and exit `0`.
 3. **Audit log:** `process_end.reason: Eof` on the rejection path
-   (rmcp emitted the envelope; this is a clean handled rejection,
-   not a server fault).
+   when the failure is an `INVALID_PARAMS` (`-32602`) handled
+   rejection. Server-fault classes (`INTERNAL_ERROR` and others)
+   that surface through `initialize` continue to propagate as
+   non-zero exit with `process_end.reason: Error`.
+
+### Why LATEST-only, not permissive
+
+rmcp 1.5's serde types target the LATEST schema only — a grep across
+`rmcp-1.5.0/src/` for version-conditional code returns no hits.
+`ProtocolVersion` is a string label; the "downgrade" in rmcp's
+negotiation rewrites only the `protocol_version` field in the
+`InitializeResult`, not the rest of the wire shapes. So accepting a
+2024-11-05 peer would produce an `InitializeResult` that echoes
+`"2024-11-05"` but carries 2025-11-25-shaped capabilities, tool
+definitions, and notifications. That's the same bug class #276 is
+fixing — clients proceeding under unproven semantics — re-introduced
+in a smaller form.
+
+LATEST-only is the honest narrowing: we accept what rmcp 1.5 actually
+speaks. The acceptance set can broaden later when (a) rmcp adds true
+per-version serialization or (b) we add a version-shape translation
+layer in this crate. Both are explicitly out of scope.
 
 ## Approach
 
@@ -74,7 +92,7 @@ async fn initialize(
     request: InitializeRequestParams,
     context: RequestContext<RoleServer>,
 ) -> Result<InitializeResult, ErrorData> {
-    if !ProtocolVersion::KNOWN_VERSIONS.contains(&request.protocol_version) {
+    if request.protocol_version != ProtocolVersion::LATEST {
         return Err(unsupported_protocol_version_error(&request.protocol_version));
     }
     if context.peer.peer_info().is_none() {
@@ -84,18 +102,14 @@ async fn initialize(
 }
 ```
 
-The check uses `rmcp::model::ProtocolVersion::KNOWN_VERSIONS` directly —
-single source of truth, automatically tracks rmcp version-list bumps.
-
-A small private helper `unsupported_protocol_version_error` lives near
-the bottom of `mcp/server.rs`:
+The exact-equality check is the only safe option given rmcp 1.5's
+LATEST-only serialization (see "Why LATEST-only" above). A small
+private helper `unsupported_protocol_version_error` lives near the
+bottom of `mcp/server.rs`:
 
 ```rust
 fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorData {
-    let supported: Vec<&str> = ProtocolVersion::KNOWN_VERSIONS
-        .iter()
-        .map(ProtocolVersion::as_str)
-        .collect();
+    let supported = [ProtocolVersion::LATEST.as_str()];
     let message = format!(
         "Unsupported protocol version: '{}'. Server supports: {}.",
         peer_version.as_str(),
@@ -106,25 +120,57 @@ fn unsupported_protocol_version_error(peer_version: &ProtocolVersion) -> ErrorDa
 }
 ```
 
+Using a single-element array (rather than a scalar) for
+`supported_versions` keeps the wire shape stable if the server ever
+broadens the supported set: clients consuming the field don't need to
+change their decoder.
+
 When the handler returns `Err`, rmcp at `service/server.rs:222` calls
 `transport.send(ServerJsonRpcMessage::error(...))` to write the envelope,
 then returns `Err(ServerInitializeError::InitializeFailed(error_data))`
-from `serve_server`. Our `main.rs::run` adds a third match arm symmetric
-to the #275 `ExpectedInitializeRequest` arm:
+from `serve_server`. Our `main.rs::run` adds two match arms that
+classify by error-code:
 
 ```rust
-Err(ServerInitializeError::InitializeFailed(_)) => {
-    // rmcp already sent the error envelope; this is a clean rejection
-    // of an invalid initialize request (unsupported protocol version,
-    // future bad-params cases), not a server fault.
-    tracing::info!("rejected initialize request with error envelope");
+Err(ServerInitializeError::InitializeFailed(error_data))
+    if initialize_failure_is_handled_rejection(error_data.code) =>
+{
+    // rmcp already sent the error envelope. INVALID_PARAMS at the
+    // initialize boundary is a handled client rejection (e.g.
+    // unsupported protocol version), not a server fault.
+    tracing::info!(
+        code = error_data.code.0,
+        "rejected initialize with error envelope",
+    );
     return Ok(());
+}
+Err(ServerInitializeError::InitializeFailed(error_data)) => {
+    // Server-fault classes (INTERNAL_ERROR and others) must surface
+    // as non-zero exit with process_end.reason: Error so initialize
+    // outages remain observable in the audit trail.
+    return Err(anyhow::anyhow!(
+        "MCP server init failed: code {}: {}",
+        error_data.code.0,
+        error_data.message,
+    ));
 }
 ```
 
-Returning `Ok(())` causes `process_end` to record `reason: Eof` and the
-process to exit `0` — the same audit semantics as #275's pre-init handled
-path.
+The classifier helper is a one-line `matches!` so it's
+unit-testable in isolation:
+
+```rust
+fn initialize_failure_is_handled_rejection(code: ErrorCode) -> bool {
+    matches!(code, ErrorCode::INVALID_PARAMS)
+}
+```
+
+Returning `Ok(())` on the handled-rejection arm causes `process_end`
+to record `reason: Eof` and the process to exit `0` — the same audit
+semantics as #275's pre-init handled path. Server-fault propagation
+flows through the existing `tracing::error!("{e:#}")` in `main.rs:49`
+and `ExitCode::FAILURE`, same as today's behavior for transport
+errors.
 
 ### Why counter-proposal isn't viable through rmcp
 
@@ -145,6 +191,13 @@ spec-legal wire outcome without an upstream rmcp patch are:
 Option 2 costs significantly more code and is explicitly out of scope.
 The spec's bug report accepts either "success result with a server-
 supported version OR a JSON-RPC error"; option 1 satisfies the latter.
+
+Even if counter-proposal were viable, it would face the same wire-shape
+limitation that drives the LATEST-only acceptance set: rmcp emits the
+LATEST shapes regardless of the negotiated version string. A counter-
+proposal of `"2024-11-05"` wrapping a 2025-11-25-shaped capabilities
+payload would be dishonest in the same way permissive acceptance would
+be.
 
 ## Dependencies
 
@@ -177,9 +230,9 @@ one diff, matching the #266 merge-blocker policy.
   "id": <echoed verbatim>,
   "error": {
     "code": -32602,
-    "message": "Unsupported protocol version: '<peer-version>'. Server supports: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25.",
+    "message": "Unsupported protocol version: '<peer-version>'. Server supports: 2025-11-25.",
     "data": {
-      "supported_versions": ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+      "supported_versions": ["2025-11-25"]
     }
   }
 }
@@ -195,11 +248,14 @@ one diff, matching the #266 merge-blocker policy.
   actionability. The peer-supplied protocol version is a client-asserted
   protocol string, not adversarial content like email body — reflection
   here doesn't carry the leakage risk #275 guards against. The supported
-  list is built at compile time from `ProtocolVersion::KNOWN_VERSIONS`,
-  so a future rmcp bump auto-updates the message without code changes.
-- **`data` field**: machine-readable `{"supported_versions": [...]}` so
-  a smart client can pick a version it speaks and retry. JSON-RPC §5.1
-  allows the field; MCP doesn't require it but doesn't forbid it.
+  version is read from `ProtocolVersion::LATEST.as_str()` at runtime, so
+  a future rmcp bump auto-updates the message without code changes.
+- **`data` field**: machine-readable `{"supported_versions": [...]}` as
+  a single-element array so a smart client can detect the field
+  uniformly. JSON-RPC §5.1 allows the field; MCP doesn't require it but
+  doesn't forbid it. If the supported set ever broadens, this same
+  array shape carries the new versions without forcing client decoders
+  to change.
 
 **No new `McpCode` constant.** `INVALID_PARAMS` is already in
 `rmcp::model::ErrorCode`; the `NOT_INITIALIZED: McpCode(-32002)` added
@@ -216,31 +272,36 @@ in #275 stays.
 - Replace the accept-either-branch with strict assertions on the error
   envelope path:
   - `envelope["error"]["code"] == -32602`
-  - `envelope["error"]["data"]["supported_versions"]` is a JSON array
-    containing `"2025-11-25"` and non-empty
+  - `envelope["error"]["data"]["supported_versions"]` equals
+    `["2025-11-25"]` exactly (one-element array — locks in the
+    LATEST-only posture, no other version names sneak into the wire)
   - `envelope["error"]["message"]` contains `"1999-01-01"` (the
     peer's version, echoed back per the message-text rule above)
+  - `envelope["error"]["message"]` contains `"2025-11-25"` (the
+    supported version, surfaced in the human-readable message)
 - Add a follow-up `response_or_close` call asserting `CleanClose`
   (proves the server exited `0` after rmcp sent the envelope).
 - Add an audit-log assertion: `read_process_end_reason(...) == Eof`.
 - Update the docstring to reference #276 as fixed.
 
-**New wire test — `initialize_with_known_older_version_succeeds`**:
+**New wire test — `initialize_with_known_older_version_is_rejected`**:
 
-- Send `initialize` with `protocolVersion: "2024-11-05"`.
-- Assert success envelope (no `error` field).
-- Assert `envelope["result"]["protocolVersion"]` is a string in
-  `KNOWN_VERSIONS` (rmcp's downgrade will produce `"2024-11-05"`,
-  which is spec-legal — peer asked for an older version we accept).
-- Pins the permissive-posture decision: older known versions are
-  NOT rejected.
+- Send `initialize` with `protocolVersion: "2024-11-05"` (a known
+  older MCP version per `ProtocolVersion::KNOWN_VERSIONS`).
+- Assert error envelope with `code == -32602`,
+  `supported_versions == ["2025-11-25"]`, message contains
+  `"2024-11-05"`.
+- Pins the strict LATEST-only posture: even known-old versions are
+  rejected because rmcp 1.5 doesn't actually emit older wire shapes.
+- This test BLOCKS a future "permissive" relaxation that would re-
+  introduce the unproven-semantics bug class.
 
 **New wire test — `initialize_with_empty_string_protocol_version`**:
 
 - Send `protocolVersion: ""` — edge case where the client sends valid
   JSON but a degenerate version string.
-- Assert error envelope with `code == -32602` (`""` is not in
-  `KNOWN_VERSIONS`).
+- Assert error envelope with `code == -32602` (`""` is not the
+  LATEST version).
 - Pins the boundary so future code that special-cases empty strings
   is caught.
 
@@ -252,19 +313,35 @@ in #275 stays.
   deserializer's fallback path produces an arbitrary string).
 - Call `unsupported_protocol_version_error(&version)`.
 - Assert: returned `ErrorData.code == INVALID_PARAMS`,
-  message contains `"1999-01-01"`, `data["supported_versions"]` is
-  a JSON array equal to the stringified `KNOWN_VERSIONS`.
+  message contains `"1999-01-01"` AND `"2025-11-25"`,
+  `data["supported_versions"] == ["2025-11-25"]` exactly.
 - Lives at the bottom of `mcp/server.rs` next to the helper. No I/O,
   fast.
 
-**Optional: `unsupported_protocol_version_error_lists_all_known_versions`**:
+**`mcp/server.rs::tests` — `unsupported_protocol_version_error_uses_runtime_latest`**:
 
 - Same helper, any peer version.
-- Assert `data["supported_versions"].len() == KNOWN_VERSIONS.len()`
-  and each value matches an entry in `KNOWN_VERSIONS`.
-- Pins the contract that the list is constructed from `KNOWN_VERSIONS`
-  (not hard-coded). Catches future drift if someone hand-edits the
-  list.
+- Assert `data["supported_versions"][0] == ProtocolVersion::LATEST.as_str()`.
+- Pins the contract that the list is constructed from
+  `ProtocolVersion::LATEST` at runtime (not hard-coded). If a future
+  rmcp bump shifts LATEST, the message updates automatically without
+  this test breaking.
+
+**`main.rs::tests` (or a new module) — `initialize_failure_classifier`**:
+
+- `initialize_failure_is_handled_rejection(ErrorCode::INVALID_PARAMS) == true`
+- `initialize_failure_is_handled_rejection(ErrorCode::INTERNAL_ERROR) == false`
+- `initialize_failure_is_handled_rejection(ErrorCode::METHOD_NOT_FOUND) == false`
+- `initialize_failure_is_handled_rejection(ErrorCode(-32099)) == false` —
+  future-proofs the gate against new server-fault codes being
+  accidentally classified as client rejections.
+
+This unit-tests the Codex-Finding-2 boundary directly. An
+integration test that triggers a non-`INVALID_PARAMS` error from
+`initialize` would require a `#[cfg(feature = "test-support")]`
+env-var hook (~30 lines of scaffolding); the helper-level unit test
+is sufficient because the gate is a pure function on the error
+code, with no I/O or state.
 
 ### Out of scope
 
@@ -275,34 +352,53 @@ in #275 stays.
 
 ## Risks
 
-1. **`KNOWN_VERSIONS` is rmcp-1.5-specific.** If we bump rmcp later, the
-   list may change shape. Mitigation: we reference
-   `ProtocolVersion::KNOWN_VERSIONS` live — bumping rmcp adjusts the
-   acceptance set automatically. The unit test that asserts the
-   stringified format flags the change visibly.
+1. **`ProtocolVersion::LATEST` is rmcp-1.5-specific.** If we bump
+   rmcp later, the constant may shift to a newer version string.
+   Mitigation: we reference `ProtocolVersion::LATEST` live — bumping
+   rmcp adjusts the acceptance string automatically. The unit test
+   that asserts `supported_versions[0] == LATEST.as_str()` keeps the
+   wire message in lockstep. The negative-path wire tests assert
+   `["2025-11-25"]` literally, so an rmcp bump that changes LATEST
+   will fail those tests visibly and force a deliberate update —
+   the test will document, by failure, that the supported version
+   shifted.
 
-2. **Permissive posture overstates compatibility.** Accepting
-   `"2024-11-05"` through `"2025-11-25"` is a claim that we speak all
-   four. Our schema fixtures and validation pin `"2025-11-25"`. A
-   client speaking an older version completes `initialize` but may
-   hit wire-shape mismatches in subsequent tool calls. Mitigation:
-   rmcp's downgrade logic claims to handle the wire differences.
-   Acknowledged limitation; explicitly accepted by the user during
-   design; out of scope for #276 to verify cross-version compat.
+2. **LATEST-only rejects clients that could otherwise work.** Some
+   well-behaved clients send older known versions
+   (`2024-11-05` etc.). After this change they get -32602 instead of
+   a working session. This is the deliberate honesty trade: rmcp 1.5
+   doesn't actually emit older wire shapes, so accepting older
+   version strings would be a misrepresentation. When (a) rmcp adds
+   per-version serialization or (b) we add a translation layer in
+   this crate, the acceptance set can broaden — guarded by the
+   `initialize_with_known_older_version_is_rejected` test, which
+   makes any broadening an explicit decision rather than an
+   accident.
 
-3. **`InitializeFailed` arm catches all initialize-handler failures,
-   not just version mismatches.** If a future change adds new
-   `initialize` validation (e.g., `capabilities` field constraints),
-   it also gets classified as clean exit. That's the correct
-   behavior — rmcp will have sent the wire envelope, so exit 0 with
-   audit Eof is the right semantics for any handled rejection at the
-   initialize layer. No change needed.
+3. **Code-gated `InitializeFailed` arm trusts rmcp's error-data
+   passthrough.** The classifier (`initialize_failure_is_handled_rejection`)
+   reads `error_data.code` to decide between clean rejection and
+   server-fault propagation. rmcp at `service/server.rs:222` calls
+   `transport.send(ServerJsonRpcMessage::error(e.clone(), id))` and
+   then `return Err(ServerInitializeError::InitializeFailed(e))` —
+   so the `e` we match on is the same `ErrorData` we constructed in
+   `initialize`. No transformation layer; the code we put in is the
+   code we see back. Confirmed by reading the rmcp source.
 
 4. **rmcp upstream lex-comparison fix.** If rmcp ever fixes the
    downgrade logic to consult `KNOWN_VERSIONS` directly, our override
    becomes a no-op (the peer's bad version would already be rejected
    upstream). That's fine — the override is defensive, costs nothing
    when redundant.
+
+5. **rmcp upstream adds per-version serialization.** Different
+   problem class: our LATEST-only rejection would then over-reject
+   clients rmcp *could* serve. Mitigation: the
+   `initialize_with_known_older_version_is_rejected` test would
+   fail at the next rmcp bump that introduces per-version
+   serialization (the test asserts rejection at the wire layer,
+   regardless of rmcp's internal capability). The failure surfaces
+   the now-actionable broadening as a deliberate spec revision.
 
 ## What does not change
 
@@ -317,23 +413,42 @@ in #275 stays.
 
 - Counter-proposal via transport wrapper (requires significantly more
   code; rmcp's lex-min logic blocks the direct path).
-- Cross-version wire compatibility (we accept older known versions
-  but don't actively translate wire shapes).
+- Supporting any protocol version other than `ProtocolVersion::LATEST`.
+  Older known versions (`2024-11-05`, `2025-03-26`, `2025-06-18`)
+  are deliberately rejected. Broadening requires either an rmcp
+  upstream fix that adds true per-version serialization or a
+  translation layer in `rimap-server`; both belong in a separate
+  spec.
 - Patching rmcp upstream to use `KNOWN_VERSIONS` instead of lex
   comparison (worth filing but separate from #276).
+- An integration test that injects `INTERNAL_ERROR` from `initialize`
+  via a test-support hook. The classifier unit test on
+  `initialize_failure_is_handled_rejection` is sufficient to pin the
+  Codex-Finding-2 boundary; a wire-level test would require ~30 lines
+  of `#[cfg(feature = "test-support")]` scaffolding for marginal
+  signal.
 - #277 (hung-on-unknown-method) — separate bug, separate plan.
 
 ## Acceptance
 
-Mirrors the issue:
+Mirrors the issue, with the LATEST-only narrowing per Codex Finding 1:
 
-- `initialize` with an unknown version returns a JSON-RPC `-32602`
-  error envelope listing the supported versions; the server exits
-  `0` and the audit log records `process_end.reason: Eof`.
-- `initialize` with a known older version (e.g., `"2024-11-05"`)
-  succeeds; the response's `protocolVersion` is the peer's version
-  (per rmcp's downgrade logic).
+- `initialize` with any version other than `ProtocolVersion::LATEST`
+  (`"2025-11-25"`) returns a JSON-RPC `-32602` error envelope with
+  `supported_versions == ["2025-11-25"]`; the server exits `0` and
+  the audit log records `process_end.reason: Eof`.
+- This applies to both unknown versions (e.g., `"1999-01-01"`) and
+  known-older versions (`"2024-11-05"`, `"2025-03-26"`,
+  `"2025-06-18"`). Known-older versions are not silently accepted.
+- `initialize` with `"2025-11-25"` succeeds; the handshake completes
+  and the response's `protocolVersion` is `"2025-11-25"`.
 - `initialize_unsupported_protocol_version` and the new wire tests
-  pass with strict assertions on the chosen behavior.
+  (`initialize_with_known_older_version_is_rejected`,
+  `initialize_with_empty_string_protocol_version`) pass with strict
+  assertions on the chosen behavior.
+- Server-fault classes (`INTERNAL_ERROR` and other non-`INVALID_PARAMS`
+  codes) returned from `initialize` propagate as non-zero exit with
+  `process_end.reason: Error`. Pinned by the
+  `initialize_failure_classifier` unit test.
 - No crash, no `Crashed(...)` outcome from the harness on
   unsupported-version input.

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -1,0 +1,466 @@
+# JSON-RPC Envelope Validator (#277)
+
+**Date:** 2026-05-15
+**Issue:** [#277](https://github.com/randomparity/rusty-imap-mcp/issues/277)
+**Discovered by:** Phase 4 property testing (#266) — `mcp_wire_proptest::prop_envelope_never_panics`
+**Status:** Design approved; implementation pending
+**Depends on:** PR #278 (the un-ignore of `prop_envelope_never_panics` lands in the same diff)
+
+## Problem
+
+A client sending a JSON envelope that fails JSON-RPC 2.0 shape validation
+— e.g. `{"method":"a"}` (no `jsonrpc`, no `id`) — gets no response and the
+connection does not close. The proptest harness times out after
+`REQUEST_TIMEOUT` (2 s) and records a `Hung` outcome.
+
+Either response shape — a JSON-RPC `-32600 Invalid Request` envelope or
+a clean connection close — would satisfy the spec. Hanging does not.
+
+## Root cause
+
+rmcp 1.5's `JsonRpcMessageCodec::decode`
+([`rmcp-1.5.0/src/transport/async_rw.rs:350-354`](https://docs.rs/rmcp/1.5.0/src/rmcp/transport/async_rw.rs.html))
+calls `try_parse_with_compatibility` and silently drops the line whenever
+that helper returns `Ok(None)`:
+
+```rust
+let item = match try_parse_with_compatibility(line, "decode")? {
+    Some(item) => item,
+    None => return Ok(None), // Skip non-standard message
+};
+```
+
+`try_parse_with_compatibility`
+(`async_rw.rs:245-279`) tries to deserialize as the typed message enum;
+on failure it consults `should_ignore_notification`
+(`async_rw.rs:223-243`):
+
+```rust
+let is_notification = json_value.get("id").is_none();
+if is_notification && !is_standard_method(method) {
+    return true; // silently ignore
+}
+```
+
+For the shrunk failing case `{"method":"a"}`: typed deserialization
+fails (no `jsonrpc` field), the value parses as a JSON object with a
+string `method`, `id` is absent so `is_notification=true`, method `"a"`
+isn't on rmcp's `is_standard_method` allowlist, and the helper returns
+`true`. The codec returns `Ok(None)`, which `tokio_util::codec::Decoder`
+interprets as "not enough data yet — call me again." `FramedRead`
+treats this as backpressure and silently waits for the next line. The
+dropped line never surfaces on the `Stream`, `service.waiting()` never
+sees it, and no response is emitted. The client request id sits
+unresolved forever — the observed hang.
+
+The same path applies on EOF: `decode_eof`
+(`async_rw.rs:373-393`) routes unparsable terminal lines through
+`try_parse_with_compatibility` and returns `Ok(None)` on failure, so
+EOF after a malformed line also produces no diagnostic.
+
+The originating property —
+`crates/rimap-server/tests/mcp_wire_proptest.rs:311`
+(`prop_envelope_never_panics`) — is currently `#[ignore]`'d pending
+this fix. The nightly fuzz workflow's per-property guard fails until
+the property un-ignores.
+
+### Two cases collapsed under #277
+
+rmcp's silent-drop branch fires for two distinct input classes that
+both manifest as `Hung` in the proptest harness:
+
+1. **Invalid JSON-RPC 2.0 envelope** — e.g. `{"method":"a"}` (missing
+   `jsonrpc`). The original #277 hang. The server-side fix is to
+   respond `-32600` or `-32700` per the validation rules below.
+2. **Valid JSON-RPC notification with non-standard method** — e.g.
+   `{"jsonrpc":"2.0","method":"foo"}`. Per JSON-RPC 2.0 §4.1, the
+   server "MUST NOT reply to a Notification." rmcp's silent-ignore is
+   spec-compliant; the proptest's `Hung` outcome is the bug, not the
+   server's silence. The fix here is in the property body, not the
+   server.
+
+The implementation must address both. The validator (below) closes
+case 1; a small property-body change classifies case 2 as a non-fault
+outcome.
+
+## Desired behavior
+
+For every line received on stdin after the initialize handshake
+completes:
+
+1. **Valid JSON-RPC 2.0 envelope** (request or notification): forward
+   unchanged to rmcp.
+2. **Empty or whitespace-only line**: skip silently. (Transport noise;
+   not part of the JSON-RPC spec.)
+3. **Invalid JSON**: emit `-32700 Parse error` envelope with `id: null`.
+4. **Valid JSON failing shape checks** (missing `jsonrpc`, wrong
+   `jsonrpc` value, missing/non-string `method`, malformed `id`,
+   batches): emit `-32600 Invalid Request` envelope with `id` echoed
+   if it's the right shape, else `null`.
+5. **Session stays alive after rejection**: the next valid envelope on
+   the wire continues to dispatch normally.
+
+Pre-initialize handling is unchanged. The validator and the existing
+`preinit.rs` are independent: `preinit` handles
+`ServerInitializeError::ExpectedInitializeRequest` from rmcp (a
+semantically-wrong-but-syntactically-valid first message); the validator
+catches everything that rmcp's codec would otherwise silently drop, both
+pre- and post-initialize.
+
+### Why respond rather than close
+
+Both are spec-legal. Responding is preferable because:
+
+- **Diagnostic clarity** for real MCP clients with a transient bug — a
+  `-32600` envelope tells them what's wrong; a connection close looks
+  like an unrelated transport failure.
+- **Property-test throughput**: `prop_envelope_never_panics` runs 1000
+  cases per invocation. Closing the connection forces the harness to
+  respawn the server between cases. Pinned tests in
+  `mcp_wire_negative.rs` already prove session-keepalive after
+  `-32602` rejections (#276); the same pattern extends here.
+- **Consistency**: pre-init rejection (#275) emits `-32002`, version
+  rejection (#276) emits `-32602`. Wire-shape rejection joining as
+  `-32600` keeps the rejection surface uniform.
+
+## Approach
+
+Replace `rmcp::transport::io::stdio()` in
+`crates/rimap-server/src/main.rs:140` with a validator that sandwiches
+rmcp's transport via `tokio::io::duplex`:
+
+```
+                          ┌──────────── Arc<Mutex<Stdout>> ───────────┐
+                          ↓ (rejections)                              ↓ (rmcp frames)
+real stdin → [validator] ─┴─valid line─→ duplex_in.our_end            │
+                                         duplex_in.rmcp_end → rmcp ───┤
+                            duplex_out.our_end ← duplex_out.rmcp_end ←┘
+                              ↓
+                          [passthrough] ─────────────────────────→ real stdout
+```
+
+Two background tokio tasks live for the lifetime of the MCP session,
+plus a shared `Arc<tokio::sync::Mutex<tokio::io::Stdout>>` that
+serializes all writes to real `stdout` so the validator's rejection
+envelopes and rmcp's frames never interleave mid-line:
+
+- **Inbound validator** (`validate_inbound`): reads from real
+  `tokio::io::stdin()` via `AsyncBufReadExt::read_until(b'\n', ...)`
+  so the terminating `\n` is preserved verbatim. Runs shape
+  validation on each line. Valid lines (including the trailing
+  newline) are forwarded byte-for-byte to the inbound duplex;
+  rmcp's codec sees exactly what the client sent. Invalid lines
+  synthesize an error envelope and write it through the shared
+  stdout mutex.
+- **Outbound passthrough** (`passthrough_outbound`): reads
+  newline-framed frames from the outbound duplex via
+  `read_until(b'\n', ...)` and writes each complete frame through
+  the shared stdout mutex. Line-framed (rather than `tokio::io::copy`)
+  so the lock is acquired per complete envelope and never held
+  across an await on rmcp's writer.
+
+**Stdout serialization invariant:** all writes to real `stdout` go
+through `Arc<Mutex<Stdout>>`; each lock acquisition writes exactly
+one complete line (terminating `\n` included) plus a `flush()`, then
+releases. Both tasks observe this contract.
+
+EOF on real stdin → validator's `read_until` returns 0 → validator
+drops its inbound duplex end → rmcp's `FramedRead` sees EOF on its
+next poll → `service.waiting()` resolves cleanly. EOF on the
+outbound duplex (rmcp dropped) → passthrough exits → tasks complete.
+Broken pipe on real stdout propagates as `io::Error` from the locked
+write; whichever task hit it logs and exits, the other follows when
+its duplex peer drops.
+
+rmcp's `IntoTransport` impl
+(`rmcp/transport/async_rw.rs:22-31`) accepts any
+`(R: AsyncRead, W: AsyncWrite)` pair. Our pair is two
+`tokio::io::DuplexStream` ends — substitution requires zero changes to
+rmcp.
+
+### Validator entry point
+
+```rust
+// crates/rimap-server/src/mcp/wire_validator.rs
+
+/// Return a transport-compatible (read, write) pair that pre-validates
+/// JSON-RPC 2.0 envelopes on the inbound side. Invalid envelopes are
+/// rejected directly to real stdout; valid envelopes are forwarded to
+/// the returned read half. The write half is bridged to real stdout
+/// unchanged.
+///
+/// Drop both returned streams to terminate the background tasks.
+pub fn stdio_with_validation() -> (DuplexStream, DuplexStream) {
+    let (inbound_our_end, inbound_rmcp_end) = tokio::io::duplex(BUF_SIZE);
+    let (outbound_rmcp_end, outbound_our_end) = tokio::io::duplex(BUF_SIZE);
+
+    let stdout = Arc::new(tokio::sync::Mutex::new(tokio::io::stdout()));
+
+    tokio::spawn(validate_inbound(
+        tokio::io::stdin(),
+        inbound_our_end,
+        Arc::clone(&stdout),
+    ));
+    tokio::spawn(passthrough_outbound(outbound_our_end, stdout));
+
+    (inbound_rmcp_end, outbound_rmcp_end)
+}
+```
+
+`BUF_SIZE = 64 * 1024`. Generous enough that one well-formed envelope
+fits in a single write; both directions are independent tasks so
+inbound stalls cannot cause outbound deadlock.
+
+`main.rs::run` swap:
+
+```rust
+- let transport = rmcp::transport::io::stdio();
++ let transport = rimap_server::mcp::wire_validator::stdio_with_validation();
+```
+
+`rmcp::serve_server(mcp_server, transport)` accepts the duplex pair
+via `IntoTransport::<RoleServer, std::io::Error, TransportAdapterAsyncRW>::into_transport`.
+
+### Validation rules
+
+| Input shape | Decision | Wire response | Notes |
+|---|---|---|---|
+| Empty / whitespace-only line | Skip silently | (none) | Transport noise; rmcp tolerates the same today. |
+| Bytes that are not valid JSON | Reject | `-32700 Parse error`, `id: null` | The id is unknowable — `null` per JSON-RPC §5. |
+| Valid JSON, not an object (incl. JSON arrays — MCP forbids batches) | Reject | `-32600 Invalid Request`, `id: null` | rmcp 1.5 doesn't speak batches; we reject for forward-compat. |
+| Object missing `jsonrpc` | Reject | `-32600`, `id: <echoed or null>` | The #277 minimal failing case. |
+| Object with `jsonrpc` ≠ `"2.0"` | Reject | `-32600`, `id: <echoed or null>` | E.g. `"1.0"`, `2.0` (number), `"2.00"`. |
+| Object missing `method` | Reject | `-32600`, `id: <echoed or null>` | A response or error message — not valid client input. |
+| Object with non-string `method` | Reject | `-32600`, `id: <echoed or null>` | |
+| Object with `id` field of disallowed type (object/array/boolean) | Reject | `-32600`, `id: null` | Per JSON-RPC §5: "if there was an error in detecting the id … it MUST be Null." |
+| Everything else | Forward to rmcp | — | rmcp may still reject for MCP-specific reasons (unknown method, schema mismatch). |
+
+The forward set is a strict subset of the JSON-RPC 2.0 envelope grammar.
+Any envelope rmcp 1.5 accepts and that is also spec-compliant passes
+through. The only behavior change vs today is: malformed inputs that
+rmcp silently drops now get a `-32600`/`-32700` response.
+
+### `id`-echo policy
+
+Decision tree for the `id` field on a rejection envelope:
+
+- Top-level `"id"` is a JSON string → echo as-is.
+- Top-level `"id"` is a JSON number → echo as-is.
+- Top-level `"id"` is JSON `null` → echo `null`.
+- Top-level `"id"` is missing → `null`.
+- Top-level `"id"` is any other shape (object, array, bool) → `null`.
+- Input not parseable as JSON → `null`.
+
+Matches `preinit.rs::synthesize_pre_init_error_envelope` and JSON-RPC §5
+exactly.
+
+## Error envelope shapes
+
+**Invalid Request** (`-32600`):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <echoed-or-null>,
+  "error": {
+    "code": -32600,
+    "message": "Invalid Request"
+  }
+}
+```
+
+**Parse error** (`-32700`):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32700,
+    "message": "Parse error"
+  }
+}
+```
+
+No `data` field on either — JSON-RPC §5.1 makes it optional and the
+envelope shape is self-describing. Pre-init envelopes (#275) and
+version-rejection envelopes (#276) likewise omit `data` unless adding
+machine-readable detail (supported-version array for #276); there is no
+analogous structured detail for "your envelope was malformed."
+
+Lines are emitted with a trailing `\n` and flushed, same as
+`preinit.rs:emit_pre_init_error_envelope`.
+
+## File layout
+
+- **New:** `crates/rimap-server/src/mcp/wire_validator.rs`
+  - `pub fn stdio_with_validation() -> (DuplexStream, DuplexStream)` —
+    entry point used by `main.rs`.
+  - `fn validate(line: &str) -> ValidationOutcome` — pure
+    function, no I/O. Unit-testable in isolation.
+  - `enum ValidationOutcome { Forward, Skip, Reject(ErrorEnvelope) }`
+  - `fn synthesize_error_envelope(code: i32, message: &str, id: Option<Value>) -> String`
+  - `async fn validate_inbound(...)` and `async fn passthrough_outbound(...)` —
+    the two background tasks.
+- **Modified:** `crates/rimap-server/src/main.rs:140` — swap the
+  transport constructor as above. One-line change.
+- **Modified:** `crates/rimap-server/src/mcp/mod.rs` — `pub mod wire_validator;`
+- **Modified:** `crates/rimap-server/tests/mcp_wire_proptest.rs:310` —
+  remove the `#[ignore]` from `prop_envelope_never_panics`, and amend
+  the property body to recognize spec-legal notifications (see
+  "Property body adjustment").
+- **Modified:** `crates/rimap-server/tests/mcp_wire_negative.rs` — new
+  pinned tests (see "Testing" below).
+- **No changes to** `crates/rimap-server/src/mcp/preinit.rs` — its
+  responsibility (intercepting `ServerInitializeError::ExpectedInitializeRequest`
+  from rmcp) is orthogonal.
+
+## Property body adjustment (case 2)
+
+`prop_envelope_never_panics` currently treats `CloseOrResponse::Hung`
+as a `panic!`. After the validator lands, the only remaining `Hung`
+source is the spec-compliant silent-ignore path: valid JSON-RPC 2.0
+notifications (`jsonrpc:"2.0"`, no `id`, non-standard `method`). The
+property body must distinguish that case from a real hang:
+
+```rust
+let is_spec_legal_notification = envelope
+    .get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
+    && envelope.get("id").is_none()
+    && envelope.get("method").and_then(|v| v.as_str()).is_some();
+
+// ...
+match outcome {
+    CloseOrResponse::Response(line) => assert_envelope_valid(&parsed),
+    CloseOrResponse::CleanClose => {},
+    CloseOrResponse::Crashed(d) => panic!("crashed: {d}"),
+    CloseOrResponse::Hung if is_spec_legal_notification => {
+        // JSON-RPC §4.1: server MUST NOT reply to a notification.
+        // Silence within REQUEST_TIMEOUT is the correct outcome.
+        // Harness is poisoned by the timeout path; `with_live_harness`
+        // respawns on the next case. The throughput cost is the
+        // proptest's choice, not the server's.
+    }
+    CloseOrResponse::Hung => panic!("hung on {envelope}"),
+}
+```
+
+The `is_spec_legal_notification` check is in the test body, not the
+strategy, so the missing-`jsonrpc` cases that originally triggered
+#277 stay in coverage and exercise the validator's reject path. The
+strategy is unchanged.
+
+The harness respawn overhead (every notification-shaped case triggers
+`with_live_harness` to spawn a fresh server) is acceptable for 1000-
+case property runs and matches the cost we already pay for
+`CleanClose` outcomes in #275/#276 tests. If the overhead becomes a
+problem under nightly higher case counts, a follow-up can add a
+`send_notification_and_confirm_silence(line, dur)` harness method
+that doesn't poison on timeout.
+
+## Testing
+
+**Property — must un-ignore and pass:**
+
+- `prop_envelope_never_panics` at 1000 cases (`PROPTEST_CASES=1000`,
+  the default). Nightly scales via the existing
+  `mcp-fuzz-nightly.yml` workflow. The property body is amended per
+  the section above before un-ignoring.
+
+**Wire-pinned negative tests** in `mcp_wire_negative.rs` (mirrors the
+#275 / #276 conventions — one test per row, strict assertions on code
+and id):
+
+1. `envelope_missing_jsonrpc_returns_invalid_request` — input
+   `{"method":"a"}` → `-32600`, `id: null`.
+2. `envelope_missing_jsonrpc_with_numeric_id_echoes_id` —
+   `{"method":"a","id":42}` → `-32600`, `id: 42`.
+3. `envelope_missing_jsonrpc_with_string_id_echoes_id` —
+   `{"method":"a","id":"abc"}` → `-32600`, `id: "abc"`.
+4. `envelope_missing_jsonrpc_with_malformed_id_uses_null` —
+   `{"method":"a","id":[1,2]}` → `-32600`, `id: null`.
+5. `envelope_with_wrong_jsonrpc_value_returns_invalid_request` —
+   `{"jsonrpc":"1.0","method":"x","id":1}` → `-32600`, `id: 1`.
+6. `envelope_with_non_string_method_returns_invalid_request` —
+   `{"jsonrpc":"2.0","method":42,"id":1}` → `-32600`, `id: 1`.
+7. `envelope_batch_array_returns_invalid_request` —
+   `[{"jsonrpc":"2.0","method":"x","id":1}]` → `-32600`, `id: null`.
+8. `envelope_invalid_json_returns_parse_error` — `not valid json` →
+   `-32700`, `id: null`.
+9. `envelope_empty_line_is_skipped` — empty line followed by valid
+   `tools/list` request → `tools/list` response arrives on time, no
+   spurious error envelope precedes it.
+10. `session_survives_invalid_envelope` — valid `initialize` →
+    invalid envelope → valid `tools/list`. The third message gets a
+    normal response; the session is not closed.
+
+All tests run against the production binary via the existing
+`Harness` — no test-only hooks needed in the validator.
+
+**Unit tests** in `wire_validator.rs::tests` covering `validate()` in
+isolation, one assertion per row of the validation rules table. Pure
+function, no async, ~30 lines of test code.
+
+**Integration regression** — full `mcp_wire_negative.rs` and
+`mcp_wire_proptest.rs` suites must pass with the validator in place
+without ANY existing test going from pass → fail. The validator's
+forward set is a strict superset of the JSON-RPC 2.0 grammar, so
+this should hold by construction.
+
+## Risks & mitigations
+
+- **Validator framing drift from rmcp's codec.** rmcp splits on `\n`
+  and tolerates a trailing `\r` (`without_carriage_return` in
+  `async_rw.rs`). Validator uses `read_until(b'\n', ...)` and forwards
+  the buffer (including the trailing `\n`) verbatim — rmcp's codec
+  then strips `\r` and parses normally. Strict validation runs on
+  the buffer minus the trailing `\n`/`\r`, matching rmcp's view.
+  Pin a wire-level test with `\r\n` line endings.
+- **Validator stricter than rmcp on a shape rmcp accepts.** The
+  forward set is the JSON-RPC 2.0 envelope grammar — rmcp's
+  compatibility shim is a strict subset of that. Mitigation: every
+  existing `mcp_wire_negative.rs` test continues to pass unchanged.
+- **Duplex buffer deadlock.** The two duplex pairs are independent;
+  one direction stalling cannot block the other. Buffer is 64 KiB,
+  far larger than any sane envelope. Mitigation: leave the buffer
+  generous; the proptest will exercise heterogeneous envelope sizes.
+- **Async cancellation safety.** The validator and passthrough tasks
+  are spawned with `tokio::spawn`; they own their I/O handles and
+  drop them on task exit. Cancellation on the outer runtime cancels
+  the tasks, which closes the duplex ends, which surfaces to rmcp as
+  EOF or write-error — the same shutdown shape as today's direct
+  stdio transport.
+- **Backpressure under sustained malformed input.** Each rejection
+  writes to real stdout from the validator task. A slow consumer
+  could stall the validator; that's identical to today's stall
+  behavior on rmcp's outbound write under a slow consumer, and is
+  out of scope.
+
+## Dependencies and merge plan
+
+This fix is the final merge blocker for PR #278 (the #266 fuzzing
+umbrella). The implementation lands on
+`feature/issue-266-mcp-fuzzing` directly, in one diff that includes:
+
+1. `wire_validator.rs` and `main.rs` swap.
+2. Property body amendment for `is_spec_legal_notification` (case 2
+   distinction).
+3. Un-ignore `prop_envelope_never_panics`.
+4. The 10 new wire-pinned tests in `mcp_wire_negative.rs`.
+5. Mirror docs (this spec is committed before implementation starts).
+
+Once green, PR #278 comes out of draft and goes to review with all
+three blockers (#275, #276, #277) resolved.
+
+## Out of scope
+
+- **Upstream rmcp fix.** Filing a separate issue against rmcp to make
+  `JsonRpcMessageCodec::decode` propagate rejections is reasonable
+  future work but not on this critical path. The local validator
+  closes the contract independently.
+- **Outbound validation.** Our server's outbound envelopes come
+  through rmcp's typed `ServerJsonRpcMessage` and are well-formed by
+  construction. The passthrough side does not need to validate.
+- **Custom error data fields.** Sticking to `{code, message}` for
+  these envelopes is sufficient. Re-evaluate if a client reports
+  needing structured diagnostics.

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -80,8 +80,8 @@ both manifest as `Hung` in the proptest harness:
    server.
 
 The implementation must address both. The validator (below) closes
-case 1; a small property-body change classifies case 2 as a non-fault
-outcome.
+case 1; a property-strategy filter excludes case 2 from the property
+entirely (notifications get their own fixed-case test instead).
 
 ## Desired behavior
 
@@ -279,7 +279,22 @@ impl ValidatorSupervisor {
     /// returns the first error encountered. Used after
     /// `service.waiting()` resolves so final-write failures
     /// surface.
+    ///
+    /// **Do not call on init-failure paths** — the inbound bridge
+    /// only exits on real stdin EOF, but a client may legitimately
+    /// keep stdin open while waiting for the error response,
+    /// causing this to hang. Use `shutdown_after_init_failure`
+    /// instead.
     pub async fn drain(self) -> io::Result<()>;
+
+    /// Init-failure shutdown. Aborts the inbound bridge
+    /// (the client may keep stdin open after an init error;
+    /// without abort, we'd block forever waiting for EOF), then
+    /// awaits the outbound bridge to drain rmcp's queued init
+    /// error envelope plus any validator-synthesized rejections.
+    /// Returns the first error from the outbound path; inbound
+    /// cancellation is expected and ignored.
+    pub async fn shutdown_after_init_failure(self) -> io::Result<()>;
 }
 ```
 
@@ -293,15 +308,24 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)
     Ok(svc) => svc,
     Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
         emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
-        // Drop the supervisor (drain on the way out so any pre-init
-        // queued frames flush; failures surface as Err).
-        return match validated.supervisor.drain().await {
+        // Init-failure shutdown: abort inbound (client may hold
+        // stdin open), drain outbound (our pre-init envelope plus
+        // any rmcp-queued frames must flush).
+        return match validated.supervisor.shutdown_after_init_failure().await {
             Ok(()) => Ok(()),
-            Err(e) => Err(anyhow!("validator bridge drain after pre-init: {e}")),
+            Err(e) => Err(anyhow!("validator bridge after pre-init: {e}")),
         };
     }
     Err(ServerInitializeError::InitializeFailed(error_data)) => {
-        return handle_initialize_failed(&error_data);
+        let handled = handle_initialize_failed(&error_data);
+        // rmcp already wrote the error envelope (e.g. -32602 for
+        // #276) into the outbound duplex before returning. Drain
+        // outbound so it actually reaches stdout; failures during
+        // drain promote a handled rejection to Error.
+        return match validated.supervisor.shutdown_after_init_failure().await {
+            Ok(()) => handled,
+            Err(e) => Err(anyhow!("validator bridge after init failure: {e}")),
+        };
     }
     Err(other) => return Err(anyhow!("MCP server init: {other}")),
 };
@@ -390,6 +414,19 @@ parse cleanly.
 
 ### Validation rules
 
+JSON-RPC 2.0 §4-5 defines four valid envelope shapes from a peer:
+
+- **Request**: `{jsonrpc:"2.0", method:string, id:string|number, params?}`
+- **Notification**: `{jsonrpc:"2.0", method:string, params?}` (no `id`)
+- **Response (success)**: `{jsonrpc:"2.0", id:string|number|null, result:any}` (no `method`, no `error`)
+- **Error response**: `{jsonrpc:"2.0", id:string|number|null, error:{code,message,data?}}` (no `method`, no `result`)
+
+The validator forwards all four; rejects everything else. Responses
+and Errors from the client side are part of MCP's server-initiated
+flow (e.g. sampling requests where the server asks the client to
+invoke its LLM and the client returns a response) — rejecting them
+would be a feature regression, not just a test gap.
+
 | Input shape | Decision | Wire response | Notes |
 |---|---|---|---|
 | Empty / whitespace-only line | Skip silently | (none) | Transport noise; rmcp tolerates the same today. |
@@ -397,15 +434,70 @@ parse cleanly.
 | Valid JSON, not an object (incl. JSON arrays — MCP forbids batches) | Reject | `-32600 Invalid Request`, `id: null` | rmcp 1.5 doesn't speak batches; we reject for forward-compat. |
 | Object missing `jsonrpc` | Reject | `-32600`, `id: <echoed or null>` | The #277 minimal failing case. |
 | Object with `jsonrpc` ≠ `"2.0"` | Reject | `-32600`, `id: <echoed or null>` | E.g. `"1.0"`, `2.0` (number), `"2.00"`. |
-| Object missing `method` | Reject | `-32600`, `id: <echoed or null>` | A response or error message — not valid client input. |
-| Object with non-string `method` | Reject | `-32600`, `id: <echoed or null>` | |
 | Object with `id` field of disallowed type (object/array/boolean) | Reject | `-32600`, `id: null` | Per JSON-RPC §5: "if there was an error in detecting the id … it MUST be Null." |
-| Everything else | Forward to rmcp | — | rmcp may still reject for MCP-specific reasons (unknown method, schema mismatch). |
+| **Has `method` (string)**, no `result`, no `error` | Forward | — | Request (if `id`) or Notification (if no `id`). |
+| **Has `method` (non-string)** | Reject | `-32600`, `id: <echoed or null>` | |
+| **Has `result`** (and `id` present + valid), no `method`, no `error` | Forward | — | Client Response to a server-initiated request. |
+| **Has `error`** (and `id` present + valid), no `method`, no `result` | Forward | — | Client Error response to a server-initiated request. |
+| **Has both `result` AND `error`** | Reject | `-32600`, `id: <echoed or null>` | Per JSON-RPC §5: exactly one of result/error. |
+| Has `result` or `error` but no `id` | Reject | `-32600`, `id: null` | Response/Error envelopes MUST have an `id`. |
+| Empty object (no `method`, no `result`, no `error`) | Reject | `-32600`, `id: <echoed or null>` | |
+| Mixes `method` with `result` or `error` | Reject | `-32600`, `id: <echoed or null>` | A line is exactly one envelope shape. |
 
-The forward set is a strict subset of the JSON-RPC 2.0 envelope grammar.
-Any envelope rmcp 1.5 accepts and that is also spec-compliant passes
-through. The only behavior change vs today is: malformed inputs that
-rmcp silently drops now get a `-32600`/`-32700` response.
+The forward set is the JSON-RPC 2.0 envelope grammar restricted to
+non-batch shapes. The only behavior change vs today is: malformed
+inputs that rmcp silently drops now get a `-32600`/`-32700` response.
+
+### `validate()` decision logic
+
+```rust
+fn validate(line: &str) -> ValidationOutcome {
+    if line.trim().is_empty() {
+        return ValidationOutcome::Skip;
+    }
+    let parsed: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return ValidationOutcome::Reject(parse_error()),
+    };
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return ValidationOutcome::Reject(invalid_request(None)),
+    };
+    if obj.get("jsonrpc").and_then(|v| v.as_str()) != Some("2.0") {
+        return ValidationOutcome::Reject(invalid_request(extract_id(obj)));
+    }
+    let id = obj.get("id");
+    if let Some(id) = id {
+        if !is_valid_id(id) {
+            return ValidationOutcome::Reject(invalid_request(None));
+        }
+    }
+
+    let method = obj.get("method");
+    let result = obj.get("result");
+    let error = obj.get("error");
+
+    match (method, result, error) {
+        // Request or Notification
+        (Some(m), None, None) if m.is_string() => ValidationOutcome::Forward,
+        (Some(_), None, None) /* non-string method */ => {
+            ValidationOutcome::Reject(invalid_request(extract_id(obj)))
+        }
+        // Response / Error response — id MUST be present and valid
+        (None, Some(_), None) | (None, None, Some(_)) if id.is_some() => {
+            ValidationOutcome::Forward
+        }
+        // Response without id, or empty / mixed shape
+        _ => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
+    }
+}
+```
+
+`extract_id(obj)` returns `Some(Value)` if `obj["id"]` is
+`string|number|null`, else `None` (we use `null` on the wire). The
+catch-all arm covers: empty object, both `result` and `error`, method
+mixed with result/error, and response/error without id — all single-
+line `-32600` rejections.
 
 ### `id`-echo policy
 
@@ -481,112 +573,79 @@ Lines are emitted with a trailing `\n` and flushed, same as
     then unconditionally `supervisor.drain().await` before classifying
     `mcp_outcome`.
 - **Modified:** `crates/rimap-server/src/mcp/mod.rs` — `pub mod wire_validator;`
-- **Modified:** `crates/rimap-server/tests/support/wire/harness.rs` —
-  - `pub enum NotificationOutcome { SilentThenAlive, UnexpectedResponse(String), FailedLiveness(CloseOrResponse) }`
-  - `pub async fn assert_notification_then_alive(&mut self, line, silence_dur, liveness_dur) -> NotificationOutcome`
-    that does not poison the harness on `SilentThenAlive`.
-  - `pub const SILENCE_TIMEOUT: Duration = Duration::from_millis(250);`
-  - `pub const LIVENESS_TIMEOUT: Duration = Duration::from_secs(1);`
-  - `pub async fn request_with_timeout(&mut self, method, params, dur) -> CloseOrResponse`
-    (small extension; reuses the existing send + `response_or_close` core
-    with a parameterized timeout).
-- **Modified:** `crates/rimap-server/tests/mcp_wire_proptest.rs:310` —
-  remove the `#[ignore]` from `prop_envelope_never_panics`, and amend
-  the property body to dispatch spec-legal notifications through
-  `assert_notification_then_alive` (see "Property body adjustment").
+- **Modified:** `crates/rimap-server/tests/mcp_wire_proptest.rs` —
+  - add `prop_filter` to `arb_envelope()` excluding spec-legal
+    notifications (see "Property strategy adjustment"),
+  - remove the `#[ignore]` from `prop_envelope_never_panics` so it
+    runs at the default 1000 cases and nightly 100k.
+  - No changes to the property body; no liveness probe needed.
+- **No changes to** `tests/support/wire/harness.rs` for the
+  notification path — earlier drafts proposed a non-poisoning
+  `assert_notification_then_alive` method but the strategy filter
+  approach removes the need. The closed-stdout helpers added for
+  #275 remain in use for tests 12-14.
 - **Modified:** `crates/rimap-server/tests/mcp_wire_negative.rs` — new
   pinned tests (see "Testing" below).
 - **No changes to** `crates/rimap-server/src/mcp/preinit.rs` itself —
   its `synthesize_pre_init_error_envelope` remains a pure formatter;
   the I/O caller in `main.rs` is what changes.
 
-## Property body adjustment (case 2)
+## Property strategy adjustment (case 2)
 
 `prop_envelope_never_panics` currently treats `CloseOrResponse::Hung`
 as a `panic!`. After the validator lands, the only remaining `Hung`
 source is the spec-compliant silent-ignore path: valid JSON-RPC 2.0
-notifications (`jsonrpc:"2.0"`, no `id`, non-standard `method`). The
-property body must distinguish that case from a real hang — AND not
-poison the harness, since `Harness::response_or_close` poisons on
-every `Hung` outcome (`harness.rs:514-516`). Poisoning means
-`with_live_harness` respawns the harness for the next case,
-defeating the throughput rationale for accepting notifications at
-all.
+notifications (`jsonrpc:"2.0"`, no `id`, non-standard `method`).
 
-### Non-poisoning probe on the harness
+**Approach: filter notifications out of the property strategy
+entirely; cover the notification path via a fixed-case test.**
 
-Add a method to `Harness` (in `tests/support/wire/harness.rs`) that
-handles the entire send → expected-silence → liveness-ping pattern
-atomically without poisoning on the spec-legal silent timeout:
+This is the simplest design that keeps the property meaningful and
+the nightly workflow within budget. Earlier drafts threaded an
+in-test liveness probe to distinguish spec-legal silence from a real
+hang; that approach was rejected because it (a) added a non-trivial
+non-poisoning harness API, and (b) extrapolated to ~104 minutes on
+nightly runs at `PROPTEST_CASES=100000`, exceeding the workflow's
+90-minute timeout.
+
+### Strategy filter
 
 ```rust
-pub enum NotificationOutcome {
-    /// Expected: notification produced no response, ping confirmed
-    /// the server is still responsive.
-    SilentThenAlive,
-    /// Spec violation: notification produced a response.
-    UnexpectedResponse(String),
-    /// Liveness ping failed (hung, crashed, or closed unexpectedly).
-    /// Harness IS poisoned in this case.
-    FailedLiveness(CloseOrResponse),
+fn arb_envelope() -> impl Strategy<Value = Value> {
+    (
+        prop::option::of(Just("2.0".to_string())),
+        prop::option::of(arb_id),
+        prop::option::of(arb_method),
+        prop::option::of(arb_params),
+    )
+        .prop_map(/* ... unchanged ... */)
+        .prop_filter(
+            "exclude spec-legal notifications (jsonrpc==\"2.0\" + missing id + present method) — \
+             their silent-ignore is JSON-RPC §4.1 compliant and covered separately by \
+             valid_notification_does_not_hang_session",
+            |env| {
+                let is_notification = env.get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
+                    && env.get("id").is_none()
+                    && env.get("method").and_then(|v| v.as_str()).is_some();
+                !is_notification
+            },
+        )
 }
-
-/// Send `line` as a notification (no response expected), wait
-/// `silence_dur` to confirm no response arrives, then send a `ping`
-/// request and require a well-formed response within `liveness_dur`.
-///
-/// `self.poisoned` is set to `true` ONLY for `UnexpectedResponse`
-/// and `FailedLiveness` outcomes — the `SilentThenAlive` path
-/// leaves the harness usable so subsequent proptest cases can reuse it.
-pub async fn assert_notification_then_alive(
-    &mut self,
-    line: &str,
-    silence_dur: Duration,
-    liveness_dur: Duration,
-) -> NotificationOutcome;
 ```
 
-Behavior detail:
-- Send `line` via `send_line`.
-- Read with timeout `silence_dur`. If a line arrives:
-  → `UnexpectedResponse(line)`, set `poisoned = true`.
-- If `silence_dur` elapses with no read: **do not poison** (this is
-  the spec-legal outcome). Continue to liveness probe.
-- Send a `ping` request via `request_with_timeout("ping", json!({}), liveness_dur)`.
-- If `CloseOrResponse::Response` with a well-formed result envelope:
-  → `SilentThenAlive`, harness stays usable.
-- Otherwise (Hung, CleanClose, Crashed): → `FailedLiveness(outcome)`,
-  `poisoned = true`.
+`prop_filter` drops cases that fail the predicate — proptest will
+generate replacement cases until the strategy yields a non-
+notification envelope. The missing-`jsonrpc` cases that originally
+triggered #277 stay in coverage (they aren't notifications because
+the first clause of the filter fails). Request-shaped, invalid, and
+batch envelopes all flow unchanged.
 
-### Property body using the probe
+### Property body
+
+With notifications filtered out, the body reverts to the simple
+original form — no liveness probe, no non-poisoning machinery:
 
 ```rust
-let is_spec_legal_notification = envelope
-    .get("jsonrpc").and_then(|v| v.as_str()) == Some("2.0")
-    && envelope.get("id").is_none()
-    && envelope.get("method").and_then(|v| v.as_str()).is_some();
-
-if is_spec_legal_notification {
-    match h
-        .assert_notification_then_alive(
-            &envelope.to_string(),
-            SILENCE_TIMEOUT,
-            LIVENESS_TIMEOUT,
-        )
-        .await
-    {
-        NotificationOutcome::SilentThenAlive => {} // pass; harness stays usable
-        NotificationOutcome::UnexpectedResponse(line) => panic!(
-            "notification {envelope} produced a response: {line}",
-        ),
-        NotificationOutcome::FailedLiveness(o) => panic!(
-            "ping after notification {envelope} failed liveness: {o:?}",
-        ),
-    }
-    return h;
-}
-
-// Non-notification path: the existing flow.
 h.send_line(&envelope.to_string()).await;
 let outcome = h.response_or_close(REQUEST_TIMEOUT).await;
 match outcome {
@@ -595,46 +654,41 @@ match outcome {
             .expect("server response must be valid JSON");
         assert_envelope_valid(&env);
     }
-    CloseOrResponse::CleanClose => {} // harness already poisoned by harness.rs
+    CloseOrResponse::CleanClose => {} // spec-legal; harness drops + respawns
     CloseOrResponse::Crashed(d) => panic!("crashed on {envelope}: {d}"),
-    CloseOrResponse::Hung => panic!("hung on {envelope} (post-validator)"),
+    CloseOrResponse::Hung => panic!(
+        "hung on {envelope} (validator should reject malformed or rmcp should respond)",
+    ),
 }
 ```
 
-The `is_spec_legal_notification` check is in the test body, not the
-strategy, so the missing-`jsonrpc` cases that originally triggered
-#277 stay in coverage and exercise the validator's reject path. The
-strategy is unchanged.
+### Fixed-case notification coverage
 
-**New constants** in `harness.rs`:
-- `SILENCE_TIMEOUT: Duration = Duration::from_millis(250)` — long
-  enough that a spec-legal notification doesn't false-positive as
-  `UnexpectedResponse`, short enough that 1000 cases × 25% × 250ms
-  ≈ 62.5s isn't unbearable. Tunable.
-- `LIVENESS_TIMEOUT: Duration = Duration::from_secs(1)` — same order
-  as the existing `REQUEST_TIMEOUT`.
+One wire-pinned test in `mcp_wire_negative.rs` covers the notification
+path explicitly:
 
-**Liveness rationale.** `Hung` is just "no bytes within timeout" — it
-does not prove the child process is responsive. Without the ping, a
-panic-on-notification or a deadlock-on-notification would be silently
-classified as spec-legal silence, defeating the `never_panics`
-guarantee for this input class. The probe forces the server to
-*demonstrate* it is still processing requests before the case passes.
+- `valid_notification_does_not_hang_session` — send a standard MCP
+  notification (`notifications/cancelled` with `params.requestId: 0`),
+  then a `tools/list` request, and assert `tools/list` returns a
+  well-formed response within `REQUEST_TIMEOUT`. Proves notifications
+  don't poison or hang the session, without needing a property-level
+  liveness probe.
 
-**Overhead under 1000-case runs.** Roughly 25% of envelopes are
-notification-shaped → ~250 cases each pay `SILENCE_TIMEOUT` +
-`LIVENESS_TIMEOUT` round-trip (`~250ms + ~5ms ≈ 255ms`). Total
-overhead: ~64s. Significantly larger than the prior estimate
-(~2.5s); the SILENCE_TIMEOUT dominates. Trade-off note:
-shortening `SILENCE_TIMEOUT` to e.g. 50ms cuts overhead 5× at the
-cost of false-positive risk on slow systems. The 250ms default
-matches the rmcp `FramedRead` poll cadence and gives generous
-margin; nightly runs can override via env var if needed.
+This is sufficient regression coverage because rmcp's notification
+handling is a single control-flow path (silent-ignore for non-MCP
+notifications, dispatch for standard ones). One test exercises both
+sides — `notifications/cancelled` is on the standard list, so rmcp
+dispatches it; the subsequent `tools/list` proves the session is
+still alive.
 
-Critically, this is the cost of the **probe**, NOT the cost of
-respawning the harness — which under the original (poisoning) design
-would have been ~1.5s × 250 cases ≈ 6 minutes. The non-poisoning
-probe is what keeps the property practical.
+### Overhead
+
+Filtering removes the ~25% notification share of generated cases.
+The remaining strategy still generates 1000 cases per invocation;
+proptest's `prop_filter` may generate slightly more upstream
+candidates to maintain that, but the cost is negligible (proptest
+strategies are cheap). Nightly remains within its 90-minute
+budget; no env-overridable timeouts needed.
 
 ## Testing
 
@@ -696,19 +750,45 @@ and id):
     fails. `supervisor.drain()` surfaces the error, audit records
     `process_end.reason: Error`, exit non-zero. Pins the race-vs-drain
     distinction.
-15. `harness_notification_probe_does_not_poison` — unit test on the
-    harness alone (no proptest involvement): construct a harness,
-    complete the initialize handshake, call
-    `assert_notification_then_alive("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":0}}", SILENCE_TIMEOUT, LIVENESS_TIMEOUT)`,
-    assert the outcome is `SilentThenAlive`, then assert
-    `harness.is_usable() == true`. Pins the non-poisoning contract
-    so a regression in the harness method gets caught before the
-    proptest runs it 250 times per session.
+15. `valid_notification_does_not_hang_session` — fixed-case
+    notification coverage (replaces the property's notification
+    strategy). Send a standard MCP notification
+    (`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":0}}`),
+    then a `tools/list` request, and assert `tools/list` returns a
+    well-formed response within `REQUEST_TIMEOUT`. Proves the
+    notification path doesn't poison or hang the session.
+16. `valid_response_envelope_forwards` — send a client-shaped
+    Response envelope (`{"jsonrpc":"2.0","id":99,"result":{"x":1}}`)
+    after init. The validator must NOT reject. rmcp handles the
+    spurious response (likely a `notifications/cancelled`-style
+    silent drop since there's no pending server request), so the
+    test asserts no `-32600` envelope appears within
+    `REQUEST_TIMEOUT`, then issues a `tools/list` and verifies the
+    session is alive. Pins that the validator does not regress
+    MCP's server-initiated flow.
+17. `valid_error_envelope_forwards` — send a client-shaped Error
+    envelope (`{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"not found"}}`)
+    after init. Same shape as test 16: no validator rejection,
+    session stays alive.
+18. `envelope_with_both_result_and_error_returns_invalid_request`
+    — `{"jsonrpc":"2.0","id":1,"result":{},"error":{}}` → `-32600`
+    with `id: 1`.
+19. `envelope_response_without_id_returns_invalid_request` —
+    `{"jsonrpc":"2.0","result":{}}` → `-32600` with `id: null`.
+20. `init_failure_with_open_stdin_returns_promptly` — client sends
+    `initialize` with an unsupported `protocolVersion` (rmcp emits
+    `-32602`), then **does NOT close stdin**. The server must
+    `shutdown_after_init_failure`, write the `-32602` envelope,
+    abort inbound, drain outbound, and exit within a bounded
+    timeout (e.g. 2 s). Pins that the drain path does not require
+    real stdin EOF.
 
 All tests run against the production binary via the existing
-`Harness`. Tests 12, 13, and 14 use the closed-stdout harness variant
-added in `tests/support/wire/harness.rs` for #275. Test 15 exercises
-the new `assert_notification_then_alive` method in isolation.
+`Harness`. Tests 12-14 use the closed-stdout harness variant added
+in `tests/support/wire/harness.rs` for #275. Tests 16-17 add small
+client-side helpers (`send_line` + bounded silence wait) reusing
+existing primitives. Test 20 needs a harness variant that holds
+stdin open after sending — small extension.
 
 **Unit tests** in `wire_validator.rs::tests` covering `validate()` in
 isolation, one assertion per row of the validation rules table. Pure
@@ -766,19 +846,26 @@ this should hold by construction.
   duplex; a subsequent `BrokenPipe` on that write would be lost.
   Mitigation: drain is unconditional after the race; test 14
   exercises exactly this ordering.
-- **Notification liveness blind spot.** The property's amended
-  arm for spec-legal notifications must prove the server is still
-  responsive, not merely silent. Mitigation: each notification-
-  shaped envelope dispatches through `assert_notification_then_alive`
-  which sends a `ping` after the silence wait — a hung or crashed
-  server fails the case instead of being respawned as "spec-legal
-  silence."
-- **Harness poisoning kills proptest throughput.** The existing
-  `Harness::response_or_close` poisons on every `Hung`, so a naïve
-  liveness-ping after `Hung` would still leave the harness flagged
-  for respawn. Mitigation: `assert_notification_then_alive` owns
-  the entire send → silence → ping cycle and only poisons on
-  actual liveness failure. Test 15 pins the non-poisoning contract.
+- **Notification path narrows proptest coverage.** Filtering
+  spec-legal notifications out of the property strategy means the
+  property no longer exercises the ~25% notification share of the
+  case space. Mitigation: notifications collapse to a single
+  control-flow path (silent-ignore for non-MCP, dispatch for
+  standard); test 15 exercises both ends explicitly. The
+  alternative (in-test liveness probe) was rejected on nightly-
+  budget grounds (~104 min at 100k cases) and complexity.
+- **Init-failure shutdown hang.** A naïve `drain()` after init
+  failure would wait for real stdin EOF; clients legitimately keep
+  stdin open while waiting for the error response. Mitigation:
+  `shutdown_after_init_failure` aborts the inbound bridge before
+  awaiting the outbound; test 20 pins prompt exit with stdin open.
+- **Validator rejecting server-initiated flow responses.** MCP's
+  sampling and similar flows send a server-initiated request and
+  expect a client-shaped Response or Error envelope back. An
+  over-strict validator (rejecting any envelope without `method`)
+  would silently break these. Mitigation: validator forwards all
+  four spec-defined envelope shapes (Request, Notification,
+  Response, Error); tests 16-19 pin the inclusive forward set.
 
 ## Dependencies and merge plan
 
@@ -787,23 +874,31 @@ umbrella). The implementation lands on
 `feature/issue-266-mcp-fuzzing` directly, in one diff that includes:
 
 1. `wire_validator.rs` with `ValidatedStdio` / `ValidatorSupervisor`
-   (`watch_for_error` + `drain`), the `validate()` pure function,
-   and the two bridge tasks.
+   (`watch_for_error` + `drain` + `shutdown_after_init_failure`),
+   the `validate()` pure function recognizing all four spec
+   envelope shapes, and the two bridge tasks.
 2. `main.rs` updates: transport swap, `emit_pre_init_error_envelope`
-   signature thread-through, two-phase shutdown
-   (race `watch_for_error` against `service.waiting()` then
-   unconditional `drain`).
-3. Harness extensions in `tests/support/wire/harness.rs`:
-   `NotificationOutcome`, `assert_notification_then_alive`,
-   `request_with_timeout`, `SILENCE_TIMEOUT`, `LIVENESS_TIMEOUT`.
-4. Property body amendment dispatching spec-legal notifications
-   through `assert_notification_then_alive`.
-5. Un-ignore `prop_envelope_never_panics`.
-6. 15 new wire-pinned tests across `mcp_wire_negative.rs` and the
-   harness suite (10 for validation rules, 1 for pre-init ordering,
-   3 for closed-stdout audit semantics on both shutdown phases,
-   1 for the non-poisoning harness contract).
-7. Mirror docs (this spec, committed before implementation starts).
+   signature thread-through, two-phase shutdown for the
+   post-init path (race + drain), and `shutdown_after_init_failure`
+   for both init-failure arms (`ExpectedInitializeRequest` and
+   `InitializeFailed`).
+3. `mcp_wire_proptest.rs`: `prop_filter` on `arb_envelope()` to
+   exclude spec-legal notifications; un-ignore
+   `prop_envelope_never_panics`. No property-body changes beyond
+   that (no liveness probe, no non-poisoning harness method).
+4. Small harness extension for test 20: variant that holds stdin
+   open after sending. Existing closed-stdout helpers cover
+   tests 12-14 unchanged.
+5. 20 new wire-pinned tests in `mcp_wire_negative.rs`:
+   - 10 for validation rules (tests 1-10)
+   - 1 for pre-init ordering (test 11)
+   - 3 for closed-stdout audit semantics on both shutdown phases
+     (tests 12-14)
+   - 1 fixed-case notification path (test 15)
+   - 2 for Response/Error envelope forwarding (tests 16-17)
+   - 2 for malformed Response/Error rejection (tests 18-19)
+   - 1 for init-failure-with-open-stdin shutdown (test 20)
+6. Mirror docs (this spec, committed before implementation starts).
 
 Once green, PR #278 comes out of draft and goes to review with all
 three blockers (#275, #276, #277) resolved.

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -259,11 +259,31 @@ inbound stalls cannot cause outbound deadlock.
 
 ### Bridge-task supervisor
 
-`main.rs::run` races `service.waiting()` against the supervisor so a
-broken-pipe write from either bridge task short-circuits to an error
-return — recording `process_end.reason: Error` instead of `Eof`. This
-preserves the audit semantics established by #275 for pre-init write
-failures (`tests/mcp_wire_negative.rs::process_end_on_pre_init_write_failure`).
+The supervisor has two methods so the shutdown logic can both
+**fail-fast** during service runtime and **drain** after service
+completion — `service.waiting()` resolving `Ok(())` only proves
+rmcp finished writing to the duplex, not that the passthrough
+flushed those bytes to real stdout. Without the drain phase, a
+`BrokenPipe` on the final response would be silently lost.
+
+```rust
+impl ValidatorSupervisor {
+    /// Non-consuming. Resolves when either bridge task returns
+    /// `Err`, OR when both bridges exit `Ok` cleanly (an exotic
+    /// mid-service condition — usually one side stays alive
+    /// until the service ends and drains it). Used for fail-fast
+    /// during the `service.waiting()` race.
+    pub async fn watch_for_error(&mut self) -> io::Result<()>;
+
+    /// Consuming. Awaits both bridge tasks to completion;
+    /// returns the first error encountered. Used after
+    /// `service.waiting()` resolves so final-write failures
+    /// surface.
+    pub async fn drain(self) -> io::Result<()>;
+}
+```
+
+`main.rs::run` runs two phases — race, then drain:
 
 ```rust
 let validated = wire_validator::stdio_with_validation();
@@ -273,35 +293,59 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)
     Ok(svc) => svc,
     Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
         emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
-        // Drop the supervisor: both tasks see EOF/closed-duplex and exit.
-        return Ok(());
+        // Drop the supervisor (drain on the way out so any pre-init
+        // queued frames flush; failures surface as Err).
+        return match validated.supervisor.drain().await {
+            Ok(()) => Ok(()),
+            Err(e) => Err(anyhow!("validator bridge drain after pre-init: {e}")),
+        };
     }
     Err(ServerInitializeError::InitializeFailed(error_data)) => {
         return handle_initialize_failed(&error_data);
     }
-    Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+    Err(other) => return Err(anyhow!("MCP server init: {other}")),
 };
 
-let mcp_outcome = tokio::select! {
+let mut supervisor = validated.supervisor;
+let mut service_fut = Box::pin(service.waiting());
+
+// Phase 1: race service against bridge errors.
+let service_outcome: anyhow::Result<()> = tokio::select! {
     biased;
-    bridge_err = validated.supervisor.join() => {
-        bridge_err.map_err(|e| anyhow::anyhow!("validator bridge: {e}"))
+    bridge = supervisor.watch_for_error() => {
+        match bridge {
+            Err(e) => Err(anyhow!("validator bridge: {e}")),
+            Ok(()) => {
+                // Both bridges exited cleanly while service still
+                // running (exotic). Treat as a transport teardown
+                // and let service finish — it will see EOF.
+                (&mut service_fut).await.map_err(|e| anyhow!("rmcp: {e}"))
+            }
+        }
     }
-    result = service.waiting() => {
-        result.map_err(|e| anyhow::anyhow!("MCP server error: {e}"))
-    }
+    result = &mut service_fut => result.map_err(|e| anyhow!("rmcp: {e}")),
+};
+
+// Phase 2: drop service to release rmcp's transport ends, then drain.
+drop(service_fut);
+let drain_outcome = supervisor
+    .drain()
+    .await
+    .map_err(|e| anyhow!("validator bridge drain: {e}"));
+
+let mcp_outcome = match (service_outcome, drain_outcome) {
+    (Err(e), _) => Err(e),         // race-phase failure dominates
+    (Ok(()), Err(e)) => Err(e),    // drain-phase failure surfaces
+    (Ok(()), Ok(())) => Ok(()),
 };
 ```
 
-`biased` prefers the supervisor arm so a write error during a
-near-simultaneous EOF resolution still records as `Error`. After
-either arm wins, the dropped streams cascade EOF to the other path
-and any remaining queued audit work flushes via the existing
-`drainer_handle.await`.
-
-The `Validator entry point`'s code block returns to `main.rs`
-unchanged: same `mcp_outcome` then `emit_process_end(&audit, &mcp_outcome)`
-as today.
+The `biased` discriminator gives the supervisor arm priority on
+race-phase ties; the drain phase is unconditional after the race
+resolves so a final-write `BrokenPipe` always lands in
+`mcp_outcome: Err` → `process_end.reason: Error`. Any audit work
+still flushes via the existing `drainer_handle.await` further down
+in `main.rs::run`.
 
 ### Pre-init shares the validator stdout
 
@@ -432,13 +476,24 @@ Lines are emitted with a trailing `\n` and flushed, same as
   - swap the transport constructor (`stdio_with_validation()`),
   - thread `Arc<Mutex<Stdout>>` into `emit_pre_init_error_envelope` so
     pre-init rejections share the validator's stdout writer,
-  - race `service.waiting()` against `supervisor.join()` via
-    `tokio::select! { biased; ... }`.
+  - two-phase shutdown: race `service.waiting()` against
+    `supervisor.watch_for_error()` via `tokio::select! { biased; ... }`,
+    then unconditionally `supervisor.drain().await` before classifying
+    `mcp_outcome`.
 - **Modified:** `crates/rimap-server/src/mcp/mod.rs` — `pub mod wire_validator;`
+- **Modified:** `crates/rimap-server/tests/support/wire/harness.rs` —
+  - `pub enum NotificationOutcome { SilentThenAlive, UnexpectedResponse(String), FailedLiveness(CloseOrResponse) }`
+  - `pub async fn assert_notification_then_alive(&mut self, line, silence_dur, liveness_dur) -> NotificationOutcome`
+    that does not poison the harness on `SilentThenAlive`.
+  - `pub const SILENCE_TIMEOUT: Duration = Duration::from_millis(250);`
+  - `pub const LIVENESS_TIMEOUT: Duration = Duration::from_secs(1);`
+  - `pub async fn request_with_timeout(&mut self, method, params, dur) -> CloseOrResponse`
+    (small extension; reuses the existing send + `response_or_close` core
+    with a parameterized timeout).
 - **Modified:** `crates/rimap-server/tests/mcp_wire_proptest.rs:310` —
   remove the `#[ignore]` from `prop_envelope_never_panics`, and amend
-  the property body to recognize spec-legal notifications (see
-  "Property body adjustment").
+  the property body to dispatch spec-legal notifications through
+  `assert_notification_then_alive` (see "Property body adjustment").
 - **Modified:** `crates/rimap-server/tests/mcp_wire_negative.rs` — new
   pinned tests (see "Testing" below).
 - **No changes to** `crates/rimap-server/src/mcp/preinit.rs` itself —
@@ -451,7 +506,59 @@ Lines are emitted with a trailing `\n` and flushed, same as
 as a `panic!`. After the validator lands, the only remaining `Hung`
 source is the spec-compliant silent-ignore path: valid JSON-RPC 2.0
 notifications (`jsonrpc:"2.0"`, no `id`, non-standard `method`). The
-property body must distinguish that case from a real hang:
+property body must distinguish that case from a real hang — AND not
+poison the harness, since `Harness::response_or_close` poisons on
+every `Hung` outcome (`harness.rs:514-516`). Poisoning means
+`with_live_harness` respawns the harness for the next case,
+defeating the throughput rationale for accepting notifications at
+all.
+
+### Non-poisoning probe on the harness
+
+Add a method to `Harness` (in `tests/support/wire/harness.rs`) that
+handles the entire send → expected-silence → liveness-ping pattern
+atomically without poisoning on the spec-legal silent timeout:
+
+```rust
+pub enum NotificationOutcome {
+    /// Expected: notification produced no response, ping confirmed
+    /// the server is still responsive.
+    SilentThenAlive,
+    /// Spec violation: notification produced a response.
+    UnexpectedResponse(String),
+    /// Liveness ping failed (hung, crashed, or closed unexpectedly).
+    /// Harness IS poisoned in this case.
+    FailedLiveness(CloseOrResponse),
+}
+
+/// Send `line` as a notification (no response expected), wait
+/// `silence_dur` to confirm no response arrives, then send a `ping`
+/// request and require a well-formed response within `liveness_dur`.
+///
+/// `self.poisoned` is set to `true` ONLY for `UnexpectedResponse`
+/// and `FailedLiveness` outcomes — the `SilentThenAlive` path
+/// leaves the harness usable so subsequent proptest cases can reuse it.
+pub async fn assert_notification_then_alive(
+    &mut self,
+    line: &str,
+    silence_dur: Duration,
+    liveness_dur: Duration,
+) -> NotificationOutcome;
+```
+
+Behavior detail:
+- Send `line` via `send_line`.
+- Read with timeout `silence_dur`. If a line arrives:
+  → `UnexpectedResponse(line)`, set `poisoned = true`.
+- If `silence_dur` elapses with no read: **do not poison** (this is
+  the spec-legal outcome). Continue to liveness probe.
+- Send a `ping` request via `request_with_timeout("ping", json!({}), liveness_dur)`.
+- If `CloseOrResponse::Response` with a well-formed result envelope:
+  → `SilentThenAlive`, harness stays usable.
+- Otherwise (Hung, CleanClose, Crashed): → `FailedLiveness(outcome)`,
+  `poisoned = true`.
+
+### Property body using the probe
 
 ```rust
 let is_spec_legal_notification = envelope
@@ -459,37 +566,38 @@ let is_spec_legal_notification = envelope
     && envelope.get("id").is_none()
     && envelope.get("method").and_then(|v| v.as_str()).is_some();
 
-// ...
-match outcome {
-    CloseOrResponse::Response(line) => assert_envelope_valid(&parsed),
-    CloseOrResponse::CleanClose => {},
-    CloseOrResponse::Crashed(d) => panic!("crashed: {d}"),
-    CloseOrResponse::Hung if is_spec_legal_notification => {
-        // JSON-RPC §4.1 permits no response. BUT silence by itself
-        // doesn't prove the server is healthy — it could be hung
-        // or deadlocked. Send a `ping` request and require a
-        // well-formed response within LIVENESS_TIMEOUT; otherwise
-        // the notification poisoned the session and the property
-        // must fail.
-        let ping_outcome = h
-            .request_with_timeout("ping", json!({}), LIVENESS_TIMEOUT)
-            .await;
-        match ping_outcome {
-            CloseOrResponse::Response(line) => {
-                let env: Value = serde_json::from_str(line.trim_end())
-                    .expect("ping response must be valid JSON");
-                assert_envelope_valid(&env);
-                assert!(
-                    env.get("result").is_some(),
-                    "ping after notification {envelope} did not return a result envelope",
-                );
-            }
-            other => panic!(
-                "ping liveness check failed after notification {envelope}: {other:?}",
-            ),
-        }
+if is_spec_legal_notification {
+    match h
+        .assert_notification_then_alive(
+            &envelope.to_string(),
+            SILENCE_TIMEOUT,
+            LIVENESS_TIMEOUT,
+        )
+        .await
+    {
+        NotificationOutcome::SilentThenAlive => {} // pass; harness stays usable
+        NotificationOutcome::UnexpectedResponse(line) => panic!(
+            "notification {envelope} produced a response: {line}",
+        ),
+        NotificationOutcome::FailedLiveness(o) => panic!(
+            "ping after notification {envelope} failed liveness: {o:?}",
+        ),
     }
-    CloseOrResponse::Hung => panic!("hung on {envelope}"),
+    return h;
+}
+
+// Non-notification path: the existing flow.
+h.send_line(&envelope.to_string()).await;
+let outcome = h.response_or_close(REQUEST_TIMEOUT).await;
+match outcome {
+    CloseOrResponse::Response(line) => {
+        let env: Value = serde_json::from_str(line.trim_end())
+            .expect("server response must be valid JSON");
+        assert_envelope_valid(&env);
+    }
+    CloseOrResponse::CleanClose => {} // harness already poisoned by harness.rs
+    CloseOrResponse::Crashed(d) => panic!("crashed on {envelope}: {d}"),
+    CloseOrResponse::Hung => panic!("hung on {envelope} (post-validator)"),
 }
 ```
 
@@ -498,22 +606,35 @@ strategy, so the missing-`jsonrpc` cases that originally triggered
 #277 stay in coverage and exercise the validator's reject path. The
 strategy is unchanged.
 
-**Liveness check rationale.** `CloseOrResponse::Hung` is just "no
-bytes within `REQUEST_TIMEOUT`" — it does not prove the child process
-is alive or responsive. Without the follow-up `ping`, a panic-on-
-notification or a deadlock-on-notification would be silently
-classified as spec-legal silence and the property would respawn the
-harness, defeating the `never_panics` guarantee for this input class.
-The ping forces the server to *demonstrate* it is still processing
-requests before we accept the case. `LIVENESS_TIMEOUT` is a new
-harness constant (suggested 1 s — same order as `REQUEST_TIMEOUT`)
-and `request_with_timeout` is a small extension to the existing
-`Harness::request` API.
+**New constants** in `harness.rs`:
+- `SILENCE_TIMEOUT: Duration = Duration::from_millis(250)` — long
+  enough that a spec-legal notification doesn't false-positive as
+  `UnexpectedResponse`, short enough that 1000 cases × 25% × 250ms
+  ≈ 62.5s isn't unbearable. Tunable.
+- `LIVENESS_TIMEOUT: Duration = Duration::from_secs(1)` — same order
+  as the existing `REQUEST_TIMEOUT`.
 
-**Overhead.** Roughly 25% of generated envelopes are notification-
-shaped under the current strategy. Each contributes one extra ping
-round-trip (~5–10 ms on the local harness without Dovecot). Total
-overhead on a 1000-case run: ~2.5 s. Acceptable and stable.
+**Liveness rationale.** `Hung` is just "no bytes within timeout" — it
+does not prove the child process is responsive. Without the ping, a
+panic-on-notification or a deadlock-on-notification would be silently
+classified as spec-legal silence, defeating the `never_panics`
+guarantee for this input class. The probe forces the server to
+*demonstrate* it is still processing requests before the case passes.
+
+**Overhead under 1000-case runs.** Roughly 25% of envelopes are
+notification-shaped → ~250 cases each pay `SILENCE_TIMEOUT` +
+`LIVENESS_TIMEOUT` round-trip (`~250ms + ~5ms ≈ 255ms`). Total
+overhead: ~64s. Significantly larger than the prior estimate
+(~2.5s); the SILENCE_TIMEOUT dominates. Trade-off note:
+shortening `SILENCE_TIMEOUT` to e.g. 50ms cuts overhead 5× at the
+cost of false-positive risk on slow systems. The 250ms default
+matches the rmcp `FramedRead` poll cadence and gives generous
+margin; nightly runs can override via env var if needed.
+
+Critically, this is the cost of the **probe**, NOT the cost of
+respawning the harness — which under the original (poisoning) design
+would have been ~1.5s × 250 cases ≈ 6 minutes. The non-poisoning
+probe is what keeps the property practical.
 
 ## Testing
 
@@ -562,16 +683,32 @@ and id):
     error to `mcp_outcome`, audit records `process_end.reason: Error`,
     exit is non-zero. Mirrors #275's `process_end_on_pre_init_write_failure`.
 13. `process_end_on_rmcp_response_write_failure` — closed-stdout
-    harness variant: client sends a valid `tools/list`, rmcp's
-    response write into the passthrough fails downstream, supervisor
-    surfaces the error to `mcp_outcome`, audit records
-    `process_end.reason: Error`, exit is non-zero. Companion to test
-    12 for the outbound bridge.
+    harness variant during race phase: client sends a valid
+    `tools/list`, rmcp's response write into the passthrough fails
+    while `service.waiting()` is still running, `watch_for_error`
+    catches it, audit records `process_end.reason: Error`, exit
+    non-zero. Companion to test 12 for the outbound bridge.
+14. `process_end_on_drain_phase_write_failure` — closed-stdout
+    harness variant during drain phase: client sends valid
+    `initialize` + `tools/list`, then closes stdin so `service.waiting()`
+    resolves `Ok(())`. rmcp's `tools/list` response is queued in the
+    outbound duplex but the passthrough's write to (closed) stdout
+    fails. `supervisor.drain()` surfaces the error, audit records
+    `process_end.reason: Error`, exit non-zero. Pins the race-vs-drain
+    distinction.
+15. `harness_notification_probe_does_not_poison` — unit test on the
+    harness alone (no proptest involvement): construct a harness,
+    complete the initialize handshake, call
+    `assert_notification_then_alive("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":0}}", SILENCE_TIMEOUT, LIVENESS_TIMEOUT)`,
+    assert the outcome is `SilentThenAlive`, then assert
+    `harness.is_usable() == true`. Pins the non-poisoning contract
+    so a regression in the harness method gets caught before the
+    proptest runs it 250 times per session.
 
 All tests run against the production binary via the existing
-`Harness` — no test-only hooks needed in the validator. Tests 12 and
-13 use the closed-stdout harness variant added in
-`tests/support/wire/harness.rs` for #275.
+`Harness`. Tests 12, 13, and 14 use the closed-stdout harness variant
+added in `tests/support/wire/harness.rs` for #275. Test 15 exercises
+the new `assert_notification_then_alive` method in isolation.
 
 **Unit tests** in `wire_validator.rs::tests` covering `validate()` in
 isolation, one assertion per row of the validation rules table. Pure
@@ -618,15 +755,30 @@ this should hold by construction.
   with `BrokenPipe` and `service.waiting()` could resolve `Ok(())`
   on its own EOF path, recording `process_end.reason: Eof` even
   though no response ever reached the client. Mitigation: the
-  supervisor races `service.waiting()` via `tokio::select!` with
-  `biased` priority on the supervisor arm, and tests 12 and 13
-  pin the audit semantics on both bridge sides.
+  supervisor uses two-phase shutdown — `watch_for_error()` for
+  race-phase fail-fast plus an unconditional `drain()` after
+  service completion. Tests 12, 13, and 14 pin the audit
+  semantics on both bridges across both shutdown phases.
+- **Drain-phase write failure invisibility.** If we only raced
+  `service.waiting()` against the supervisor and short-circuited
+  on whichever resolved first, `service.waiting() → Ok(())` could
+  fire while a final passthrough frame is still queued in the
+  duplex; a subsequent `BrokenPipe` on that write would be lost.
+  Mitigation: drain is unconditional after the race; test 14
+  exercises exactly this ordering.
 - **Notification liveness blind spot.** The property's amended
   arm for spec-legal notifications must prove the server is still
   responsive, not merely silent. Mitigation: each notification-
-  shaped `Hung` is followed by a `ping` round-trip with a bounded
-  timeout — a hung or crashed server fails the case instead of
-  being respawned as "spec-legal silence."
+  shaped envelope dispatches through `assert_notification_then_alive`
+  which sends a `ping` after the silence wait — a hung or crashed
+  server fails the case instead of being respawned as "spec-legal
+  silence."
+- **Harness poisoning kills proptest throughput.** The existing
+  `Harness::response_or_close` poisons on every `Hung`, so a naïve
+  liveness-ping after `Hung` would still leave the harness flagged
+  for respawn. Mitigation: `assert_notification_then_alive` owns
+  the entire send → silence → ping cycle and only poisons on
+  actual liveness failure. Test 15 pins the non-poisoning contract.
 
 ## Dependencies and merge plan
 
@@ -634,18 +786,24 @@ This fix is the final merge blocker for PR #278 (the #266 fuzzing
 umbrella). The implementation lands on
 `feature/issue-266-mcp-fuzzing` directly, in one diff that includes:
 
-1. `wire_validator.rs` with `ValidatedStdio` / `ValidatorSupervisor`,
-   the `validate()` pure function, and the two bridge tasks.
-2. `main.rs` updates: transport swap, supervisor `tokio::select!`,
-   `emit_pre_init_error_envelope` signature thread-through.
-3. Property body amendment for `is_spec_legal_notification` and the
-   liveness ping (with `LIVENESS_TIMEOUT` + `request_with_timeout`
-   on the harness if not present).
-4. Un-ignore `prop_envelope_never_panics`.
-5. 13 new wire-pinned tests in `mcp_wire_negative.rs` (10 for the
-   validation rules, 1 for pre-init ordering, 2 for closed-stdout
-   audit semantics).
-6. Mirror docs (this spec, committed before implementation starts).
+1. `wire_validator.rs` with `ValidatedStdio` / `ValidatorSupervisor`
+   (`watch_for_error` + `drain`), the `validate()` pure function,
+   and the two bridge tasks.
+2. `main.rs` updates: transport swap, `emit_pre_init_error_envelope`
+   signature thread-through, two-phase shutdown
+   (race `watch_for_error` against `service.waiting()` then
+   unconditional `drain`).
+3. Harness extensions in `tests/support/wire/harness.rs`:
+   `NotificationOutcome`, `assert_notification_then_alive`,
+   `request_with_timeout`, `SILENCE_TIMEOUT`, `LIVENESS_TIMEOUT`.
+4. Property body amendment dispatching spec-legal notifications
+   through `assert_notification_then_alive`.
+5. Un-ignore `prop_envelope_never_panics`.
+6. 15 new wire-pinned tests across `mcp_wire_negative.rs` and the
+   harness suite (10 for validation rules, 1 for pre-init ordering,
+   3 for closed-stdout audit semantics on both shutdown phases,
+   1 for the non-poisoning harness contract).
+7. Mirror docs (this spec, committed before implementation starts).
 
 Once green, PR #278 comes out of draft and goes to review with all
 three blockers (#275, #276, #277) resolved.

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -100,12 +100,14 @@ completes:
 5. **Session stays alive after rejection**: the next valid envelope on
    the wire continues to dispatch normally.
 
-Pre-initialize handling is unchanged. The validator and the existing
-`preinit.rs` are independent: `preinit` handles
-`ServerInitializeError::ExpectedInitializeRequest` from rmcp (a
-semantically-wrong-but-syntactically-valid first message); the validator
-catches everything that rmcp's codec would otherwise silently drop, both
-pre- and post-initialize.
+Pre-initialize handling is otherwise unchanged — `preinit` still owns
+`ServerInitializeError::ExpectedInitializeRequest` (a
+semantically-wrong-but-syntactically-valid first message), and the
+validator catches everything that rmcp's codec would otherwise silently
+drop, both pre- and post-initialize. **One mechanical change is
+required**: `emit_pre_init_error_envelope` in `main.rs` writes to real
+stdout and so must lock the validator's shared mutex — see "Pre-init
+shares the validator stdout" below.
 
 ### Why respond rather than close
 
@@ -130,13 +132,18 @@ Replace `rmcp::transport::io::stdio()` in
 rmcp's transport via `tokio::io::duplex`:
 
 ```
-                          ┌──────────── Arc<Mutex<Stdout>> ───────────┐
-                          ↓ (rejections)                              ↓ (rmcp frames)
-real stdin → [validator] ─┴─valid line─→ duplex_in.our_end            │
-                                         duplex_in.rmcp_end → rmcp ───┤
-                            duplex_out.our_end ← duplex_out.rmcp_end ←┘
-                              ↓
-                          [passthrough] ─────────────────────────→ real stdout
+                       ┌──── Arc<Mutex<Stdout>> ─ shared writer ────┐
+                       ↑ rejections     ↑ rmcp frames     ↑ pre-init envelope
+                       │                │                 │
+real stdin → [validator] ──valid line→ duplex_in.our_end  │     main.rs::run
+                                       duplex_in.rmcp_end →─→ rmcp transport
+                       [passthrough] ← duplex_out.our_end ←─ duplex_out.rmcp_end
+                                          │
+                                          └──── locks shared writer ──→ real stdout
+
+   supervisor.join() races service.waiting() in main.rs:
+     - validator/passthrough JoinHandle errors → mcp_outcome: Err → process_end.reason: Error
+     - clean EOF on both directions               → mcp_outcome: Ok  → process_end.reason: Eof
 ```
 
 Two background tokio tasks live for the lifetime of the MCP session,
@@ -169,8 +176,10 @@ drops its inbound duplex end → rmcp's `FramedRead` sees EOF on its
 next poll → `service.waiting()` resolves cleanly. EOF on the
 outbound duplex (rmcp dropped) → passthrough exits → tasks complete.
 Broken pipe on real stdout propagates as `io::Error` from the locked
-write; whichever task hit it logs and exits, the other follows when
-its duplex peer drops.
+write; the affected bridge task returns that error from its
+`JoinHandle` and the supervisor surfaces it to `main.rs::run` so
+`process_end.reason: Error` is recorded (see "Bridge-task supervisor"
+below).
 
 rmcp's `IntoTransport` impl
 (`rmcp/transport/async_rw.rs:22-31`) accepts any
@@ -180,30 +189,67 @@ rmcp.
 
 ### Validator entry point
 
+The validator returns a struct rather than a bare tuple so the bridge
+tasks' lifecycle, the shared stdout writer, and the rmcp-facing
+transport are owned together. The shared stdout is exposed so all
+synchronized stdout writers in the process (validator rejections,
+passthrough frames, **and** the pre-init error envelope emitted from
+`main.rs`) lock the same mutex — see "Pre-init shares the validator
+stdout" below.
+
 ```rust
 // crates/rimap-server/src/mcp/wire_validator.rs
 
-/// Return a transport-compatible (read, write) pair that pre-validates
-/// JSON-RPC 2.0 envelopes on the inbound side. Invalid envelopes are
-/// rejected directly to real stdout; valid envelopes are forwarded to
-/// the returned read half. The write half is bridged to real stdout
-/// unchanged.
-///
-/// Drop both returned streams to terminate the background tasks.
-pub fn stdio_with_validation() -> (DuplexStream, DuplexStream) {
+pub struct ValidatedStdio {
+    /// Hand to rmcp via `rmcp::serve_server(server, validated.transport)`.
+    pub transport: (DuplexStream, DuplexStream),
+    /// Shared writer for synchronized stdout output. `main.rs`'s
+    /// pre-init error path locks this same mutex; the bridge tasks
+    /// hold `Arc::clone`s.
+    pub stdout: Arc<tokio::sync::Mutex<tokio::io::Stdout>>,
+    /// Bridge-task supervisor; must be polled alongside
+    /// `service.waiting()` so write errors propagate.
+    pub supervisor: ValidatorSupervisor,
+}
+
+pub struct ValidatorSupervisor {
+    inbound: JoinHandle<io::Result<()>>,
+    outbound: JoinHandle<io::Result<()>>,
+}
+
+impl ValidatorSupervisor {
+    /// Resolves with the first bridge-task error encountered, or
+    /// `Ok(())` once both tasks exit cleanly (the normal EOF path).
+    ///
+    /// On error from either task, the other is aborted; both
+    /// duplex ends are dropped, which surfaces to rmcp as a
+    /// transport error on its next read/write.
+    pub async fn join(mut self) -> io::Result<()> { ... }
+}
+
+/// Build the validated stdio transport. The two bridge tasks are
+/// spawned immediately; their lifecycle is exposed via `supervisor`.
+pub fn stdio_with_validation() -> ValidatedStdio {
     let (inbound_our_end, inbound_rmcp_end) = tokio::io::duplex(BUF_SIZE);
     let (outbound_rmcp_end, outbound_our_end) = tokio::io::duplex(BUF_SIZE);
 
     let stdout = Arc::new(tokio::sync::Mutex::new(tokio::io::stdout()));
 
-    tokio::spawn(validate_inbound(
+    let inbound = tokio::spawn(validate_inbound(
         tokio::io::stdin(),
         inbound_our_end,
         Arc::clone(&stdout),
     ));
-    tokio::spawn(passthrough_outbound(outbound_our_end, stdout));
+    let outbound = tokio::spawn(passthrough_outbound(
+        outbound_our_end,
+        Arc::clone(&stdout),
+    ));
 
-    (inbound_rmcp_end, outbound_rmcp_end)
+    ValidatedStdio {
+        transport: (inbound_rmcp_end, outbound_rmcp_end),
+        stdout,
+        supervisor: ValidatorSupervisor { inbound, outbound },
+    }
 }
 ```
 
@@ -211,15 +257,92 @@ pub fn stdio_with_validation() -> (DuplexStream, DuplexStream) {
 fits in a single write; both directions are independent tasks so
 inbound stalls cannot cause outbound deadlock.
 
-`main.rs::run` swap:
+### Bridge-task supervisor
+
+`main.rs::run` races `service.waiting()` against the supervisor so a
+broken-pipe write from either bridge task short-circuits to an error
+return — recording `process_end.reason: Error` instead of `Eof`. This
+preserves the audit semantics established by #275 for pre-init write
+failures (`tests/mcp_wire_negative.rs::process_end_on_pre_init_write_failure`).
 
 ```rust
-- let transport = rmcp::transport::io::stdio();
-+ let transport = rimap_server::mcp::wire_validator::stdio_with_validation();
+let validated = wire_validator::stdio_with_validation();
+let stdout_for_preinit = Arc::clone(&validated.stdout);
+
+let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)).await {
+    Ok(svc) => svc,
+    Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+        emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
+        // Drop the supervisor: both tasks see EOF/closed-duplex and exit.
+        return Ok(());
+    }
+    Err(ServerInitializeError::InitializeFailed(error_data)) => {
+        return handle_initialize_failed(&error_data);
+    }
+    Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+};
+
+let mcp_outcome = tokio::select! {
+    biased;
+    bridge_err = validated.supervisor.join() => {
+        bridge_err.map_err(|e| anyhow::anyhow!("validator bridge: {e}"))
+    }
+    result = service.waiting() => {
+        result.map_err(|e| anyhow::anyhow!("MCP server error: {e}"))
+    }
+};
 ```
 
-`rmcp::serve_server(mcp_server, transport)` accepts the duplex pair
-via `IntoTransport::<RoleServer, std::io::Error, TransportAdapterAsyncRW>::into_transport`.
+`biased` prefers the supervisor arm so a write error during a
+near-simultaneous EOF resolution still records as `Error`. After
+either arm wins, the dropped streams cascade EOF to the other path
+and any remaining queued audit work flushes via the existing
+`drainer_handle.await`.
+
+The `Validator entry point`'s code block returns to `main.rs`
+unchanged: same `mcp_outcome` then `emit_process_end(&audit, &mcp_outcome)`
+as today.
+
+### Pre-init shares the validator stdout
+
+`main.rs`'s `emit_pre_init_error_envelope` currently writes directly to
+`tokio::io::stdout()` (`main.rs:199-211`). After the transport swap,
+the bridge tasks hold the synchronized stdout writer; a direct
+`tokio::io::stdout()` write from `emit_pre_init_error_envelope` races
+the passthrough task and can corrupt line-delimited output (e.g. a
+pre-init `ping` request arrives, rmcp emits a response via passthrough,
+and the next line is a `tools/list` rejection envelope — interleaved
+mid-line).
+
+Mechanical change to `main.rs`:
+
+```rust
+async fn emit_pre_init_error_envelope(
+    msg: &rmcp::model::ClientJsonRpcMessage,
+    stdout: &Arc<tokio::sync::Mutex<tokio::io::Stdout>>,
+) -> anyhow::Result<()> {
+    let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(msg) else {
+        return Ok(());
+    };
+    let mut out = stdout.lock().await;
+    out.write_all(line.as_bytes())
+        .await
+        .context("writing pre-init error envelope to stdout")?;
+    out.flush()
+        .await
+        .context("flushing pre-init error envelope")?;
+    Ok(())
+}
+```
+
+`preinit::synthesize_pre_init_error_envelope` itself is unchanged — it
+remains a pure formatter. Only the caller in `main.rs` and the
+function's signature change.
+
+The new pre-init wire test
+`preinit_envelope_does_not_interleave_with_rmcp_frame` (see "Testing")
+exercises the formerly racy ordering and asserts both stdout lines
+parse cleanly.
 
 ### Validation rules
 
@@ -294,16 +417,23 @@ Lines are emitted with a trailing `\n` and flushed, same as
 ## File layout
 
 - **New:** `crates/rimap-server/src/mcp/wire_validator.rs`
-  - `pub fn stdio_with_validation() -> (DuplexStream, DuplexStream)` —
-    entry point used by `main.rs`.
+  - `pub struct ValidatedStdio { transport, stdout, supervisor }` and
+    `pub fn stdio_with_validation() -> ValidatedStdio` — entry point
+    used by `main.rs`.
+  - `pub struct ValidatorSupervisor` with `pub async fn join(self) -> io::Result<()>`.
   - `fn validate(line: &str) -> ValidationOutcome` — pure
     function, no I/O. Unit-testable in isolation.
   - `enum ValidationOutcome { Forward, Skip, Reject(ErrorEnvelope) }`
   - `fn synthesize_error_envelope(code: i32, message: &str, id: Option<Value>) -> String`
   - `async fn validate_inbound(...)` and `async fn passthrough_outbound(...)` —
-    the two background tasks.
-- **Modified:** `crates/rimap-server/src/main.rs:140` — swap the
-  transport constructor as above. One-line change.
+    the two bridge tasks, each returning `io::Result<()>` so write
+    failures surface via the supervisor's `JoinHandle`s.
+- **Modified:** `crates/rimap-server/src/main.rs` —
+  - swap the transport constructor (`stdio_with_validation()`),
+  - thread `Arc<Mutex<Stdout>>` into `emit_pre_init_error_envelope` so
+    pre-init rejections share the validator's stdout writer,
+  - race `service.waiting()` against `supervisor.join()` via
+    `tokio::select! { biased; ... }`.
 - **Modified:** `crates/rimap-server/src/mcp/mod.rs` — `pub mod wire_validator;`
 - **Modified:** `crates/rimap-server/tests/mcp_wire_proptest.rs:310` —
   remove the `#[ignore]` from `prop_envelope_never_panics`, and amend
@@ -311,9 +441,9 @@ Lines are emitted with a trailing `\n` and flushed, same as
   "Property body adjustment").
 - **Modified:** `crates/rimap-server/tests/mcp_wire_negative.rs` — new
   pinned tests (see "Testing" below).
-- **No changes to** `crates/rimap-server/src/mcp/preinit.rs` — its
-  responsibility (intercepting `ServerInitializeError::ExpectedInitializeRequest`
-  from rmcp) is orthogonal.
+- **No changes to** `crates/rimap-server/src/mcp/preinit.rs` itself —
+  its `synthesize_pre_init_error_envelope` remains a pure formatter;
+  the I/O caller in `main.rs` is what changes.
 
 ## Property body adjustment (case 2)
 
@@ -335,11 +465,29 @@ match outcome {
     CloseOrResponse::CleanClose => {},
     CloseOrResponse::Crashed(d) => panic!("crashed: {d}"),
     CloseOrResponse::Hung if is_spec_legal_notification => {
-        // JSON-RPC §4.1: server MUST NOT reply to a notification.
-        // Silence within REQUEST_TIMEOUT is the correct outcome.
-        // Harness is poisoned by the timeout path; `with_live_harness`
-        // respawns on the next case. The throughput cost is the
-        // proptest's choice, not the server's.
+        // JSON-RPC §4.1 permits no response. BUT silence by itself
+        // doesn't prove the server is healthy — it could be hung
+        // or deadlocked. Send a `ping` request and require a
+        // well-formed response within LIVENESS_TIMEOUT; otherwise
+        // the notification poisoned the session and the property
+        // must fail.
+        let ping_outcome = h
+            .request_with_timeout("ping", json!({}), LIVENESS_TIMEOUT)
+            .await;
+        match ping_outcome {
+            CloseOrResponse::Response(line) => {
+                let env: Value = serde_json::from_str(line.trim_end())
+                    .expect("ping response must be valid JSON");
+                assert_envelope_valid(&env);
+                assert!(
+                    env.get("result").is_some(),
+                    "ping after notification {envelope} did not return a result envelope",
+                );
+            }
+            other => panic!(
+                "ping liveness check failed after notification {envelope}: {other:?}",
+            ),
+        }
     }
     CloseOrResponse::Hung => panic!("hung on {envelope}"),
 }
@@ -350,13 +498,22 @@ strategy, so the missing-`jsonrpc` cases that originally triggered
 #277 stay in coverage and exercise the validator's reject path. The
 strategy is unchanged.
 
-The harness respawn overhead (every notification-shaped case triggers
-`with_live_harness` to spawn a fresh server) is acceptable for 1000-
-case property runs and matches the cost we already pay for
-`CleanClose` outcomes in #275/#276 tests. If the overhead becomes a
-problem under nightly higher case counts, a follow-up can add a
-`send_notification_and_confirm_silence(line, dur)` harness method
-that doesn't poison on timeout.
+**Liveness check rationale.** `CloseOrResponse::Hung` is just "no
+bytes within `REQUEST_TIMEOUT`" — it does not prove the child process
+is alive or responsive. Without the follow-up `ping`, a panic-on-
+notification or a deadlock-on-notification would be silently
+classified as spec-legal silence and the property would respawn the
+harness, defeating the `never_panics` guarantee for this input class.
+The ping forces the server to *demonstrate* it is still processing
+requests before we accept the case. `LIVENESS_TIMEOUT` is a new
+harness constant (suggested 1 s — same order as `REQUEST_TIMEOUT`)
+and `request_with_timeout` is a small extension to the existing
+`Harness::request` API.
+
+**Overhead.** Roughly 25% of generated envelopes are notification-
+shaped under the current strategy. Each contributes one extra ping
+round-trip (~5–10 ms on the local harness without Dovecot). Total
+overhead on a 1000-case run: ~2.5 s. Acceptable and stable.
 
 ## Testing
 
@@ -393,9 +550,28 @@ and id):
 10. `session_survives_invalid_envelope` — valid `initialize` →
     invalid envelope → valid `tools/list`. The third message gets a
     normal response; the session is not closed.
+11. `preinit_envelope_does_not_interleave_with_rmcp_frame` — pre-init
+    `ping` (which rmcp answers via the passthrough) immediately
+    followed by a pre-init `tools/list` (which `emit_pre_init_error_envelope`
+    rejects with `-32002`) → both stdout lines parse as well-formed,
+    distinct JSON-RPC envelopes with the expected `id` mapping. Pins
+    the new shared-stdout invariant.
+12. `process_end_on_validator_rejection_write_failure` — closed-stdout
+    harness variant: client sends an invalid envelope, validator's
+    `-32600` write fails with `BrokenPipe`, supervisor surfaces the
+    error to `mcp_outcome`, audit records `process_end.reason: Error`,
+    exit is non-zero. Mirrors #275's `process_end_on_pre_init_write_failure`.
+13. `process_end_on_rmcp_response_write_failure` — closed-stdout
+    harness variant: client sends a valid `tools/list`, rmcp's
+    response write into the passthrough fails downstream, supervisor
+    surfaces the error to `mcp_outcome`, audit records
+    `process_end.reason: Error`, exit is non-zero. Companion to test
+    12 for the outbound bridge.
 
 All tests run against the production binary via the existing
-`Harness` — no test-only hooks needed in the validator.
+`Harness` — no test-only hooks needed in the validator. Tests 12 and
+13 use the closed-stdout harness variant added in
+`tests/support/wire/harness.rs` for #275.
 
 **Unit tests** in `wire_validator.rs::tests` covering `validate()` in
 isolation, one assertion per row of the validation rules table. Pure
@@ -425,16 +601,32 @@ this should hold by construction.
   far larger than any sane envelope. Mitigation: leave the buffer
   generous; the proptest will exercise heterogeneous envelope sizes.
 - **Async cancellation safety.** The validator and passthrough tasks
-  are spawned with `tokio::spawn`; they own their I/O handles and
-  drop them on task exit. Cancellation on the outer runtime cancels
-  the tasks, which closes the duplex ends, which surfaces to rmcp as
-  EOF or write-error — the same shutdown shape as today's direct
-  stdio transport.
+  are spawned with `tokio::spawn`; the supervisor owns their
+  `JoinHandle`s. On `service.waiting()` resolution the supervisor's
+  `join()` is dropped, which aborts the tasks; the tasks own their
+  I/O handles and drop them on exit, surfacing EOF/write-error to
+  rmcp. Same shutdown shape as today's direct stdio transport, with
+  the added guarantee that a write error from either task is
+  captured by `tokio::select!` before the supervisor is dropped.
 - **Backpressure under sustained malformed input.** Each rejection
   writes to real stdout from the validator task. A slow consumer
   could stall the validator; that's identical to today's stall
   behavior on rmcp's outbound write under a slow consumer, and is
   out of scope.
+- **Audit-record masking by silent task failures.** Without the
+  supervisor (the original spec draft), a bridge task could die
+  with `BrokenPipe` and `service.waiting()` could resolve `Ok(())`
+  on its own EOF path, recording `process_end.reason: Eof` even
+  though no response ever reached the client. Mitigation: the
+  supervisor races `service.waiting()` via `tokio::select!` with
+  `biased` priority on the supervisor arm, and tests 12 and 13
+  pin the audit semantics on both bridge sides.
+- **Notification liveness blind spot.** The property's amended
+  arm for spec-legal notifications must prove the server is still
+  responsive, not merely silent. Mitigation: each notification-
+  shaped `Hung` is followed by a `ping` round-trip with a bounded
+  timeout — a hung or crashed server fails the case instead of
+  being respawned as "spec-legal silence."
 
 ## Dependencies and merge plan
 
@@ -442,12 +634,18 @@ This fix is the final merge blocker for PR #278 (the #266 fuzzing
 umbrella). The implementation lands on
 `feature/issue-266-mcp-fuzzing` directly, in one diff that includes:
 
-1. `wire_validator.rs` and `main.rs` swap.
-2. Property body amendment for `is_spec_legal_notification` (case 2
-   distinction).
-3. Un-ignore `prop_envelope_never_panics`.
-4. The 10 new wire-pinned tests in `mcp_wire_negative.rs`.
-5. Mirror docs (this spec is committed before implementation starts).
+1. `wire_validator.rs` with `ValidatedStdio` / `ValidatorSupervisor`,
+   the `validate()` pure function, and the two bridge tasks.
+2. `main.rs` updates: transport swap, supervisor `tokio::select!`,
+   `emit_pre_init_error_envelope` signature thread-through.
+3. Property body amendment for `is_spec_legal_notification` and the
+   liveness ping (with `LIVENESS_TIMEOUT` + `request_with_timeout`
+   on the harness if not present).
+4. Un-ignore `prop_envelope_never_panics`.
+5. 13 new wire-pinned tests in `mcp_wire_negative.rs` (10 for the
+   validation rules, 1 for pre-init ordering, 2 for closed-stdout
+   audit semantics).
+6. Mirror docs (this spec, committed before implementation starts).
 
 Once green, PR #278 comes out of draft and goes to review with all
 three blockers (#275, #276, #277) resolved.

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -311,33 +311,74 @@ impl ValidatorSupervisor {
 let validated = wire_validator::stdio_with_validation();
 let stdout_for_preinit = Arc::clone(&validated.stdout);
 
-let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)).await {
+let mut supervisor = validated.supervisor;
+let mut init_fut = Box::pin(rmcp::serve_server(mcp_server, validated.transport));
+
+// Race init against bridge errors. Without this, a bridge BrokenPipe
+// during the pre-initialize phase (e.g. client sends a pre-init `ping`
+// rmcp accepts, then stdout breaks before the response flushes) goes
+// unobserved while rmcp waits indefinitely for `initialize`. The
+// process would hang and never record `process_end.reason: Error`.
+let init_outcome = tokio::select! {
+    biased;
+    bridge = supervisor.watch_for_error() => {
+        // Bridge failed (or both bridges exited) before init resolved.
+        Err(InitOutcome::Bridge(bridge))
+    }
+    result = &mut init_fut => match result {
+        Ok(svc) => Ok(svc),
+        Err(e) => Err(InitOutcome::Rmcp(e)),
+    },
+};
+drop(init_fut); // releases rmcp's transport handles on any error path
+
+let service = match init_outcome {
     Ok(svc) => svc,
-    Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+    Err(InitOutcome::Bridge(bridge_result)) => {
+        let primary = bridge_result
+            .err()
+            .map(|e| anyhow!("validator bridge during init: {e}"))
+            .unwrap_or_else(|| anyhow!("validator bridges exited before init completed"));
+        return match supervisor.shutdown_after_failure().await {
+            Ok(()) => Err(primary),
+            Err(_secondary) => Err(primary), // primary already captures the failure
+        };
+    }
+    Err(InitOutcome::Rmcp(ServerInitializeError::ExpectedInitializeRequest(Some(msg)))) => {
         emit_pre_init_error_envelope(&msg, &stdout_for_preinit).await?;
-        // Init-failure shutdown: abort inbound (client may hold
-        // stdin open), drain outbound (our pre-init envelope plus
-        // any rmcp-queued frames must flush).
-        return match validated.supervisor.shutdown_after_failure().await {
+        return match supervisor.shutdown_after_failure().await {
             Ok(()) => Ok(()),
             Err(e) => Err(anyhow!("validator bridge after pre-init: {e}")),
         };
     }
-    Err(ServerInitializeError::InitializeFailed(error_data)) => {
+    Err(InitOutcome::Rmcp(ServerInitializeError::InitializeFailed(error_data))) => {
         let handled = handle_initialize_failed(&error_data);
-        // rmcp already wrote the error envelope (e.g. -32602 for
-        // #276) into the outbound duplex before returning. Drain
-        // outbound so it actually reaches stdout; failures during
-        // drain promote a handled rejection to Error.
-        return match validated.supervisor.shutdown_after_failure().await {
+        return match supervisor.shutdown_after_failure().await {
             Ok(()) => handled,
             Err(e) => Err(anyhow!("validator bridge after init failure: {e}")),
         };
     }
-    Err(other) => return Err(anyhow!("MCP server init: {other}")),
+    Err(InitOutcome::Rmcp(other)) => {
+        // Any non-handled init error: clean shutdown then propagate.
+        let _ = supervisor.shutdown_after_failure().await;
+        return Err(anyhow!("MCP server init: {other}"));
+    }
 };
+```
 
-let mut supervisor = validated.supervisor;
+`InitOutcome` is a small local enum:
+
+```rust
+enum InitOutcome<Svc> {
+    Bridge(io::Result<()>),
+    Rmcp(ServerInitializeError),
+}
+```
+
+After this block, `service` is bound and `supervisor` is still owned
+locally for the post-init race below.
+
+```rust
 let mut service_fut = Box::pin(service.waiting());
 
 // Phase 1: race service against bridge errors.
@@ -449,14 +490,24 @@ JSON-RPC 2.0 §4-5 defines four valid envelope shapes from a peer:
 
 - **Request**: `{jsonrpc:"2.0", method:string, id:string|number, params?}`
 - **Notification**: `{jsonrpc:"2.0", method:string, params?}` (no `id`)
-- **Response (success)**: `{jsonrpc:"2.0", id:string|number|null, result:any}` (no `method`, no `error`)
-- **Error response**: `{jsonrpc:"2.0", id:string|number|null, error:{code,message,data?}}` (no `method`, no `result`)
+- **Response (success)**: `{jsonrpc:"2.0", id:string|number, result:any}` (no `method`, no `error`)
+- **Error response**: `{jsonrpc:"2.0", id:string|number, error:{code:number, message:string, data?:any}}` (no `method`, no `result`)
 
 The validator forwards all four; rejects everything else. Responses
 and Errors from the client side are part of MCP's server-initiated
 flow (e.g. sampling requests where the server asks the client to
 invoke its LLM and the client returns a response) — rejecting them
 would be a feature regression, not just a test gap.
+
+**`id` is string|number — NOT null — on incoming envelopes.** rmcp 1.5
+deserializes id fields via `RequestId = NumberOrString`; null ids fail
+deserialization on `JsonRpcRequest`, `JsonRpcResponse`, and
+`JsonRpcError`. The JSON-RPC 2.0 spec allows null id only on
+*synthesized server responses* when the server couldn't detect the
+request's id (e.g. parse errors). The validator emits null in those
+synthesized responses (see "`id`-echo policy") but rejects incoming
+envelopes with null id. This matches rmcp's accepted grammar and
+upholds the "validator forwards only what rmcp can parse" promise.
 
 | Input shape | Decision | Wire response | Notes |
 |---|---|---|---|
@@ -466,10 +517,13 @@ would be a feature regression, not just a test gap.
 | Object missing `jsonrpc` | Reject | `-32600`, `id: <echoed or null>` | The #277 minimal failing case. |
 | Object with `jsonrpc` ≠ `"2.0"` | Reject | `-32600`, `id: <echoed or null>` | E.g. `"1.0"`, `2.0` (number), `"2.00"`. |
 | Object with `id` field of disallowed type (object/array/boolean) | Reject | `-32600`, `id: null` | Per JSON-RPC §5: "if there was an error in detecting the id … it MUST be Null." |
-| **Has `method` (string)**, no `result`, no `error` | Forward | — | Request (if `id`) or Notification (if no `id`). |
+| Object with `id: null` | Reject | `-32600`, `id: null` | rmcp's `RequestId` = `NumberOrString`; null isn't deserializable on Request/Response/Error. |
+| **Has `method` (string)** with `id: string|number`, no `result`, no `error` | Forward | — | Request. |
+| **Has `method` (string)** with no `id`, no `result`, no `error` | Forward | — | Notification. |
 | **Has `method` (non-string)** | Reject | `-32600`, `id: <echoed or null>` | |
-| **Has `result`** (and `id` present + valid), no `method`, no `error` | Forward | — | Client Response to a server-initiated request. |
-| **Has `error`** (and `id` present + valid), no `method`, no `result` | Forward | — | Client Error response to a server-initiated request. |
+| **Has `result`** with `id: string|number`, no `method`, no `error` | Forward | — | Client Response to a server-initiated request. |
+| **Has `error`** with `id: string|number`, valid error object, no `method`, no `result` | Forward | — | Client Error response to a server-initiated request. |
+| **Has `error`** but error is not an object, or missing numeric `code`, or missing string `message` | Reject | `-32600`, `id: <echoed or null>` | JSON-RPC §5.1 grammar for `error`. |
 | **Has both `result` AND `error`** | Reject | `-32600`, `id: <echoed or null>` | Per JSON-RPC §5: exactly one of result/error. |
 | Has `result` or `error` but no `id` | Reject | `-32600`, `id: null` | Response/Error envelopes MUST have an `id`. |
 | Empty object (no `method`, no `result`, no `error`) | Reject | `-32600`, `id: <echoed or null>` | |
@@ -482,6 +536,20 @@ inputs that rmcp silently drops now get a `-32600`/`-32700` response.
 ### `validate()` decision logic
 
 ```rust
+/// `id` accepted by rmcp's RxJsonRpcMessage. Null is excluded
+/// because rmcp's RequestId = NumberOrString.
+fn is_forwardable_id(v: &Value) -> bool {
+    v.is_string() || v.is_number()
+}
+
+/// `error` body matches JSON-RPC §5.1: an object with numeric
+/// `code` and string `message`. `data` is optional.
+fn is_well_formed_error(v: &Value) -> bool {
+    let Some(obj) = v.as_object() else { return false; };
+    obj.get("code").is_some_and(Value::is_number)
+        && obj.get("message").is_some_and(Value::is_string)
+}
+
 fn validate(line: &str) -> ValidationOutcome {
     if line.trim().is_empty() {
         return ValidationOutcome::Skip;
@@ -497,52 +565,68 @@ fn validate(line: &str) -> ValidationOutcome {
     if obj.get("jsonrpc").and_then(|v| v.as_str()) != Some("2.0") {
         return ValidationOutcome::Reject(invalid_request(extract_id(obj)));
     }
-    let id = obj.get("id");
-    if let Some(id) = id {
-        if !is_valid_id(id) {
-            return ValidationOutcome::Reject(invalid_request(None));
-        }
-    }
+
+    let id_present_and_valid = match obj.get("id") {
+        None => false,                                   // notification or invalid response
+        Some(v) if is_forwardable_id(v) => true,         // string|number
+        Some(_) => return ValidationOutcome::Reject(invalid_request(None)), // null/array/object/bool
+    };
 
     let method = obj.get("method");
     let result = obj.get("result");
     let error = obj.get("error");
 
     match (method, result, error) {
-        // Request or Notification
-        (Some(m), None, None) if m.is_string() => ValidationOutcome::Forward,
-        (Some(_), None, None) /* non-string method */ => {
-            ValidationOutcome::Reject(invalid_request(extract_id(obj)))
-        }
-        // Response / Error response — id MUST be present and valid
-        (None, Some(_), None) | (None, None, Some(_)) if id.is_some() => {
+        // Request: method+id, no result, no error
+        (Some(m), None, None) if m.is_string() && id_present_and_valid => {
             ValidationOutcome::Forward
         }
-        // Response without id, or empty / mixed shape
+        // Notification: method, no id, no result, no error
+        (Some(m), None, None) if m.is_string() && !id_present_and_valid => {
+            ValidationOutcome::Forward
+        }
+        // Non-string method
+        (Some(_), None, None) => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
+        // Response: id+result, no method, no error
+        (None, Some(_), None) if id_present_and_valid => ValidationOutcome::Forward,
+        // Error response: id+error, no method, no result, error well-formed
+        (None, None, Some(err)) if id_present_and_valid && is_well_formed_error(err) => {
+            ValidationOutcome::Forward
+        }
+        // Catch-all: empty object, response/error without id, malformed error,
+        // both result+error, method mixed with result/error.
         _ => ValidationOutcome::Reject(invalid_request(extract_id(obj))),
     }
 }
 ```
 
 `extract_id(obj)` returns `Some(Value)` if `obj["id"]` is
-`string|number|null`, else `None` (we use `null` on the wire). The
-catch-all arm covers: empty object, both `result` and `error`, method
-mixed with result/error, and response/error without id — all single-
-line `-32600` rejections.
+`string|number`, else `None` (we use `null` on the wire — note that
+synthesized rejection envelopes can carry `id: null` per JSON-RPC §5,
+but incoming envelopes with `id: null` are rejected at the third
+check above). The catch-all arm covers: empty object, both `result`
+and `error`, method mixed with result/error, response/error without
+id, and malformed `error` bodies — all single-line `-32600` rejections.
 
 ### `id`-echo policy
 
-Decision tree for the `id` field on a rejection envelope:
+Decision tree for the `id` field on a **synthesized rejection
+envelope** (validator → wire). Note: incoming envelopes with `id: null`
+are *rejected* by the validator (see "Validation rules" — null doesn't
+deserialize on rmcp's `RequestId`), but the rejection envelope itself
+emits `id: null` per JSON-RPC §5 when the original id couldn't be
+detected:
 
 - Top-level `"id"` is a JSON string → echo as-is.
 - Top-level `"id"` is a JSON number → echo as-is.
-- Top-level `"id"` is JSON `null` → echo `null`.
+- Top-level `"id"` is JSON `null` → echo `null` (envelope rejected
+  for null id, but we preserve the spec's "couldn't detect id" path
+  by reflecting it on the wire — alternative is `null` either way).
 - Top-level `"id"` is missing → `null`.
 - Top-level `"id"` is any other shape (object, array, bool) → `null`.
 - Input not parseable as JSON → `null`.
 
-Matches `preinit.rs::synthesize_pre_init_error_envelope` and JSON-RPC §5
-exactly.
+Matches `preinit.rs::synthesize_pre_init_error_envelope` and JSON-RPC §5.
 
 ## Error envelope shapes
 
@@ -823,13 +907,41 @@ and id):
     (e.g. 2 s), record `process_end.reason: Error`, and exit
     non-zero. Pins the bounded-exit invariant for the post-init
     failure path; companion to test 20 for the post-init equivalent.
+22. `process_end_on_pre_init_bridge_error_with_open_stdin` —
+    closed-stdout harness variant for an INIT-PHASE bridge failure:
+    client sends a pre-init `ping` (rmcp accepts and queues a
+    response). The passthrough write to (closed) stdout fails
+    while rmcp is still waiting for `initialize`. **Client keeps
+    stdin open** and never sends `initialize`. The init-phase
+    `tokio::select!` (race `serve_server` against
+    `watch_for_error`) must observe the bridge error and route
+    through `shutdown_after_failure`, exit within bounded time,
+    record `process_end.reason: Error`. Pins the init-phase
+    supervisor visibility added in revision 15.
+23. `envelope_request_with_null_id_returns_invalid_request` —
+    `{"jsonrpc":"2.0","method":"tools/list","id":null}` → `-32600`
+    with `id: null`. Pins that the validator rejects null ids that
+    rmcp's `RequestId = NumberOrString` cannot deserialize — without
+    this, the envelope would pass the validator and produce an
+    inconsistent error path inside rmcp.
+24. `envelope_error_response_with_malformed_body_returns_invalid_request`
+    — `{"jsonrpc":"2.0","id":1,"error":{"code":"not-a-number"}}` →
+    `-32600` with `id: 1`. Pins the `is_well_formed_error` check
+    (`code` must be number, `message` must be string).
+25. `envelope_error_response_without_code_returns_invalid_request`
+    — `{"jsonrpc":"2.0","id":1,"error":{"message":"oops"}}` →
+    `-32600` with `id: 1`. Same `is_well_formed_error` check —
+    missing-`code` variant.
+
+Note: tests 16-17 use **non-null integer ids** (e.g. `99`) so they
+pass the validator's `is_forwardable_id` check.
 
 All tests run against the production binary via the existing
-`Harness`. Tests 12-14 use the closed-stdout harness variant added
-in `tests/support/wire/harness.rs` for #275. Tests 16-17 add small
-client-side helpers (`send_line` + bounded silence wait) reusing
-existing primitives. Tests 20 and 21 need a harness variant that
-holds stdin open after sending — small extension.
+`Harness`. Tests 12-14 and 22 use the closed-stdout harness variant
+added in `tests/support/wire/harness.rs` for #275. Tests 16-17 add
+small client-side helpers (`send_line` + bounded silence wait)
+reusing existing primitives. Tests 20-22 need a harness variant
+that holds stdin open after sending — small extension.
 
 **Unit tests** in `wire_validator.rs::tests` covering `validate()` in
 isolation, one assertion per row of the validation rules table. Pure
@@ -912,6 +1024,22 @@ this should hold by construction.
   would silently break these. Mitigation: validator forwards all
   four spec-defined envelope shapes (Request, Notification,
   Response, Error); tests 16-19 pin the inclusive forward set.
+- **Validator forwarding what rmcp can't deserialize.** The
+  validator's grammar must be a subset of rmcp's accepted grammar
+  — forwarding an envelope rmcp then rejects with a deserialization
+  error defeats the "no silent drop" promise (the result is not a
+  hang, but an inconsistent error path). Specifically: rmcp 1.5's
+  `RequestId = NumberOrString` excludes null ids. The validator
+  rejects `id: null` on incoming envelopes, restricting the forward
+  set to `id: string|number` per rmcp. Test 23 pins this.
+- **Init-phase bridge errors going unobserved.** Until rmcp returns
+  a service, the supervisor isn't being polled. A bridge `BrokenPipe`
+  during the pre-init handshake (e.g. rmcp answers a pre-init
+  `ping` and stdout breaks) would otherwise let rmcp wait
+  indefinitely for `initialize` while the validator is dead.
+  Mitigation: `rmcp::serve_server(...).await` is itself wrapped in
+  `tokio::select!` against `supervisor.watch_for_error()`; test 22
+  pins bounded exit on this path.
 
 ## Dependencies and merge plan
 
@@ -925,10 +1053,14 @@ umbrella). The implementation lands on
    recognizing all four spec envelope shapes, and the two bridge
    tasks.
 2. `main.rs` updates: transport swap, `emit_pre_init_error_envelope`
-   signature thread-through, two-phase post-init shutdown (race
-   then dispatch — `drain` on success, `shutdown_after_failure`
-   on failure), and `shutdown_after_failure` for both init-failure
-   arms (`ExpectedInitializeRequest` and `InitializeFailed`).
+   signature thread-through, init-phase race (`rmcp::serve_server`
+   future against `supervisor.watch_for_error()`), two-phase
+   post-init shutdown (race then dispatch — `drain` on success,
+   `shutdown_after_failure` on failure), and `shutdown_after_failure`
+   for both init-failure arms (`ExpectedInitializeRequest` and
+   `InitializeFailed`) plus the new init-phase bridge-error arm.
+   Local `InitOutcome` enum disambiguates init-phase failure
+   sources.
 3. `mcp_wire_proptest.rs`: `prop_filter` on `arb_envelope()` to
    exclude spec-legal notifications; un-ignore
    `prop_envelope_never_panics`. No property-body changes beyond
@@ -936,16 +1068,19 @@ umbrella). The implementation lands on
 4. Small harness extension for test 20: variant that holds stdin
    open after sending. Existing closed-stdout helpers cover
    tests 12-14 unchanged.
-5. 21 new wire-pinned tests in `mcp_wire_negative.rs`:
+5. 25 new wire-pinned tests in `mcp_wire_negative.rs`:
    - 10 for validation rules (tests 1-10)
    - 1 for pre-init ordering (test 11)
-   - 3 for closed-stdout audit semantics on both shutdown phases
+   - 3 for closed-stdout audit semantics during post-init phases
      (tests 12-14)
    - 1 fixed-case notification path (test 15)
    - 2 for Response/Error envelope forwarding (tests 16-17)
    - 2 for malformed Response/Error rejection (tests 18-19)
-   - 2 for bounded-exit with open stdin on failure paths
-     (tests 20 pre-init, 21 post-init)
+   - 3 for bounded-exit with open stdin on failure paths
+     (tests 20 pre-init init-failure, 21 post-init service error,
+     22 init-phase bridge error)
+   - 3 for rmcp-grammar id and error-body matching
+     (test 23 null id, tests 24-25 malformed error body)
 6. Mirror docs (this spec, committed before implementation starts).
 
 Once green, PR #278 comes out of draft and goes to review with all

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -283,18 +283,25 @@ impl ValidatorSupervisor {
     /// **Do not call on init-failure paths** — the inbound bridge
     /// only exits on real stdin EOF, but a client may legitimately
     /// keep stdin open while waiting for the error response,
-    /// causing this to hang. Use `shutdown_after_init_failure`
+    /// causing this to hang. Use `shutdown_after_failure`
     /// instead.
     pub async fn drain(self) -> io::Result<()>;
 
-    /// Init-failure shutdown. Aborts the inbound bridge
-    /// (the client may keep stdin open after an init error;
-    /// without abort, we'd block forever waiting for EOF), then
-    /// awaits the outbound bridge to drain rmcp's queued init
-    /// error envelope plus any validator-synthesized rejections.
-    /// Returns the first error from the outbound path; inbound
-    /// cancellation is expected and ignored.
-    pub async fn shutdown_after_init_failure(self) -> io::Result<()>;
+    /// Failure-path shutdown. Aborts the inbound bridge (the
+    /// client may keep stdin open while waiting for an error
+    /// response; without abort, we'd block forever in `read_until`
+    /// on real stdin), then awaits the outbound bridge to drain
+    /// rmcp's queued error envelope plus any validator-synthesized
+    /// rejections. Returns the first error from the outbound path;
+    /// inbound cancellation is expected and ignored.
+    ///
+    /// Used on EVERY failure path — pre-init `ExpectedInitializeRequest`,
+    /// `InitializeFailed`, post-init bridge race error, and post-init
+    /// `service.waiting()` error. The only path that uses `drain` is
+    /// the clean post-init success, where `service.waiting()`
+    /// returning `Ok` already implies the inbound bridge exited
+    /// (rmcp saw EOF on its read).
+    pub async fn shutdown_after_failure(self) -> io::Result<()>;
 }
 ```
 
@@ -311,7 +318,7 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)
         // Init-failure shutdown: abort inbound (client may hold
         // stdin open), drain outbound (our pre-init envelope plus
         // any rmcp-queued frames must flush).
-        return match validated.supervisor.shutdown_after_init_failure().await {
+        return match validated.supervisor.shutdown_after_failure().await {
             Ok(()) => Ok(()),
             Err(e) => Err(anyhow!("validator bridge after pre-init: {e}")),
         };
@@ -322,7 +329,7 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, validated.transport)
         // #276) into the outbound duplex before returning. Drain
         // outbound so it actually reaches stdout; failures during
         // drain promote a handled rejection to Error.
-        return match validated.supervisor.shutdown_after_init_failure().await {
+        return match validated.supervisor.shutdown_after_failure().await {
             Ok(()) => handled,
             Err(e) => Err(anyhow!("validator bridge after init failure: {e}")),
         };
@@ -350,26 +357,50 @@ let service_outcome: anyhow::Result<()> = tokio::select! {
     result = &mut service_fut => result.map_err(|e| anyhow!("rmcp: {e}")),
 };
 
-// Phase 2: drop service to release rmcp's transport ends, then drain.
+// Phase 2: drop service to release rmcp's transport ends, then
+// shut down the supervisor. Dispatch on service_outcome — clean
+// success can wait for natural EOF on both bridges; any failure
+// must abort inbound first because the client may keep stdin open.
 drop(service_fut);
-let drain_outcome = supervisor
-    .drain()
-    .await
-    .map_err(|e| anyhow!("validator bridge drain: {e}"));
+let shutdown_outcome = match &service_outcome {
+    Ok(()) => {
+        // service.waiting() Ok implies rmcp saw EOF on its read,
+        // which implies the inbound bridge already exited. drain()
+        // resolves inbound instantly and waits for outbound to
+        // flush any queued frames.
+        supervisor.drain().await
+    }
+    Err(_) => {
+        // Any failure path: inbound may still be blocked in
+        // `read_until` on real stdin. Abort before awaiting
+        // outbound drain.
+        supervisor.shutdown_after_failure().await
+    }
+}
+.map_err(|e| anyhow!("validator bridge shutdown: {e}"));
 
-let mcp_outcome = match (service_outcome, drain_outcome) {
+let mcp_outcome = match (service_outcome, shutdown_outcome) {
     (Err(e), _) => Err(e),         // race-phase failure dominates
-    (Ok(()), Err(e)) => Err(e),    // drain-phase failure surfaces
+    (Ok(()), Err(e)) => Err(e),    // shutdown-phase failure surfaces
     (Ok(()), Ok(())) => Ok(()),
 };
 ```
 
 The `biased` discriminator gives the supervisor arm priority on
-race-phase ties; the drain phase is unconditional after the race
+race-phase ties; the shutdown phase is unconditional after the race
 resolves so a final-write `BrokenPipe` always lands in
 `mcp_outcome: Err` → `process_end.reason: Error`. Any audit work
 still flushes via the existing `drainer_handle.await` further down
 in `main.rs::run`.
+
+**Why two shutdown methods.** `drain()` is the natural success path —
+it waits for both bridges to exit, which on `service.waiting() == Ok`
+is essentially immediate. `shutdown_after_failure()` aborts the
+inbound bridge first because a client legitimately keeping stdin open
+after a server error would otherwise cause `drain()` to hang forever
+in inbound's `read_until`. Tests 12-14 (race-phase and drain-phase
+write failures), 20 (init-failure with open stdin), and 21 (post-init
+failure with open stdin) pin the bounded-exit invariant on all paths.
 
 ### Pre-init shares the validator stdout
 
@@ -778,17 +809,27 @@ and id):
 20. `init_failure_with_open_stdin_returns_promptly` — client sends
     `initialize` with an unsupported `protocolVersion` (rmcp emits
     `-32602`), then **does NOT close stdin**. The server must
-    `shutdown_after_init_failure`, write the `-32602` envelope,
-    abort inbound, drain outbound, and exit within a bounded
-    timeout (e.g. 2 s). Pins that the drain path does not require
+    `shutdown_after_failure`, write the `-32602` envelope, abort
+    inbound, drain outbound, and exit within a bounded timeout
+    (e.g. 2 s). Pins that the failure-shutdown path does not require
     real stdin EOF.
+21. `process_end_on_post_init_service_error_with_open_stdin` —
+    closed-stdout harness variant for a POST-init failure: client
+    completes `initialize`, sends a valid `tools/list`, rmcp's
+    response write into the passthrough fails (closed stdout) →
+    `service.waiting()` returns Err. **Client keeps stdin open**
+    and sends nothing more. The server must `shutdown_after_failure`
+    (abort inbound, drain outbound), exit within a bounded timeout
+    (e.g. 2 s), record `process_end.reason: Error`, and exit
+    non-zero. Pins the bounded-exit invariant for the post-init
+    failure path; companion to test 20 for the post-init equivalent.
 
 All tests run against the production binary via the existing
 `Harness`. Tests 12-14 use the closed-stdout harness variant added
 in `tests/support/wire/harness.rs` for #275. Tests 16-17 add small
 client-side helpers (`send_line` + bounded silence wait) reusing
-existing primitives. Test 20 needs a harness variant that holds
-stdin open after sending — small extension.
+existing primitives. Tests 20 and 21 need a harness variant that
+holds stdin open after sending — small extension.
 
 **Unit tests** in `wire_validator.rs::tests` covering `validate()` in
 isolation, one assertion per row of the validation rules table. Pure
@@ -854,11 +895,16 @@ this should hold by construction.
   standard); test 15 exercises both ends explicitly. The
   alternative (in-test liveness probe) was rejected on nightly-
   budget grounds (~104 min at 100k cases) and complexity.
-- **Init-failure shutdown hang.** A naïve `drain()` after init
-  failure would wait for real stdin EOF; clients legitimately keep
-  stdin open while waiting for the error response. Mitigation:
-  `shutdown_after_init_failure` aborts the inbound bridge before
-  awaiting the outbound; test 20 pins prompt exit with stdin open.
+- **Shutdown hang on open stdin.** A naïve `drain()` waits for both
+  bridge tasks; the inbound bridge only exits on real stdin EOF.
+  A client legitimately keeping stdin open while waiting for an
+  error response (pre-init OR post-init failure) would otherwise
+  cause the server to hang forever instead of exiting with
+  `process_end.reason: Error`. Mitigation: every failure path
+  routes through `shutdown_after_failure` (abort inbound, drain
+  outbound); only the clean post-init success path uses plain
+  `drain`. Tests 20 (pre-init) and 21 (post-init) pin bounded exit
+  with stdin held open by the client.
 - **Validator rejecting server-initiated flow responses.** MCP's
   sampling and similar flows send a server-initiated request and
   expect a client-shaped Response or Error envelope back. An
@@ -874,14 +920,15 @@ umbrella). The implementation lands on
 `feature/issue-266-mcp-fuzzing` directly, in one diff that includes:
 
 1. `wire_validator.rs` with `ValidatedStdio` / `ValidatorSupervisor`
-   (`watch_for_error` + `drain` + `shutdown_after_init_failure`),
-   the `validate()` pure function recognizing all four spec
-   envelope shapes, and the two bridge tasks.
+   (three methods: `watch_for_error`, `drain`,
+   `shutdown_after_failure`), the `validate()` pure function
+   recognizing all four spec envelope shapes, and the two bridge
+   tasks.
 2. `main.rs` updates: transport swap, `emit_pre_init_error_envelope`
-   signature thread-through, two-phase shutdown for the
-   post-init path (race + drain), and `shutdown_after_init_failure`
-   for both init-failure arms (`ExpectedInitializeRequest` and
-   `InitializeFailed`).
+   signature thread-through, two-phase post-init shutdown (race
+   then dispatch — `drain` on success, `shutdown_after_failure`
+   on failure), and `shutdown_after_failure` for both init-failure
+   arms (`ExpectedInitializeRequest` and `InitializeFailed`).
 3. `mcp_wire_proptest.rs`: `prop_filter` on `arb_envelope()` to
    exclude spec-legal notifications; un-ignore
    `prop_envelope_never_panics`. No property-body changes beyond
@@ -889,7 +936,7 @@ umbrella). The implementation lands on
 4. Small harness extension for test 20: variant that holds stdin
    open after sending. Existing closed-stdout helpers cover
    tests 12-14 unchanged.
-5. 20 new wire-pinned tests in `mcp_wire_negative.rs`:
+5. 21 new wire-pinned tests in `mcp_wire_negative.rs`:
    - 10 for validation rules (tests 1-10)
    - 1 for pre-init ordering (test 11)
    - 3 for closed-stdout audit semantics on both shutdown phases
@@ -897,7 +944,8 @@ umbrella). The implementation lands on
    - 1 fixed-case notification path (test 15)
    - 2 for Response/Error envelope forwarding (tests 16-17)
    - 2 for malformed Response/Error rejection (tests 18-19)
-   - 1 for init-failure-with-open-stdin shutdown (test 20)
+   - 2 for bounded-exit with open stdin on failure paths
+     (tests 20 pre-init, 21 post-init)
 6. Mirror docs (this spec, committed before implementation starts).
 
 Once green, PR #278 comes out of draft and goes to review with all

--- a/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-277-envelope-validator-design.md
@@ -1086,6 +1086,35 @@ umbrella). The implementation lands on
 Once green, PR #278 comes out of draft and goes to review with all
 three blockers (#275, #276, #277) resolved.
 
+## Implementation follow-ups
+
+These items are NOT spec gaps that need design work — they're
+narrow tightenings the implementer applies at the `validate()` call
+site, captured here so they don't get lost between spec and code.
+Each is bounded to a few lines plus matching tests.
+
+- **Tighten `is_forwardable_id` to rmcp's numeric grammar.** rmcp 1.5
+  deserializes `RequestId::Number` as `i64`. The current
+  `Value::is_number()` check accepts fractional or out-of-range
+  values that pass the validator but fail inside rmcp — defeating
+  the "no silent drop" promise. Replace with
+  `v.as_i64().is_some()` (which already rejects fractional and
+  out-of-i64-range values via serde_json's number representation).
+  Add tests for fractional id (`{"jsonrpc":"2.0","method":"x","id":1.5}`
+  → -32600) and out-of-range id (`{...,"id":9223372036854775808}` →
+  -32600 — note: serde_json may parse very large integers as f64,
+  also rejected by `as_i64()`).
+- **Tighten `is_well_formed_error.code` to rmcp's `ErrorCode = i32`.**
+  Same class of issue: replace `Value::is_number()` on `code` with
+  `v.as_i64().is_some_and(|n| i32::try_from(n).is_ok())`. Add tests
+  for fractional `code` (`{"code":1.5,"message":"x"}` → -32600 on
+  the parent envelope) and out-of-i32-range `code` (`{"code":2147483648,...}` →
+  -32600).
+
+These were surfaced by Codex round 6 after the agreed stop on spec
+iteration. The implementer applies them when writing the actual
+validator; no further spec change is needed.
+
 ## Out of scope
 
 - **Upstream rmcp fix.** Filing a separate issue against rmcp to make

--- a/docs/superpowers/specs/2026-05-15-pre-push-hook-trim-design.md
+++ b/docs/superpowers/specs/2026-05-15-pre-push-hook-trim-design.md
@@ -1,0 +1,234 @@
+# Pre-push Hook Trim — Replace `just test` With `cargo check`
+
+**Date:** 2026-05-15
+**Status:** Design approved; implementation pending
+**Scope:** Developer tooling only. No runtime code changes.
+**Related memory:** `[[project-push-ssh-keepalive]]`
+
+## Problem
+
+`git push` to `origin` on this repo regularly drops the ref transfer
+silently. The `pre-push` stage of `.pre-commit-config.yaml` runs
+
+- `just test` — `prune-containers` + `cargo nextest run --workspace --locked --no-tests=pass` (~25–60 s)
+- `cargo deny check advisories bans` (~5 s)
+
+github.com's SSH server has an idle timeout (~30 s) on the
+connection. While the hook runs, the SSH session sits idle; the
+server severs the connection mid-hook, but the hook itself succeeds.
+`git push` then exits 0 with no refs transferred. Symptom and
+diagnosis are pinned in this session's `project-push-ssh-keepalive`
+auto-memory; the workaround is
+
+```sh
+GIT_SSH_COMMAND='ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=20' git push ...
+```
+
+which has to be prefixed on every push. That's the everyday friction
+this spec eliminates.
+
+## Root cause
+
+The slow step is `just test`. Its runtime exceeds the SSH idle window
+for any push large enough that the hook can't finish in ≤30 s. The
+nextest run is a full workspace test sweep — useful as a CI gate, but
+unnecessary as a *pre-push* gate when:
+
+1. `pre-commit` already runs `cargo clippy --workspace --all-targets --locked -- -D warnings`
+   on every commit. Clippy is a superset of `cargo check`, so any
+   commit that reaches `pre-push` has already passed compile + type
+   + lint checks.
+2. CI runs the full `just ci` (cargo-deny + nextest + workspace build
+   + mcp-conformance + typos) on every push and PR.
+3. Per project convention, contributors run `just ci` locally before
+   substantive pushes.
+
+Pre-push as currently configured duplicates work already covered
+elsewhere, AND breaks the very network transfer it's supposed to
+gate. Net value: negative.
+
+## Desired behavior
+
+After the fix:
+
+1. `git push` to `origin` completes the ref transfer without
+   `GIT_SSH_COMMAND` keepalive flags, for any push the developer
+   would normally make.
+2. Pre-push still surfaces a fast, meaningful local signal:
+   compile/type errors before the network round-trip.
+3. Cargo-deny advisory/ban gating remains pre-push — it is fast (~5 s)
+   and catches new advisories before they hit CI.
+4. Test-failure detection moves entirely to CI (already there).
+
+## Approach
+
+Replace the `cargo-nextest` hook in the `pre-push` stage with a
+`cargo check` invocation. Single-file edit to
+`.pre-commit-config.yaml`:
+
+```yaml
+# Before
+- id: cargo-nextest
+  name: just test (prune stale containers + cargo nextest)
+  entry: just test
+  language: system
+  types: [rust]
+  pass_filenames: false
+  stages: [pre-push]
+
+# After
+- id: cargo-check
+  name: cargo check --workspace --all-targets --locked
+  entry: cargo check --workspace --all-targets --locked
+  language: system
+  always_run: true
+  pass_filenames: false
+  stages: [pre-push]
+```
+
+`cargo-deny check advisories bans` stays unchanged. Total pre-push
+time drops from ~30-65 s to ~10 s (compile-check ~5 s + deny ~5 s)
+on a warm `target/`, comfortably under github's SSH idle window. Cold-
+cache pushes are not bounded by this fix; see "Risks and mitigations."
+
+### Why `always_run: true` and not `types: [rust]`
+
+prek's `rust` type matches `.rs` files only. A push that touches only
+`Cargo.toml` or `Cargo.lock` — e.g. a dependency bump or
+Dependabot-style update — would skip a `types: [rust]` hook entirely,
+which is the exact failure mode `--locked` is meant to catch. The
+hook is workspace-wide (no per-file behavior) and we always want it
+to run on `git push`, so `always_run: true` is correct here.
+
+The existing `cargo-fmt` and `cargo-clippy` pre-commit hooks use
+`types: [rust]` and have the same gap on Cargo.toml-only commits.
+That's out of scope for this spec but flagged for a future cleanup:
+swap those `types: [rust]` clauses for `files: '\.(rs|toml|lock)$'`
+or `always_run: true`.
+
+### Why `cargo check` and not nothing
+
+A push could in theory contain a commit that bypassed `pre-commit`
+(`--no-verify`, an amended-without-rerun, or a force-pushed branch).
+`cargo check` is a 5-second insurance step against those paths. It
+costs nothing meaningful relative to the cargo-deny step that's also
+running. Honesty bullet: most pushes flow through clippy-at-commit
+and don't need this, but the 5 s premium is cheap.
+
+### Why not `cargo clippy` at pre-push
+
+Clippy is already run at pre-commit. Re-running it at pre-push is
+the same belt-and-suspenders argument as `cargo check` but slower
+(~15 s vs ~5 s). The `cargo check` step covers the same "compile
+sanity" failure mode at a third of the runtime; the lint failure mode
+is covered at commit time.
+
+### Why not `--all-features`
+
+`cargo check --workspace --all-targets --locked` checks default
+features. `--all-features` is slower and CI handles the all-features
+variant separately. Pre-push is about speed and a meaningful gate,
+not exhaustiveness.
+
+### Why keep `--locked`
+
+`--locked` fails if `Cargo.lock` would be modified — i.e. a stale
+or out-of-sync lockfile. Catching this at pre-push is *exactly* the
+right time: better than CI's "your branch needs a lockfile update"
+failure that requires another round-trip.
+
+## File layout
+
+- **Modified:** `.pre-commit-config.yaml` — single hook entry change.
+- **No new files.** No new `just` targets needed; the hook entry is
+  the canonical command. Developers running `just check` interactively
+  get a similar but `--locked`-free invocation, which is fine for
+  inner-loop iteration.
+
+## Memory update
+
+The session-local `project-push-ssh-keepalive` auto-memory becomes
+outdated once this ships. As an implementation follow-up, add a
+"Resolved by" stanza pointing to the resulting commit so future
+sessions know the workaround is no longer required. The
+`GIT_SSH_COMMAND` workaround stays documented as historical context
+— useful if a future change to the pre-push hooks reintroduces a
+slow step. Auto-memory updates happen locally; nothing to check into
+git for this step.
+
+## Testing
+
+This is a configuration change in `.pre-commit-config.yaml`; the hook
+itself is the test. Manual verification:
+
+1. **Clean push smoke.** Make a trivial commit, push without
+   `GIT_SSH_COMMAND` keepalive, observe ref transfer succeeds. The
+   memory's repro condition — push exits 0 with no ref transfer —
+   should not occur.
+2. **Compile-fail rejection.** Introduce a deliberate compile error
+   on a feature branch, attempt push, observe the hook fails the
+   push with the `cargo check` diagnostic.
+3. **Stale-lockfile rejection.** Hand-edit `Cargo.lock` to introduce
+   a mismatch with `Cargo.toml`, attempt push, observe `cargo check`
+   fails on the `--locked` constraint.
+4. **Dep-only push still triggers the hook.** Commit a change that
+   touches *only* `Cargo.toml` (e.g. bump a patch version) and push;
+   observe `cargo check` runs (proving `always_run: true` works) and
+   the push succeeds when the lockfile is in sync, fails when it
+   isn't. Pins the `types: [rust]` regression Codex caught in review.
+5. **Cargo-deny still gates.** Briefly add a deny rule that flags an
+   existing dep (e.g. a known-CVE entry in `deny.toml`), attempt
+   push, observe cargo-deny fails the hook. Revert.
+
+No automated regression suite for this change — `prek run --all-files`
+exercises the hook in CI's mcp-conformance / lint paths but doesn't
+simulate the network timing.
+
+## Risks and mitigations
+
+- **Test regression slips past pre-push** → CI catches it; PR fails
+  before merge. Acceptable. The pre-push test gate was already
+  unreliable (silent push failures); a reliable lighter gate beats
+  an unreliable heavy one.
+- **`cargo check` is too lax to catch a real regression** → CI runs
+  the full nextest, deny, build, and conformance sweep. Pre-push is
+  a smoke gate, not the final word.
+- **Developer assumes pre-push runs the tests and is surprised when
+  CI catches a failure they could've caught locally** → mitigate
+  with a one-liner in the project's CONTRIBUTING / setup notes:
+  "Pre-push runs `cargo check` + `cargo deny` only. Run `just ci`
+  before pushing if you want the full local sweep." A small docs
+  follow-up; out of scope for this spec but flagged here.
+- **Pre-commit `cargo clippy` is itself bypassed** (`--no-verify`,
+  exotic git workflow). `cargo check` at pre-push catches the
+  resulting compile-fail; clippy failures slip through to CI. Same
+  net behavior as today, just with the test step removed.
+- **Cold `target/` blows the SSH idle window.** `cargo check
+  --workspace --all-targets --locked` from a fresh clone or post-
+  `cargo clean` state can take several minutes — far beyond
+  github's ~30 s idle timeout. Same for a major dependency bump that
+  triggers a wide recompile, or a stale advisory DB that cargo-deny
+  refreshes on first run. The ~10 s estimate is the *warm-cache*
+  case, which is the norm in practice because developers compile
+  during inner-loop iteration before pushing. Mitigation when cold:
+  fall back to the documented `GIT_SSH_COMMAND='ssh -o ServerAliveInterval=15
+  -o ServerAliveCountMax=20' git push ...` workaround from the
+  `project-push-ssh-keepalive` memory. A permanent transport-layer
+  fix would require `~/.ssh/config` (user's call) or a per-repo
+  `git config --local core.sshCommand 'ssh -o ServerAliveInterval=15'`
+  documented in CONTRIBUTING — both out of scope for this spec.
+
+## Out of scope
+
+- **`~/.ssh/config` keepalive.** Adding `ServerAliveInterval 15`
+  globally for github.com is the user's call — not a repo-level
+  concern. The memory mentions it as an alternative permanent fix;
+  this spec doesn't preclude or require it.
+- **Restructuring `just ci` or the CI workflow.** Untouched.
+- **Other pre-commit/pre-push hooks.** `cargo-deny check advisories
+  bans` stays in pre-push; pre-commit (fmt, clippy, typos,
+  branch-name, forbidden-macros, ts-typecheck) is unchanged.
+- **Making `just check` use `--locked` to match the hook.** `just check`
+  is the inner-loop developer command and `--locked` would friction
+  developers mid-Cargo.toml-edit. The hook owns the `--locked`
+  invariant; `just check` stays liberal.


### PR DESCRIPTION
**Status: WIP. Two of the three blocker bugs (#275, #276) are now folded into this PR; #277 remains.**

## Summary

Phase 4 of the MCP test plan (#266): malformed-input negative tests, property-based envelope and tool-call fuzzing, wire-layer cancellation acceptance, audit fail-closed boundary tests, and a nightly fuzz CI workflow. Also bundles fixes for two server bugs that this phase surfaced — #275 (pre-initialize handling) and #276 (protocol-version negotiation).

- Spec: `docs/superpowers/specs/2026-05-13-mcp-protocol-fuzzing-design.md`
- Plan: `docs/superpowers/plans/2026-05-13-mcp-protocol-fuzzing.md`
- Issue: #266 (Phase 4); also closes #275 and #276

Both Phase 4 spec and plan went through Codex adversarial review with their findings addressed in follow-up commits. A final adversarial review of the implementation surfaced three more findings, all addressed in commit `9c56e5e`. Each folded fix (#275, #276) has its own spec, plan, and Codex adversarial review under `docs/superpowers/`.

## What landed

| Area | File | Tests |
|---|---|---|
| Harness primitives | `tests/support/wire/harness.rs` | extended in place |
| Negative-path tests | `tests/mcp_wire_negative.rs` | 8 pass, ignored markers removed for #275 and #276 |
| Property tests | `tests/mcp_wire_proptest.rs` | 2 pass at 1000 cases, 1 ignored on #277, +1 sentinel |
| Audit fail-closed | `tests/mcp_audit_failure.rs` | 3 pass (control + armed + initialize-unaffected) |
| Wire-layer cancellation | `tests/e2e_wire_cancellation.rs` | 2 pass (Dovecot-backed, silent skip on no-Docker) |
| Wrapper-level cancellation | extended in `src/mcp/audit_envelope.rs::tests` | 1 new + 1 tightened |
| Test-support hook | `src/main.rs` + `Cargo.toml` | `RIMAP_TEST_FORCE_NEXT_AUDIT_WRITE_FAILURE` env-var arms `force_next_write_failure()` |
| Dovecot collision fix | `tests/support/dovecot/harness.rs` | new `uuid_like()` helper mirroring rimap-imap PR #273 |
| Nightly CI | `.github/workflows/mcp-fuzz-nightly.yml` | per-property guard + zero-test-run guard |
| **#275 pre-init handling** | `src/mcp/preinit.rs` + `src/mcp/server.rs` + `mcp/error.rs` | 5 wire-pinned tests in `tests/mcp_wire_negative.rs` |
| **#276 protocol-version negotiation** | `src/main.rs` + `mcp/error.rs` | 4 wire-pinned tests in `tests/mcp_wire_negative.rs` |

## Remaining blocker

- **#277** — server hangs on JSON envelopes with unknown `method` and missing `jsonrpc`/`id` fields. `prop_envelope_never_panics` remains `#[ignore]`'d; the nightly fuzz workflow's per-property guard continues to fail until that property is un-ignored.

## Test plan

- [x] `cargo test -p rimap-server` (with Docker) — passes
- [x] `cargo test --workspace` — 1222 tests pass, 1 skipped
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check -p rimap-server --features test-support --bin rusty-imap-mcp --locked` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `actionlint` + `zizmor` on the new workflow — clean
- [x] `mcp-conformance` (tsc + oxlint + oxfmt + vitest, 24 tests) — green

## Notes for reviewers

- **One server bug filed during this work remains open** (#277). It has a spec-aligned property pinned in an `#[ignore]`'d proptest ready to un-ignore once the bug lands.
- **#275 and #276 were stacked onto this branch** rather than merged via separate PRs (originally #279). The folded commits are `850463f…41c89a0` (#275) and `7a93572…60cff26` (#276), each with its own spec, plan, and Codex adversarial review.
- **A separate flake found and fixed** (commit `100ad68`): the Dovecot compose project name collided on parallel test execution. Mirrors rimap-imap's `uuid_like` fix from PR #273.
- **Codex adversarial reviews** were run at three checkpoints: after the spec, after the plan, and after the implementation. The implementation review (`9c56e5e`) closed three findings: a vacuous audit fail-closed test, a missing `rimap-audit/test-injection` feature edge, and a nightly guard that couldn't see ignored properties.

Closes #275.
Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
