### PR TITLE
test(rimap-server): pin #277 regression seed in proptest-regressions

### DIFF
--- a/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
+++ b/crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc e6e6f11c123dd9d50f094d49679036594530158355116c207c4d7c383115bf4b # shrinks to envelope = Object {"id": Number(0), "jsonrpc": String("2.0"), "method": String("tools/list"), "params": Number(0)}
+cc bcb9e70682863c34c8b32fada7bce9c0f1f8d3f6027bc3664a72860ac71674ac # issue #277 shrunk to {"method":"a"} — server hung on unknown-method envelopes missing jsonrpc/id


### PR DESCRIPTION
## Summary
- Pin the issue #277 shrunk failing case `{"method":"a"}` (proptest seed `cc bcb9e706...74ac`) in `crates/rimap-server/tests/mcp_wire_proptest.proptest-regressions` so it replays before novel cases on every future run.

## Context
The fix for #277 (envelope validator) already landed via 31 commits ending at 979d311. This PR pins the specific shrunk seed the issue cites so the regression coverage is explicit. Verified on the current main tip with `PROPTEST_CASES=100000 cargo test -p rimap-server --test mcp_wire_proptest -- prop_envelope_never_panics` — pass, 5.00s, zero Hung outcomes.

## Test plan
- [x] `cargo check --workspace --all-targets --locked` (pre-push hook)
- [x] `cargo deny check advisories bans` (pre-push hook)
- [x] `PROPTEST_CASES=100000 cargo test -p rimap-server --test mcp_wire_proptest -- prop_envelope_never_panics` — pass

Closes #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)