### PR TITLE
fix(rimap-audit): give parse_line a dedicated AuditError::Parse variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boots in infrastructure-only mode (only `list_accounts` /
   `use_account` are functionally useful). Unblocks the wire-conformance
   harness. Removes `ConfigError::NoAccounts`.
+- `rimap_audit::reader::parse_line` now returns
+  `AuditError::Parse(serde_json::Error)` instead of `AuditError::Read`
+  with an empty path and a synthesized `io::Error`. The previous
+  Display rendered with empty backticks (``failed to read audit file
+  `` `` ``); the new variant renders as `failed to parse audit
+  record: ...`. The `Read` variant remains in use for `stream_records`,
+  which still has the real path and line number. `AuditError` is
+  `#[non_exhaustive]` so adding the variant is source-compatible for
+  downstream wildcard matches. Issue #255.
 
 ### Fixed
 

--- a/crates/rimap-audit/src/reader/mod.rs
+++ b/crates/rimap-audit/src/reader/mod.rs
@@ -103,21 +103,17 @@ fn kind_of(payload: &Payload) -> &'static str {
 /// Parse a single JSONL line into an [`AuditRecord`].
 ///
 /// Thin wrapper around `serde_json::from_slice` that maps any decode
-/// failure to [`AuditError::Read`] with `line: None` (callers track line
-/// numbers when they have them — `parse_line` itself does not). Empty
-/// input is treated as malformed and returns `Err`; callers that want
-/// the trailing-empty-line tolerance enforced by `stream_records` should
-/// use that function instead.
+/// failure to [`AuditError::Parse`]. Callers that have file path / line
+/// context (like `stream_records`) rewrap the error as
+/// [`AuditError::Read`] before propagating. Empty input is treated as
+/// malformed and returns `Err`; callers that want the trailing-empty-line
+/// tolerance enforced by `stream_records` should use that function instead.
 ///
 /// # Errors
-/// [`AuditError::Read`] when the bytes do not deserialize to a valid
+/// [`AuditError::Parse`] when the bytes do not deserialize to a valid
 /// [`AuditRecord`].
 pub fn parse_line(raw: &[u8]) -> Result<AuditRecord, AuditError> {
-    serde_json::from_slice::<AuditRecord>(raw).map_err(|err| AuditError::Read {
-        path: std::path::PathBuf::new(),
-        line: None,
-        source: std::io::Error::new(std::io::ErrorKind::InvalidData, err),
-    })
+    serde_json::from_slice::<AuditRecord>(raw).map_err(AuditError::Parse)
 }
 
 /// Open the audit file with a shared lock.
@@ -231,7 +227,7 @@ where
             }
             Ok(())
         }
-        Err(AuditError::Read { source, .. }) if is_trailing => {
+        Err(AuditError::Parse(source)) if is_trailing => {
             tracing::warn!(
                 path = %path.display(),
                 line = line_no,
@@ -240,10 +236,10 @@ where
             );
             Ok(())
         }
-        Err(AuditError::Read { source, .. }) => Err(AuditError::Read {
+        Err(AuditError::Parse(source)) => Err(AuditError::Read {
             path: path.to_path_buf(),
             line: Some(line_no),
-            source,
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
         }),
         Err(other) => Err(other),
     }
@@ -479,15 +475,37 @@ mod tests {
     #[test]
     #[expect(clippy::expect_used, reason = "tests use expect for assertions")]
     #[expect(clippy::panic, reason = "tests assert variant shapes via panic")]
-    fn parse_line_returns_invalid_data_on_malformed_json() {
+    fn parse_line_returns_parse_variant_on_malformed_json() {
         let err = super::parse_line(b"{not json").expect_err("malformed JSON must error");
         match err {
-            crate::AuditError::Read { line, source, .. } => {
-                assert!(line.is_none(), "parse_line has no line context");
-                assert_eq!(source.kind(), std::io::ErrorKind::InvalidData);
+            crate::AuditError::Parse(source) => {
+                assert_eq!(source.classify(), serde_json::error::Category::Syntax);
             }
             other => panic!("unexpected error kind: {other:?}"),
         }
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "tests use expect for assertions")]
+    fn parse_line_display_is_human_readable_without_empty_backticks() {
+        // Regression test for issue #255: the previous implementation reused
+        // `AuditError::Read` with an empty `PathBuf`, rendering the message
+        // as ``failed to read audit file `` `` ... ``. The `Parse` variant
+        // must produce a clean, path-less message.
+        let err = super::parse_line(b"{not json").expect_err("malformed JSON must error");
+        let display = err.to_string();
+        assert!(
+            display.starts_with("failed to parse audit record:"),
+            "Display must lead with the parse-failure framing; got: {display}",
+        );
+        assert!(
+            !display.contains("``"),
+            "Display must not contain empty backticks; got: {display}",
+        );
+        assert!(
+            !display.contains("audit file"),
+            "path-less parse failure must not claim a file path; got: {display}",
+        );
     }
 
     #[test]

--- a/crates/rimap-audit/src/record/error.rs
+++ b/crates/rimap-audit/src/record/error.rs
@@ -41,6 +41,12 @@ pub enum AuditError {
     /// A record could not be serialized to JSON.
     #[error("failed to serialize audit record: {0}")]
     Serialize(#[source] serde_json::Error),
+    /// A record could not be deserialized from JSON when no file path /
+    /// line number is available (e.g. `parse_line` called by an external
+    /// consumer or a fuzz harness). `stream_records` rewraps these as
+    /// [`AuditError::Read`] with the real path and line.
+    #[error("failed to parse audit record: {0}")]
+    Parse(#[source] serde_json::Error),
     /// A record could not be written to disk.
     #[error("failed to write audit record to `{path}`: {source}")]
     Write {
@@ -97,6 +103,7 @@ impl AuditError {
         match self {
             Self::Open { .. } | Self::ParentDir { .. } | Self::Locked { .. } => ErrorCode::Config,
             Self::Serialize(_)
+            | Self::Parse(_)
             | Self::Write { .. }
             | Self::Fsync { .. }
             | Self::Rotate { .. }
@@ -146,6 +153,18 @@ mod tests {
             path: PathBuf::from("/tmp/a.jsonl"),
             source: std::io::Error::from(std::io::ErrorKind::BrokenPipe),
         };
+        assert_eq!(err.code(), ErrorCode::Internal);
+    }
+
+    #[test]
+    fn parse_variant_maps_to_internal() {
+        // Pin the `Parse` variant in the runtime/Internal bucket alongside
+        // its peers (`Serialize`, `Read`, ...). A future mutation that moves
+        // `Parse` into the Config arm would silently misclassify deserialize
+        // failures from `parse_line`.
+        let serde_err = serde_json::from_slice::<serde_json::Value>(b"{not json")
+            .expect_err("malformed JSON must error");
+        let err = AuditError::Parse(serde_err);
         assert_eq!(err.code(), ErrorCode::Internal);
     }
 


### PR DESCRIPTION
## Summary

- Adds a `Parse(serde_json::Error)` variant to `AuditError` so JSON parse failures are no longer formatted through the empty-source `Read` variant.
- `parse_line` returns `Parse`; `stream_records::process_record` rewraps it as `Read` at the call site with the real path and 1-based line number, preserving existing error context for callers.
- Adds a `CHANGELOG.md` entry under `## [Unreleased] / ### Changed`.

## Why this is safe to add

- `AuditError` is `#[non_exhaustive]`, so adding a new variant is not a breaking change for downstream matchers.
- All `parse_line` callers are inside `rimap-audit`; the only caller in the workspace (`process_record`) rewraps the new variant into `Read`, so external behavior at the public surface is unchanged.
- `rimap-audit` is a workspace-internal crate and is not published to crates.io; the change is contained to this workspace.
- `Display` for the bare `parse_line` error is now human-readable (no empty backticks) when used directly in tests or future callers.

## Test plan

- [x] `cargo nextest run --package rimap-audit` (153/153 passing)
- [x] `cargo clippy --package rimap-audit --all-targets --all-features -- -D warnings` (clean)
- [x] Workspace-wide `cargo check` + `cargo deny` via the pre-push hook
- [x] `parse_line_display_is_human_readable_without_empty_backticks` regression test pins the bug fix

Closes #255