### PR TITLE
ci(mcp-fuzz-nightly): install libdbus-1-dev so build succeeds (#266)

### DIFF
--- a/.github/workflows/mcp-fuzz-nightly.yml
+++ b/.github/workflows/mcp-fuzz-nightly.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install libdbus-1-dev
+        # The keyring crate's `linux-native-sync-persistent` backend links
+        # against libdbus at build time. Without this step, the cargo build
+        # in the next step fails with `Package 'dbus-1' was not found`.
+        # Matches the pattern used by every other Linux Rust job in ci.yml
+        # and release.yml.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libdbus-1-dev pkg-config
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1 (toolchain: stable) # zizmor: ignore[superfluous-actions]
         with:


### PR DESCRIPTION
## Summary

The `mcp-fuzz-nightly.yml` workflow has been failing every scheduled run because the `keyring` crate's `linux-native-sync-persistent` backend links against libdbus at build time, and the Ubuntu runner doesn't ship `libdbus-1-dev` or `pkg-config` by default.

The build aborts before any property test executes, so the per-property guard added in PR #278 (to prevent vacuous fuzz claims) never fires. Acceptance criterion #2 of issue #266 — "property tests run for ≥1000 cases per property in CI" — was therefore not actually met on `main`.

Latest failed nightly: [run 25981529385](https://github.com/randomparity/rusty-imap-mcp/actions/runs/25981529385) — `Package 'dbus-1' was not found in the pkg-config search path` from `libdbus-sys-0.2.7/build.rs:25`.

## What this changes

Add the same `apt-get install libdbus-1-dev pkg-config` step that every other Linux Rust job in `ci.yml` (lines 42-43, 73-74, 98-99, 120-121, 181-182, 213-214) and `release.yml` (lines 61-62, 87-88) already uses.

## Test plan

- [x] `actionlint .github/workflows/mcp-fuzz-nightly.yml` — silent
- [x] `zizmor .github/workflows/mcp-fuzz-nightly.yml` — no findings
- [x] Pre-push hook (cargo check + cargo deny) — green
- [ ] After merge: manually trigger the nightly via `workflow_dispatch` on `main` to confirm the property guard fires green (then close #266)

Refs #266.