### PR TITLE
ci(fuzz): trigger PR-smoke on .clusterfuzzlite/** changes

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -10,6 +10,15 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
+# `crates/rimap-server/fuzz/` pulls in the workspace `keyring` crate's
+# `linux-native-sync-persistent` backend (transitively, via rimap-server),
+# which links against libdbus at build time. Without these packages the
+# fuzz build fails with "pkg-config command could not be found" trying to
+# resolve `dbus-1`. Same pattern as every Linux Rust job in `ci.yml`.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libdbus-1-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY . $SRC/rusty-imap-mcp
 COPY .clusterfuzzlite/build.sh $SRC/
 WORKDIR $SRC/rusty-imap-mcp

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,7 @@ on:
       - 'crates/rimap-audit/**'
       - 'crates/rimap-server/**'
       - 'fuzz/**'
+      - '.clusterfuzzlite/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/fuzz.yml'


### PR DESCRIPTION
## Summary

- Adds `.clusterfuzzlite/**` to `fuzz.yml`'s `pull_request.paths` filter.
- Closes a gap caught by Codex adversarial review of PR #290: that PR extended `.clusterfuzzlite/build.sh` to cover the nested `rimap-server` fuzz subcrate, but the Fuzz workflow's paths filter did not include `.clusterfuzzlite/**`, so PR-smoke never ran for #290. The build.sh change merged without ClusterFuzzLite-side CI validation; only the next 03:17 UTC nightly would exercise it.
- This PR itself touches `fuzz.yml`, which is already in the filter, so PR-smoke runs on the change that closes the gap. If PR-smoke passes here, that retroactively validates the nested-fuzz-subcrate build path from PR #290 as well.

Refs #287.

## Test plan

- [ ] Fuzz / pr-smoke green on this PR (6 targets enumerated in the `run_fuzzers` log: `audit_jsonl`, `content_charset`, `content_html`, `content_mime`, `content_rfc2047`, `validate`)
- [x] `actionlint .github/workflows/fuzz.yml` clean
- [x] `zizmor .github/workflows/fuzz.yml` no findings
- [x] pre-push hooks pass (`cargo check --workspace --all-targets --locked` + `cargo deny check advisories bans`)