### PR TITLE
ci(fuzz): extend ClusterFuzzLite to cover rimap-server fuzz subcrate

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,8 +1,12 @@
 # ClusterFuzzLite Rust integration for rusty-imap-mcp.
 #
 # The base-builder-rust image ships nightly Rust + cargo-fuzz pre-installed.
-# We copy the whole repo so build.sh can reach both `fuzz/` (the cargo-fuzz
-# crate) and `crates/rimap-content` (its path dependency).
+# We copy the whole repo so build.sh can reach all path dependencies needed
+# by both cargo-fuzz subcrates:
+#   - `fuzz/`                       depends on `crates/rimap-content` and
+#                                   `crates/rimap-audit`
+#   - `crates/rimap-server/fuzz/`   depends on `crates/rimap-server`
+#                                   (features = ["fuzzing"])
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,23 +1,39 @@
 #!/usr/bin/env bash
 #
-# ClusterFuzzLite build entry point. Builds every fuzz target in
-# `fuzz/fuzz_targets/` and copies binary + seed corpus to $OUT.
+# ClusterFuzzLite build entry point. Builds every fuzz target in both:
+#   - `fuzz/fuzz_targets/`                       (workspace-level)
+#   - `crates/rimap-server/fuzz/fuzz_targets/`   (nested standalone workspace,
+#                                                isolated to keep nightly
+#                                                instrumentation off the root —
+#                                                see docs/superpowers/specs/
+#                                                2026-05-17-cargo-fuzz-validator-design.md)
+# and copies each binary + seed corpus to $OUT.
+#
+# Target names across the two fuzz dirs must be globally unique: the binary
+# and `<target>_seed_corpus.zip` both land in a flat $OUT/ directory.
 #
 # Release mode (-O) is required: debug builds trip upstream
 # `debug_assert!` guards on malformed input.
 set -euo pipefail
 
-cd "$SRC/rusty-imap-mcp/fuzz"
-
-cargo +nightly fuzz build -O
-
 host_triple="$(cargo +nightly -vV | awk '/^host:/ {print $2}')"
-fuzz_out_dir="target/${host_triple}/release"
 
-for f in fuzz_targets/*.rs; do
-    name="$(basename "${f%.*}")"
-    cp "$fuzz_out_dir/$name" "$OUT/"
-    if [ -d "corpus/$name" ]; then
-        zip -j -r "$OUT/${name}_seed_corpus.zip" "corpus/$name"
-    fi
-done
+build_fuzz_dir() {
+    local fuzz_dir="$1"
+    (
+        cd "$fuzz_dir"
+        cargo +nightly fuzz build -O
+    )
+    local release_dir="${fuzz_dir}/target/${host_triple}/release"
+    local target
+    for f in "$fuzz_dir"/fuzz_targets/*.rs; do
+        target="$(basename "${f%.*}")"
+        cp "$release_dir/$target" "$OUT/"
+        if [ -d "$fuzz_dir/corpus/$target" ]; then
+            zip -j -r "$OUT/${target}_seed_corpus.zip" "$fuzz_dir/corpus/$target"
+        fi
+    done
+}
+
+build_fuzz_dir "$SRC/rusty-imap-mcp/fuzz"
+build_fuzz_dir "$SRC/rusty-imap-mcp/crates/rimap-server/fuzz"


### PR DESCRIPTION
## Summary

- Extends `.clusterfuzzlite/build.sh` into a `build_fuzz_dir` helper called for both the workspace-level `fuzz/` and the nested `crates/rimap-server/fuzz/` subcrate.
- Brings the `validate` fuzz target into ClusterFuzzLite PR-smoke and nightly so OSS-Fuzz (#288) sees all six targets.
- Documents the new layout in the `.clusterfuzzlite/Dockerfile` comment.
- No fuzz.yml changes — the existing `paths:` filter already covers `crates/rimap-server/**`.

The `validate` target was introduced by the 2026-05-17 cargo-fuzz validator design as a standalone nested workspace to keep nightly-only instrumentation off the root build. Before this PR, ClusterFuzzLite only saw the five workspace-level targets (`audit_jsonl`, `content_charset`, `content_html`, `content_mime`, `content_rfc2047`); the validator target was invisible to PR-smoke and nightly. After this PR, all six live targets are exercised.

Refs #287, #245 (supersedes the `server_jsonrpc` target name with `validate` per the 2026-05-17 design doc).

## Test plan

- [ ] CFL PR-smoke green on this PR with six targets enumerated in the run-fuzzers log (not five)
- [ ] CFL nightly green on the next 03:17 UTC cycle exercising `validate` alongside the existing five
- [x] `shellcheck .clusterfuzzlite/build.sh` clean
- [x] `shfmt -i 4 -d .clusterfuzzlite/build.sh` clean
- [x] `cargo +nightly fuzz list` enumerates the expected targets in each fuzz directory (5 + 1)
- [x] pre-push hooks pass (`cargo check --workspace --all-targets --locked` + `cargo deny check advisories bans`)