### PR TITLE
deps(rand): migrate rimap-audit to rand 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which still has the real path and line number. `AuditError` is
   `#[non_exhaustive]` so adding the variant is source-compatible for
   downstream wildcard matches. Issue #255.
+- Bumped workspace `rand` from `0.9` to `0.10`. `rand 0.10` renames
+  the core trait `RngCore` → `Rng`; the only direct caller is
+  `rimap-audit`'s `RedactionSalt::new_random` (`crates/rimap-audit/src/redact/mod.rs:18`).
+  `governor 0.10`, `ulid 1.2`, and `proptest 1.11` still pin
+  `rand = "0.9"` at their latest releases, so `deny.toml` carries a
+  time-boxed `bans.skip` entry for `rand 0.9` / `rand_core 0.9` until
+  those upstreams publish `rand 0.10`–compatible versions. Issue #256.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1047,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2152,6 +2164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2198,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2290,7 +2319,7 @@ dependencies = [
  "hex",
  "libc",
  "proptest",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rimap-core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ subtle = "2"
 # 0.26 → 0.28 bump: same maintainer, same proc-macro stack, no new
 # transitive proc-macros, no new build.rs, no fresh RUSTSEC advisories.
 strum = { version = "0.28", features = ["derive"] }
-rand = "0.9"
+rand = "0.10"
 
 # Content pipeline (Sprint 4a)
 # mail-parser 0.11 transitively pulls hashify (proc-macro), executing

--- a/crates/rimap-audit/src/redact/mod.rs
+++ b/crates/rimap-audit/src/redact/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 
-use rand::{RngCore, rng};
+use rand::{Rng, rng};
 use rimap_core::tool::ToolName;
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};

--- a/deny.toml
+++ b/deny.toml
@@ -92,16 +92,30 @@ skip = [
     #   - 0.2 via `ring 0.17` (rustls transitive). `ring` pins getrandom 0.2
     #     and has no 0.3-compatible release as of this writing. Replacing
     #     `ring`/`rustls` is out of scope.
-    #   - 0.3 via `rand 0.9` (our direct dep, also proptest transitive).
-    #     This is the version the workspace consolidates on.
-    #   - 0.4 via `tempfile 3.x` (dev-dep; also proptest/insta transitive).
-    #     `tempfile` follows the `rustix` ecosystem release cadence and
-    #     currently pins getrandom 0.4.
+    #   - 0.3 via `rand 0.9` (governor + proptest transitive — see the
+    #     `rand`/`rand_core` skips below).
+    #   - 0.4 via `rand 0.10` (our direct dep, replacing `rand_chacha` with
+    #     RustCrypto `chacha20`) and `tempfile 3.x` (dev-dep; also
+    #     proptest/insta transitive).
     # None of these can be unified without forking. Revisit when `ring`
     # publishes a release using getrandom >= 0.3.
     { name = "getrandom", version = "0.2" },
     { name = "getrandom", version = "0.3" },
     { name = "getrandom", version = "0.4" },
+
+    # `rand 0.9` and `rand_core 0.9` are pulled in by three upstream
+    # crates that pin `rand = "0.9"` at a caret range excluding 0.10:
+    #   - `governor 0.10.4` (regular dep via the `jitter` feature, used
+    #     by `rimap-authz`).
+    #   - `ulid 1.2.1` (regular dep via the default `std` feature, used
+    #     by `rimap-audit` for ULID generation).
+    #   - `proptest 1.11.0` (dev-dep across multiple crates).
+    # All three are at their latest crates.io release. The workspace
+    # itself uses `rand 0.10` for `RedactionSalt` in `rimap-audit`.
+    # Forking governor, ulid, or proptest is out of scope. Revisit when
+    # all three upstreams publish `rand 0.10`–compatible releases.
+    { name = "rand", version = "0.9" },
+    { name = "rand_core", version = "0.9" },
 
     # `hashbrown` 0.16 enters via `governor 0.10` (latest), while 0.17
     # comes in via `indexmap 2.14` (transitive of `toml`/`mail-parser`).


### PR DESCRIPTION
## Summary

- Bump workspace `rand` from `0.9` → `0.10`. Update the one direct
  caller in `rimap-audit`: `use rand::{RngCore, rng};` →
  `use rand::{Rng, rng};` (rand 0.10 renamed the core trait
  `RngCore` → `Rng`; old `Rng` → `RngExt`). The `fill_bytes` call site
  at `crates/rimap-audit/src/redact/mod.rs:79` is unchanged.
- Add a time-boxed `bans.skip` entry in `deny.toml` for `rand 0.9` and
  `rand_core 0.9`. Three upstream crates still pin `rand = "0.9"` at
  their latest crates.io release: `governor 0.10.4` (regular dep via
  `jitter`), `ulid 1.2.1` (regular dep via default `std` feature),
  and `proptest 1.11.0` (dev-dep). All three are caret ranges that
  exclude 0.10; forking is out of scope.
- Update the existing `getrandom` comment to reflect that `rand 0.10`
  now also pulls `getrandom 0.4` (via the new `chacha20` dep that
  replaces `rand_chacha` for `StdRng`).
- Add CHANGELOG entry under `## [Unreleased] / ### Changed`.

## Why this resolves #256

#253 (Dependabot's `rand 0.9 → 0.10` bump) failed CI on:
- Compile errors from the `RngCore` → `Rng` rename — fixed at the one
  call site.
- `cargo deny bans` duplicate-version errors for `rand` and `rand_core`
  — handled with the time-boxed skip entry, which the issue explicitly
  authorizes as the alternative to waiting for upstream releases.

`rand 0.10` requires MSRV 1.85 / Edition 2024; the workspace is at
MSRV 1.88.0 / Edition 2024, so this is a no-op for MSRV.

## Test plan

- [x] `cargo build --workspace --locked` — clean
- [x] `cargo test --workspace --locked` — 1272 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check advisories licenses bans sources` — clean
- [x] `cargo build --manifest-path fuzz/Cargo.toml` — clean
- [x] Pre-push hook (`cargo check` + `cargo deny`) — clean

The existing `random_salt_is_not_all_zeros` test
(`crates/rimap-audit/src/redact/mod.rs:672`) exercises
`RedactionSalt::new_random` and pins the trait-import correctness
(would fail to compile if `Rng` weren't in scope, would fail at
runtime if `fill_bytes` ever returned all zeros).

Closes #256