### PR TITLE
fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,9 +1416,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1671,7 +1671,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2554,7 +2554,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3030,7 +3030,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -24,7 +24,9 @@ use rimap_config::loader::{load_and_validate, resolve_config_path};
 use rimap_config::login::{run_login, tty_prompt};
 use rimap_config::validate::ValidatedAccountConfig;
 use rimap_imap::Connection;
+use rmcp::service::ServerInitializeError;
 use secrecy::ExposeSecret;
+use tokio::io::AsyncWriteExt;
 
 use crate::cli::{AuditAction, Cli, Command};
 
@@ -135,9 +137,14 @@ fn run(cli: Cli) -> anyhow::Result<()> {
 
         let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
         let transport = rmcp::transport::io::stdio();
-        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
-            .await
-            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                emit_pre_init_error_envelope(&msg).await?;
+                return Ok(());
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
         // waiting() takes ownership of service, consuming it and dropping the
         // ImapMcpServer (including all cancellation sender clones) when it
         // returns. The drainer task exits once all senders have dropped.
@@ -171,6 +178,28 @@ fn run(cli: Cli) -> anyhow::Result<()> {
     }
 
     mcp_result
+}
+
+/// Write the JSON-RPC -32002 error envelope for a pre-initialize request
+/// to stdout (newline-terminated, flushed). Notification / Response /
+/// Error variants synthesize no envelope (per JSON-RPC §4.1) and this
+/// helper is a no-op. Write failures (broken pipe, closed reader) are
+/// propagated via `?` so the caller records `process_end.reason: Error`.
+async fn emit_pre_init_error_envelope(
+    msg: &rmcp::model::ClientJsonRpcMessage,
+) -> anyhow::Result<()> {
+    let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(msg) else {
+        return Ok(());
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(line.as_bytes())
+        .await
+        .context("writing pre-init error envelope to stdout")?;
+    out.flush()
+        .await
+        .context("flushing pre-init error envelope")?;
+    tracing::info!("rejected pre-initialize request with -32002 envelope");
+    Ok(())
 }
 
 /// Resolve the config file path from `--config` or the

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -3,6 +3,7 @@
 //! Custom error codes in the JSON-RPC "server error" range
 //! (-32000 to -32099):
 //! - -32001: posture denied
+//! - -32002: server not initialized (pre-initialize request)
 //! - -32003: rate limited
 //! - -32004: circuit breaker open
 //! - -32005: attachment too large
@@ -21,6 +22,12 @@ pub const CIRCUIT_OPEN: McpCode = McpCode(-32004);
 
 /// Attachment exceeded size cap.
 pub const ATTACHMENT_TOO_LARGE: McpCode = McpCode(-32005);
+
+/// Server has not yet received the MCP `initialize` request. The first
+/// message a client sends MUST be `initialize` (or `ping`). Any other
+/// pre-initialize request is rejected with this code and a clean
+/// session shutdown.
+pub const NOT_INITIALIZED: McpCode = McpCode(-32002);
 
 /// Convert a `RimapError` into an rmcp `ErrorData`.
 ///
@@ -109,6 +116,11 @@ mod tests {
         let err = authz_error(ErrorCode::RateLimited, "slow down");
         let mcp = to_mcp_error(&err);
         assert!(mcp.message.contains("slow down"));
+    }
+
+    #[test]
+    fn not_initialized_code_value() {
+        assert_eq!(super::NOT_INITIALIZED, McpCode(-32002));
     }
 
     #[test]

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod audit_envelope;
 pub mod content;
 pub(crate) mod dispatch;
 pub mod error;
-pub(crate) mod preinit;
+pub mod preinit;
 pub mod response;
 pub mod server;
 // `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod audit_envelope;
 pub mod content;
 pub(crate) mod dispatch;
 pub mod error;
+pub(crate) mod preinit;
 pub mod response;
 pub mod server;
 // `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod

--- a/crates/rimap-server/src/mcp/preinit.rs
+++ b/crates/rimap-server/src/mcp/preinit.rs
@@ -1,0 +1,144 @@
+//! Pre-initialize request handler.
+//!
+//! Synthesizes the JSON-RPC error envelope that the MCP server sends
+//! when a client violates the lifecycle by issuing any non-`initialize`,
+//! non-`ping` request as its first message (#275). The helper is pure:
+//! it does no I/O and holds no state. The transport write happens in
+//! `main.rs::run`.
+//!
+//! Notifications and Responses pre-initialize return `None`: per
+//! JSON-RPC §4.1 notifications never receive a response, and a
+//! standalone Response is malformed (no matching server request).
+
+use rmcp::model::ClientJsonRpcMessage;
+use serde_json::json;
+
+use crate::mcp::error::NOT_INITIALIZED;
+
+/// Build the newline-terminated JSON-RPC error line to emit for an
+/// offending pre-initialize message. Returns `Some` only for the
+/// `Request` variant.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into main.rs::run in the next commit (#275 task 4)"
+    )
+)]
+pub(crate) fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
+    match msg {
+        ClientJsonRpcMessage::Request(req) => {
+            let id = req.id.clone().into_json_value();
+            let envelope = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": NOT_INITIALIZED.0,
+                    "message": "Server not initialized: send `initialize` \
+                                before any other request",
+                },
+            });
+            Some(format!("{envelope}\n"))
+        }
+        ClientJsonRpcMessage::Notification(_)
+        | ClientJsonRpcMessage::Response(_)
+        | ClientJsonRpcMessage::Error(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::unwrap_used, reason = "tests")]
+
+    use std::sync::Arc;
+
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientNotification, ClientRequest, ClientResult, ErrorData,
+        JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcVersion2_0,
+        ListToolsRequest, NumberOrString, PaginatedRequestParams, ProgressNotification,
+        ProgressNotificationParam, ProgressToken,
+    };
+    use serde_json::{Value, json};
+
+    use super::synthesize_pre_init_error_envelope;
+
+    /// Build a Request variant carrying a `tools/list` request with the
+    /// supplied id.
+    fn request_msg(id: NumberOrString) -> ClientJsonRpcMessage {
+        let list_tools = ListToolsRequest::with_param(PaginatedRequestParams::default());
+        ClientJsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            request: ClientRequest::ListToolsRequest(list_tools),
+        })
+    }
+
+    #[test]
+    fn request_with_numeric_id_produces_minus_32002_envelope() {
+        let msg = request_msg(NumberOrString::Number(42));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert!(line.ends_with('\n'), "must be newline-terminated");
+        let parsed: Value = serde_json::from_str(line.trim_end()).expect("envelope is valid JSON");
+        assert_eq!(parsed["jsonrpc"], json!("2.0"));
+        assert_eq!(parsed["id"], json!(42));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+        assert!(
+            parsed["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Server not initialized")
+        );
+    }
+
+    #[test]
+    fn request_with_string_id_preserves_string_id() {
+        let msg = request_msg(NumberOrString::String(Arc::from("abc-123")));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], json!("abc-123"));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+    }
+
+    #[test]
+    fn line_is_single_line_with_one_trailing_newline() {
+        let msg = request_msg(NumberOrString::Number(1));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert_eq!(line.matches('\n').count(), 1, "exactly one newline");
+        assert!(line.ends_with('\n'), "newline is trailing");
+        assert!(!line.trim_end().contains('\n'), "no embedded newlines");
+    }
+
+    #[test]
+    fn notification_returns_none() {
+        let progress = ProgressNotification::new(ProgressNotificationParam::new(
+            ProgressToken(NumberOrString::Number(1)),
+            0.0,
+        ));
+        let msg = ClientJsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: JsonRpcVersion2_0,
+            notification: ClientNotification::ProgressNotification(progress),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn response_returns_none() {
+        let msg = ClientJsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            result: ClientResult::empty(()),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn error_variant_returns_none() {
+        let msg = ClientJsonRpcMessage::Error(JsonRpcError {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            error: ErrorData::internal_error("synthetic".to_string(), None),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+}

--- a/crates/rimap-server/src/mcp/preinit.rs
+++ b/crates/rimap-server/src/mcp/preinit.rs
@@ -18,14 +18,8 @@ use crate::mcp::error::NOT_INITIALIZED;
 /// Build the newline-terminated JSON-RPC error line to emit for an
 /// offending pre-initialize message. Returns `Some` only for the
 /// `Request` variant.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into main.rs::run in the next commit (#275 task 4)"
-    )
-)]
-pub(crate) fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
+#[must_use]
+pub fn synthesize_pre_init_error_envelope(msg: &ClientJsonRpcMessage) -> Option<String> {
     match msg {
         ClientJsonRpcMessage::Request(req) => {
             let id = req.id.clone().into_json_value();

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -431,6 +431,37 @@ async fn tools_list_before_initialize_str_id() {
     }
 }
 
+/// Pre-initialize NOTIFICATION (no `id`) must NOT receive an error
+/// envelope — per JSON-RPC §4.1 notifications never get a response.
+/// Server closes cleanly and exits 0 with audit reason Eof.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_notification_silent_close() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Send a pre-initialize notification (not a request — no id).
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({"requestId": 1, "reason": "client decided not to initialize"}),
+        )
+        .await;
+
+    // No response should arrive; the server should close cleanly.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            panic!("pre-initialize notification must NOT produce an envelope, got {envelope}");
+        }
+        other => panic!("expected clean close, got {other:?}"),
+    }
+
+    // Audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+
 // ---------------------------------------------------------------------------
 // Test 9: two `tools/list` requests in flight simultaneously
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -399,6 +399,38 @@ async fn tools_list_before_initialize() {
     );
 }
 
+/// Same contract as `tools_list_before_initialize`, but with a string
+/// id. Pins id-type preservation at the wire layer: numeric coercion
+/// of `id` in the synthesizer would surface here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize_str_id() {
+    let mut harness = Harness::spawn().await;
+
+    // Send a hand-crafted request with a STRING id rather than using
+    // send_request_no_wait (which auto-assigns a u64).
+    let raw = r#"{"jsonrpc":"2.0","id":"abc-123","method":"tools/list","params":{}}"#;
+    harness.send_line(raw).await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list w/ str id, got {other:?}"
+        ),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32002));
+    assert_eq!(
+        envelope["id"],
+        json!("abc-123"),
+        "string id must survive verbatim through the envelope synthesizer, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 9: two `tools/list` requests in flight simultaneously
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -29,6 +29,24 @@ fn parse_response_line(line: &str) -> Value {
     })
 }
 
+/// Read the `process_end.reason` from the audit log produced by the
+/// harness. Panics if no `process_end` record is found.
+fn read_process_end_reason(path: &std::path::Path) -> rimap_audit::ProcessEndReason {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read audit log at {}: {e}", path.display()));
+    for line in contents.lines() {
+        let record: rimap_audit::AuditRecord = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("parse audit record {line:?}: {e}"));
+        if let rimap_audit::Payload::ProcessEnd(p) = record.payload {
+            return p.reason;
+        }
+    }
+    panic!(
+        "no process_end record found in audit log at {}",
+        path.display()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: unparsable JSON
 // ---------------------------------------------------------------------------
@@ -327,44 +345,58 @@ async fn initialize_after_already_initialized() {
 // Test 7: `tools/list` before `initialize`
 // ---------------------------------------------------------------------------
 
-/// `tools/list` before `initialize` must error or close the session
-/// cleanly. Server is in the "uninitialized" state and cannot answer
-/// protocol-level requests until handshake completes.
+/// `tools/list` before `initialize` must return a JSON-RPC error
+/// envelope with code -32002 (Server not initialized), echo the
+/// request id verbatim, then close stdin and exit `0`. Fixed by #275.
 ///
-/// Probed 2026-05-13 (rmcp 1.5): server CRASHES with exit code 1.
-/// This is a bug filed as #275. The test below pins the spec-
-/// compliant behavior (error envelope OR clean close); it is
-/// `#[ignore]`'d until the underlying bug is fixed. Un-ignore
-/// after #275 lands.
+/// Audit log MUST record `process_end.reason: Eof` on the success
+/// path — this is the contract the bug report flagged as broken.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "blocked on #275: server crashes on pre-initialize requests"]
 async fn tools_list_before_initialize() {
     let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
     // Deliberately skip initialize_handshake.
+    let id = harness.send_request_no_wait("tools/list", json!({})).await;
 
-    let _id = harness.send_request_no_wait("tools/list", json!({})).await;
+    // Phase 1: error envelope arrives with -32002.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => {
+            panic!("expected -32002 error envelope for pre-initialize tools/list, got {other:?}")
+        }
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32002),
+        "must be code -32002 (Server not initialized), got {envelope}",
+    );
+    assert_eq!(
+        envelope["id"],
+        json!(id),
+        "id must be echoed verbatim, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
 
+    // Phase 2: stdout closes and the server exits 0.
     match harness.response_or_close(REQUEST_TIMEOUT).await {
-        CloseOrResponse::Response(line) => {
-            let envelope = parse_response_line(&line);
-            assert!(
-                envelope["error"].is_object(),
-                "tools/list before initialize must return an error envelope, got {envelope}",
-            );
-            assert_envelope_valid(&envelope);
-        }
-        CloseOrResponse::CleanClose => {
-            // Spec-compliant: server closed cleanly.
-        }
-        CloseOrResponse::Crashed(diag) => {
-            panic!("server crashed on pre-initialize tools/list (bug #275): {diag}",);
-        }
-        CloseOrResponse::Hung => {
-            panic!(
-                "server hung (no response within {REQUEST_TIMEOUT:?}) on pre-initialize tools/list",
-            );
-        }
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on pre-initialize tools/list, got {other:?}"
+        ),
     }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on successful pre-initialize handling",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/mcp_wire_negative.rs
+++ b/crates/rimap-server/tests/mcp_wire_negative.rs
@@ -12,6 +12,7 @@
 //! fail the test, regardless of which input produced them.
 
 #![expect(clippy::panic, reason = "test assertions render diagnostics")]
+#![expect(clippy::expect_used, reason = "integration tests")]
 
 #[path = "support/mod.rs"]
 mod support;
@@ -460,6 +461,74 @@ async fn pre_initialize_notification_silent_close() {
     // Audit log captured the success path as reason Eof.
     let reason = read_process_end_reason(&audit_path);
     assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+
+/// Codex review finding 2026-05-14 (medium): transport-level write
+/// failures while emitting the pre-initialize envelope must NOT be
+/// classified as clean EOF. Server's stdout read end is closed
+/// before the request arrives; the envelope write fails with
+/// `BrokenPipe`; the server exits non-zero and the audit log records
+/// `reason: Error`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_envelope_write_failure_records_error() {
+    use support::wire::harness::SHUTDOWN_TIMEOUT;
+    use tokio::io::AsyncWriteExt;
+    use tokio::time::timeout;
+
+    let mut detached = support::wire::harness::Harness::spawn_with_closed_stdout().await;
+
+    // Send a pre-initialize request. Server will read it, attempt to
+    // write the envelope, and fail with BrokenPipe because stdout's
+    // read end is already closed.
+    let line = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#.to_string() + "\n";
+    detached
+        .stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write request");
+    detached.stdin.flush().await.expect("flush request");
+
+    // Wait for the child to exit.
+    let status = timeout(SHUTDOWN_TIMEOUT, detached.child.wait())
+        .await
+        .expect("child exit within SHUTDOWN_TIMEOUT")
+        .expect("child wait");
+
+    // Server must NOT exit 0 on a broken-pipe write failure. It may
+    // exit with a non-zero status (anyhow propagated) or, if Rust's
+    // SIGPIPE handling regresses, be killed by signal 13 — both are
+    // failures we want to surface but only the first is the
+    // contract we lock in.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert!(
+            status.signal().is_none(),
+            "server must not be killed by SIGPIPE (regression in Rust runtime); got {status:?}\n--- captured stderr ---\n{}",
+            detached.captured_stderr(),
+        );
+    }
+    assert!(
+        !status.success(),
+        "server must exit non-zero when envelope write fails; got {status:?}\n--- captured stderr ---\n{}",
+        detached.captured_stderr(),
+    );
+
+    // Audit log must record reason Error, NOT Eof.
+    let reason = read_process_end_reason(detached.audit_path());
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Error,
+        "process_end.reason must be Error when envelope delivery fails, not Eof — \
+         masking transport failures as clean EOF defeats the audit-correctness goal",
+    );
+
+    // The propagated anyhow context must surface in stderr.
+    let stderr = detached.captured_stderr();
+    assert!(
+        stderr.contains("pre-init error envelope"),
+        "expected propagated 'pre-init error envelope' anyhow context in stderr, got:\n{stderr}",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -136,6 +136,19 @@ fn force_use_for_dead_code_link() {
     // Method used by mcp_wire_negative (pre-initialize tests), not by
     // other binaries.
     let _ = Harness::audit_path;
+    // Method used by mcp_wire_negative (pre-initialize write-failure
+    // test), not by other binaries.
+    let _ = Harness::spawn_with_closed_stdout;
+    // DetachedStdoutHarness methods used by mcp_wire_negative, not by
+    // other binaries. The pub `child` / `stdin` fields are read by the
+    // pre-initialize write-failure test only; reference them here so
+    // every test-binary compilation sees them as used.
+    let _ = DetachedStdoutHarness::audit_path;
+    let _ = DetachedStdoutHarness::captured_stderr;
+    let _ = |h: &DetachedStdoutHarness| {
+        let _ = &h.child;
+        let _ = &h.stdin;
+    };
     // Methods used by mcp_wire_negative and e2e_wire_cancellation, not
     // by other binaries.
     let _ = Harness::send_request_no_wait;
@@ -219,6 +232,59 @@ allowed_base_dir = "{}"
             stderr_log,
             buffered_responses: std::collections::VecDeque::new(),
             poisoned: false,
+            _tempdir: tempdir,
+        }
+    }
+
+    /// Spawn the binary with the legacy zero-account config, then
+    /// immediately drop the `BufReader<ChildStdout>` read handle. The
+    /// child's stdout pipe write end is now connected to a closed
+    /// reader; the next write the server attempts will fail with
+    /// `BrokenPipe`. Used by `pre_initialize_envelope_write_failure`
+    /// to exercise the propagated-error path on transport failure.
+    #[expect(clippy::unused_async, reason = "uniform async surface")]
+    pub async fn spawn_with_closed_stdout() -> DetachedStdoutHarness {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let stderr_log = tempdir.path().join("rusty-imap-mcp.stderr.log");
+        let stderr_file = File::create(&stderr_log).expect("create stderr log file");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(stderr_file))
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        // Take the read end of the stdout pipe and drop it immediately.
+        // The child's write end is now connected to a closed reader.
+        let stdout = child.stdout.take().expect("stdout");
+        drop(stdout);
+
+        DetachedStdoutHarness {
+            child,
+            stdin,
+            stderr_log,
+            audit_path,
             _tempdir: tempdir,
         }
     }
@@ -567,5 +633,32 @@ allowed_base_dir = "{}"
             .expect("clean exit within timeout")
             .expect("wait");
         (status, tempdir)
+    }
+}
+
+/// Lightweight harness variant used by transport-failure regression
+/// tests that intentionally close the server's stdout read end before
+/// sending input. The server's pre-initialize envelope write will
+/// fail with `BrokenPipe`. This struct cannot read stdout responses;
+/// it exists only to drive stdin, wait for the child exit, and read
+/// the resulting audit log + captured stderr.
+pub struct DetachedStdoutHarness {
+    pub child: Child,
+    pub stdin: ChildStdin,
+    stderr_log: PathBuf,
+    audit_path: PathBuf,
+    // Held until drop so the audit log path stays valid.
+    _tempdir: TempDir,
+}
+
+impl DetachedStdoutHarness {
+    /// Path to the audit log produced by the spawned binary.
+    pub fn audit_path(&self) -> &std::path::Path {
+        &self.audit_path
+    }
+
+    /// Read the captured stderr file. Empty string on read failure.
+    pub fn captured_stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
     }
 }

--- a/crates/rimap-server/tests/support/wire/harness.rs
+++ b/crates/rimap-server/tests/support/wire/harness.rs
@@ -133,6 +133,9 @@ fn force_use_for_dead_code_link() {
     // Methods used by mcp_wire_negative, not by other binaries.
     let _ = Harness::response_or_close;
     let _ = Harness::send_line;
+    // Method used by mcp_wire_negative (pre-initialize tests), not by
+    // other binaries.
+    let _ = Harness::audit_path;
     // Methods used by mcp_wire_negative and e2e_wire_cancellation, not
     // by other binaries.
     let _ = Harness::send_request_no_wait;
@@ -256,6 +259,18 @@ allowed_base_dir = "{}"
     /// panic messages.
     pub fn captured_stderr(&self) -> String {
         std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
+    }
+
+    /// Path to the audit log file for this harness. Used by tests
+    /// that need to read `process_end` records post-shutdown.
+    #[expect(
+        clippy::used_underscore_binding,
+        reason = "the leading underscore on `_tempdir` is a visual convention to flag that the \
+                  field is held purely for its drop guard; this accessor exposes its path on \
+                  purpose so audit-log assertions can read the file before the guard drops"
+    )]
+    pub fn audit_path(&self) -> std::path::PathBuf {
+        self._tempdir.path().join("audit.jsonl")
     }
 
     /// Read exactly one parsed envelope from stdout. Skips

--- a/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
+++ b/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
@@ -26,11 +26,11 @@
 
 ---
 
-## Task 0: Pre-flight — Verify dependency on #266 is satisfied
+## Task 0: Pre-flight — Sanity-check the working tree
 
 **Files:** none (verification only)
 
-**Context:** This plan exercises the wire-level negative-test harness from #266 / PR #278. As of the spec date (2026-05-14), that harness lived only on the `feature/issue-266-mcp-fuzzing` branch. Before starting any implementation, confirm the harness is present on the current branch — either because #266 merged to main and the implementer rebased, or because this branch is stacked on `feature/issue-266-mcp-fuzzing`. If absent, **stop and resolve the branching strategy with the user** per the spec's Dependencies section.
+**Context:** This branch is stacked on `feature/issue-266-mcp-fuzzing` so the wire harness from #266 (`mcp_wire_negative.rs` + `support/wire/harness.rs`) is present. The PR opened from this branch targets `feature/issue-266-mcp-fuzzing` as its base — see the spec's Dependencies section for why. This task confirms the working tree is in the expected shape before any code changes begin.
 
 - [ ] **Step 1: Confirm the harness files exist**
 
@@ -41,7 +41,7 @@ test -f crates/rimap-server/tests/support/wire/harness.rs && \
 echo "OK: harness present"
 ```
 
-Expected: `OK: harness present`. If either file is missing, halt and consult the spec's Dependencies section.
+Expected: `OK: harness present`. If either file is missing, the rebase onto `feature/issue-266-mcp-fuzzing` did not land — halt and consult the spec's Dependencies section.
 
 - [ ] **Step 2: Confirm the ignored test we plan to un-ignore is present and ignored**
 
@@ -1169,14 +1169,14 @@ EOF
 
 ```bash
 git push -u origin fix/issue-275-pre-initialize-handling
-gh pr create --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
+gh pr create --base feature/issue-266-mcp-fuzzing --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
 ## Summary
 
 - Pre-initialize Request → JSON-RPC `-32002` "Server not initialized" envelope (request id echoed verbatim), clean close, exit 0, audit `reason: Eof`.
 - Pre-initialize Notification / Response → silent clean close, exit 0, audit `reason: Eof`.
 - Envelope write failure → propagated `anyhow::Error`, non-zero exit, audit `reason: Error` (Codex adversarial-review finding 2026-05-14).
 
-Fixes #275.
+Fixes #275. One of three merge blockers (#275, #276, #277) for PR #278; targets `feature/issue-266-mcp-fuzzing` so the un-ignore commit travels with the fix.
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
+++ b/docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md
@@ -1,0 +1,1210 @@
+# Pre-Initialize Request Handling Implementation Plan (#275)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `exit 1` crash on pre-`initialize` requests with a JSON-RPC `-32002` error envelope (echoing the request id) followed by a clean exit `0`, while preserving non-zero exit + `process_end.reason: Error` on transport write failures.
+
+**Architecture:** New `mcp/preinit.rs` module owns one pure helper that converts an offending `ClientJsonRpcMessage::Request` into a newline-terminated JSON-RPC error line. `main.rs::run` matches on `rmcp::service::server::ServerInitializeError::ExpectedInitializeRequest`, writes the line through a fresh `tokio::io::stdout()`, and returns `Ok(())` on success or propagates the write error via `?`. Notifications and Responses are dropped silently with `Ok(())`.
+
+**Tech Stack:** Rust (workspace MSRV 1.88.0), tokio async I/O, rmcp 1.5, serde_json, anyhow, tracing. Wire-level integration tests use the `Harness` from `crates/rimap-server/tests/support/wire/`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md`](../specs/2026-05-14-issue-275-pre-initialize-handling-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `crates/rimap-server/src/mcp/preinit.rs` — pure helper + unit tests
+
+**Modify:**
+- `crates/rimap-server/src/mcp/mod.rs` — add `preinit` module declaration
+- `crates/rimap-server/src/mcp/error.rs` — add `NOT_INITIALIZED` constant
+- `crates/rimap-server/src/main.rs` — match arm in `run()` and import the helper
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — un-ignore one test, add three new tests, add audit-log assertions
+- `crates/rimap-server/tests/support/wire/harness.rs` — new `audit_path()` accessor and `DetachedStdoutHarness` + `spawn_with_closed_stdout()`
+
+---
+
+## Task 0: Pre-flight — Verify dependency on #266 is satisfied
+
+**Files:** none (verification only)
+
+**Context:** This plan exercises the wire-level negative-test harness from #266 / PR #278. As of the spec date (2026-05-14), that harness lived only on the `feature/issue-266-mcp-fuzzing` branch. Before starting any implementation, confirm the harness is present on the current branch — either because #266 merged to main and the implementer rebased, or because this branch is stacked on `feature/issue-266-mcp-fuzzing`. If absent, **stop and resolve the branching strategy with the user** per the spec's Dependencies section.
+
+- [ ] **Step 1: Confirm the harness files exist**
+
+Run:
+```bash
+test -f crates/rimap-server/tests/mcp_wire_negative.rs && \
+test -f crates/rimap-server/tests/support/wire/harness.rs && \
+echo "OK: harness present"
+```
+
+Expected: `OK: harness present`. If either file is missing, halt and consult the spec's Dependencies section.
+
+- [ ] **Step 2: Confirm the ignored test we plan to un-ignore is present and ignored**
+
+Run:
+```bash
+rg -n 'tools_list_before_initialize|blocked on #275' crates/rimap-server/tests/mcp_wire_negative.rs
+```
+
+Expected: a match showing `#[ignore = "blocked on #275: server crashes on pre-initialize requests"]` above an `async fn tools_list_before_initialize()`. If the line is absent or unignored, halt — the test harness has drifted from the spec and the test assertions in this plan need re-alignment.
+
+- [ ] **Step 3: Confirm the workspace builds clean before changes**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean exit, no errors. If errors, stop and address them first.
+
+- [ ] **Step 4: No commit. Move to Task 1.**
+
+---
+
+## Task 1: Add `NOT_INITIALIZED` error-code constant
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/error.rs`
+
+The wire code `-32002` is reserved for "Server not initialized" in the LSP/MCP ecosystem. Add it alongside the existing custom codes (`POSTURE_DENIED`, `RATE_LIMITED`, etc.). The constant is consumed by `preinit.rs` in Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test in `crates/rimap-server/src/mcp/error.rs` inside the existing `mod tests` block (find the existing `#[test] fn message_is_preserved()` and add after it):
+
+```rust
+    #[test]
+    fn not_initialized_code_value() {
+        assert_eq!(super::NOT_INITIALIZED, McpCode(-32002));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::error::tests::not_initialized_code_value
+```
+
+Expected: FAIL with `cannot find value 'NOT_INITIALIZED' in module 'super'`.
+
+- [ ] **Step 3: Add the constant**
+
+In `crates/rimap-server/src/mcp/error.rs`, add (after the existing `ATTACHMENT_TOO_LARGE` constant near line 23, before `pub fn to_mcp_error`):
+
+```rust
+/// Server has not yet received the MCP `initialize` request. The first
+/// message a client sends MUST be `initialize` (or `ping`). Any other
+/// pre-initialize request is rejected with this code and a clean
+/// session shutdown.
+pub const NOT_INITIALIZED: McpCode = McpCode(-32002);
+```
+
+Also update the module-level doc-comment listing custom codes (top of `error.rs`, lines 1-9). Replace the existing list with:
+
+```rust
+//! Map `RimapError` to rmcp `ErrorData` for MCP tool error responses.
+//!
+//! Custom error codes in the JSON-RPC "server error" range
+//! (-32000 to -32099):
+//! - -32001: posture denied
+//! - -32002: server not initialized (pre-initialize request)
+//! - -32003: rate limited
+//! - -32004: circuit breaker open
+//! - -32005: attachment too large
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::error::tests::not_initialized_code_value
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/error.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add NOT_INITIALIZED -32002 error code (#275)
+
+Reserve the JSON-RPC server-error code -32002 for the
+"server has not yet received the MCP initialize request"
+case, alongside the existing POSTURE_DENIED / RATE_LIMITED /
+CIRCUIT_OPEN / ATTACHMENT_TOO_LARGE codes. Consumed by the
+pre-initialize envelope synthesizer in a follow-up commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Create the `preinit` module with envelope synthesizer
+
+**Files:**
+- Create: `crates/rimap-server/src/mcp/preinit.rs`
+
+The helper is pure (no I/O, no transport access) so we can unit-test it directly against the rmcp types. `RequestId` is `rmcp::model::NumberOrString` — either an `i64` or an `Arc<str>` — so only those two id flavors are reachable. (JSON `null` ids would have failed rmcp's deserializer before reaching us; no test case needed for that.)
+
+- [ ] **Step 1: Write the failing test file with the synthesizer's contract pinned**
+
+Create `crates/rimap-server/src/mcp/preinit.rs` with the body below. The tests reference `synthesize_pre_init_error_envelope`, which does not yet exist — compilation will fail.
+
+```rust
+//! Pre-initialize request handler.
+//!
+//! Synthesizes the JSON-RPC error envelope that the MCP server sends
+//! when a client violates the lifecycle by issuing any non-`initialize`,
+//! non-`ping` request as its first message (#275). The helper is pure:
+//! it does no I/O and holds no state. The transport write happens in
+//! `main.rs::run`.
+//!
+//! Notifications and Responses pre-initialize return `None`: per
+//! JSON-RPC §4.1 notifications never receive a response, and a
+//! standalone Response is malformed (no matching server request).
+
+use rmcp::model::ClientJsonRpcMessage;
+use serde_json::json;
+
+use crate::mcp::error::NOT_INITIALIZED;
+
+/// Build the newline-terminated JSON-RPC error line to emit for an
+/// offending pre-initialize message. Returns `Some` only for the
+/// `Request` variant.
+pub(crate) fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String> {
+    match msg {
+        ClientJsonRpcMessage::Request(req) => {
+            let id = req.id.clone().into_json_value();
+            let envelope = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": NOT_INITIALIZED.0,
+                    "message": "Server not initialized: send `initialize` \
+                                before any other request",
+                },
+            });
+            Some(format!("{envelope}\n"))
+        }
+        ClientJsonRpcMessage::Notification(_)
+        | ClientJsonRpcMessage::Response(_)
+        | ClientJsonRpcMessage::Error(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests")]
+    #![expect(clippy::unwrap_used, reason = "tests")]
+
+    use std::sync::Arc;
+
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorData,
+        JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+        JsonRpcVersion2_0, ListToolsRequest, NumberOrString,
+        PaginatedRequestParamInner, ProgressNotification, ProgressNotificationParam,
+    };
+    use serde_json::{Value, json};
+
+    use super::synthesize_pre_init_error_envelope;
+
+    /// Build a Request variant carrying a `tools/list` request with the
+    /// supplied id.
+    fn request_msg(id: NumberOrString) -> ClientJsonRpcMessage {
+        let list_tools = ListToolsRequest {
+            method: Default::default(),
+            params: Some(PaginatedRequestParamInner { cursor: None }),
+            extensions: Default::default(),
+        };
+        ClientJsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            request: ClientRequest::ListToolsRequest(list_tools),
+        })
+    }
+
+    #[test]
+    fn request_with_numeric_id_produces_minus_32002_envelope() {
+        let msg = request_msg(NumberOrString::Number(42));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert!(line.ends_with('\n'), "must be newline-terminated");
+        let parsed: Value = serde_json::from_str(line.trim_end())
+            .expect("envelope is valid JSON");
+        assert_eq!(parsed["jsonrpc"], json!("2.0"));
+        assert_eq!(parsed["id"], json!(42));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+        assert!(parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Server not initialized"));
+    }
+
+    #[test]
+    fn request_with_string_id_preserves_string_id() {
+        let msg = request_msg(NumberOrString::String(Arc::from("abc-123")));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        let parsed: Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["id"], json!("abc-123"));
+        assert_eq!(parsed["error"]["code"], json!(-32002));
+    }
+
+    #[test]
+    fn line_is_single_line_with_one_trailing_newline() {
+        let msg = request_msg(NumberOrString::Number(1));
+        let line = synthesize_pre_init_error_envelope(&msg).expect("Some line");
+        assert_eq!(line.matches('\n').count(), 1, "exactly one newline");
+        assert!(line.ends_with('\n'), "newline is trailing");
+        assert!(!line.trim_end().contains('\n'), "no embedded newlines");
+    }
+
+    #[test]
+    fn notification_returns_none() {
+        let progress = ProgressNotification {
+            method: Default::default(),
+            params: ProgressNotificationParam {
+                progress: 0,
+                total: None,
+                progress_token: NumberOrString::Number(1),
+                message: None,
+            },
+            extensions: Default::default(),
+        };
+        let msg = ClientJsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: JsonRpcVersion2_0,
+            notification: ClientNotification::ProgressNotification(progress),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn response_returns_none() {
+        let msg = ClientJsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            result: Default::default(),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+
+    #[test]
+    fn error_variant_returns_none() {
+        let msg = ClientJsonRpcMessage::Error(JsonRpcError {
+            jsonrpc: JsonRpcVersion2_0,
+            id: NumberOrString::Number(1),
+            error: ErrorData::internal_error("synthetic".to_string(), None),
+        });
+        assert!(synthesize_pre_init_error_envelope(&msg).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Verify the tests fail to compile**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::preinit 2>&1 | head -30
+```
+
+Expected: compile error — `unresolved import` for `crate::mcp::preinit` (the module is not declared in `mcp/mod.rs` yet). That's the next task.
+
+- [ ] **Step 3: No commit yet — proceed to Task 3 to wire the module in.**
+
+---
+
+## Task 3: Declare the `preinit` module
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/mod.rs`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `crates/rimap-server/src/mcp/mod.rs`, add `pub(crate) mod preinit;` alphabetically. After this change the top of the file reads:
+
+```rust
+//! MCP runtime: server handler, response/error types, content parsing.
+
+pub(crate) mod audit_envelope;
+pub mod content;
+pub(crate) mod dispatch;
+pub mod error;
+pub(crate) mod preinit;
+pub mod response;
+pub mod server;
+// `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod
+// mcp` in `lib.rs`) so the binary's test-support `dump-tool-catalog`
+// subcommand (#264) can reach `TOOL_DEFS`. Production callers route through
+// `dispatch` and `server` and do not import this module directly.
+pub mod tool_catalog;
+pub(crate) mod tool_name;
+```
+
+- [ ] **Step 2: Run the preinit tests**
+
+Run:
+```bash
+cargo test -p rimap-server --lib mcp::preinit
+```
+
+Expected: all six tests pass:
+- `request_with_numeric_id_produces_minus_32002_envelope`
+- `request_with_string_id_preserves_string_id`
+- `line_is_single_line_with_one_trailing_newline`
+- `notification_returns_none`
+- `response_returns_none`
+- `error_variant_returns_none`
+
+If any test fails to compile because an rmcp type name differs in your local rmcp 1.5 (e.g. `ProgressNotificationParam` vs `ProgressNotificationParams`), fix the test to match the actual rmcp type — the helper's contract is what matters, not the exact constructor shape.
+
+- [ ] **Step 3: Run clippy on the new module**
+
+Run:
+```bash
+cargo clippy -p rimap-server --lib --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/preinit.rs crates/rimap-server/src/mcp/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add pre-initialize envelope synthesizer (#275)
+
+New `mcp/preinit.rs` module exposes a pure helper that converts an
+offending pre-initialize ClientJsonRpcMessage into a newline-terminated
+JSON-RPC error line with code -32002 and the request id echoed
+verbatim. Notifications, Responses, and Error variants return None
+(no envelope, silent close at the call site).
+
+Includes unit tests for numeric id, string id, framing (single line,
+trailing newline), and all None-returning variants. Not yet wired into
+the server entrypoint — that's the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire the helper into `main.rs::run`
+
+**Files:**
+- Modify: `crates/rimap-server/src/main.rs`
+
+This is the behavior-change commit. Lines 136-140 currently wrap any `rmcp::serve_server` error in `anyhow!` and exit 1. We split that into three cases: `Ok` (normal run), `ExpectedInitializeRequest(Some(msg))` (synthesize envelope, return `Ok(())`), and everything else (preserve today's behavior).
+
+- [ ] **Step 1: Add the imports near the top of `main.rs`**
+
+Find the existing `use` block (lines 7-29 approximately). Add these imports alphabetically with the other module-level uses:
+
+```rust
+use rmcp::service::server::ServerInitializeError;
+use tokio::io::AsyncWriteExt;
+```
+
+`anyhow::Context` is already imported via line 16 (`use anyhow::Context;`) — no change there.
+
+- [ ] **Step 2: Replace the serve_server call block**
+
+In `crates/rimap-server/src/main.rs`, locate the existing block (currently `main.rs:136-147`):
+
+```rust
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
+        let transport = rmcp::transport::io::stdio();
+        let service = Box::pin(rmcp::serve_server(mcp_server, transport))
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server init: {e}"))?;
+        // waiting() takes ownership of service, consuming it and dropping the
+        // ImapMcpServer (including all cancellation sender clones) when it
+        // returns. The drainer task exits once all senders have dropped.
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+```
+
+Replace with:
+
+```rust
+        let mcp_server = server::ImapMcpServer::new(registry, audit, cancellation_tx);
+        let transport = rmcp::transport::io::stdio();
+        let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+            Ok(svc) => svc,
+            Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+                if let Some(line) = rimap_server::mcp::preinit::synthesize_pre_init_error_envelope(&msg) {
+                    let mut out = tokio::io::stdout();
+                    out.write_all(line.as_bytes())
+                        .await
+                        .context("writing pre-init error envelope to stdout")?;
+                    out.flush()
+                        .await
+                        .context("flushing pre-init error envelope")?;
+                    tracing::info!(
+                        "rejected pre-initialize request with -32002 envelope",
+                    );
+                }
+                return Ok(());
+            }
+            Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+        };
+        // waiting() takes ownership of service, consuming it and dropping the
+        // ImapMcpServer (including all cancellation sender clones) when it
+        // returns. The drainer task exits once all senders have dropped.
+        service
+            .waiting()
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+```
+
+Note the path: `rimap_server::mcp::preinit::synthesize_pre_init_error_envelope`. `main.rs` is the binary crate's entry point and reaches into the library crate `rimap_server` (see existing line 7-8). The function is `pub(crate)` in `mcp/preinit.rs`, so the path needs adjustment.
+
+- [ ] **Step 3: Adjust the function visibility**
+
+Because `main.rs` calls the helper through the library crate boundary, change the visibility in `crates/rimap-server/src/mcp/preinit.rs` from `pub(crate)` to `pub`:
+
+```rust
+pub fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String> {
+```
+
+Also export it from the `mcp` module hierarchy. In `crates/rimap-server/src/mcp/mod.rs`, change the line you added in Task 3 from:
+
+```rust
+pub(crate) mod preinit;
+```
+
+to:
+
+```rust
+pub mod preinit;
+```
+
+The `mcp` module itself is `#[doc(hidden)] pub` (see `crates/rimap-server/src/lib.rs`) so this widens reachability only across the same workspace, not for external consumers.
+
+- [ ] **Step 4: Build the workspace and verify the binary still compiles**
+
+Run:
+```bash
+cargo check --workspace --tests
+```
+
+Expected: clean. If errors mention `rmcp::service::server::ServerInitializeError` not being in scope, your rmcp version may re-export it from a different path — check `rg "pub use.*ServerInitializeError" ~/.cargo/registry/src/index.crates.io-*/rmcp-*/src/lib.rs` and adjust the use statement.
+
+- [ ] **Step 5: Run lints**
+
+Run:
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/main.rs crates/rimap-server/src/mcp/mod.rs crates/rimap-server/src/mcp/preinit.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)
+
+Match on ServerInitializeError::ExpectedInitializeRequest in main.rs::run
+and reply with a JSON-RPC -32002 error envelope (request id echoed
+verbatim) instead of exiting 1. Write errors are propagated via `?` so
+broken-pipe / closed-reader cases still record process_end.reason: Error
+and exit non-zero. Notification / Response variants are dropped silently
+with a clean exit 0.
+
+Widens synthesize_pre_init_error_envelope visibility to pub so main.rs
+can reach it through the rimap_server library crate.
+
+Wire-level regression tests follow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Un-ignore `tools_list_before_initialize` and tighten assertions
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs` (add `audit_path()` accessor)
+
+This is the first wire-level verification of the Task 4 change.
+
+- [ ] **Step 1: Add `audit_path()` accessor on `Harness`**
+
+In `crates/rimap-server/tests/support/wire/harness.rs`, find the `impl Harness {` block and add this method near the other accessors (e.g., next to `captured_stderr`). The audit log path is `{_tempdir}/audit.jsonl` per `spawn()`'s config template.
+
+```rust
+    /// Path to the audit log file for this harness. Used by tests
+    /// that need to read `process_end` records post-shutdown.
+    pub fn audit_path(&self) -> std::path::PathBuf {
+        self._tempdir.path().join("audit.jsonl")
+    }
+```
+
+The `_tempdir` field has a leading underscore to indicate "held only for lifetime"; accessing it through `self._tempdir.path()` is still legal — the underscore convention is purely visual.
+
+Also add a reference to this accessor in the `force_use_for_dead_code_link` function near the top of the file so it isn't flagged as unused in test binaries that don't call it:
+
+```rust
+    // Method used by mcp_wire_negative (pre-initialize tests), not by
+    // other binaries.
+    let _ = Harness::audit_path;
+```
+
+Add this line alongside the other `let _ = Harness::...` lines in that function.
+
+- [ ] **Step 2: Replace the un-ignored test**
+
+In `crates/rimap-server/tests/mcp_wire_negative.rs`, locate the existing `tools_list_before_initialize` test (around line 326-368). Replace the entire test (docstring + attributes + body) with:
+
+```rust
+// ---------------------------------------------------------------------------
+// Test 7: `tools/list` before `initialize`
+// ---------------------------------------------------------------------------
+
+/// `tools/list` before `initialize` must return a JSON-RPC error
+/// envelope with code -32002 (Server not initialized), echo the
+/// request id verbatim, then close stdin and exit `0`. Fixed by #275.
+///
+/// Audit log MUST record `process_end.reason: Eof` on the success
+/// path — this is the contract the bug report flagged as broken.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Deliberately skip initialize_handshake.
+    let id = harness.send_request_no_wait("tools/list", json!({})).await;
+
+    // Phase 1: error envelope arrives with -32002.
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list, got {other:?}"
+        ),
+    };
+    assert!(
+        envelope["error"].is_object(),
+        "must be an error envelope, got {envelope}",
+    );
+    assert_eq!(
+        envelope["error"]["code"],
+        json!(-32002),
+        "must be code -32002 (Server not initialized), got {envelope}",
+    );
+    assert_eq!(
+        envelope["id"],
+        json!(id),
+        "id must be echoed verbatim, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    // Phase 2: stdout closes and the server exits 0.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!(
+            "expected clean close after envelope on pre-initialize tools/list, got {other:?}"
+        ),
+    }
+
+    // Phase 3: audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Eof,
+        "process_end.reason must be Eof on successful pre-initialize handling",
+    );
+}
+```
+
+- [ ] **Step 3: Add the audit-reading helper at the top of `mcp_wire_negative.rs`**
+
+Below the existing `parse_response_line` helper (around line 26-30), add:
+
+```rust
+/// Read the `process_end.reason` from the audit log produced by the
+/// harness. Panics if no `process_end` record is found.
+fn read_process_end_reason(path: &std::path::Path) -> rimap_audit::ProcessEndReason {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read audit log at {}: {e}", path.display()));
+    for line in contents.lines() {
+        let record: rimap_audit::AuditRecord = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("parse audit record {line:?}: {e}"));
+        if let rimap_audit::Payload::ProcessEnd(p) = record.payload {
+            return p.reason;
+        }
+    }
+    panic!("no process_end record found in audit log at {}", path.display());
+}
+```
+
+- [ ] **Step 4: Confirm `rimap-audit` is a dev-dependency of `rimap-server`**
+
+Run:
+```bash
+rg -n 'rimap-audit\|rimap_audit' crates/rimap-server/Cargo.toml
+```
+
+If `rimap-audit` is only listed under `[dependencies]` and not `[dev-dependencies]`, add it under `[dev-dependencies]` too. Typically the entry exists in both — confirm before adding.
+
+- [ ] **Step 5: Run the un-ignored test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative tools_list_before_initialize -- --nocapture
+```
+
+Expected: PASS. If it fails:
+- Crashed (non-zero exit): Task 4 didn't land — check `main.rs` for the match arm.
+- Wrong error code: check the constant in `error.rs` (Task 1) and the synthesizer in `preinit.rs` (Task 2).
+- `no process_end record found`: the audit log may not be flushed; check the existing `log_process_end` block in `main.rs:168-171` is still on the early-return path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs crates/rimap-server/tests/support/wire/harness.rs crates/rimap-server/Cargo.toml
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin -32002 contract for pre-init tools/list (#275)
+
+Un-ignore tools_list_before_initialize with strict assertions:
+- response envelope must be code -32002 with the request id echoed
+- server must close stdin cleanly with exit 0
+- audit log must record process_end.reason: Eof
+
+Adds the audit_path() accessor on Harness and a read_process_end_reason
+helper in the test file so subsequent audit-reason assertions can reuse
+the pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `tools_list_before_initialize_str_id` test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the string-id roundtrip at the wire layer. Catches future regressions where the helper accidentally coerces ids through `as_u64()`.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `tools_list_before_initialize`:
+
+```rust
+/// Same contract as `tools_list_before_initialize`, but with a string
+/// id. Pins id-type preservation at the wire layer: numeric coercion
+/// of `id` in the synthesizer would surface here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_before_initialize_str_id() {
+    let mut harness = Harness::spawn().await;
+
+    // Send a hand-crafted request with a STRING id rather than using
+    // send_request_no_wait (which auto-assigns a u64).
+    let raw = r#"{"jsonrpc":"2.0","id":"abc-123","method":"tools/list","params":{}}"#;
+    harness.send_line(raw).await;
+
+    let envelope = match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::Response(line) => parse_response_line(&line),
+        other => panic!(
+            "expected -32002 error envelope for pre-initialize tools/list w/ str id, got {other:?}"
+        ),
+    };
+    assert_eq!(envelope["error"]["code"], json!(-32002));
+    assert_eq!(
+        envelope["id"],
+        json!("abc-123"),
+        "string id must survive verbatim through the envelope synthesizer, got {envelope}",
+    );
+    assert_envelope_valid(&envelope);
+
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        other => panic!("expected clean close, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative tools_list_before_initialize_str_id -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin string-id roundtrip for pre-init reject (#275)
+
+Hand-crafts a pre-initialize tools/list request with a string id and
+verifies the -32002 envelope echoes the same string. Guards against
+future regressions where the synthesizer might coerce ids through
+as_u64() or similar.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add `pre_initialize_notification_silent_close` test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the Notification-path contract: no envelope, clean close, audit reason Eof.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `tools_list_before_initialize_str_id`:
+
+```rust
+/// Pre-initialize NOTIFICATION (no `id`) must NOT receive an error
+/// envelope — per JSON-RPC §4.1 notifications never get a response.
+/// Server closes cleanly and exits 0 with audit reason Eof.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_notification_silent_close() {
+    let mut harness = Harness::spawn().await;
+    let audit_path = harness.audit_path();
+
+    // Send a pre-initialize notification (not a request — no id).
+    harness
+        .notify(
+            "notifications/cancelled",
+            json!({"requestId": 1, "reason": "client decided not to initialize"}),
+        )
+        .await;
+
+    // No response should arrive; the server should close cleanly.
+    match harness.response_or_close(REQUEST_TIMEOUT).await {
+        CloseOrResponse::CleanClose => {}
+        CloseOrResponse::Response(line) => {
+            let envelope = parse_response_line(&line);
+            panic!(
+                "pre-initialize notification must NOT produce an envelope, got {envelope}"
+            );
+        }
+        other => panic!("expected clean close, got {other:?}"),
+    }
+
+    // Audit log captured the success path as reason Eof.
+    let reason = read_process_end_reason(&audit_path);
+    assert_eq!(reason, rimap_audit::ProcessEndReason::Eof);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative pre_initialize_notification_silent_close -- --nocapture
+```
+
+Expected: PASS. The server's match arm in `main.rs` returns `Ok(())` because `synthesize_pre_init_error_envelope` returned `None` for the Notification variant.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin silent-close for pre-init notifications (#275)
+
+Asserts notifications/cancelled before initialize produces NO wire
+response and the server exits 0 with audit reason Eof. Per JSON-RPC
+§4.1, notifications never receive a response.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add the closed-stdout harness variant
+
+**Files:**
+- Modify: `crates/rimap-server/tests/support/wire/harness.rs`
+
+Adds a separate spawn helper that closes the stdout read end before the child writes, so the broken-pipe test in Task 9 has scaffolding. We introduce a small sister struct (`DetachedStdoutHarness`) rather than refactoring `Harness::stdout` to `Option<BufReader<...>>` — that refactor would touch every existing harness call site for one new test.
+
+- [ ] **Step 1: Define the sister struct and its accessors**
+
+Add to `crates/rimap-server/tests/support/wire/harness.rs`, after the `Harness` struct definition (and after any existing `impl Harness {` blocks — keep the file's existing structure intact):
+
+```rust
+/// Lightweight harness variant used by transport-failure regression
+/// tests that intentionally close the server's stdout read end before
+/// sending input. The server's pre-initialize envelope write will
+/// fail with `BrokenPipe`. This struct cannot read stdout responses;
+/// it exists only to drive stdin, wait for the child exit, and read
+/// the resulting audit log + captured stderr.
+pub struct DetachedStdoutHarness {
+    pub child: Child,
+    pub stdin: ChildStdin,
+    stderr_log: PathBuf,
+    audit_path: PathBuf,
+    // Held until drop so the audit log path stays valid.
+    _tempdir: TempDir,
+}
+
+impl DetachedStdoutHarness {
+    /// Path to the audit log produced by the spawned binary.
+    pub fn audit_path(&self) -> &std::path::Path {
+        &self.audit_path
+    }
+
+    /// Read the captured stderr file. Empty string on read failure.
+    pub fn captured_stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_log).unwrap_or_default()
+    }
+}
+```
+
+- [ ] **Step 2: Add the spawn helper**
+
+Add this method inside the existing `impl Harness { ... }` block (the one that contains `spawn()` and `spawn_with_config()`):
+
+```rust
+    /// Spawn the binary with the legacy zero-account config, then
+    /// immediately drop the BufReader<ChildStdout> read handle. The
+    /// child's stdout pipe write end is now connected to a closed
+    /// reader; the next write the server attempts will fail with
+    /// `BrokenPipe`. Used by `pre_initialize_envelope_write_failure`
+    /// to exercise the propagated-error path on transport failure.
+    pub async fn spawn_with_closed_stdout() -> DetachedStdoutHarness {
+        let tempdir = TempDir::new().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        let audit_path = tempdir.path().join("audit.jsonl");
+        let allowed_base = tempdir.path();
+        let config = format!(
+            r#"
+accounts = []
+
+[audit]
+path = "{}"
+allowed_base_dir = "{}"
+"#,
+            audit_path.display(),
+            allowed_base.display(),
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let stderr_log = tempdir.path().join("rusty-imap-mcp.stderr.log");
+        let stderr_file = File::create(&stderr_log).expect("create stderr log file");
+
+        let mut cmd = Command::new(cargo_bin("rusty-imap-mcp"));
+        cmd.arg("--config")
+            .arg(&config_path)
+            .arg("--allow-empty-accounts")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(stderr_file))
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn rusty-imap-mcp binary");
+
+        let stdin = child.stdin.take().expect("stdin");
+        // Take the read end of the stdout pipe and drop it immediately.
+        // The child's write end is now connected to a closed reader.
+        let stdout = child.stdout.take().expect("stdout");
+        drop(stdout);
+
+        DetachedStdoutHarness {
+            child,
+            stdin,
+            stderr_log,
+            audit_path,
+            _tempdir: tempdir,
+        }
+    }
+```
+
+- [ ] **Step 3: Suppress per-binary dead-code on the new symbol**
+
+Add to the `force_use_for_dead_code_link` function near the top of the file (this prevents the new method from being flagged as unused in test binaries that don't use it):
+
+```rust
+    // Method used by mcp_wire_negative (pre-initialize write-failure
+    // test), not by other binaries.
+    let _ = Harness::spawn_with_closed_stdout;
+```
+
+Same for `DetachedStdoutHarness`'s methods if needed — if clippy complains in CI, add `let _ = DetachedStdoutHarness::audit_path;` and `let _ = DetachedStdoutHarness::captured_stderr;` lines.
+
+- [ ] **Step 4: Build the harness**
+
+Run:
+```bash
+cargo check -p rimap-server --tests
+```
+
+Expected: clean. If unused-import warnings fire on `File`, `Command`, etc. — they're already imported by `spawn_with_config()`, no new imports should be needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/tests/support/wire/harness.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): add closed-stdout harness variant (#275)
+
+Adds Harness::spawn_with_closed_stdout() and a sister
+DetachedStdoutHarness struct for the upcoming pre-initialize
+write-failure regression test. The spawn helper drops the
+BufReader<ChildStdout> immediately so the child's stdout-write end
+is connected to a closed reader; the server's next write fails with
+BrokenPipe.
+
+Scaffolding only — no behavior change. Used in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Add the write-failure regression test
+
+**Files:**
+- Modify: `crates/rimap-server/tests/mcp_wire_negative.rs`
+
+Pins the Codex finding #2 contract: write failures while emitting the envelope must record `process_end.reason: Error` and exit non-zero.
+
+- [ ] **Step 1: Write the test**
+
+Add this test in `crates/rimap-server/tests/mcp_wire_negative.rs` immediately after `pre_initialize_notification_silent_close`:
+
+```rust
+/// Codex review finding 2026-05-14 (medium): transport-level write
+/// failures while emitting the pre-initialize envelope must NOT be
+/// classified as clean EOF. Server's stdout read end is closed
+/// before the request arrives; the envelope write fails with
+/// BrokenPipe; the server exits non-zero and the audit log records
+/// `reason: Error`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_initialize_envelope_write_failure_records_error() {
+    use support::wire::harness::SHUTDOWN_TIMEOUT;
+    use tokio::time::timeout;
+
+    let mut detached =
+        support::wire::harness::Harness::spawn_with_closed_stdout().await;
+
+    // Send a pre-initialize request. Server will read it, attempt to
+    // write the envelope, and fail with BrokenPipe because stdout's
+    // read end is already closed.
+    let line = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#.to_string()
+        + "\n";
+    use tokio::io::AsyncWriteExt;
+    detached
+        .stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write request");
+    detached.stdin.flush().await.expect("flush request");
+
+    // Wait for the child to exit.
+    let status = timeout(SHUTDOWN_TIMEOUT, detached.child.wait())
+        .await
+        .expect("child exit within SHUTDOWN_TIMEOUT")
+        .expect("child wait");
+
+    // Server must NOT exit 0 on a broken-pipe write failure. It may
+    // exit with a non-zero status (anyhow propagated) or, if Rust's
+    // SIGPIPE handling regresses, be killed by signal 13 — both are
+    // failures we want to surface but only the first is the
+    // contract we lock in.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert!(
+            status.signal().is_none(),
+            "server must not be killed by SIGPIPE (regression in Rust runtime); got {status:?}\n--- captured stderr ---\n{}",
+            detached.captured_stderr(),
+        );
+    }
+    assert!(
+        !status.success(),
+        "server must exit non-zero when envelope write fails; got {status:?}\n--- captured stderr ---\n{}",
+        detached.captured_stderr(),
+    );
+
+    // Audit log must record reason Error, NOT Eof.
+    let reason = read_process_end_reason(detached.audit_path());
+    assert_eq!(
+        reason,
+        rimap_audit::ProcessEndReason::Error,
+        "process_end.reason must be Error when envelope delivery fails, not Eof — \
+         masking transport failures as clean EOF defeats the audit-correctness goal",
+    );
+
+    // The propagated anyhow context must surface in stderr.
+    let stderr = detached.captured_stderr();
+    assert!(
+        stderr.contains("pre-init error envelope"),
+        "expected propagated 'pre-init error envelope' anyhow context in stderr, got:\n{stderr}",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+```bash
+cargo test -p rimap-server --test mcp_wire_negative pre_initialize_envelope_write_failure_records_error -- --nocapture
+```
+
+Expected: PASS.
+
+Common failure modes:
+- **Killed by signal 13**: Rust's SIGPIPE handler regression — the cargo-built binary inherited a SIGPIPE handler that terminates the process. Check that nothing in `main.rs::main()` calls `signal_hook::register` or similar before `init()`.
+- **`process_end.reason == Eof`**: the `?` propagation in `main.rs` was lost — re-check Task 4.
+- **`no process_end record found`**: the binary panicked before `audit_for_shutdown.log_process_end(...)` fired. Check `main.rs:158-171` is still reachable on the early-return path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/rimap-server/tests/mcp_wire_negative.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): pin Error reason on pre-init envelope write fail (#275)
+
+Closes the harness's stdout read end before sending a pre-initialize
+tools/list request, then asserts:
+- server exits non-zero (not killed by SIGPIPE)
+- process_end.reason: Error (not Eof — would mask the failure)
+- propagated anyhow context surfaces in stderr
+
+Addresses Codex adversarial-review finding 2026-05-14 (medium).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Full local-CI sweep and final commit (if needed)
+
+**Files:** none expected; this task verifies everything composes.
+
+- [ ] **Step 1: Run `just ci`**
+
+Run:
+```bash
+just ci
+```
+
+Expected: PASS. This runs fmt-check, clippy with `-D warnings`, the workspace test suite, and `cargo deny`.
+
+Common late-stage failures:
+- **Clippy `unused_imports` in `mcp_wire_negative.rs`**: the test file gained `use tokio::time::timeout` / `use tokio::io::AsyncWriteExt` inside one test function. If a sibling test binary compiles the same `support/` module and doesn't use them, no warning fires. If it does, lift the `use` statements to the top of `mcp_wire_negative.rs` so they're shared.
+- **`AuditRecord` / `Payload` / `ProcessEndReason` not in scope**: confirm the `rimap-audit` dev-dependency in `crates/rimap-server/Cargo.toml` is present.
+- **`audit_path` field is private on `DetachedStdoutHarness`**: confirm the accessor method exists and returns `&Path`.
+- **`stderr_log` field also private**: the `captured_stderr` accessor must be `pub` on `DetachedStdoutHarness`.
+
+- [ ] **Step 2: Verify no `#[ignore]` remains pinned to #275**
+
+Run:
+```bash
+rg -n '#\[ignore.*#275' crates/
+```
+
+Expected: no matches. If a match appears, un-ignore it (it was missed during Task 5) and re-run tests.
+
+- [ ] **Step 3: Verify the issue-closing references are accurate**
+
+Run:
+```bash
+rg -n '#275' crates/ docs/superpowers/
+```
+
+Expected: references in the spec file, the plan file, and any commit messages. No stale "blocked on #275" comments.
+
+- [ ] **Step 4: Final commit (only if any cleanup happened)**
+
+Only commit if there were fixups in Steps 1-3. If nothing was changed:
+
+```bash
+git status
+# (should report nothing to commit)
+```
+
+Otherwise:
+
+```bash
+git add -p   # stage cleanup hunks
+git commit -m "$(cat <<'EOF'
+chore(rimap-server): tidy after #275 implementation
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin fix/issue-275-pre-initialize-handling
+gh pr create --title "fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)" --body "$(cat <<'EOF'
+## Summary
+
+- Pre-initialize Request → JSON-RPC `-32002` "Server not initialized" envelope (request id echoed verbatim), clean close, exit 0, audit `reason: Eof`.
+- Pre-initialize Notification / Response → silent clean close, exit 0, audit `reason: Eof`.
+- Envelope write failure → propagated `anyhow::Error`, non-zero exit, audit `reason: Error` (Codex adversarial-review finding 2026-05-14).
+
+Fixes #275.
+
+## Test plan
+
+- [ ] `cargo test -p rimap-server --test mcp_wire_negative` passes — four pre-initialize cases covered (numeric id, string id, notification silent close, write-failure).
+- [ ] `cargo test -p rimap-server --lib mcp::preinit` passes — six unit tests on the envelope synthesizer.
+- [ ] `just ci` passes locally.
+
+Spec: `docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md`
+Plan: `docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done
+
+All tasks complete. Verify with one final read-through of `git log fix/issue-275-pre-initialize-handling ^main` — should show:
+
+1. `docs(spec): pre-initialize request handling design (#275)` (already present)
+2. `docs(spec): address Codex adversarial-review findings (#275)` (already present)
+3. `feat(rimap-server): add NOT_INITIALIZED -32002 error code (#275)` (Task 1)
+4. `feat(rimap-server): add pre-initialize envelope synthesizer (#275)` (Task 3)
+5. `fix(rimap-server): handle pre-initialize requests with -32002 envelope (#275)` (Task 4)
+6. `test(rimap-server): pin -32002 contract for pre-init tools/list (#275)` (Task 5)
+7. `test(rimap-server): pin string-id roundtrip for pre-init reject (#275)` (Task 6)
+8. `test(rimap-server): pin silent-close for pre-init notifications (#275)` (Task 7)
+9. `test(rimap-server): add closed-stdout harness variant (#275)` (Task 8)
+10. `test(rimap-server): pin Error reason on pre-init envelope write fail (#275)` (Task 9)

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -38,7 +38,10 @@ The originating test —
 2. **Pre-initialize Notification or Response**: drop silently, close cleanly,
    exit `0`. (Per JSON-RPC §4.1, notifications never receive a response;
    a response without a matching server request is malformed.)
-3. **Audit log**: `process_end` emits with `reason: Eof`, not `Error`.
+3. **Audit log**: `process_end` emits with `reason: Eof` (not `Error`)
+   on the success path. Transport-level write failures while emitting
+   the envelope remain classified as `reason: Error` and exit non-zero
+   — those are real server faults, not misbehaving-client input.
 
 ## Approach
 
@@ -63,8 +66,13 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
     Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
         if let Some(line) = synthesize_pre_init_error_envelope(&msg) {
             let mut out = tokio::io::stdout();
-            let _ = out.write_all(line.as_bytes()).await;
-            let _ = out.flush().await;
+            out.write_all(line.as_bytes())
+                .await
+                .context("writing pre-init error envelope to stdout")?;
+            out.flush()
+                .await
+                .context("flushing pre-init error envelope")?;
+            tracing::info!("rejected pre-initialize request with -32002 envelope");
         }
         return Ok(());
     }
@@ -72,9 +80,18 @@ let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
 };
 ```
 
-Returning `Ok(())` causes the outer `mcp_result` to be `Ok`, which the
-existing `process_end` block at `main.rs:158-171` records as `reason: Eof`
-and the process exits `0`.
+Returning `Ok(())` on the success path causes the outer `mcp_result` to
+be `Ok`, which the existing `process_end` block at `main.rs:158-171`
+records as `reason: Eof` and the process exits `0`.
+
+Write/flush failures are propagated with `?`. A failed stdout write is
+a genuine server fault: the client never received the envelope and we
+have no other transport to recover. The `?` returns `Err` to
+`mcp_result`, which records `reason: Error` and exits non-zero —
+correct for that case. The bug we are fixing was misclassifying a
+successful handling of a misbehaving client as an error; propagating
+real transport faults to the same shutdown machinery preserves that
+audit-correctness goal at the failure boundary.
 
 Because rmcp has already consumed its `tokio::io::Stdout` by the time the
 error returns, the helper writes through a freshly acquired
@@ -83,6 +100,34 @@ process stdout file descriptor.
 
 The cancellation channel + drainer (`main.rs:133-134`) only matter for
 mid-dispatch cancellation; the early-return path skips them entirely.
+
+## Dependencies
+
+This spec assumes the wire-level negative-test harness from #266 / PR
+#278. As of 2026-05-14, that PR is still in DRAFT and the harness lives
+only on the `feature/issue-266-mcp-fuzzing` branch:
+
+- `crates/rimap-server/tests/mcp_wire_negative.rs` — file under
+  which `tools_list_before_initialize` is `#[ignore]`'d
+- `crates/rimap-server/tests/support/wire/harness.rs` — the
+  `Harness` / `CloseOrResponse` / `response_or_close` plumbing the
+  test plan below references
+
+Implementation of #275 is therefore gated on #266 landing. Branching
+strategy is decided at implementation kickoff, not here:
+
+1. **Preferred: rebase onto `main` after #266 merges.** Clean history,
+   independent PR review.
+2. **Fallback: stack `fix/issue-275-pre-initialize-handling` on
+   `feature/issue-266-mcp-fuzzing`** and mark the PR as merge-after-#266.
+   Use this only if both PRs need to be in flight simultaneously.
+
+If #266's harness shape changes during its review (e.g. `CloseOrResponse`
+gains variants, `response_or_close` signature shifts), the test
+assertions in this spec are re-aligned to the merged shape before
+implementation begins. Adopting #266's harness wholesale into #275 is
+explicitly rejected: it would duplicate ~600 lines of #266's
+contribution and guarantee a merge conflict.
 
 ## Envelope shape
 
@@ -148,10 +193,38 @@ mid-dispatch cancellation; the early-return path skips them entirely.
 
 ### Audit log
 
-One assertion in either the un-ignored test or a sibling test that
-reads the audit log post-shutdown and verifies `process_end.reason
-== Eof`. The pattern follows existing audit-tail tests under
-`crates/rimap-server/tests/`.
+Two cases, both reading the audit log post-shutdown via the pattern
+established by existing audit-tail tests under
+`crates/rimap-server/tests/`:
+
+1. **Success path.** `tools_list_before_initialize` (and the string-id
+   variant) asserts `process_end.reason == Eof` after the envelope is
+   written and the server exits `0`. This is the case the bug report
+   is asking us to fix.
+2. **Write-failure path.** A new wire test
+   `pre_initialize_envelope_write_failure_records_error` closes the
+   harness's child-stdout read end before the server attempts to write
+   the envelope (Codex review finding 2026-05-14, medium). Asserts:
+   - server exits non-zero
+   - `process_end.reason == Error`
+   - the rejected envelope is observable in stderr or via the
+     `tracing::error!` machinery (no silent audit success on
+     transport failure)
+
+   This test requires a new harness helper —
+   `Harness::drop_stdout_reader()` or equivalent — that drops the
+   `BufReader<ChildStdout>` while keeping `child` alive so its exit
+   status can still be observed. Adding this helper is in scope for
+   #275 (small, ~10 lines in `support/wire/harness.rs`).
+
+### SIGPIPE handling
+
+The broken-stdout test relies on Rust's default SIGPIPE behavior
+(`SIG_IGN` since 1.0): writes to a closed pipe return `Err(BrokenPipe)`
+rather than terminating the process. This is checked by the test
+itself — if the assertion that the server exits non-zero (rather than
+being killed by SIGPIPE with `status.signal() == Some(13)`) ever
+fails, the test surfaces a SIGPIPE regression.
 
 ### Out of scope
 
@@ -168,11 +241,16 @@ reads the audit log post-shutdown and verifies `process_end.reason
    `Err(other) =>` arm preserves today's behavior for every other
    initialization failure (transport errors, unsupported protocol
    version, etc.) so we do not silently swallow real bugs.
-2. **stderr behavior.** The early-return path no longer emits
-   `tracing::error!`. A single `tracing::info!` log entry is added
-   at envelope-write time so audit operators can correlate the
-   wire event — kept at `info` because this is a normal handled
-   case, not a fault.
+2. **stderr behavior.** Two distinct outcomes:
+   - **Success** (envelope written, exit 0, `reason: Eof`): one
+     `tracing::info!` entry so audit operators can correlate the
+     wire event. Kept at `info` because this is a normal handled
+     case, not a fault.
+   - **Write failure** (envelope could not be delivered, exit
+     non-zero, `reason: Error`): the existing `tracing::error!("{e:#}")`
+     in `main.rs:49` fires from the propagated `anyhow::Error`,
+     same as today's behavior for other transport faults. No silent
+     classification of write failures as clean EOF.
 3. **stdout fd reuse.** Acquiring a fresh `tokio::io::stdout()` after
    rmcp drops its handle is safe because both wrap the same OS file
    descriptor. Anything rmcp wrote on this path (e.g. a ping response
@@ -202,7 +280,17 @@ Mirrors the issue:
 - Pre-initialize Request results in a JSON-RPC error envelope with
   `code == -32002`; pre-initialize Notification / Response is dropped
   silently.
-- `tools_list_before_initialize` and the two new wire tests pass with
+- `tools_list_before_initialize` (un-ignored) plus the three new wire
+  tests (`tools_list_before_initialize_str_id`,
+  `pre_initialize_notification_silent_close`,
+  `pre_initialize_envelope_write_failure_records_error`) pass with
   strict assertions on the chosen behavior.
-- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input.
-- `process_end` audit record reports `reason: Eof`.
+- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input
+  when the envelope is delivered successfully.
+- `process_end` audit record reports `reason: Eof` on the success
+  path.
+- Pre-initialize handling does **not** mask transport-level write
+  failures: if the server cannot deliver the envelope, exit
+  non-zero and audit `reason: Error`. The new
+  `pre_initialize_envelope_write_failure_records_error` wire test
+  pins this contract.

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -1,0 +1,208 @@
+# Pre-Initialize Request Handling (#275)
+
+**Date:** 2026-05-14
+**Issue:** [#275](https://github.com/randomparity/rusty-imap-mcp/issues/275)
+**Discovered by:** Phase 4 negative-path testing (#266)
+**Status:** Design approved; implementation pending
+
+## Problem
+
+A JSON-RPC client that sends any non-`initialize`, non-`ping` request as its
+first message causes `rusty-imap-mcp` to exit with code `1` and a stderr log:
+
+```
+expect initialized request, but received: Some(Request(ListToolsRequest(...)))
+```
+
+The crash corrupts audit trails (the `process_end` record is emitted with
+`reason: Error`) and gives misbehaving clients no actionable wire-level signal.
+
+## Root cause
+
+The rmcp 1.5 service loop
+([`rmcp-1.5.0/src/service/server.rs:172-204`](https://docs.rs/rmcp/1.5.0/src/rmcp/service/server.rs.html))
+accepts only `PingRequest` or `InitializeRequest` as the first message; anything
+else short-circuits to
+`ServerInitializeError::ExpectedInitializeRequest(Some(msg))`. The server
+entrypoint at `crates/rimap-server/src/main.rs:138-140` wraps that error with
+`anyhow!`, which propagates to `main()` and triggers `ExitCode::FAILURE`.
+
+The originating test —
+`crates/rimap-server/tests/mcp_wire_negative.rs:339-368`
+(`tools_list_before_initialize`) — is currently `#[ignore]`'d pending this fix.
+
+## Desired behavior
+
+1. **Pre-initialize Request** (e.g. `tools/list`): reply with a JSON-RPC error
+   envelope echoing the request's `id`, then close cleanly and exit `0`.
+2. **Pre-initialize Notification or Response**: drop silently, close cleanly,
+   exit `0`. (Per JSON-RPC §4.1, notifications never receive a response;
+   a response without a matching server request is malformed.)
+3. **Audit log**: `process_end` emits with `reason: Eof`, not `Error`.
+
+## Approach
+
+A new `crates/rimap-server/src/mcp/preinit.rs` module exposes one pure helper:
+
+```rust
+pub(crate) fn synthesize_pre_init_error_envelope(
+    msg: &ClientJsonRpcMessage,
+) -> Option<String>
+```
+
+The helper returns `Some(<newline-terminated JSON line>)` for the `Request`
+variant and `None` for `Notification` / `Response` / other variants. No I/O,
+no transport access — it is trivially unit-testable against
+`serde_json::Value` snapshots.
+
+The call site in `main.rs::run` matches on the specific rmcp error variant:
+
+```rust
+let service = match Box::pin(rmcp::serve_server(mcp_server, transport)).await {
+    Ok(svc) => svc,
+    Err(ServerInitializeError::ExpectedInitializeRequest(Some(msg))) => {
+        if let Some(line) = synthesize_pre_init_error_envelope(&msg) {
+            let mut out = tokio::io::stdout();
+            let _ = out.write_all(line.as_bytes()).await;
+            let _ = out.flush().await;
+        }
+        return Ok(());
+    }
+    Err(other) => return Err(anyhow::anyhow!("MCP server init: {other}")),
+};
+```
+
+Returning `Ok(())` causes the outer `mcp_result` to be `Ok`, which the
+existing `process_end` block at `main.rs:158-171` records as `reason: Eof`
+and the process exits `0`.
+
+Because rmcp has already consumed its `tokio::io::Stdout` by the time the
+error returns, the helper writes through a freshly acquired
+`tokio::io::stdout()` handle. This is safe: both handles wrap the same
+process stdout file descriptor.
+
+The cancellation channel + drainer (`main.rs:133-134`) only matter for
+mid-dispatch cancellation; the early-return path skips them entirely.
+
+## Envelope shape
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <echoed verbatim>,
+  "error": {
+    "code": -32002,
+    "message": "Server not initialized: send `initialize` before any other request"
+  }
+}
+```
+
+- **Code `-32002`** lives in the JSON-RPC server-error band (`-32000..=-32099`)
+  and is the conventional "Server not initialized" code in the LSP / MCP
+  ecosystem. It does not collide with existing codes in
+  `crates/rimap-server/src/mcp/error.rs`: `-32001` posture-denied,
+  `-32003` rate-limited, `-32004` breaker, `-32005` attachment-too-large.
+  A new `pub const NOT_INITIALIZED: McpCode = McpCode(-32002);` is added
+  to that file so the code registry remains in one place; `preinit.rs`
+  references it from there.
+- **`id` echoing**: numbers, strings, and `null` pass through unchanged
+  via `serde_json::Value`. No `as_u64()` coercion.
+- **Message text**: a fixed string. No echo of the offending method name
+  or any client-supplied content (matches the opaque-message pattern
+  already used for `ProtectedFolder` / `ExpungeDenied` at
+  `crates/rimap-server/src/mcp/error.rs:41-44`).
+- **No `data` field**.
+
+## Test plan
+
+### Unit (`crates/rimap-server/src/mcp/preinit.rs`)
+
+1. `Request` with numeric id → envelope with same numeric id,
+   `error.code == -32002`, valid JSON-RPC framing.
+2. `Request` with string id → envelope with same string id.
+3. `Request` with `null` id → envelope with `id: null`.
+4. `Notification` → returns `None`.
+5. `Response` → returns `None`.
+6. Output ends with exactly one `\n`, is single-line, parses round-trip
+   via `serde_json::from_str`.
+
+### Integration
+
+**Un-ignore `tools_list_before_initialize`** at
+`crates/rimap-server/tests/mcp_wire_negative.rs:339-368`:
+
+- Remove `#[ignore]`.
+- Replace the accept-either-envelope-or-close branch with a strict
+  envelope assertion (`error.code == -32002`, `id` matches the id the
+  harness sent).
+- Add a follow-up `response_or_close` call that asserts `CleanClose`
+  (proves the server exited `0` after the envelope was written).
+- Update the docstring to reference #275 as fixed.
+
+**New wire tests in `mcp_wire_negative.rs`:**
+
+- `pre_initialize_notification_silent_close`: first message is
+  `notifications/cancelled`; assert `CleanClose` only (no envelope).
+- `tools_list_before_initialize_str_id`: same as the un-ignored test
+  but with a string id; pins id-type preservation at the wire layer.
+
+### Audit log
+
+One assertion in either the un-ignored test or a sibling test that
+reads the audit log post-shutdown and verifies `process_end.reason
+== Eof`. The pattern follows existing audit-tail tests under
+`crates/rimap-server/tests/`.
+
+### Out of scope
+
+- `mcp_wire_proptest.rs` already runs `initialize` first; no proptest
+  changes.
+- No e2e (Dovecot) test changes — this is a wire-level behavior.
+
+## Risks
+
+1. **rmcp upstream variant rename.** `ServerInitializeError` is
+   `#[non_exhaustive]`. If rmcp renames `ExpectedInitializeRequest`
+   or splits Request / Notification cases, the explicit match arm
+   becomes a compile error — the desired failure mode. The fallback
+   `Err(other) =>` arm preserves today's behavior for every other
+   initialization failure (transport errors, unsupported protocol
+   version, etc.) so we do not silently swallow real bugs.
+2. **stderr behavior.** The early-return path no longer emits
+   `tracing::error!`. A single `tracing::info!` log entry is added
+   at envelope-write time so audit operators can correlate the
+   wire event — kept at `info` because this is a normal handled
+   case, not a fault.
+3. **stdout fd reuse.** Acquiring a fresh `tokio::io::stdout()` after
+   rmcp drops its handle is safe because both wrap the same OS file
+   descriptor. Anything rmcp wrote on this path (e.g. a ping response
+   if the client sent `ping` before the offending request) is a
+   well-formed JSON-RPC line; our envelope simply follows it on a new
+   line. No partial writes or interleaving.
+
+## What does not change
+
+- Tool dispatch after `initialize` completes.
+- Audit-envelope guarantees for in-flight tool calls.
+- Other negative-path tests in `mcp_wire_negative.rs`.
+- The `RimapError` / `ErrorCode` taxonomy in `crates/rimap-core`
+  (the pre-init code lives only in the wire-level `McpCode` registry).
+
+## Explicitly out of scope
+
+- Issue #276 (protocol-version negotiation echoes unsupported versions).
+- Reorganizing `main.rs::run` (currently ~119 lines, over the 100-line
+  cap; flagged but addressed only if it becomes load-bearing).
+- Adding a new `ErrorCode` variant to `rimap_core::ErrorCode`.
+
+## Acceptance
+
+Mirrors the issue:
+
+- Pre-initialize Request results in a JSON-RPC error envelope with
+  `code == -32002`; pre-initialize Notification / Response is dropped
+  silently.
+- `tools_list_before_initialize` and the two new wire tests pass with
+  strict assertions on the chosen behavior.
+- `rusty-imap-mcp` exits `0` (not `1`) on misbehaving-client input.
+- `process_end` audit record reports `reason: Eof`.

--- a/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md
@@ -103,31 +103,42 @@ mid-dispatch cancellation; the early-return path skips them entirely.
 
 ## Dependencies
 
-This spec assumes the wire-level negative-test harness from #266 / PR
-#278. As of 2026-05-14, that PR is still in DRAFT and the harness lives
-only on the `feature/issue-266-mcp-fuzzing` branch:
+This spec exercises the wire-level negative-test harness introduced in
+#266 / PR #278:
 
 - `crates/rimap-server/tests/mcp_wire_negative.rs` — file under
-  which `tools_list_before_initialize` is `#[ignore]`'d
+  which `tools_list_before_initialize` is `#[ignore]`'d, plus the
+  three new pre-initialize tests added by this fix
 - `crates/rimap-server/tests/support/wire/harness.rs` — the
   `Harness` / `CloseOrResponse` / `response_or_close` plumbing the
   test plan below references
 
-Implementation of #275 is therefore gated on #266 landing. Branching
-strategy is decided at implementation kickoff, not here:
+#275 is one of three merge blockers (#275, #276, #277) explicitly
+listed on PR #278. The blocker policy from #266's plan §5 — "bugs
+found during implementation are fixed before this phase merges" —
+keeps it literally true: by the time PR #278 reaches `main`, no
+`#[ignore]`'d Phase 4 tests remain in history.
 
-1. **Preferred: rebase onto `main` after #266 merges.** Clean history,
-   independent PR review.
-2. **Fallback: stack `fix/issue-275-pre-initialize-handling` on
-   `feature/issue-266-mcp-fuzzing`** and mark the PR as merge-after-#266.
-   Use this only if both PRs need to be in flight simultaneously.
+**Branching strategy.** The fix PR targets `feature/issue-266-mcp-fuzzing`
+as its merge base:
 
-If #266's harness shape changes during its review (e.g. `CloseOrResponse`
-gains variants, `response_or_close` signature shifts), the test
-assertions in this spec are re-aligned to the merged shape before
-implementation begins. Adopting #266's harness wholesale into #275 is
-explicitly rejected: it would duplicate ~600 lines of #266's
-contribution and guarantee a merge conflict.
+- It un-ignores `tools_list_before_initialize` and adds the three new
+  pre-initialize tests in the same PR as the production fix.
+  Reviewers see "this server change makes this previously-ignored test
+  pass" in one diff.
+- Once #275, #276, and #277 have all landed on
+  `feature/issue-266-mcp-fuzzing`, PR #278 is marked ready for review
+  and merges to `main` carrying all three fixes + un-ignores together.
+
+Note: targeting the feature branch is a *workflow* decision that keeps
+the un-ignore commit attached to the fix. The fix itself can be
+verified against the harness in a working copy regardless of which
+branch the PR ultimately targets. The constraint is only on PR base,
+not on local development.
+
+Cherry-picking the negative harness from #266 into a standalone #275
+PR off `main` is explicitly rejected: it duplicates ~600 lines of
+#266's contribution and guarantees a merge conflict.
 
 ## Envelope shape
 


### PR DESCRIPTION
## Summary

- Pre-initialize Request → JSON-RPC `-32002` "Server not initialized" envelope (request id echoed verbatim), clean close, exit 0, audit `reason: Eof`.
- Pre-initialize Notification / Response → silent clean close, exit 0, audit `reason: Eof`.
- Envelope write failure → propagated `anyhow::Error`, non-zero exit, audit `reason: Error` (Codex adversarial-review finding 2026-05-14).
- Drive-by: bumps `lettre` 0.11.21 → 0.11.22 to fix RUSTSEC-2026-0141 (boring-tls hostname-verification bypass; rimap-smtp uses native-tls/rustls so was never exposed in practice, but `cargo deny` was blocking the workspace).

Fixes #275. One of three merge blockers (#275, #276, #277) for PR #278; targets `feature/issue-266-mcp-fuzzing` so the un-ignore commit travels with the fix.

## Test plan

- [x] `cargo test -p rimap-server --test mcp_wire_negative` — 15 tests pass (1 ignored, blocked on #276)
- [x] `cargo test -p rimap-server --lib mcp::preinit` — 6 unit tests pass
- [x] `cargo deny check advisories` — clean (RUSTSEC-2026-0141 resolved)
- [x] Pre-push hook (`just test` + `cargo deny`) passed locally before push

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-14-issue-275-pre-initialize-handling-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-issue-275-pre-initialize-handling.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)