### PR TITLE
test(mcp): add Phase 4 protocol fuzzing stubs and negative-path tests

### DIFF
--- a/tests/fuzz_mcp.rs
+++ b/tests/fuzz_mcp.rs
@@ -1,0 +1,75 @@
+//! Protocol fuzzing and negative-path coverage (Phase 4)
+//!
+//! Property-based tests for the MCP wire protocol:
+//! - Malformed JSON-RPC envelopes
+//! - Unknown methods
+//! - Oversized payloads
+//! - Missing required fields
+//! - Cancellation mid-call
+//! - Concurrent requests on single session
+
+use proptest::prelude::*;
+
+/// Strategy for generating malformed JSON-RPC requests
+pub fn malformed_request_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        // Missing jsonrpc version
+        r#"{"method":"test","id":1}"#,
+        // Invalid jsonrpc version
+        r#"{"jsonrpc":"1.0","method":"test","id":1}"#,
+        // Missing method
+        r#"{"jsonrpc":"2.0","id":1}"#,
+        // Empty method
+        r#"{"jsonrpc":"2.0","method":"","id":1}"#,
+        // Very long method name (oversized)
+        r#"{"jsonrpc":"2.0","method":"AAAAAAAAAA","id":1}"#,
+        // Missing id
+        r#"{"jsonrpc":"2.0","method":"test"}"#,
+        // Invalid JSON
+        r#"{not valid json}"#,
+        // Null method
+        r#"{"jsonrpc":"2.0","method":null,"id":1}"#,
+        // Array instead of object
+        r#"[1,2,3]"#,
+    ].prop_map(|s| s.to_string())
+}
+
+proptest! {
+    #[test]
+    fn fuzz_malformed_requests_does_not_panic(input in malformed_request_strategy()) {
+        // Feed malformed input to MCP parser
+        // Should return error, never panic
+        let result = parse_mcp_request(&input);
+        assert!(result.is_err() || result.is_ok());
+    }
+}
+
+fn parse_mcp_request(_input: &str) -> Result<(), ()> {
+    // Placeholder - integrate with actual MCP parser
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unknown_method_returns_error() {
+        // TODO: integrate with actual MCP handler
+    }
+
+    #[test]
+    fn test_oversized_payload_rejected() {
+        // TODO: test payload size limits
+    }
+
+    #[test]
+    fn test_concurrent_requests_handled() {
+        // TODO: test concurrent request handling on single session
+    }
+
+    #[test]
+    fn test_cancellation_mid_call() {
+        // TODO: test cancellation semantics
+    }
+}


### PR DESCRIPTION
## Summary
Adds property-based test stubs for MCP wire protocol fuzzing (Phase 4):
- Malformed JSON-RPC envelope strategies
- Unknown method handling
- Oversized payload testing
- Concurrent request handling

Implements part of #266

Wallet: zp6