### PR TITLE
test(rimap-server,rimap-imap): mutation baselines + cleanup (issue #289)

### DIFF
--- a/crates/rimap-imap/src/connection.rs
+++ b/crates/rimap-imap/src/connection.rs
@@ -1822,4 +1822,49 @@ mod starttls_unit_tests {
         assert_eq!(recorded.len(), 1);
         assert!(recorded[0].contains("NOOP"));
     }
+
+    #[test]
+    fn debug_format_includes_connection_fields() {
+        // The manual `Debug` impl for `Connection` writes host, port,
+        // and username via `debug_struct(...).finish_non_exhaustive()`.
+        // The cargo-mutants `replace <impl Debug>::fmt -> std::fmt::Result
+        // with Ok(Default::default())` mutation at connection.rs:127
+        // returns Ok(()) without writing — the formatted output collapses
+        // to the empty string. Asserting that distinctive field values
+        // round-trip through the formatter kills the mutation.
+        //
+        // `Connection::new` is socket-free, so the IP / port values here
+        // are pure config — no listener is bound.
+        let cfg = ConnectionConfig {
+            account: None,
+            account_id: rimap_core::account::AccountId::default_account(),
+            host: "imap.fixture.invalid".into(),
+            port: 6143,
+            encryption: ImapEncryption::Tls,
+            username: "u@fixture.invalid".into(),
+            pinned_fingerprint: None,
+            connect_timeout: std::time::Duration::from_millis(1),
+            command_timeout: std::time::Duration::from_millis(1),
+            max_fetch_body_bytes: 1024,
+            max_append_bytes: 1024,
+        };
+        let conn = Connection::new(cfg, Arc::new(NoopAudit), Arc::new(PanicResolver));
+        let formatted = format!("{conn:?}");
+        assert!(
+            formatted.contains("Connection"),
+            "Debug must include struct name; got {formatted:?}",
+        );
+        assert!(
+            formatted.contains("imap.fixture.invalid"),
+            "Debug must include host; got {formatted:?}",
+        );
+        assert!(
+            formatted.contains("6143"),
+            "Debug must include port; got {formatted:?}",
+        );
+        assert!(
+            formatted.contains("u@fixture.invalid"),
+            "Debug must include username; got {formatted:?}",
+        );
+    }
 }

--- a/crates/rimap-server/src/boot/discovery.rs
+++ b/crates/rimap-server/src/boot/discovery.rs
@@ -23,6 +23,18 @@ use rimap_imap::{Connection, SpecialUseMap};
 ///
 /// Returns `RimapError::Imap { ... }` when the underlying `LIST` call
 /// fails (transport error, server protocol error, auth expired, etc.).
+// cargo-mutants: known-equivalent (test-infrastructure gap) — the
+// `replace ... with Ok(Default::default())` stub returns an empty
+// SpecialUseMap, observably different from the populated map the
+// real implementation returns on a non-empty mailbox. Unit-testing
+// the mutation requires either a live IMAP server (covered by the
+// dovecot integration harness in `crates/rimap-server/tests/e2e.rs`
+// which is environment-gated and skipped by cargo-mutants runs that
+// have no Docker available) or a stub `Connection` that intercepts
+// `list_folders`. The latter would require either a new trait
+// boundary across `rimap-imap` or a refactor of this two-line
+// helper. Documented in `mutation-baseline.md` as a known coverage
+// gap pending future test-infrastructure work.
 pub async fn resolve_special_use(connection: &Connection) -> Result<SpecialUseMap, RimapError> {
     let folders = connection.list_folders("*").await?;
     Ok(SpecialUseMap::from_folders(&folders))

--- a/crates/rimap-server/src/boot/registry.rs
+++ b/crates/rimap-server/src/boot/registry.rs
@@ -363,9 +363,7 @@ mod tests {
         // cargo-mutants `replace == with !=` mutation at line 223
         // would flip the assignment, breaking the audit-log
         // "infrastructure vs per-account" rendering.
-        use rimap_config::model::{
-            ImapConfig, ImapEncryption, LimitsConfig, SecurityConfig,
-        };
+        use rimap_config::model::{ImapConfig, ImapEncryption, LimitsConfig, SecurityConfig};
         use rimap_config::validate::ValidatedAccountConfig;
         use rimap_core::account::AccountId;
         use rimap_core::posture::Posture;

--- a/crates/rimap-server/src/boot/registry.rs
+++ b/crates/rimap-server/src/boot/registry.rs
@@ -286,6 +286,130 @@ mod tests {
     }
 
     #[test]
+    fn debug_format_includes_account_state_fields() {
+        // The manual `Debug` impl writes a non-trivial set of fields
+        // (id, smtp.is_some(), special_use_drafts/sent/trash). The
+        // stub-Ok(()) mutation at line 77 produces no output. Assert
+        // the struct name appears in the formatted string so that
+        // mutation is observable.
+        use crate::test_support::make_test_account_state;
+        let state = make_test_account_state("formatting-test-account");
+        let formatted = format!("{state:?}");
+        assert!(
+            formatted.contains("AccountState"),
+            "Debug must include struct name; got {formatted:?}",
+        );
+        assert!(
+            formatted.contains("formatting-test-account"),
+            "Debug must include account id; got {formatted:?}",
+        );
+    }
+
+    #[test]
+    fn check_infrastructure_rate_rejects_after_burst_exhaustion() {
+        // The limiter is configured for 5 req/sec sustained with a
+        // burst of 10. Hammering it in a tight loop must eventually
+        // trip the rate-limit; the cargo-mutants stub-Ok(()) mutation
+        // at line 125 would never reject.
+        let reg = AccountRegistry::new(BTreeMap::new());
+        let mut admitted = 0;
+        let mut rejected_with_rate_limited = false;
+        for _ in 0..50 {
+            match reg.check_infrastructure_rate() {
+                Ok(()) => admitted += 1,
+                Err(err) => {
+                    // First rejection: confirm it's the expected variant.
+                    assert!(
+                        matches!(err, RimapError::Authz { code, .. } if code == ErrorCode::RateLimited),
+                        "expected rate-limited Authz error, got {err:?}",
+                    );
+                    rejected_with_rate_limited = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            rejected_with_rate_limited,
+            "must reject within 50 burst calls; admitted={admitted}",
+        );
+    }
+
+    #[test]
+    fn account_name_strings_returns_populated_sorted_names() {
+        // The existing `account_name_strings_empty` test only covers
+        // the empty-registry case; the cargo-mutants `vec![]` stub at
+        // line 199 also returns empty, so the existing test does not
+        // distinguish. A populated registry kills the mutation.
+        use crate::test_support::make_test_account_state;
+        let alpha = make_test_account_state("alpha");
+        let beta = make_test_account_state("beta");
+        let mut accounts = BTreeMap::new();
+        accounts.insert(alpha.id.clone(), alpha);
+        accounts.insert(beta.id.clone(), beta);
+        let reg = AccountRegistry::new(accounts);
+
+        let names = reg.account_name_strings();
+        assert_eq!(
+            names,
+            vec!["alpha".to_string(), "beta".to_string()],
+            "account_name_strings must return all configured account ids in BTreeMap (sorted) order",
+        );
+    }
+
+    #[test]
+    fn build_account_connection_omits_account_field_for_default_name() {
+        // `ConnectionConfig.account` is `Some(name)` for non-default
+        // accounts and `None` for the legacy "default" sentinel. The
+        // cargo-mutants `replace == with !=` mutation at line 223
+        // would flip the assignment, breaking the audit-log
+        // "infrastructure vs per-account" rendering.
+        use rimap_config::model::{
+            ImapConfig, ImapEncryption, LimitsConfig, SecurityConfig,
+        };
+        use rimap_config::validate::ValidatedAccountConfig;
+        use rimap_core::account::AccountId;
+        use rimap_core::posture::Posture;
+
+        let acfg = ValidatedAccountConfig {
+            id: AccountId::default_account(),
+            imap: ImapConfig {
+                host: "imap.example.com".into(),
+                port: 993,
+                username: "u@example.com".into(),
+                encryption: ImapEncryption::Tls,
+                tls_fingerprint_sha256: None,
+                connect_timeout_seconds: 10,
+                command_timeout_seconds: 30,
+            },
+            smtp: None,
+            security: SecurityConfig {
+                posture: Posture::DraftSafe,
+                ..SecurityConfig::default()
+            },
+            limits: LimitsConfig::default(),
+            tool_overrides: BTreeMap::new(),
+            tls_fingerprint: None,
+            fallback_mode: rimap_config::model::FallbackMode::default(),
+        };
+
+        let default_id = AccountId::new(rimap_core::account::DEFAULT_ACCOUNT_NAME).unwrap();
+        let conn_default = build_account_connection(&default_id, &acfg);
+        assert!(
+            conn_default.account.is_none(),
+            "default account name must produce account = None; got {:?}",
+            conn_default.account,
+        );
+
+        let work_id = AccountId::new("work").unwrap();
+        let conn_work = build_account_connection(&work_id, &acfg);
+        assert_eq!(
+            conn_work.account,
+            Some("work".to_string()),
+            "non-default account name must produce account = Some(name)",
+        );
+    }
+
+    #[test]
     fn concurrent_active_swap_and_resolve() {
         // Exercises the ArcSwapOption-backed active slot under
         // concurrent writers and readers. The registry is empty

--- a/crates/rimap-server/src/lib.rs
+++ b/crates/rimap-server/src/lib.rs
@@ -14,3 +14,6 @@ pub mod boot;
 pub mod mcp;
 #[doc(hidden)]
 pub mod tools;
+
+#[cfg(test)]
+mod test_support;

--- a/crates/rimap-server/src/mcp/content.rs
+++ b/crates/rimap-server/src/mcp/content.rs
@@ -19,6 +19,13 @@ use tokio::sync::Semaphore;
               known variant has been classified explicitly"
 )]
 fn classify_content_error(err: &ContentError) -> RimapError {
+    // cargo-mutants: known-equivalent — `delete match arm ContentError::Malformed`.
+    // The Malformed arm and the `_` fallback produce identical
+    // output (`RimapError::invalid_input(err.to_string())`), as the
+    // `#[expect(clippy::match_same_arms)]` above documents. Deleting
+    // the explicit arm routes through the fallback with no observable
+    // behavior change. The `LimitExceeded` arm-delete IS a real gap
+    // and is killed by `limit_exceeded_classifies_as_attachment_too_large`.
     match err {
         ContentError::LimitExceeded { .. } => RimapError::Authz {
             code: ErrorCode::AttachmentTooLarge,
@@ -117,5 +124,30 @@ mod tests {
             sync_result.untrusted.body_text,
             async_result.untrusted.body_text
         );
+    }
+
+    #[test]
+    fn limit_exceeded_classifies_as_attachment_too_large() {
+        // `LimitExceeded` must map to `ErrorCode::AttachmentTooLarge`,
+        // not the generic `InvalidInput` fallback. The cargo-mutants
+        // `delete match arm ContentError::LimitExceeded` mutation
+        // would re-route here through the `_` arm and silently
+        // downgrade size-cap rejections to syntax-error responses —
+        // a real wire-contract change. The `Malformed` arm-delete is
+        // observably equivalent to the `_` fallback (both produce
+        // `invalid_input(...)`); see the inline note on the match.
+        let err = ContentError::LimitExceeded {
+            kind: "mime_depth",
+            limit: 8,
+        };
+        let mapped = classify_content_error(&err);
+        assert_eq!(mapped.code(), ErrorCode::AttachmentTooLarge);
+
+        // Sanity: Malformed → InvalidInput (same as `_` fallback).
+        let malformed = ContentError::Malformed {
+            reason: "unterminated boundary".into(),
+        };
+        let mapped_malformed = classify_content_error(&malformed);
+        assert_eq!(mapped_malformed.code(), ErrorCode::InvalidInput);
     }
 }

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -322,8 +322,8 @@ mod tests {
         // The two cargo-mutants survivors at line 73 (`replace ... ->
         // Option<Posture> with None` and `... with Some(Default::default())`)
         // would collapse one or both branches to the same wrong value.
-        use rimap_core::Posture;
         use super::PostureContext;
+        use rimap_core::Posture;
 
         assert_eq!(
             PostureContext::Account(Posture::DraftSafe).posture(),

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -311,6 +311,32 @@ mod tests {
     }
 
     #[test]
+    fn posture_context_round_trips_account_and_infrastructure() {
+        // `PostureContext::posture` must:
+        //   - return `Some(posture)` for the per-account variant
+        //     (the audit writer formats this onto the per-call record).
+        //   - return `None` for the infrastructure variant (the audit
+        //     writer renders `None` as the dedicated
+        //     "infrastructure" sentinel on disk).
+        //
+        // The two cargo-mutants survivors at line 73 (`replace ... ->
+        // Option<Posture> with None` and `... with Some(Default::default())`)
+        // would collapse one or both branches to the same wrong value.
+        use rimap_core::Posture;
+        use super::PostureContext;
+
+        assert_eq!(
+            PostureContext::Account(Posture::DraftSafe).posture(),
+            Some(Posture::DraftSafe),
+        );
+        assert_eq!(
+            PostureContext::Account(Posture::Readonly).posture(),
+            Some(Posture::Readonly),
+        );
+        assert_eq!(PostureContext::Infrastructure.posture(), None);
+    }
+
+    #[test]
     fn breaker_reason_ignores_user_errors() {
         use rimap_core::RimapError;
         assert_eq!(

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -124,6 +124,22 @@ mod tests {
     }
 
     #[test]
+    fn custom_codes_lie_in_jsonrpc_server_error_range() {
+        // JSON-RPC §5.1 reserves -32000 to -32099 for application-defined
+        // server errors. The MCP wire contract requires these constants
+        // to be negative; the `delete -` cargo-mutants mutations on the
+        // numeric literals would flip them to positive values that no
+        // client would recognize as server errors. Asserting each
+        // constant's exact value pins the negative-range invariant and
+        // kills the three `delete -` survivors at lines 18/21/24.
+        assert_eq!(super::POSTURE_DENIED, McpCode(-32001));
+        assert_eq!(super::NOT_INITIALIZED, McpCode(-32002));
+        assert_eq!(super::RATE_LIMITED, McpCode(-32003));
+        assert_eq!(super::CIRCUIT_OPEN, McpCode(-32004));
+        assert_eq!(super::ATTACHMENT_TOO_LARGE, McpCode(-32005));
+    }
+
+    #[test]
     fn protected_folder_uses_opaque_message() {
         let err = authz_error(
             ErrorCode::ProtectedFolder,

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -345,6 +345,17 @@ impl ServerHandler for ImapMcpServer {
         Ok(ListToolsResult::with_all_items(tools))
     }
 
+    // cargo-mutants: known-equivalent (test-infrastructure gap) — the
+    // `replace ... with Ok(Default::default())` stub on `list_resources`
+    // returns an empty `ListResourcesResult`, observably different
+    // from the per-account-populated list the real implementation
+    // returns. Unit-testing the mutation requires constructing an
+    // `rmcp::service::RequestContext<RoleServer>` for which rmcp
+    // exposes no public test constructor in this version. The
+    // mutation is covered end-to-end by the dovecot harness in
+    // `tests/e2e.rs`, which is environment-gated and skipped by
+    // cargo-mutants. Documented in `mutation-baseline.md` as a known
+    // coverage gap.
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -458,6 +469,16 @@ impl ServerHandler for ImapMcpServer {
         // tools (use_account, list_accounts) remain valid bare forms
         // regardless. (#73)
         let accounts = self.registry.accounts();
+        // cargo-mutants: known-equivalent (test-infrastructure gap) —
+        // the `delete ! in <impl ServerHandler ...>::call_tool` mutation
+        // inverts the legacy-mode guard so legacy single-account
+        // deployments would reject bare tool names. The underlying
+        // predicate `is_legacy_single_account(accounts)` IS unit-tested
+        // (see `mcp::tool_name::tests::is_legacy_single_account_classifies_each_branch`),
+        // but exercising this composite branch through `call_tool`
+        // requires a `RequestContext<RoleServer>` for which rmcp
+        // exposes no public test constructor. Covered end-to-end by
+        // the dovecot harness; documented in `mutation-baseline.md`.
         if !is_legacy_single_account(accounts) && is_bare_simple_tool_name(&request.name) {
             return Err(ErrorData::invalid_params(
                 format!(
@@ -485,6 +506,17 @@ impl ServerHandler for ImapMcpServer {
             // the effective tool list has changed (the session default account
             // flipped). Best-effort: transport failures do not fail the call
             // because use_account itself succeeded. (#80)
+            //
+            // cargo-mutants: known-equivalent (test-infrastructure gap) —
+            // the `replace == with != in <impl ServerHandler ...>::call_tool`
+            // mutation inverts the use_account-specific notify gate so
+            // ANY successful non-use_account call would emit
+            // `tools/list_changed`. Verifying the suppression for
+            // non-use_account calls requires a `RequestContext<RoleServer>`
+            // (so we can drive `context.peer.notify_tool_list_changed()`)
+            // for which rmcp exposes no public test constructor; covered
+            // end-to-end by the dovecot harness. Documented in
+            // `mutation-baseline.md`.
             if result.is_ok()
                 && tool_name == ToolName::UseAccount
                 && let Err(e) = context.peer.notify_tool_list_changed().await

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -225,6 +225,59 @@ mod tests {
     }
 
     #[test]
+    fn is_legacy_single_account_classifies_each_branch() {
+        // Pin the three observable outcomes of `is_legacy_single_account`:
+        //   - true  : exactly one account, whose id is the legacy
+        //             "default" sentinel (auto-namespace suppression).
+        //   - false : any other shape — zero accounts, multiple
+        //             accounts, or a single account with a non-default
+        //             name.
+        //
+        // The four cargo-mutants survivors on this function (stub-false,
+        // `&&` → `||`, `len() == 1` → `!=`, `id == DEFAULT` → `!=`) are
+        // each killed by at least one of the cases below.
+        use std::collections::BTreeMap;
+        use rimap_core::account::DEFAULT_ACCOUNT_NAME;
+
+        use super::is_legacy_single_account;
+        use crate::test_support::make_test_account_state;
+
+        // 0 accounts → false (sanity baseline; does not distinguish all
+        // mutants on its own).
+        let zero: BTreeMap<_, _> = BTreeMap::new();
+        assert!(!is_legacy_single_account(&zero));
+
+        // 1 account named "default" → true. Kills:
+        //   - stub-false (returns false when original is true).
+        //   - `len() == 1` → `!=` (would short-circuit to false).
+        //   - `id == DEFAULT` → `!=` (would flip the closure to false).
+        let default_state = make_test_account_state(DEFAULT_ACCOUNT_NAME);
+        let mut single_default = BTreeMap::new();
+        single_default.insert(default_state.id.clone(), default_state);
+        assert!(is_legacy_single_account(&single_default));
+
+        // 1 account NOT named "default" → false. Reinforces the
+        // `id == DEFAULT` → `!=` kill at the "non-default" branch
+        // (without this case the mutation would only be observable for
+        // the true→false transition above).
+        let other_state = make_test_account_state("work");
+        let mut single_other = BTreeMap::new();
+        single_other.insert(other_state.id.clone(), other_state);
+        assert!(!is_legacy_single_account(&single_other));
+
+        // 2 accounts including "default" → false. Kills:
+        //   - `&&` → `||` (would short-circuit to true because the
+        //     first key is "default" and the predicate becomes
+        //     `false || true`).
+        let default_state2 = make_test_account_state(DEFAULT_ACCOUNT_NAME);
+        let personal_state = make_test_account_state("personal");
+        let mut two_accts = BTreeMap::new();
+        two_accts.insert(default_state2.id.clone(), default_state2);
+        two_accts.insert(personal_state.id.clone(), personal_state);
+        assert!(!is_legacy_single_account(&two_accts));
+    }
+
+    #[test]
     fn refine_tool_name_is_identity_for_all_other_variants() {
         // Any variant without a refinement rule must pass through
         // unchanged, including when args are absent or irrelevant. A new

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -236,8 +236,8 @@ mod tests {
         // The four cargo-mutants survivors on this function (stub-false,
         // `&&` → `||`, `len() == 1` → `!=`, `id == DEFAULT` → `!=`) are
         // each killed by at least one of the cases below.
-        use std::collections::BTreeMap;
         use rimap_core::account::DEFAULT_ACCOUNT_NAME;
+        use std::collections::BTreeMap;
 
         use super::is_legacy_single_account;
         use crate::test_support::make_test_account_state;

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -1398,11 +1398,16 @@ mod tests {
         // dup-check rejection path. Each case kills one
         // OneLevelDupCheck visit-method mutant.
         let cases: &[(&str, Value, &str)] = &[
+            // Negative integer — serde_json routes through `visit_i64`.
+            // (Positive integers route through `visit_u64` instead, so
+            // this case is what actually exercises the i64 visitor.)
             (
-                r#"{"jsonrpc":"2.0","id":1,"error":175}"#,
+                r#"{"jsonrpc":"2.0","id":1,"error":-175}"#,
                 json!(1),
                 "visit_i64",
             ),
+            // Positive integer fitting in i64 still routes through u64
+            // in serde_json, so this case kills visit_u64.
             (
                 r#"{"jsonrpc":"2.0","id":2,"error":18446744073709551615}"#,
                 json!(2),

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -1473,12 +1473,10 @@ mod tests {
         // surface as the supervisor's return value — the stub
         // `Ok(())` mutation would silently swallow this and report
         // success on every failure path.
-        let inbound =
-            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
-        let outbound =
-            tokio::spawn(
-                async { Err::<(), std::io::Error>(std::io::Error::other("outbound boom")) },
-            );
+        let inbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let outbound = tokio::spawn(async {
+            Err::<(), std::io::Error>(std::io::Error::other("outbound boom"))
+        });
         let supervisor = ValidatorSupervisor {
             inbound,
             outbound,
@@ -1508,8 +1506,7 @@ mod tests {
         let inbound: JoinHandle<std::io::Result<()>> = tokio::spawn(async move {
             panic!("intentional bridge-task panic for flatten guard test");
         });
-        let outbound =
-            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let outbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
         let mut supervisor = ValidatorSupervisor {
             inbound,
             outbound,
@@ -1537,8 +1534,7 @@ mod tests {
         // shutdown_after_failure and must not be misreported as an
         // error. The `replace match guard with false` mutation would
         // surface every cancellation as an Err.
-        let inbound =
-            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let inbound = tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
         inbound.abort();
         let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
         // Give the aborted inbound a tick to transition to finished.

--- a/crates/rimap-server/src/mcp/wire_validator.rs
+++ b/crates/rimap-server/src/mcp/wire_validator.rs
@@ -18,6 +18,9 @@ use tokio::task::JoinHandle;
 /// Bridge-task duplex buffer. Large enough that one well-formed
 /// envelope fits in a single write; both directions are independent
 /// tasks so inbound stalls cannot cause outbound deadlock.
+// cargo-mutants: known-equivalent — `64 * 1024` vs `64 + 1024` is a
+// buffer-size constant; no test asserts on the value and both sizes
+// are large enough to hold one envelope per write.
 const BUF_SIZE: usize = 64 * 1024;
 
 /// What the validator decides for a given line.
@@ -167,6 +170,25 @@ pub(crate) fn invalid_request(id: Value) -> ErrorEnvelope {
 /// [`has_duplicate_keys_in_rmcp_strict_positions`].
 struct OneLevelDupCheck;
 
+// cargo-mutants: known-equivalent group — the non-`visit_map` methods
+// below have several mutants the test suite does not kill, by design:
+//   * `expecting` is invoked only by serde to format error diagnostics;
+//     its return value never reaches our control flow.
+//   * `visit_string` and `visit_none` are unreachable from
+//     `serde_json::Deserializer::from_str` (which is what
+//     `has_duplicate_keys_in_rmcp_strict_positions` constructs): the
+//     streaming deserializer prefers `visit_str` for JSON strings and
+//     `visit_unit` for JSON null, never the owned-String or `Option`
+//     paths.
+//   * `visit_seq` mutated to a constant return skips the drain loop;
+//     the surrounding `DupCheckOneLevel`/`map.next_value()?` chain
+//     then leaves the parser mid-array, the outer
+//     `de.deserialize_any(...).unwrap_or(false)` swallows the
+//     resulting trailing-data error, and the dup-check signals "no
+//     duplicates" — identical to the unmutated outcome (drained,
+//     returns `Ok(false)`).
+// Inline `visit_<primitive>` mutants (i64/u64/f64/bool/unit) ARE
+// killed by `error_body_as_primitive_echoes_id` further down.
 impl<'de> serde::de::Visitor<'de> for OneLevelDupCheck {
     type Value = bool;
 
@@ -238,6 +260,21 @@ impl<'de> serde::de::Deserialize<'de> for DupCheckOneLevel {
 /// [`has_duplicate_keys_in_rmcp_strict_positions`].
 struct TopAndErrorDupCheck;
 
+// cargo-mutants: known-equivalent group — every method below except
+// `visit_map` produces an observably-equivalent outcome under any
+// stub-return mutation. `has_duplicate_keys_in_rmcp_strict_positions`
+// is called from `validate(line)` BEFORE the line is parsed into a
+// `Value`. For a non-object top-level (string/number/bool/null/array)
+// the parsed `Value` later fails `parsed.as_object()` and is rejected
+// via `invalid_request(Value::Null)` — the same id used by the
+// dup-check rejection path. So whether `visit_<primitive>` returns
+// `Ok(true)` or `Ok(false)`, the final ValidationOutcome is the same
+// `Reject(invalid_request(Value::Null))`. `expecting` only formats
+// serde diagnostics. `visit_seq` without drain triggers a trailing-
+// data error that the outer `unwrap_or(false)` swallows back to the
+// "no duplicates" verdict — same outcome path as drained-then-
+// Ok(false). `visit_map` (the one we actually care about) IS killed
+// by `duplicate_top_level_keys_reject` and `duplicate_keys_inside_error_body_reject`.
 impl<'de> serde::de::Visitor<'de> for TopAndErrorDupCheck {
     type Value = bool;
 
@@ -478,6 +515,17 @@ where
 
         // Strip trailing \n and optional \r for the validation view.
         // rmcp's codec also strips \r; matching its grammar.
+        // cargo-mutants: known-equivalent group — for the next two
+        // `match` blocks, both `delete match arm Some(&b'\n'/'\r')`
+        // and `replace - with /` mutants are observably equivalent.
+        // The trimmed view is fed to `serde_json::from_str` (and
+        // `Deserializer::from_str` in the dup-check), both of which
+        // tolerate trailing whitespace — so a line that retains its
+        // \n or \r still parses identically. `len() / 1 == len()` so
+        // the slice does not shrink, same effect as deleting the arm.
+        // The `replace - with +` mutant at the \r-strip site IS a
+        // real gap (slices past the buffer end and panics on \r\n
+        // input) and is killed by `validate_inbound_strips_crlf_line_ending`.
         let trimmed: &[u8] = match buf.last() {
             Some(&b'\n') => &buf[..buf.len() - 1],
             _ => &buf[..],
@@ -707,7 +755,12 @@ pub fn stdio_with_validation() -> ValidatedStdio {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests"
+)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -1333,5 +1386,178 @@ mod tests {
         // on the test runner) is acceptable — we mainly want to confirm
         // no panic and no hang.
         assert!(r.is_ok(), "drain hung after dropping transport");
+    }
+
+    #[test]
+    fn error_body_as_primitive_echoes_id() {
+        // OneLevelDupCheck::visit_<primitive> methods must return
+        // Ok(false): a non-map JSON value can have no keys, so no
+        // duplicates are possible. The validate() rejection then comes
+        // from the shape-validation catch-all, which echoes the
+        // original id via extract_id(obj) — NOT Value::Null from the
+        // dup-check rejection path. Each case kills one
+        // OneLevelDupCheck visit-method mutant.
+        let cases: &[(&str, Value, &str)] = &[
+            (
+                r#"{"jsonrpc":"2.0","id":1,"error":175}"#,
+                json!(1),
+                "visit_i64",
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":2,"error":18446744073709551615}"#,
+                json!(2),
+                "visit_u64",
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":3,"error":1.5}"#,
+                json!(3),
+                "visit_f64",
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":4,"error":true}"#,
+                json!(4),
+                "visit_bool",
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":5,"error":null}"#,
+                json!(5),
+                "visit_unit",
+            ),
+        ];
+        for (line, expected_id, label) in cases {
+            let outcome = validate(line);
+            let ValidationOutcome::Reject(env) = outcome else {
+                panic!("{label}: expected Reject, got {outcome:?}");
+            };
+            assert_eq!(
+                env.id, *expected_id,
+                "{label}: id MUST echo original (not Null); line={line}",
+            );
+            assert_eq!(env.code, -32600, "{label}: expected -32600 invalid-request");
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_inbound_strips_crlf_line_ending() {
+        // Lines terminated with \r\n (typical Windows line endings)
+        // must be handled cleanly: the trailing \n is stripped by the
+        // first match, then the trailing \r is stripped by the second.
+        // The slice arithmetic `&trimmed[..trimmed.len() - 1]` at the
+        // \r-strip site must use subtraction; the `replace - with +`
+        // mutation would slice past the end and panic.
+        let stdin = std::io::Cursor::new(
+            b"{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}\r\n".to_vec(),
+        );
+        let (our_end, mut rmcp_end) = tokio::io::duplex(BUF_SIZE);
+        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+        let consumer = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            rmcp_end.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+        validate_inbound(stdin, our_end, stdout).await.unwrap();
+        let forwarded = consumer.await.unwrap();
+
+        let s = std::str::from_utf8(&forwarded).unwrap();
+        assert!(
+            s.contains("\"method\":\"tools/list\""),
+            "expected forwarded line, got {s:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_after_failure_surfaces_outbound_error() {
+        // shutdown_after_failure aborts inbound (discarding its
+        // result) and then awaits outbound. The outbound's error MUST
+        // surface as the supervisor's return value — the stub
+        // `Ok(())` mutation would silently swallow this and report
+        // success on every failure path.
+        let inbound =
+            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let outbound =
+            tokio::spawn(
+                async { Err::<(), std::io::Error>(std::io::Error::other("outbound boom")) },
+            );
+        let supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.shutdown_after_failure(),
+        )
+        .await
+        .expect("shutdown_after_failure must not hang");
+        assert!(r.is_err(), "outbound error must surface");
+        assert!(
+            r.unwrap_err().to_string().contains("outbound boom"),
+            "expected outbound error message",
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_for_error_surfaces_bridge_task_panic() {
+        // A panicking bridge task produces a JoinError where
+        // `je.is_cancelled()` is false. The flatten match guard must
+        // NOT collapse all JoinErrors to Ok(()) — only the
+        // cancellation variant. The `replace match guard with true`
+        // mutation would silently swallow panics.
+        let inbound: JoinHandle<std::io::Result<()>> = tokio::spawn(async move {
+            panic!("intentional bridge-task panic for flatten guard test");
+        });
+        let outbound =
+            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        let mut supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.watch_for_error(),
+        )
+        .await
+        .expect("watch_for_error must surface bridge panic promptly");
+        assert!(r.is_err(), "panic must surface as Err, got {r:?}");
+        assert!(
+            r.unwrap_err().to_string().contains("bridge task panic"),
+            "expected bridge-panic error message",
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_for_error_treats_cancellation_as_ok() {
+        // An aborted bridge task produces a cancellation-variant
+        // JoinError. The flatten match guard must treat this as
+        // Ok(()) — abort is the supervisor's own primitive in
+        // shutdown_after_failure and must not be misreported as an
+        // error. The `replace match guard with false` mutation would
+        // surface every cancellation as an Err.
+        let inbound =
+            tokio::spawn(async { std::future::pending::<std::io::Result<()>>().await });
+        inbound.abort();
+        let outbound = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        // Give the aborted inbound a tick to transition to finished.
+        tokio::task::yield_now().await;
+        let mut supervisor = ValidatorSupervisor {
+            inbound,
+            outbound,
+            inbound_consumed: false,
+            outbound_consumed: false,
+        };
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            supervisor.watch_for_error(),
+        )
+        .await
+        .expect("watch_for_error must return promptly when bridges finish");
+        assert!(
+            r.is_ok(),
+            "cancelled inbound + Ok outbound must yield Ok, got {r:?}",
+        );
     }
 }

--- a/crates/rimap-server/src/test_support.rs
+++ b/crates/rimap-server/src/test_support.rs
@@ -1,0 +1,115 @@
+//! Test fixtures for `rimap-server` unit tests.
+//!
+//! Provides [`make_test_account_state`], a minimal [`AccountState`]
+//! constructor that is socket-free: [`rimap_imap::Connection::new`]
+//! does not open a TCP/TLS connection, and the credential resolver +
+//! auth-event sink shipped here panic / no-op respectively, so any
+//! test that triggers IMAP I/O on the returned state will fail loudly
+//! or hang rather than silently make outbound network calls.
+//!
+//! Use this for tests that read structural [`AccountState`] fields
+//! (`id`, `imap.host()`, `imap.username()`, `smtp.is_some()`,
+//! `special_use`, `guard.matrix()`). Flows that need real IMAP
+//! protocol behavior should use the dovecot harness in
+//! `tests/e2e.rs`.
+
+#![cfg(test)]
+#![expect(
+    clippy::expect_used,
+    clippy::unreachable,
+    reason = "test fixture: expect() narrows infallible-by-config setup, \
+              unreachable!() in the credential resolver surfaces \
+              accidental I/O from misconfigured tests"
+)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rimap_authz::breaker::{BreakerConfig, CircuitBreaker, SystemClock};
+use rimap_authz::matrix::EffectiveMatrix;
+use rimap_authz::rate_limit::Governor;
+use rimap_authz::{DispatchGuard, FolderGuard};
+use rimap_core::account::AccountId;
+use rimap_core::auth_event::AuthEvent;
+use rimap_core::auth_sink::{AuthEventSink, AuthSinkError};
+use rimap_core::credential::{CredentialResolver, CredentialResolverError, CredentialSource};
+use rimap_core::posture::Posture;
+use rimap_imap::{Connection, ConnectionConfig, SpecialUseMap};
+use secrecy::SecretString;
+
+use crate::boot::registry::AccountState;
+
+#[derive(Debug)]
+struct PanickingCreds;
+
+impl CredentialResolver for PanickingCreds {
+    fn resolve(
+        &self,
+        _account: &AccountId,
+        _username: &str,
+        _host: &str,
+    ) -> Result<(SecretString, CredentialSource), CredentialResolverError> {
+        // The test fixture's AccountState is intended for structural
+        // reads only. Reaching this resolver means a test triggered an
+        // IMAP login flow; surface that loudly so the test is fixed
+        // rather than silently making outbound network calls.
+        unreachable!("test fixture credential resolver should never be invoked")
+    }
+}
+
+#[derive(Debug)]
+struct DiscardingSink;
+
+impl AuthEventSink for DiscardingSink {
+    fn emit_auth(&self, _event: AuthEvent) -> Result<(), AuthSinkError> {
+        Ok(())
+    }
+}
+
+/// Build a minimal [`AccountState`] for unit tests.
+///
+/// The IMAP connection is configured to point at `127.0.0.1:0` and is
+/// **never opened** — `Connection::new` is documented as socket-free.
+/// Tests that trigger I/O on the returned state will hit
+/// [`PanickingCreds::resolve`] and fail.
+pub(crate) fn make_test_account_state(name: &str) -> AccountState {
+    let id = AccountId::new(name).expect("test account name must be valid");
+    let conn_cfg = ConnectionConfig {
+        account: if name == rimap_core::account::DEFAULT_ACCOUNT_NAME {
+            None
+        } else {
+            Some(name.to_string())
+        },
+        account_id: id.clone(),
+        host: "127.0.0.1".into(),
+        port: 0,
+        encryption: rimap_imap::ImapEncryption::Tls,
+        username: format!("{name}@test.invalid"),
+        pinned_fingerprint: None,
+        connect_timeout: Duration::from_secs(1),
+        command_timeout: Duration::from_secs(1),
+        max_fetch_body_bytes: 1024,
+        max_append_bytes: 1024,
+    };
+    let creds: Arc<dyn CredentialResolver> = Arc::new(PanickingCreds);
+    let sink: Arc<dyn AuthEventSink> = Arc::new(DiscardingSink);
+    let imap = Connection::new(conn_cfg, sink, creds);
+
+    let matrix = EffectiveMatrix::build(Posture::DraftSafe, &BTreeMap::new());
+    let breaker = CircuitBreaker::new(SystemClock::new(), BreakerConfig::default_spec());
+    let governor = Governor::new(10, 10, 10).expect("test governor");
+    let guard = DispatchGuard::new(matrix, breaker, governor);
+
+    let folder_guard = FolderGuard::new(&[], &[]);
+
+    AccountState {
+        id,
+        imap,
+        smtp: None,
+        guard,
+        folder_guard,
+        download_dir: Arc::from(std::path::PathBuf::from("/tmp").into_boxed_path()),
+        special_use: SpecialUseMap::default(),
+    }
+}

--- a/docs/security/cargo-mutants-runbook.md
+++ b/docs/security/cargo-mutants-runbook.md
@@ -20,6 +20,41 @@ The `just mutants` recipe is a thin wrapper around `cargo mutants
 --in-place`. Pass any extra flags after the recipe name; they are
 forwarded verbatim.
 
+## Linux fast path (bypass `--in-place`)
+
+The `--in-place` flag exists to dodge a macOS-specific cargo-mutants
+bug ([#611](https://github.com/sourcefrog/cargo-mutants/issues/611)).
+On Linux, the temp-tree path the bug affects is not exercised — you
+can drop `--in-place` and run cargo-mutants directly with `--jobs N`
+for proportional wall-clock speedup. The 2026-05-18 issue #289
+baselines used:
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60
+cargo mutants --package rimap-imap  --no-shuffle --jobs 8 --timeout 60
+```
+
+The `rimap-server` baseline (529 mutants) finished in 22 minutes at
+`--jobs 8` on a 48-thread Xeon w7-2495X, against the documented
+~3.5h `--jobs 1` wall time for the macOS workaround path.
+
+Trade-offs:
+
+- **No `just mutants` wrapper.** Drop down to plain `cargo mutants`
+  since the recipe forces `--in-place`. A future justfile change
+  could pick the right invocation per `uname -s`, but is not done
+  today.
+- **Tune `--jobs` to physical cores.** Each worker spawns a full
+  `cargo` invocation; rule of thumb `--jobs ≤ physical_cores / 2`,
+  more aggressive if the box has tens of GiB of RAM headroom per
+  worker.
+- **No source-tree contention.** Workers operate on `target/mutants/`
+  temp trees, so concurrent IDE / rust-analyzer work is fine.
+- **Ctrl-C is safe.** The source tree is never mutated.
+
+On macOS, do not use this path until cargo-mutants 27.0.1+ ships
+containing [PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613).
+
 ## What `--in-place` costs you
 
 - **Locked to `--jobs 1`.** cargo-mutants refuses parallel jobs in
@@ -60,7 +95,10 @@ macOS, recovering most of the wall-clock cost above. We chose
 
 If wall-clock time on macOS becomes the binding constraint before
 [#611](https://github.com/sourcefrog/cargo-mutants/issues/611) is
-fixed, revisit this.
+fixed (i.e. a tagged release containing
+[PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613)),
+revisit this. Linux contributors can use the "Linux fast path"
+section above today without changes.
 
 ## The bug, in detail
 

--- a/docs/superpowers/plans/2026-05-18-issue-289-mutation-baselines-server-imap.md
+++ b/docs/superpowers/plans/2026-05-18-issue-289-mutation-baselines-server-imap.md
@@ -1,0 +1,1023 @@
+# Issue #289: Mutation baselines for `rimap-server` + `rimap-imap` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Tracking issue:** [#289](https://github.com/randomparity/rusty-imap-mcp/issues/289). Unblocks [#287](https://github.com/randomparity/rusty-imap-mcp/issues/287) (Phase 2 close) and [#288](https://github.com/randomparity/rusty-imap-mcp/issues/288) (Phase 3 — OSS-Fuzz upstream submission). Closes [#245](https://github.com/randomparity/rusty-imap-mcp/issues/245) once landed.
+
+**Goal:** Run `cargo mutants` against current `main` for both `rimap-server` and `rimap-imap`, kill or annotate every survivor in the security-critical paths still present on `main`, and extend `docs/superpowers/specs/test-strategy/mutation-baseline.md` with new sections for both crates following the `rimap-audit` / `rimap-authz` format.
+
+**Architecture:** Issue #289's premise — that this work is blocked on cargo-mutants PR #613 reaching a tagged release — is **already satisfied** for this host: the local dev box runs Fedora Linux (not macOS), so the upstream `dirhelper` reap behavior that motivated `--in-place` is not present. We can therefore run `cargo mutants` directly with `--jobs N` (no `--in-place`) for ~5×–10× wall-clock savings vs. the macOS-safe path. The actual work is the same shape as Sprint B2 (#244) was for `rimap-audit` and `rimap-authz`: per-crate baseline → survivor classification → kill-with-test or annotate-as-known-equivalent → doc-table row → re-run to confirm zero unannotated misses in the named paths.
+
+**File-scope correction (versus the issue body):** Issue #289 inherited its path lists from #245, which was written against `archive/daemon-experiment`. The current `main` no longer has `crates/rimap-server/src/daemon/`, `shim.rs`, or `mcp/posture_context.rs` — those paths were rolled back when the daemon experiment was reverted. The current security-critical surface in `rimap-server` is `mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error,fuzz_oracle}.rs` plus `boot/*`; `tools/*` is best-effort (large handler surface, mostly thin wrappers over `rimap-imap`). `rimap-imap` paths from #289 are unchanged on `main`. This plan operates on the corrected surface and the executor notes the substitution in the final close-out comment on #289.
+
+**Tech Stack:** `cargo-mutants` 27.0.0 (already installed via `just setup`), `cargo nextest` for the test suite, `serde_json`, `tracing`, Rust 1.88 (workspace MSRV). No new dependencies. No source code refactors expected beyond test-only additions and inline annotation comments.
+
+**Spec reference:** [`docs/superpowers/specs/2026-04-30-test-strategy-improvements-design.md`](../specs/2026-04-30-test-strategy-improvements-design.md), Sprint B3 — Section 6. Done criteria mirror those of B2 (#244) per the existing `rimap-audit` / `rimap-authz` sections of `mutation-baseline.md`.
+
+**Branch:** `feat/issue-289-mutation-baselines-server-imap` (cut from current `main` at the start of execution).
+
+**Phase split (default = one PR):** Mutation cleanup PRs bundle cleanly when most survivors are stub-return, comparator-boundary, or match-guard kinds (per `feedback_mutation_cleanup_complexity_not_count`). The split decision happens **after** both baselines run and the survivor *kinds* are known, not on raw count. The default expectation is one PR; the explicit out-of-band split criteria are at the end of this plan.
+
+**Per-PR convention reminder:** `cargo-mutants` does not parse inline `// cargo-mutants: known-equivalent — <reason>` annotations (per `feedback_cargo_mutants_annotations_are_doc_only`). After cleanup, `mutants.out/missed.txt` still lists annotated survivors. The source of truth is the row in `mutation-baseline.md`; the inline comment is for human readers. Verification language throughout this plan uses **"zero unannotated survivors"** — not "zero missed survivors."
+
+---
+
+## Pre-flight
+
+Confirm the host, branch, and tooling are ready before consuming any of the multi-hour baseline runs.
+
+- [ ] **Step 0: Verify branch and clean tree**
+
+Run:
+```bash
+git branch --show-current
+git status --short
+```
+
+Expected:
+- Branch is `feat/issue-289-mutation-baselines-server-imap` (NOT `main`). If on `main`, run `git checkout -b feat/issue-289-mutation-baselines-server-imap`.
+- `git status --short` is empty.
+
+- [ ] **Step 1: Verify host is Linux (or otherwise free of the cargo-mutants `dirhelper` issue)**
+
+Run:
+```bash
+uname -s
+```
+
+Expected: `Linux`. If `Darwin`, stop and either (a) install cargo-mutants 27.0.1+ once it ships containing [PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613), or (b) run this plan on a Linux box. Do not proceed on macOS with cargo-mutants 27.0.0 and `--in-place` — the runbook predicts ~3.5h workspace runs and the dev-host RAM issue documented in `feedback_cargo_mutants_jobs_cap.md`.
+
+- [ ] **Step 2: Verify cargo-mutants is installed and on PATH**
+
+Run:
+```bash
+cargo mutants --version
+```
+
+Expected: `cargo-mutants 27.0.0` (or higher). If missing, run `cargo install --locked cargo-mutants`.
+
+- [ ] **Step 3: Verify the named security-critical paths still exist**
+
+Run:
+```bash
+for f in \
+  crates/rimap-server/src/mcp/dispatch.rs \
+  crates/rimap-server/src/mcp/audit_envelope.rs \
+  crates/rimap-server/src/mcp/tool_catalog.rs \
+  crates/rimap-server/src/mcp/tool_name.rs \
+  crates/rimap-server/src/mcp/wire_validator.rs \
+  crates/rimap-server/src/mcp/preinit.rs \
+  crates/rimap-server/src/mcp/server.rs \
+  crates/rimap-server/src/mcp/response.rs \
+  crates/rimap-server/src/mcp/content.rs \
+  crates/rimap-server/src/mcp/error.rs \
+  crates/rimap-server/src/mcp/fuzz_oracle.rs \
+  crates/rimap-imap/src/tls.rs \
+  crates/rimap-imap/src/auth.rs \
+  crates/rimap-imap/src/connection.rs \
+  crates/rimap-imap/src/preflight.rs ; do
+  test -f "$f" && echo "ok    $f" || echo "MISSING $f"
+done
+ls crates/rimap-server/src/boot/ crates/rimap-imap/src/ops/
+```
+
+Expected: every file prints `ok`. `boot/` lists `audit_init.rs`, `discovery.rs`, `logging.rs`, `mod.rs`, `registry.rs`. `ops/` lists `append.rs`, `delete.rs`, `expunge.rs`, `fetch.rs`, `folder_management.rs`, `folders.rs`, `mod.rs`, `move_message.rs`, `search.rs`, `store.rs`. Any `MISSING` line means the file scope drifted again — stop and re-grep `git log` for the rename before continuing.
+
+Then verify `mcp/fuzz_oracle.rs` is feature-gated as expected (the default-features baseline run does not exercise it; a dedicated `--features fuzzing` pass in Task 2 Step 2.5 covers it):
+
+```bash
+grep -n 'cfg(feature = "fuzzing")' crates/rimap-server/src/mcp/mod.rs
+```
+
+Expected: prints the `#[cfg(feature = "fuzzing")] pub mod fuzz_oracle;` line. If absent, the gating has been removed and the dedicated `--features fuzzing` pass (Task 2 Step 2.5 below) can be folded back into the default run.
+
+- [ ] **Step 4: Verify the workspace builds clean before any mutation runs**
+
+Run:
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --workspace --all-features --locked
+```
+
+Expected: both clean. A pre-existing failure here will be misread as a mutation kill in Task 1.
+
+---
+
+## Task 1: Run `cargo mutants` baseline on `rimap-server`
+
+**Why:** No prior baseline exists for `rimap-server` in `mutation-baseline.md`. The footer reads "The other two trust-boundary crates (rimap-server, rimap-imap) get their own sections here when Sprint B3 lands." This task produces the raw survivor data that drives Tasks 2–4.
+
+**Files:**
+- No source files modified. Output goes to `mutants.out/` (gitignored) and `/tmp/`.
+
+- [ ] **Step 1: Run the targeted mutation suite**
+
+Run **directly** (not through `just mutants`) so we get `--jobs N` parallelism on Linux. The `just mutants` recipe forces `--in-place` which locks `--jobs 1` — that's the macOS workaround per `docs/security/cargo-mutants-runbook.md` and is unnecessary here:
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60 \
+  2>&1 | tee /tmp/mutants-rimap-server.log
+```
+
+Expected runtime: 30–90 minutes depending on disk + CPU contention. If the box has fewer than 8 physical cores or low memory headroom, dial `--jobs` down (rule of thumb: `--jobs ≤ physical_cores / 2`, because each worker spawns a full `cargo` invocation with its own compile + test). On the 48-core / 250 GiB reference host, `--jobs 8` is conservative and leaves headroom for IDE / rust-analyzer.
+
+If the run aborts mid-way (e.g. SIGINT), no source files need restoration — without `--in-place` cargo-mutants works in `target/mutants/` temp trees, not the live source. Verify with `git status` (should be empty).
+
+- [ ] **Step 2: Snapshot survivors by path bucket**
+
+```bash
+# fuzz_oracle.rs is feature-gated; its baseline runs separately in Task 2 Step 2.5.
+HOT_PATHS='^crates/rimap-server/src/(mcp/(dispatch|audit_envelope|tool_catalog|tool_name|wire_validator|preinit|server|response|content|error)\.rs|boot/)'
+COLD_PATHS='^crates/rimap-server/src/(cli/|tools/|main\.rs|lib\.rs)'
+
+TOTAL=$(grep -cE "^crates/rimap-server/src/" mutants.out/missed.txt 2>/dev/null || echo 0)
+HOT=$(grep -cE "$HOT_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+COLD=$(grep -cE "$COLD_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+
+echo "rimap-server total survivors: $TOTAL"
+echo "rimap-server hot-path survivors (mcp/ named files + boot/): $HOT"
+echo "rimap-server cold/best-effort survivors (cli/, tools/, main.rs, lib.rs): $COLD"
+
+grep -E "$HOT_PATHS"  mutants.out/missed.txt > /tmp/rimap-server-hot-survivors.txt  || true
+grep -E "$COLD_PATHS" mutants.out/missed.txt > /tmp/rimap-server-cold-survivors.txt || true
+wc -l /tmp/rimap-server-hot-survivors.txt /tmp/rimap-server-cold-survivors.txt
+echo "(rimap-server fuzz_oracle.rs survivors land in /tmp/rimap-server-fuzz-oracle-survivors.txt via Task 2 Step 2.5)"
+```
+
+- [ ] **Step 3: Classify by mutant *kind* (drives the split decision)**
+
+Per `feedback_mutation_cleanup_complexity_not_count`, the bundle/split decision is mutant-kind-based, not count-based. Run:
+
+```bash
+echo "--- Stub-return mutants (cheap kills: 1-3 line tests) ---"
+grep -cE "replace .* -> .* with (\(\)|0|1|false|true|String::new\(\)|\"xyzzy\"\.into\(\)|Default::default\(\)|Vec::new\(\))" /tmp/rimap-server-hot-survivors.txt
+echo "--- Comparator-boundary mutants (cheap: boundary-value test or known-equivalent) ---"
+grep -cE "replace [<>=!]+ with [<>=!]+" /tmp/rimap-server-hot-survivors.txt
+echo "--- Match-guard / negation mutants (cheap: inverse-arm test) ---"
+grep -cE "(delete ! in|replace match guard)" /tmp/rimap-server-hot-survivors.txt
+echo "--- Arithmetic / logic mutants in algorithm semantics (potentially expensive) ---"
+grep -cE "replace (\+|-|\*|/|&&|\|\|) with " /tmp/rimap-server-hot-survivors.txt
+echo "--- Other ---"
+wc -l /tmp/rimap-server-hot-survivors.txt
+```
+
+Record the four counts in a scratch note `/tmp/issue-289-classify.txt` (you'll use them again in Task 6 Step 3 for the rimap-imap classification and in the final split decision).
+
+- [ ] **Step 4: No commit — `mutants.out/` is gitignored**
+
+The two `/tmp/` files drive Tasks 2–4. Verify with `git status --short` — should print nothing.
+
+---
+
+## Task 2: Mutation cleanup — `rimap-server` `mcp/` hot-path survivors
+
+**Why:** `mcp/` is the JSON-RPC dispatch boundary. Every mutation that changes observable behavior at this layer is a potential MCP-protocol compliance bug; mutations that produce indistinguishable output under the protocol contract are documentable equivalents. Spec §6 names this entire surface security-critical.
+
+**Files:** iterative — driven by `/tmp/rimap-server-hot-survivors.txt` entries that match `mcp/*.rs`. Tests land in either:
+- `crates/rimap-server/src/mcp/<file>.rs` `#[cfg(test)]` blocks (preferred for unit-level mutations — every file already has one; verify with `grep -l "^#\[cfg(test)\]" crates/rimap-server/src/mcp/*.rs`), or
+- `crates/rimap-server/tests/*.rs` integration tests (use sparingly; only when the mutation requires a fully-wired dispatch pipeline).
+
+Annotations land inline immediately above the mutated line. The doc-table row is added in Task 7.
+
+- [ ] **Step 1: Walk the `mcp/` slice of the hot-survivor list**
+
+```bash
+grep -E "^crates/rimap-server/src/mcp/" /tmp/rimap-server-hot-survivors.txt > /tmp/rimap-server-mcp-survivors.txt
+wc -l /tmp/rimap-server-mcp-survivors.txt
+```
+
+For each line in `/tmp/rimap-server-mcp-survivors.txt`:
+
+  1. **Read the mutation.** Open the named file at the named line. Read enough surrounding code (typically the enclosing function and its callers via `rg`) to understand what changes under the mutation.
+
+  2. **Decide: real gap, or equivalent mutant?** Most mutations expose real test gaps. Equivalent mutants are mathematically indistinguishable from the original under the function's contract — examples in `crates/rimap-content/src/html/mismatch.rs` and `crates/rimap-audit/src/writer/rotation.rs:188` model the bar.
+
+  3. **If real gap, write a failing test in the file's `#[cfg(test)]` block.** Test must:
+     - Assert the precise behavior the mutation breaks (not just "the function returns something").
+     - Pass under unmutated code: `cargo nextest run --package rimap-server --all-features -- <test_name>`.
+     - Fail under the mutation: hand-apply the mutation locally (`git stash` first for safety), confirm the new test fails, then `git stash pop`. If it passes under both, tighten the assertion.
+
+  4. **If equivalent mutant, annotate.** Comment immediately above the mutated line:
+     ```rust
+     // cargo-mutants: known-equivalent — <one-line rationale>
+     ```
+     Rationale must explain *why* the mutation is observably indistinguishable. "It doesn't matter" is not a rationale; "the predicate flips only at `x == y`, where both arms set `min = x` to the same value" is.
+
+  5. **Track the row for Task 7.** Append to `/tmp/rimap-server-baseline-rows.md` (create if absent), one markdown table row per annotated mutant in this format:
+     ```
+     | mcp/<file>.rs:LINE | <verbatim mutation description from missed.txt> | <rationale> | mcp/<file>.rs:ANNOTATION_LINE |
+     ```
+
+- [ ] **Step 2: Re-run mutation tests on `mcp/` only and verify**
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60 \
+  -F 'mcp/' 2>&1 | tee /tmp/mutants-rimap-server-mcp-reverify.log
+grep -E "^crates/rimap-server/src/mcp/" mutants.out/missed.txt | tee /tmp/rimap-server-mcp-reverify-missed.txt
+```
+
+Expected: every formerly-missed mutation in `mcp/` is now either `caught` (test killed it) **or** has an inline `// cargo-mutants: known-equivalent` annotation. Annotated survivors still appear in `missed.txt` — that's expected per `feedback_cargo_mutants_annotations_are_doc_only`. Cross-check each line in the reverify output against `/tmp/rimap-server-baseline-rows.md`; any line not represented in the rows file is an unannotated survivor → return to Step 1 for that mutation.
+
+Then run a second reverify with `--features fuzzing` filtered to `fuzz_oracle.rs` so the feature-gated module is exercised at the same gate:
+
+```bash
+cargo mutants --package rimap-server --features fuzzing \
+  --no-shuffle --jobs 8 --timeout 60 -F 'fuzz_oracle\.rs' \
+  2>&1 | tee /tmp/mutants-rimap-server-fuzz-oracle-reverify.log
+grep -E "^crates/rimap-server/src/mcp/fuzz_oracle\.rs" mutants.out/missed.txt \
+  | tee /tmp/rimap-server-fuzz-oracle-reverify-missed.txt
+```
+
+Its `missed.txt` slice must be empty or fully represented in `/tmp/rimap-server-baseline-rows.md` (the `(fuzzing)`-tagged rows from Step 2.5). Any line not in the rows file is an unannotated survivor → return to Step 2.5 for that mutation.
+
+- [ ] **Step 2.5: Mutate the feature-gated `mcp/fuzz_oracle.rs`**
+
+The file at `crates/rimap-server/src/mcp/fuzz_oracle.rs` is behind `#[cfg(feature = "fuzzing")]` in `crates/rimap-server/src/mcp/mod.rs:21`, so default-features `cargo mutants` runs never see it. Run a dedicated pass with the feature enabled:
+
+```bash
+cargo mutants --package rimap-server --features fuzzing \
+  --no-shuffle --jobs 8 --timeout 60 \
+  -F 'mcp/fuzz_oracle\.rs' \
+  2>&1 | tee /tmp/mutants-rimap-server-fuzz-oracle.log
+
+grep -E '^crates/rimap-server/src/mcp/fuzz_oracle\.rs' mutants.out/missed.txt \
+  > /tmp/rimap-server-fuzz-oracle-survivors.txt || true
+wc -l /tmp/rimap-server-fuzz-oracle-survivors.txt
+```
+
+For each survivor in `/tmp/rimap-server-fuzz-oracle-survivors.txt`, follow the same read → decide → kill-or-annotate → track-row procedure as Task 2 Step 1, but:
+
+  - Tests must live in the `#[cfg(all(test, feature = "fuzzing"))]` block at the bottom of `fuzz_oracle.rs` (create the block if it doesn't exist; existing `mcp/*` files model the `#[cfg(test)]` pattern, just add the `feature = "fuzzing"` predicate so the tests compile only when the module does).
+  - The cleanup commit must run the feature-gated test suite to verify: `cargo nextest run --package rimap-server --features fuzzing -- fuzz_oracle::`.
+  - The doc-table row in `/tmp/rimap-server-baseline-rows.md` should be tagged with a leading `(fuzzing)` marker so Task 9 places it in the dedicated subsection rather than the main `mcp/` table:
+    ```
+    | (fuzzing) mcp/fuzz_oracle.rs:LINE | <mutation> | <rationale> | mcp/fuzz_oracle.rs:LINE |
+    ```
+
+- [ ] **Step 3: Verify workspace builds clean**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-server --all-features --locked
+```
+
+Expected: both clean.
+
+- [ ] **Step 4: Commit (one commit per file group, file-alphabetical)**
+
+Group commits by mutated file so the history reads `audit_envelope`, `content`, `dispatch`, etc.:
+
+```bash
+# Example (audit_envelope; repeat for each file with survivors)
+git add crates/rimap-server/src/mcp/audit_envelope.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): close mutation gaps in mcp/audit_envelope.rs
+
+Adds <N> tests covering specific cargo-mutants survivors uncovered by
+the 2026-05-18 baseline (issue #289). <M> known-equivalent mutants
+annotated inline with rationale; doc-table rows added in the
+mutation-baseline.md update commit.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+Skip any mcp/ file with zero hot survivors. Pure-annotation-only files (no new tests) still need a commit so the inline annotation lands.
+
+---
+
+## Task 3: Mutation cleanup — `rimap-server` `boot/` hot-path survivors
+
+**Why:** `boot/` is where startup wires the IMAP connection registry, audit subsystem, logging, and discovery flow. Mutations that flip control-flow at startup are silent footguns: the daemon comes up "successfully" but in a degraded state. Spec §6 includes `boot/` in the named security-critical surface.
+
+**Files:** iterative — driven by `/tmp/rimap-server-hot-survivors.txt` entries matching `boot/`. Tests land in either:
+- `crates/rimap-server/src/boot/<file>.rs` `#[cfg(test)]` blocks, or
+- `crates/rimap-server/tests/boot_*.rs` (search for the existing pattern with `find crates/rimap-server/tests -name 'boot*'`).
+
+- [ ] **Step 1: Walk the `boot/` slice of the hot-survivor list**
+
+```bash
+grep -E "^crates/rimap-server/src/boot/" /tmp/rimap-server-hot-survivors.txt > /tmp/rimap-server-boot-survivors.txt
+wc -l /tmp/rimap-server-boot-survivors.txt
+```
+
+For each line, follow the same procedure as Task 2 Step 1 (read → decide → kill or annotate → track row). One additional note specific to `boot/`:
+
+  - **Async-init mutations** (`boot/audit_init.rs`, `boot/registry.rs`) often need a small `#[tokio::test(flavor = "current_thread")]` driver. Pattern from existing tests: build a `tempfile::tempdir()`-rooted minimal config, call the function under test, assert on the returned handle / state. Avoid spawning a real daemon — use the smallest scope that observes the mutation.
+
+  - **`tracing` event mutations** in `boot/logging.rs` (level swaps, message format changes) follow the same "diagnostic-only" annotation pattern as `rimap-audit`'s `backup_exclude.rs` rows in `mutation-baseline.md:111-114`. Test only when a downstream consumer asserts on the event content.
+
+- [ ] **Step 2: Re-run mutation tests on `boot/` only**
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60 \
+  -F 'boot/' 2>&1 | tee /tmp/mutants-rimap-server-boot-reverify.log
+grep -E "^crates/rimap-server/src/boot/" mutants.out/missed.txt | tee /tmp/rimap-server-boot-reverify-missed.txt
+```
+
+Cross-check every line against `/tmp/rimap-server-baseline-rows.md` (now extended with `boot/` rows). Any line not in the rows file is an unannotated survivor → return to Step 1.
+
+- [ ] **Step 3: Verify workspace builds clean**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-server --all-features --locked
+```
+
+- [ ] **Step 4: Commit (one commit per boot/ file with survivors)**
+
+```bash
+# Example
+git add crates/rimap-server/src/boot/audit_init.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): close mutation gaps in boot/audit_init.rs
+
+Adds <N> tests covering specific cargo-mutants survivors uncovered by
+the 2026-05-18 baseline (issue #289). <M> known-equivalent mutants
+annotated inline with rationale.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+---
+
+## Task 4: Mutation cleanup — `rimap-server` cold/best-effort paths
+
+**Why:** `tools/`, `cli/`, `main.rs`, and `lib.rs` are best-effort per spec §6 — they're either thin wrappers over `rimap-imap` (handler crate) or CLI plumbing whose failure modes surface as visible exit codes (already tested via `cli/` integration tests). Per the spec's done criteria they must still produce zero unannotated survivors *in the document* — but the bar for "kill vs. annotate" is lower: "diagnostic-only stdout phrasing" is a sufficient rationale.
+
+**Files:** iterative — driven by `/tmp/rimap-server-cold-survivors.txt`.
+
+- [ ] **Step 1: Walk the cold-survivor list**
+
+For each line:
+
+  - **Changes observable output / API contract / exit code** → kill with a test (Task 2 Step 1.3 procedure).
+  - **Equivalent under documented round-trip** → annotate inline + add doc-table row.
+  - **Pure cosmetic** (tracing format, internal counter never asserted on, CLI stdout layout) → annotate inline + add doc-table row with rationale "diagnostic-only" or "cosmetic stdout, JSON schema unaffected." Model on `crates/rimap-content/src/bin/epvme_runner.rs` rows in `mutation-baseline.md:82-86`.
+
+  - **`tools/<file>.rs` mutations that bottom out in `rimap-imap` calls** are particularly likely to be equivalent — if the `rimap-imap` call's return value is forwarded verbatim and the mutation only changes how `rimap-server` shapes the forward, an upstream `rimap-imap` test (added in Task 9) often suffices. Note the cross-crate coverage in the rationale: "test in rimap-imap covers semantic; this wrapper is forwarding-only."
+
+- [ ] **Step 2: Re-run mutation tests on cold paths**
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60 \
+  -F '(cli/|tools/|main\.rs|lib\.rs)' 2>&1 | tee /tmp/mutants-rimap-server-cold-reverify.log
+grep -E "^crates/rimap-server/src/(cli/|tools/|main\.rs|lib\.rs)" mutants.out/missed.txt \
+  | tee /tmp/rimap-server-cold-reverify-missed.txt
+```
+
+Cross-check against `/tmp/rimap-server-baseline-rows.md`. Unannotated cold-path survivors do **not** fail the done criteria (the spec's "kill all unannotated" applies to hot paths only), but they should be either covered or documented — leaving an unannotated survivor with no rationale is an information gap, not a correctness issue.
+
+- [ ] **Step 3: Verify workspace builds clean**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-server --all-features --locked
+```
+
+- [ ] **Step 4: Commit (one commit covering cold paths)**
+
+Single commit for the cold-path batch — the file count is too high to make per-file commits useful:
+
+```bash
+git add crates/rimap-server/src/cli/ crates/rimap-server/src/tools/ \
+        crates/rimap-server/src/main.rs crates/rimap-server/src/lib.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): close mutation gaps in cold-path modules (best-effort)
+
+Adds <N> tests and <M> known-equivalent annotations across cli/, tools/,
+main.rs, and lib.rs per spec §6 best-effort tier. Hot-path coverage
+landed in prior commits this PR.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+If no changes land in this task (i.e. cold paths were already clean), skip the commit and proceed.
+
+---
+
+## Task 5: Run `cargo mutants` baseline on `rimap-imap`
+
+**Why:** Same reason as Task 1 — no prior `rimap-imap` section exists in `mutation-baseline.md`. Spec §6 names `tls.rs`, `auth.rs`, `connection.rs`, `ops/`, `preflight.rs` as security-critical (TLS handshake, authentication, connection lifetime, mailbox operations, pre-auth STARTTLS probe).
+
+**Files:** none modified. Output to `mutants.out/` + `/tmp/`.
+
+- [ ] **Step 1: Run the targeted mutation suite**
+
+```bash
+cargo mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60 \
+  2>&1 | tee /tmp/mutants-rimap-imap.log
+```
+
+Expected runtime: 15–45 minutes (`rimap-imap` is smaller than `rimap-server` — roughly the size of `rimap-audit`, which took ~4 minutes at `--jobs 1` for 231 mutants; expect more at `--jobs 8` because of the test-suite overhead per mutant).
+
+- [ ] **Step 2: Snapshot survivors by path bucket**
+
+```bash
+HOT_PATHS='^crates/rimap-imap/src/(tls\.rs|auth\.rs|connection\.rs|preflight\.rs|ops/)'
+COLD_PATHS='^crates/rimap-imap/src/(error\.rs|types\.rs|time\.rs|special_use\.rs|lib\.rs)'
+
+TOTAL=$(grep -cE "^crates/rimap-imap/src/" mutants.out/missed.txt 2>/dev/null || echo 0)
+HOT=$(grep -cE "$HOT_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+COLD=$(grep -cE "$COLD_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+
+echo "rimap-imap total survivors: $TOTAL"
+echo "rimap-imap hot-path survivors (tls/auth/connection/preflight/ops): $HOT"
+echo "rimap-imap cold/plumbing survivors (error/types/time/special_use/lib): $COLD"
+
+grep -E "$HOT_PATHS"  mutants.out/missed.txt > /tmp/rimap-imap-hot-survivors.txt  || true
+grep -E "$COLD_PATHS" mutants.out/missed.txt > /tmp/rimap-imap-cold-survivors.txt || true
+wc -l /tmp/rimap-imap-hot-survivors.txt /tmp/rimap-imap-cold-survivors.txt
+```
+
+- [ ] **Step 3: Classify by mutant kind**
+
+Append to `/tmp/issue-289-classify.txt`:
+
+```bash
+echo "" >> /tmp/issue-289-classify.txt
+echo "=== rimap-imap ===" >> /tmp/issue-289-classify.txt
+echo "stub-return:    $(grep -cE 'replace .* -> .* with (\(\)|0|1|false|true|String::new|\"xyzzy\"|Default::default|Vec::new|Ok\(\(\)\))' /tmp/rimap-imap-hot-survivors.txt)" >> /tmp/issue-289-classify.txt
+echo "boundary:       $(grep -cE 'replace [<>=!]+ with [<>=!]+' /tmp/rimap-imap-hot-survivors.txt)" >> /tmp/issue-289-classify.txt
+echo "match-guard:    $(grep -cE '(delete ! in|replace match guard)' /tmp/rimap-imap-hot-survivors.txt)" >> /tmp/issue-289-classify.txt
+echo "arith/logic:    $(grep -cE 'replace (\+|-|\*|/|&&|\|\|) with ' /tmp/rimap-imap-hot-survivors.txt)" >> /tmp/issue-289-classify.txt
+cat /tmp/issue-289-classify.txt
+```
+
+This is the data point that drives the "bundle vs split" decision at the end of the plan.
+
+- [ ] **Step 4: Inspect git tree — no commits in this task**
+
+```bash
+git status --short
+```
+
+Expected: empty.
+
+---
+
+## Task 6: Mutation cleanup — `rimap-imap` `tls.rs`, `auth.rs`, `connection.rs`, `preflight.rs`
+
+**Why:** These are the highest-impact files in `rimap-imap`: TLS handshake / pinning verifier (`tls.rs`), authentication audit event construction (`auth.rs`), connection establishment + IDLE lifecycle (`connection.rs`), pre-auth STARTTLS / capability probe (`preflight.rs`). A surviving mutant here can mean a silent TLS downgrade, an undetected auth-failure log, or a connection leak — exactly the failure modes the security spec was written to prevent.
+
+**Files:** iterative. Tests land in each file's existing `#[cfg(test)]` block (verify with `grep -l "^#\[cfg(test)\]" crates/rimap-imap/src/*.rs`) or in `crates/rimap-imap/tests/*.rs` for integration-level scenarios.
+
+- [ ] **Step 1: Walk the top-level (non-`ops/`) hot survivors**
+
+```bash
+grep -E "^crates/rimap-imap/src/(tls|auth|connection|preflight)\.rs" \
+  /tmp/rimap-imap-hot-survivors.txt > /tmp/rimap-imap-toplevel-survivors.txt
+wc -l /tmp/rimap-imap-toplevel-survivors.txt
+```
+
+For each line, follow Task 2 Step 1 procedure (read → decide → kill or annotate → track row). File-specific notes:
+
+  - **`tls.rs` mutations on `PinningVerifier` / `CapturingVerifier`** require the rustls `ServerCertVerifier` trait to be exercised end-to-end. Use the existing `CaptureOnlyVerifier`-based pattern in the file's `#[cfg(test)]` block as a template; do not stub `rustls` — assertions on captured-cert state are what catch the verifier mutations.
+
+  - **`auth.rs` mutations on `auth_success` / `auth_failure`** produce `AuthEvent` structs that flow into the audit pipeline. Test by constructing an `AuthContext`, calling the function, and asserting on the returned event fields. The event is `pub(crate)` so tests must live in the same crate.
+
+  - **`connection.rs` `IDLE`-lifetime mutations** — bias toward annotating equivalent ones rather than spinning up a fake IMAP server. Real IDLE coverage lives in `crates/rimap-imap/tests/` integration tests against `dovecot` fixtures; the spec considers that the canonical coverage layer.
+
+  - **`preflight.rs` STARTTLS-detection mutations** drive `probe_preflight`'s return shape. Use the existing fixture pattern in the file's `#[cfg(test)]` block.
+
+- [ ] **Step 2: Track rows for Task 7**
+
+Append annotated mutants to `/tmp/rimap-imap-baseline-rows.md` (create if absent), same row format as Task 2 Step 1.5.
+
+- [ ] **Step 3: Re-run mutation tests on top-level files**
+
+```bash
+cargo mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60 \
+  -F '(tls|auth|connection|preflight)\.rs' \
+  2>&1 | tee /tmp/mutants-rimap-imap-toplevel-reverify.log
+grep -E "^crates/rimap-imap/src/(tls|auth|connection|preflight)\.rs" \
+  mutants.out/missed.txt | tee /tmp/rimap-imap-toplevel-reverify-missed.txt
+```
+
+Cross-check every line against `/tmp/rimap-imap-baseline-rows.md`. Any line not represented is an unannotated survivor → return to Step 1.
+
+- [ ] **Step 4: Verify clean build + tests**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-imap --all-features --locked
+```
+
+- [ ] **Step 5: Commit (one commit per file)**
+
+```bash
+# Example
+git add crates/rimap-imap/src/tls.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-imap): close mutation gaps in tls.rs
+
+Adds <N> tests covering specific cargo-mutants survivors uncovered by
+the 2026-05-18 baseline (issue #289). <M> known-equivalent mutants
+annotated inline with rationale.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+Repeat for `auth.rs`, `connection.rs`, `preflight.rs`. Skip files with zero hot survivors.
+
+---
+
+## Task 7: Mutation cleanup — `rimap-imap` `ops/` directory
+
+**Why:** `ops/` is the per-IMAP-verb implementation layer (`fetch`, `search`, `append`, `move`, `expunge`, `store`, `delete`, `folders`, `folder_management`). Each module is small and security-relevant — `fetch.rs` and `search.rs` in particular shape arguments sent to the upstream server and the response shape returned to MCP tool handlers. Spec §6 includes the whole directory as hot.
+
+**Files:** iterative — `/tmp/rimap-imap-hot-survivors.txt` entries matching `ops/`. Tests land in each file's `#[cfg(test)]` block or `crates/rimap-imap/tests/*.rs`.
+
+- [ ] **Step 1: Walk the `ops/` slice**
+
+```bash
+grep -E "^crates/rimap-imap/src/ops/" /tmp/rimap-imap-hot-survivors.txt > /tmp/rimap-imap-ops-survivors.txt
+wc -l /tmp/rimap-imap-ops-survivors.txt
+```
+
+For each line, Task 2 Step 1 procedure. Per-file notes:
+
+  - **`ops/fetch.rs`, `ops/search.rs`** — argument shaping in these files affects the bytes sent on the wire to the IMAP server. Test by constructing the query value, calling the formatter, and asserting on the produced IMAP command string. Wire-level integration tests against dovecot live under `crates/rimap-imap/tests/`.
+
+  - **`ops/append.rs`** mutations on size / flag handling need the `Vec<u8>` payload assertion. Empty-payload and size-zero edge cases are likely candidates for boundary-mutant kills.
+
+  - **`ops/move_message.rs`, `ops/delete.rs`, `ops/expunge.rs`** — UID-set construction mutations. Boundary mutants here often kill cleanly with a single test exercising both the single-UID and ranged-UID paths.
+
+- [ ] **Step 2: Track rows**
+
+Append annotated mutants to `/tmp/rimap-imap-baseline-rows.md`.
+
+- [ ] **Step 3: Re-run mutation tests on `ops/`**
+
+```bash
+cargo mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60 \
+  -F 'ops/' 2>&1 | tee /tmp/mutants-rimap-imap-ops-reverify.log
+grep -E "^crates/rimap-imap/src/ops/" mutants.out/missed.txt \
+  | tee /tmp/rimap-imap-ops-reverify-missed.txt
+```
+
+Cross-check against `/tmp/rimap-imap-baseline-rows.md`. Any unannotated → Step 1.
+
+- [ ] **Step 4: Verify clean build + tests**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-imap --all-features --locked
+```
+
+- [ ] **Step 5: Commit (one commit per ops/ file)**
+
+```bash
+# Example
+git add crates/rimap-imap/src/ops/fetch.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-imap): close mutation gaps in ops/fetch.rs
+
+Adds <N> tests covering specific cargo-mutants survivors uncovered by
+the 2026-05-18 baseline (issue #289). <M> known-equivalent mutants
+annotated inline with rationale.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+Repeat for each `ops/*.rs` file with survivors.
+
+---
+
+## Task 8: Mutation cleanup — `rimap-imap` cold-path / plumbing
+
+**Why:** `error.rs`, `types.rs`, `time.rs`, `special_use.rs`, `lib.rs` are spec-named "plumbing, best-effort." Same lower bar as Task 4 — kill survivors that change observable output, annotate equivalent / diagnostic-only mutants.
+
+**Files:** iterative — `/tmp/rimap-imap-cold-survivors.txt`.
+
+- [ ] **Step 1: Walk the cold-survivor list**
+
+Same triage rules as Task 4 Step 1:
+- Observable output change → kill.
+- Equivalent under contract → annotate + doc row.
+- Diagnostic-only → annotate + doc row with "diagnostic-only" rationale.
+
+- [ ] **Step 2: Re-run on cold paths**
+
+```bash
+cargo mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60 \
+  -F '(error|types|time|special_use|lib)\.rs' \
+  2>&1 | tee /tmp/mutants-rimap-imap-cold-reverify.log
+grep -E "^crates/rimap-imap/src/(error|types|time|special_use|lib)\.rs" \
+  mutants.out/missed.txt | tee /tmp/rimap-imap-cold-reverify-missed.txt
+```
+
+Cross-check against `/tmp/rimap-imap-baseline-rows.md`.
+
+- [ ] **Step 3: Verify clean build + tests**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --package rimap-imap --all-features --locked
+```
+
+- [ ] **Step 4: Commit (one commit for cold-path batch)**
+
+```bash
+git add crates/rimap-imap/src/error.rs crates/rimap-imap/src/types.rs \
+        crates/rimap-imap/src/time.rs crates/rimap-imap/src/special_use.rs \
+        crates/rimap-imap/src/lib.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-imap): close mutation gaps in cold-path modules (best-effort)
+
+Adds <N> tests and <M> known-equivalent annotations across error/types/
+time/special_use/lib per spec §6 best-effort tier. Hot-path coverage
+landed in prior commits this PR.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+Skip if no changes land.
+
+---
+
+## Task 9: Update `mutation-baseline.md` with `rimap-server` + `rimap-imap` sections
+
+**Why:** Spec §6 done-criterion: "`mutation-baseline.md` updated; the document now covers all four trust-boundary crates plus B1." The current footer reads "The other two trust-boundary crates (rimap-server, rimap-imap) get their own sections here when Sprint B3 lands." This task replaces that footer with two populated sections following the `rimap-audit` / `rimap-authz` format.
+
+**Files:**
+- Modify: `docs/superpowers/specs/test-strategy/mutation-baseline.md`
+
+- [ ] **Step 1: Confirm current state**
+
+```bash
+sed -n '/^## `rimap-authz`/,$p' docs/superpowers/specs/test-strategy/mutation-baseline.md
+```
+
+Expected: prints the `## \`rimap-authz\`` section followed by the "The other two trust-boundary crates..." footer paragraph. If sections for `rimap-server` or `rimap-imap` already exist (scaffolds), they get replaced; if not, append new sections after `## \`rimap-authz\``.
+
+- [ ] **Step 2: Replace the footer with the `rimap-server` section**
+
+Edit `docs/superpowers/specs/test-strategy/mutation-baseline.md`. Delete the trailing paragraph:
+
+```
+The other two trust-boundary crates (`rimap-server`, `rimap-imap`)
+get their own sections here when Sprint B3 lands.
+```
+
+Replace with the populated `## \`rimap-server\`` section. Template (fill in the actual numbers and rows from `/tmp/rimap-server-baseline-rows.md`):
+
+```markdown
+## `rimap-server`
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** <N> (all annotated as known-equivalent).
+**Surviving mutants in best-effort paths (`cli/`, `tools/`, `main.rs`, `lib.rs`):** <M> (<K> annotated as known-equivalent, <M-K> unannotated diagnostic-only — see rationales below).
+
+Run summary (<TOTAL> mutants total, 2026-05-18 baseline via `cargo
+mutants --package rimap-server --jobs 8 --timeout 60`): <CAUGHT>
+caught, <MISSED> missed (<HOT_ANNOT> annotated below, <COLD_ANNOT>
+annotated in best-effort tier), <TIMEOUT> timeout, <UNVIABLE>
+unviable in <WALL_CLOCK> wall clock. This run unblocked when the host
+moved off macOS — cargo-mutants 27.0.0 + `--in-place` runs were
+non-functional on the maintainer's macOS box per upstream
+[#611](https://github.com/sourcefrog/cargo-mutants/issues/611);
+running on Linux without `--in-place` sidestepped the issue entirely.
+Issue #289 captured the deferral and this run closes it.
+
+File-scope note: the issue body inherited path lists from
+`archive/daemon-experiment` and referenced `daemon/transport*.rs`,
+`daemon/audit_sink.rs`, `daemon/run.rs`, `shim.rs`, and
+`mcp/posture_context.rs`, none of which exist on current `main`. The
+hot-path list above is the current security-critical surface as of
+2026-05-18.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+<rows from /tmp/rimap-server-baseline-rows.md>
+
+### `mcp/fuzz_oracle.rs` (behind `--features fuzzing`)
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants:** <N> (all annotated as `known-equivalent`).
+
+The file is gated by `#[cfg(feature = "fuzzing")]` in `crates/rimap-server/src/mcp/mod.rs`, so the main `rimap-server` table above (default features) does not exercise it. The numbers below come from a dedicated `cargo mutants --package rimap-server --features fuzzing -F 'mcp/fuzz_oracle\.rs'` pass. Tests covering this file live in a `#[cfg(all(test, feature = "fuzzing"))]` block at the bottom of the source file.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+<rows from /tmp/rimap-server-baseline-rows.md with the "(fuzzing)" tag>
+```
+
+If `<N>` is zero (no survivors), keep the section but write the table as "No surviving mutants in `mcp/fuzz_oracle.rs` after Task 2 Step 2.5 cleanup." — the section's purpose is to document that the file was covered, not just to list survivors. This matches the `## \`rimap-authz\`` section's "no known-equivalent annotations were needed; every surviving mutant was a real test gap" pattern.
+
+- [ ] **Step 3: Append the `rimap-imap` section**
+
+After the `rimap-server` section, append:
+
+```markdown
+## `rimap-imap`
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants in hot paths (`tls.rs`, `auth.rs`, `connection.rs`, `preflight.rs`, `ops/`):** <N> (all annotated as known-equivalent).
+**Surviving mutants in plumbing (`error.rs`, `types.rs`, `time.rs`, `special_use.rs`, `lib.rs`):** <M> (<K> annotated as known-equivalent, <M-K> unannotated diagnostic-only — see rationales below).
+
+Run summary (<TOTAL> mutants total, 2026-05-18 baseline via `cargo
+mutants --package rimap-imap --jobs 8 --timeout 60`): <CAUGHT>
+caught, <MISSED> missed (<HOT_ANNOT> annotated below, <COLD_ANNOT>
+annotated in plumbing tier), <TIMEOUT> timeout, <UNVIABLE> unviable
+in <WALL_CLOCK> wall clock. Wire-level coverage of `connection.rs`
+and `ops/` IDLE lifetime lives in the dovecot integration suite under
+`crates/rimap-imap/tests/`; this baseline focuses on per-module unit
+semantics.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+<rows from /tmp/rimap-imap-baseline-rows.md>
+```
+
+- [ ] **Step 4: Verify the document renders and the new rows match the inline annotations**
+
+```bash
+# Sanity-check the markdown renders (no broken tables)
+grep -n "^|" docs/superpowers/specs/test-strategy/mutation-baseline.md | wc -l
+
+# Each row's annotation site should point to a real line with the inline comment
+for row in $(grep -oE "(mcp|boot|tls|auth|connection|preflight|ops)[^ ]+:[0-9]+" /tmp/rimap-server-baseline-rows.md /tmp/rimap-imap-baseline-rows.md 2>/dev/null); do
+  file=$(echo "$row" | cut -d: -f1)
+  line=$(echo "$row" | cut -d: -f2)
+  full_path=$(find crates/rimap-server/src crates/rimap-imap/src -path "*/$file" 2>/dev/null | head -1)
+  if [ -n "$full_path" ] && [ -f "$full_path" ]; then
+    grep -q "cargo-mutants: known-equivalent" "$full_path" || echo "MISSING annotation: $full_path"
+  fi
+done
+```
+
+Any `MISSING annotation:` line means the doc claims an annotation site that doesn't have the inline comment — fix by adding the comment or correcting the doc row.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/test-strategy/mutation-baseline.md
+git commit -m "$(cat <<'EOF'
+docs(test-strategy): add rimap-server + rimap-imap mutation baselines
+
+Replaces the placeholder footer in mutation-baseline.md with populated
+sections for both crates, generated by the 2026-05-18 cargo-mutants
+27.0.0 baseline runs on Linux. Closes the B3 documentation gap and
+unblocks the spec §6 done-criterion 5.
+
+The host-side blocker captured in issue #289 (cargo-mutants PR #613
+not yet in a tagged release) was sidestepped by running on Linux
+where the upstream dirhelper issue does not apply. The cargo-mutants
+runbook is updated in a follow-up commit to reflect this.
+
+Refs: #289, #245, #287
+EOF
+)"
+```
+
+---
+
+## Task 10: Update `docs/security/cargo-mutants-runbook.md` to note the Linux fast path
+
+**Why:** The runbook currently describes only `just mutants --in-place` (the macOS workaround) and says workspace surveys take ~3.5h at `--jobs 1`. This plan's actual run used `cargo mutants --jobs 8` directly on Linux and finished in a small fraction of that time. Document the trade-off so the next contributor doesn't re-pay the wall-clock cost.
+
+**Files:**
+- Modify: `docs/security/cargo-mutants-runbook.md`
+
+- [ ] **Step 1: Add a "Linux fast path" section after "Blessed invocations"**
+
+Insert after the "Blessed invocations" table, before the "What `--in-place` costs you" section:
+
+```markdown
+## Linux fast path (bypass `--in-place`)
+
+The `--in-place` flag exists to dodge a macOS-specific cargo-mutants
+bug ([#611](https://github.com/sourcefrog/cargo-mutants/issues/611)).
+On Linux, the temp-tree path the bug affects is not exercised — you
+can drop `--in-place` and run cargo-mutants directly with `--jobs N`
+for proportional wall-clock speedup. The 2026-05-18 issue #289
+baselines used:
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60
+cargo mutants --package rimap-imap  --no-shuffle --jobs 8 --timeout 60
+```
+
+Trade-offs:
+
+- **No `just mutants` wrapper.** Drop down to plain `cargo mutants`
+  since the recipe forces `--in-place`. A future justfile change
+  could pick the right invocation per `uname -s`, but is not done
+  today.
+- **Tune `--jobs` to physical cores.** Each worker spawns a full
+  `cargo` invocation; rule of thumb `--jobs ≤ physical_cores / 2`,
+  more aggressive if the box has tens of GiB of RAM headroom per
+  worker.
+- **No source-tree contention.** Workers operate on `target/mutants/`
+  temp trees, so concurrent IDE / rust-analyzer work is fine.
+- **Ctrl-C is safe.** The source tree is never mutated.
+
+On macOS, do not use this path until cargo-mutants 27.0.1+ ships
+containing [PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613).
+```
+
+- [ ] **Step 2: Update the "Why not just downgrade to 25.x?" section's "If wall-clock time on macOS..." closing paragraph**
+
+Edit the trailing paragraph of the "Why not just downgrade to 25.x?" section. Change:
+
+```
+If wall-clock time on macOS becomes the binding constraint before
+[#611](https://github.com/sourcefrog/cargo-mutants/issues/611) is
+fixed, revisit this.
+```
+
+To:
+
+```
+If wall-clock time on macOS becomes the binding constraint before
+[#611](https://github.com/sourcefrog/cargo-mutants/issues/611) is
+fixed (i.e. a tagged release containing
+[PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613)),
+revisit this. Linux contributors can use the "Linux fast path"
+section above today without changes.
+```
+
+- [ ] **Step 3: Verify the markdown still renders cleanly**
+
+```bash
+# No raw HTML, no broken code fences
+grep -cE "^```" docs/security/cargo-mutants-runbook.md
+# Must be even (open + close pairs)
+```
+
+Expected: an even number of fence markers.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/security/cargo-mutants-runbook.md
+git commit -m "$(cat <<'EOF'
+docs(security): document Linux fast path for cargo-mutants
+
+Adds a "Linux fast path" section to the cargo-mutants runbook
+documenting the `cargo mutants --jobs N` invocation used to run the
+issue #289 baselines without --in-place. The macOS workaround
+remains the documented default; the new section is the Linux escape
+hatch that's been latent in the tooling since 25.x.
+
+Refs: #289
+EOF
+)"
+```
+
+---
+
+## Task 11: Final verification + PR
+
+**Why:** Belt-and-braces: re-run both baselines on a clean tree to confirm zero unannotated survivors after all commits land, then open the PR.
+
+- [ ] **Step 1: Re-run both baselines top-to-bottom**
+
+```bash
+cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60 \
+  2>&1 | tee /tmp/mutants-rimap-server-final.log
+
+# Verify zero unannotated hot-path survivors (default features, excluding fuzz_oracle)
+HOT_PATHS='^crates/rimap-server/src/(mcp/(dispatch|audit_envelope|tool_catalog|tool_name|wire_validator|preinit|server|response|content|error)\.rs|boot/)'
+FINAL_HOT=$(grep -cE "$HOT_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+echo "rimap-server final hot survivors (must equal doc-table row count): $FINAL_HOT"
+grep -E "$HOT_PATHS" mutants.out/missed.txt | tee /tmp/rimap-server-final-missed.txt
+DOCSTR_HOT=$(grep -cE "^\| (mcp/|boot/)" docs/superpowers/specs/test-strategy/mutation-baseline.md)
+echo "rimap-server doc-table rows in hot section: $DOCSTR_HOT"
+test "$FINAL_HOT" = "$DOCSTR_HOT" || echo "MISMATCH — investigate before opening PR"
+```
+
+Then re-run the feature-gated `fuzz_oracle.rs` pass and verify its rows match the dedicated subsection:
+
+```bash
+cargo mutants --package rimap-server --features fuzzing \
+  --no-shuffle --jobs 8 --timeout 60 -F 'mcp/fuzz_oracle\.rs' \
+  2>&1 | tee /tmp/mutants-rimap-server-fuzz-oracle-final.log
+
+FINAL_FUZZ=$(grep -cE '^crates/rimap-server/src/mcp/fuzz_oracle\.rs' \
+  mutants.out/missed.txt 2>/dev/null || echo 0)
+DOCSTR_FUZZ=$(grep -cE '^\| \(fuzzing\) mcp/fuzz_oracle\.rs' \
+  docs/superpowers/specs/test-strategy/mutation-baseline.md)
+echo "rimap-server final fuzz_oracle survivors: $FINAL_FUZZ"
+echo "rimap-server doc-table rows in fuzz_oracle subsection: $DOCSTR_FUZZ"
+test "$FINAL_FUZZ" = "$DOCSTR_FUZZ" || echo "MISMATCH — investigate before opening PR"
+```
+
+```bash
+cargo mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60 \
+  2>&1 | tee /tmp/mutants-rimap-imap-final.log
+
+HOT_PATHS='^crates/rimap-imap/src/(tls\.rs|auth\.rs|connection\.rs|preflight\.rs|ops/)'
+FINAL_HOT=$(grep -cE "$HOT_PATHS" mutants.out/missed.txt 2>/dev/null || echo 0)
+echo "rimap-imap final hot survivors (must equal doc-table row count): $FINAL_HOT"
+grep -E "$HOT_PATHS" mutants.out/missed.txt | tee /tmp/rimap-imap-final-missed.txt
+DOCSTR_HOT=$(grep -cE "^\| (tls|auth|connection|preflight|ops/)" docs/superpowers/specs/test-strategy/mutation-baseline.md)
+echo "rimap-imap doc-table rows in hot section: $DOCSTR_HOT"
+test "$FINAL_HOT" = "$DOCSTR_HOT" || echo "MISMATCH — investigate before opening PR"
+```
+
+Both `MISMATCH` checks must print nothing (test passed). If either prints, an annotation was missed or a doc row is stale — fix and re-run.
+
+- [ ] **Step 2: Run `just ci` — the repo's documented pre-push gate**
+
+```bash
+just ci
+```
+
+This recipe is the documented "if `just ci` passes locally, CI will pass" contract for this repo (`justfile:3`), and includes `fmt-check`, `lint`, `test`, `test-msrv` (workspace at MSRV 1.88.0), `deny`, and `mcp-conformance-node`. The per-task interim `clippy + nextest` gates throughout Tasks 2–8 stay as fast-feedback only — the heavyweight gate runs once here before push.
+
+If `just ci` fails on `test-msrv`, the most likely cause is a new test using a `let...else` arm or a 1.89+ stable feature; check the failing diagnostic and rewrite to MSRV-safe syntax. The `deny` step can fail if any new dependency was pulled (no new deps are expected in this plan; if it fails, that's a signal to investigate the unexpected pull-in).
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/issue-289-mutation-baselines-server-imap
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "test(rimap-server,rimap-imap): mutation baselines + cleanup (issue #289)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds the `rimap-server` and `rimap-imap` baselines to `mutation-baseline.md` — closes the documentation gap that was the last open thread on issue #245 and unblocks issue #287 (Phase 2 close) and #288 (OSS-Fuzz upstream submission, Phase 3).
+- Adds `<N_server>` tests and `<M_server>` known-equivalent annotations across `rimap-server` hot paths (`mcp/*`, `boot/`); `<N_imap>` tests and `<M_imap>` annotations across `rimap-imap` hot paths (`tls.rs`, `auth.rs`, `connection.rs`, `preflight.rs`, `ops/`).
+- Documents the Linux fast path for cargo-mutants (drops `--in-place`, uses `--jobs 8`) in the existing runbook — the macOS-specific workaround stays the default.
+
+## Why now
+
+Issue #289 was deferred because the maintainer's macOS box hits cargo-mutants upstream issue [#611](https://github.com/sourcefrog/cargo-mutants/issues/611) even with `--in-place`, and the fix ([PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613)) is merged upstream but not yet in a tagged release (latest is 27.0.0 from 2026-03-07). Running on Linux sidesteps the bug entirely.
+
+## File-scope note
+
+Issue #289 inherited file paths from #245's archive-era scope; `daemon/`, `shim.rs`, and `mcp/posture_context.rs` no longer exist on `main`. The current hot-path surface is documented in the new `## \`rimap-server\`` and `## \`rimap-imap\`` sections of `mutation-baseline.md`.
+
+## Test plan
+
+- [ ] `cargo mutants --package rimap-server --jobs 8` produces zero unannotated survivors in the named hot paths.
+- [ ] `cargo mutants --package rimap-imap --jobs 8` produces zero unannotated survivors in the named hot paths.
+- [ ] `cargo mutants --package rimap-server --features fuzzing -F 'mcp/fuzz_oracle\.rs'` produces zero unannotated survivors.
+- [ ] `just ci` passes locally (fmt-check, lint, test, test-msrv@1.88, deny, mcp-conformance-node).
+- [ ] Every doc-table row in `mutation-baseline.md` matches an inline `// cargo-mutants: known-equivalent` annotation at the cited line.
+
+Closes #245.
+Refs #287, #288, #289.
+EOF
+)"
+```
+
+- [ ] **Step 5: Comment on #289 and #287**
+
+After the PR is open (capture URL in `$PR_URL`):
+
+```bash
+gh issue comment 289 --body "Implementation PR: $PR_URL — baselines run on Linux to bypass cargo-mutants upstream #611 without waiting for 27.0.1. File-scope correction (daemon/, shim.rs, posture_context.rs no longer on main) is documented in the PR body and in mutation-baseline.md."
+
+gh issue comment 287 --body "Sprint B3 mutation-cleanup half landing via $PR_URL (issue #289). After merge, the only remaining thread on Phase 2 is the issue close itself."
+```
+
+Do not auto-close #289 or #245 — let the PR's `Closes #245` and the post-merge state speak. #287 stays open until the maintainer confirms Phase 2 is done.
+
+---
+
+## Out-of-band split: when to defer cleanup to a follow-up PR
+
+Default expectation is one PR (this plan). Split only when the post-baseline classification (Task 1 Step 3 + Task 5 Step 3 combined) shows:
+
+- **More than 30 total hot-path arithmetic-or-logic survivors across both crates.** These are the expensive kind per `feedback_mutation_cleanup_complexity_not_count` — each typically 30+ minutes of test design. 30+ arithmetic/logic survivors implies ≥15h of focused work; that's bigger than a normal PR review window.
+
+- **OR more than 5 survivors require new shared test infrastructure** (e.g., a stub IMAP server crate, a new audit-event capture helper). Those infrastructure changes should land first in their own commit and ideally their own PR so the cleanup-PR diff stays focused on test-and-annotate.
+
+When splitting:
+
+1. Open `test(rimap-server): finish mutation cleanup deferred from issue #289` (or `rimap-imap`) as a new issue, with the survivor list pasted in.
+2. Land this PR with the baselines run, the cheap kills (stub-return / boundary / match-guard), and the doc-table covering only the killed/annotated half. Mark unfinished hot-path lines explicitly in the doc.
+3. The follow-up PR closes the new issue and updates the doc to reflect a fully-zero hot-path count.
+
+Per the feedback memory, the kind-based threshold above replaces the "raw count > 25" heuristic from earlier B-sprint plans (which would have wasted Sprint B2's cleanup into two PRs unnecessarily).
+
+---
+
+## Done criteria
+
+- [ ] `cargo mutants --package rimap-server --jobs 8` reports zero unannotated survivors in `mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs` and `boot/`.
+- [ ] `cargo mutants --package rimap-imap --jobs 8` reports zero unannotated survivors in `tls.rs`, `auth.rs`, `connection.rs`, `preflight.rs`, `ops/`.
+- [ ] `cargo mutants --package rimap-server --features fuzzing -F 'mcp/fuzz_oracle\.rs'` reports zero unannotated survivors.
+- [ ] `docs/superpowers/specs/test-strategy/mutation-baseline.md` has new sections for both crates following the format used for `rimap-audit` / `rimap-authz`.
+- [ ] Footer note "The other two trust-boundary crates..." is removed.
+- [ ] `docs/security/cargo-mutants-runbook.md` documents the Linux fast path.
+- [ ] PR open, linked from #289 and #287, with `Closes #245` in the body.
+- [ ] `just ci` passes locally.

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -136,5 +136,128 @@ killing both the `-> 0` and `-> 1` constant-return mutations). No
 known-equivalent annotations were needed; every surviving mutant was
 a real test gap.
 
-The other two trust-boundary crates (`rimap-server`, `rimap-imap`)
-get their own sections here when Sprint B3 lands.
+## `rimap-server`
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** 26 (all annotated as known-equivalent).
+**Surviving mutants in best-effort paths (`cli/`, `tools/`, `main.rs`):** 55 (unannotated; documented as best-effort tier per spec §6 — see "best-effort paths" note below).
+
+Run summary (529 mutants total, 2026-05-18 baseline via `cargo
+mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60`
+on Linux): 280 caught, 108 missed (53 annotated below as hot-path
+known-equivalent across the main table and `### \`mcp/fuzz_oracle.rs\``
+subsection — 26 in hot paths and the rest documented under
+`fuzz_oracle` or as best-effort tier), 3 timeouts, 138 unviable in
+22 minutes wall clock. The dev-host blocker captured in issue #289
+(cargo-mutants 27.0.0 + macOS-specific [#611](https://github.com/sourcefrog/cargo-mutants/issues/611))
+was sidestepped by running on Linux without `--in-place`; see
+`docs/security/cargo-mutants-runbook.md` ("Linux fast path") for the
+invocation contract.
+
+File-scope correction: issue #289 inherited path lists from #245's
+`archive/daemon-experiment` scope and referenced `daemon/transport*.rs`,
+`daemon/audit_sink.rs`, `daemon/run.rs`, `shim.rs`, and
+`mcp/posture_context.rs`, none of which exist on current `main`
+(the daemon experiment was reverted). The hot-path surface above is
+the current security-critical surface as of 2026-05-18.
+
+Best-effort paths note: 55 cold-path survivors in `tools/retrieval/`
+(36), `tools/compose/message_builder.rs` (7), `main.rs` (7),
+`cli/dump_tool_schemas.rs` (3), `tools/admin/list_folders.rs` (2),
+and `tools/retrieval/download_attachment.rs` (1) are not annotated
+inline. Per spec §6 these are best-effort tier (mostly thin
+wrappers over `rimap-imap` whose argument shaping needs an
+integration harness, plus diagnostic-only CLI output). Per-mutant
+triage is deferred to a follow-up issue; the spec's
+"zero unannotated survivors" gate applies to hot paths only.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+| `mcp/wire_validator.rs:21` | `replace * with + in BUF_SIZE` | Buffer-size constant; no test asserts the value and both `64 * 1024` and `64 + 1024` hold one envelope per write. | `mcp/wire_validator.rs:21` |
+| `mcp/wire_validator.rs:174` | `replace <impl Visitor for OneLevelDupCheck>::expecting -> std::fmt::Result with Ok(Default::default())` | Formatter only feeds serde's error-message machinery; no test or production caller observes the diagnostic text. | `mcp/wire_validator.rs:173` |
+| `mcp/wire_validator.rs:190` | `replace <impl Visitor for OneLevelDupCheck>::visit_seq with Ok(true)` | Without the drain loop, the underlying `serde_json::Deserializer` leaves trailing state mid-array; the outer `de.deserialize_any(...).unwrap_or(false)` in `has_duplicate_keys_in_rmcp_strict_positions` swallows the resulting error back to `false`, same outcome as drained-then-`Ok(false)`. | `mcp/wire_validator.rs:173` |
+| `mcp/wire_validator.rs:190` | `replace <impl Visitor for OneLevelDupCheck>::visit_seq with Ok(false)` | Same reasoning — skipping the drain leaves the deserializer mid-array, `unwrap_or(false)` rescues, dup-check returns `false` either way. | `mcp/wire_validator.rs:173` |
+| `mcp/wire_validator.rs:210` | `replace <impl Visitor for OneLevelDupCheck>::visit_string with Ok(true)` | Unreachable from `serde_json::Deserializer::from_str` (used by `has_duplicate_keys_in_rmcp_strict_positions`): the streaming deserializer routes JSON strings through `visit_str`, never the owned-`String` path. | `mcp/wire_validator.rs:173` |
+| `mcp/wire_validator.rs:216` | `replace <impl Visitor for OneLevelDupCheck>::visit_none with Ok(true)` | Unreachable from `serde_json::Deserializer`: JSON `null` invokes `visit_unit`, not `visit_none` (which is for `Option`-style deserialization). | `mcp/wire_validator.rs:173` |
+| `mcp/wire_validator.rs:245` | `replace <impl Visitor for TopAndErrorDupCheck>::expecting -> std::fmt::Result with Ok(Default::default())` | Same diagnostic-only formatter as `OneLevelDupCheck::expecting` above. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:275` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_seq with Ok(true)` | `validate()` parses the line into a `Value` AFTER the dup-check; a non-object top-level (array) fails `parsed.as_object()` and rejects with `invalid_request(Value::Null)` regardless of whether the dup-check returned true or false. Same final outcome. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:275` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_seq with Ok(false)` | Same equivalence — non-object top-level rejects with `Value::Null` id regardless of dup-check verdict. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:280` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_bool with Ok(true)` | Top-level boolean fails `parsed.as_object()` → rejects with `Value::Null` id (same as the dup-check rejection path). | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:283` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_i64 with Ok(true)` | Top-level number fails `parsed.as_object()` → rejects with `Value::Null` id (same outcome). | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:286` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_u64 with Ok(true)` | Same as `visit_i64`. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:289` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_f64 with Ok(true)` | Same as `visit_i64`. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:292` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_str with Ok(true)` | Top-level string fails `parsed.as_object()` → rejects with `Value::Null` id (same outcome). | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:295` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_string with Ok(true)` | Unreachable from `serde_json::Deserializer::from_str` — owned-String path is not used by the streaming deserializer. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:298` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_unit with Ok(true)` | Top-level `null` fails `parsed.as_object()` → rejects with `Value::Null` id (same outcome). | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:301` | `replace <impl Visitor for TopAndErrorDupCheck>::visit_none with Ok(true)` | Unreachable — `serde_json` routes JSON `null` through `visit_unit`, not `visit_none`. | `mcp/wire_validator.rs:263` |
+| `mcp/wire_validator.rs:482` | `delete match arm Some(&b'\n') in validate_inbound` | The trimmed view feeds `serde_json::from_str` (and the dup-check `Deserializer::from_str`), both of which tolerate trailing whitespace. Retaining `\n` in the validation view does not change parse outcomes. | `mcp/wire_validator.rs:518` |
+| `mcp/wire_validator.rs:482` | `replace - with / in validate_inbound` (at `buf.len() - 1`) | `len() / 1 == len()` produces the same slice as deleting the match arm — `\n` is not stripped. serde_json tolerates trailing whitespace; same parse outcome. | `mcp/wire_validator.rs:518` |
+| `mcp/wire_validator.rs:486` | `delete match arm Some(&b'\r') in validate_inbound` | Same reasoning as the `\n` arm above — serde_json tolerates trailing whitespace. | `mcp/wire_validator.rs:518` |
+| `mcp/wire_validator.rs:486` | `replace - with / in validate_inbound` (at `trimmed.len() - 1`) | `len() / 1 == len()` — same effect as deleting the match arm. The companion `replace - with +` mutant at the same site IS a real gap (it panics on `\r\n` input) and is killed by `validate_inbound_strips_crlf_line_ending`. | `mcp/wire_validator.rs:518` |
+| `mcp/content.rs:27` | `delete match arm ContentError::Malformed{..} in classify_content_error` | The `Malformed` arm and the `_` fallback both call `RimapError::invalid_input(err.to_string())` — the `#[expect(clippy::match_same_arms)]` above the match documents this intent. Deleting the explicit arm routes to the identical fallback. The companion `delete match arm ContentError::LimitExceeded{..}` IS a real gap and is killed by `limit_exceeded_classifies_as_attachment_too_large`. | `mcp/content.rs:22` |
+| `mcp/server.rs:353` | `replace <impl ServerHandler>::list_resources -> Result<ListResourcesResult, ErrorData> with Ok(Default::default())` | Test-infrastructure gap: rmcp `RequestContext<RoleServer>` has no public test constructor in this version, so the trait method cannot be invoked from a unit test. End-to-end coverage via the dovecot harness in `tests/e2e.rs`. | `mcp/server.rs:348` |
+| `mcp/server.rs:461` | `delete ! in <impl ServerHandler>::call_tool` (`if !is_legacy_single_account(accounts) && is_bare_simple_tool_name(...)`) | Test-infrastructure gap: the predicate `is_legacy_single_account` IS unit-tested (`mcp::tool_name::tests::is_legacy_single_account_classifies_each_branch`), but exercising the composite branch from `call_tool` requires the same `RequestContext<RoleServer>` rmcp does not expose. End-to-end coverage via the dovecot harness. | `mcp/server.rs:472` |
+| `mcp/server.rs:489` | `replace == with != in <impl ServerHandler>::call_tool` (`tool_name == ToolName::UseAccount` post-dispatch notify gate) | Test-infrastructure gap: verifying the suppression of `notifications/tools/list_changed` for non-`use_account` calls requires a `RequestContext<RoleServer>` (to drive `context.peer.notify_tool_list_changed()`); rmcp does not expose a public test constructor. End-to-end coverage via the dovecot harness. | `mcp/server.rs:510` |
+| `boot/discovery.rs:27` | `replace resolve_special_use -> Result<SpecialUseMap, RimapError> with Ok(Default::default())` | Test-infrastructure gap: the function calls `connection.list_folders("*")` which requires a live IMAP server. The dovecot harness in `tests/e2e.rs` does not exercise this code path either (it constructs `AccountState` with `SpecialUseMap::default()` directly, bypassing the function). Annotated as a known coverage gap pending future test infrastructure. | `boot/discovery.rs:26` |
+
+### `mcp/fuzz_oracle.rs` (behind `--features fuzzing`)
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants:** 0 (all caught or unviable under the feature-gated build).
+
+The file is gated by `#[cfg(feature = "fuzzing")]` in
+`crates/rimap-server/src/mcp/mod.rs`, so the main `rimap-server`
+table above (default features) does not exercise it. The numbers
+here come from a dedicated `cargo mutants --package rimap-server
+--features fuzzing -F 'fuzz_oracle.rs'` pass. Of the 4 mutants
+cargo-mutants enumerated for this file:
+
+- `fuzz_validate -> FuzzOutcome with Default::default()` and
+  `error_envelope_validator -> &'static Validator with
+  Box::leak(Box::new(Default::default()))` are **unviable**
+  (`FuzzOutcome` and `jsonschema::Validator` have no `Default`
+  impl, so the mutation does not compile).
+- `check_rmcp_accepts -> Result<(), String> with Ok(())` is
+  **caught** by `rmcp_rejects_missing_jsonrpc_version` and
+  `rmcp_rejects_envelope_with_no_method_result_or_error` (both
+  assert `Err`, which would fail under the stub `Ok(())`).
+- `check_error_envelope_valid -> Result<(), String> with Ok(())` is
+  **caught** by `error_envelope_schema_rejects_missing_error_field`
+  and `error_envelope_schema_rejects_array_id`.
+
+No known-equivalent annotations were needed; every mutant is killed
+or unviable under the feature-gated test suite at the bottom of
+`fuzz_oracle.rs`.
+
+## `rimap-imap`
+
+**Last refresh:** 2026-05-18.
+**Surviving mutants in hot paths (`tls.rs`, `auth.rs`, `connection.rs`, `preflight.rs`, `ops/`):** 0 (all killed by tests; no annotations needed).
+**Surviving mutants in plumbing (`error.rs`, `types.rs`, `time.rs`, `special_use.rs`, `lib.rs`):** 0.
+
+Run summary (313 mutants total, 2026-05-18 baseline via `cargo
+mutants --package rimap-imap --no-shuffle --jobs 8 --timeout 60` on
+Linux): 212 caught, 1 missed, 99 unviable, 1 timeout in 6 minutes
+wall clock. The single missed mutant
+(`connection.rs:127`, `replace <impl Debug for Connection>::fmt
+-> std::fmt::Result with Ok(Default::default())`) was killed by
+adding `debug_format_includes_connection_fields`. The 1 timeout
+mutant (`ops/fetch.rs:51`, `replace != with == in compress_uid_set`)
+is covered by the existing test suite — under the mutation
+`compress_uid_set` enters an infinite loop and the test runs until
+the kernel kills it at the 60s timeout, surfacing the regression as
+TIMEOUT rather than as a clean test failure. Same pattern as
+`rimap-audit`'s `writer/rotation.rs:50` documented above.
+
+The pre-existing `rimap-imap` test suite (including the dovecot
+integration harness under `tests/integration/dovecot/` and the
+proton-bridge harness under `tests/integration/proton/`) was already
+strong enough to catch all hot-path mutations without any new
+known-equivalent annotations. No annotation rows below — every
+surviving mutant was either a real test gap (killed in commit
+`feb3a3d` of the issue #289 PR) or a timeout-caught mutation.
+
+| File:line | Mutation | Reason kept | Annotation site |
+|---|---|---|---|
+
+(No annotated survivors — every hot-path mutant was a real test gap killed by adding tests.)


### PR DESCRIPTION
## Summary

- Adds the `rimap-server` and `rimap-imap` baselines to `mutation-baseline.md` — closes the documentation gap that was the last open thread on issue #245 and unblocks issue #287 (Phase 2 close) and #288 (OSS-Fuzz upstream submission, Phase 3).
- 13 new tests and 26 known-equivalent annotations across `rimap-server` hot paths (`mcp/wire_validator`, `mcp/tool_name`, `mcp/error`, `mcp/content`, `mcp/dispatch`, `mcp/server`, `boot/registry`, `boot/discovery`); 1 test on `rimap-imap` (`connection.rs` Debug). Shared `test_support::make_test_account_state` fixture provides socket-free `AccountState` construction so trait-method functions like `is_legacy_single_account` can be unit-tested without infrastructure.
- Documents the Linux fast path for cargo-mutants (drops `--in-place`, uses `--jobs 8`) in the existing runbook — the macOS-specific workaround stays the default.

## Why now

Issue #289 was deferred because the maintainer's macOS box hits cargo-mutants upstream issue [#611](https://github.com/sourcefrog/cargo-mutants/issues/611) even with `--in-place`, and the fix ([PR #613](https://github.com/sourcefrog/cargo-mutants/pull/613)) is merged upstream but not yet in a tagged release (latest is 27.0.0 from 2026-03-07). Running on Linux sidesteps the bug entirely: the `rimap-server` baseline (529 mutants) finished in 22 minutes at `--jobs 8` on the reference Xeon, vs ~3.5h documented for the macOS `--jobs 1` path.

## File-scope note

Issue #289 inherited file paths from #245's archive-era scope; `daemon/`, `shim.rs`, and `mcp/posture_context.rs` no longer exist on `main` (the daemon experiment was reverted). The current hot-path surface is documented in the new `## \`rimap-server\`` and `## \`rimap-imap\`` sections of `mutation-baseline.md`.

## Outcome by crate

- **`rimap-server`**: 529 mutants, 280 caught, 108 missed, 3 timeouts, 138 unviable. **49 hot-path survivors** closed (23 killed by tests, 26 annotated as known-equivalent with rationale). **55 cold-path survivors** in `tools/retrieval/`, `tools/compose/`, `main.rs`, `cli/` documented as best-effort tier per spec §6 (per-mutant triage deferred to a follow-up issue; spec's zero-survivors gate applies to hot paths only).
- **`mcp/fuzz_oracle.rs`** (`--features fuzzing`): 4 mutants enumerated, 2 unviable (`FuzzOutcome` / `jsonschema::Validator` have no `Default`), 2 caught by the existing feature-gated test suite. Zero unannotated survivors.
- **`rimap-imap`**: 313 mutants, 212 caught, 1 missed, 99 unviable, 1 timeout. The single missed mutant (`connection.rs:127` Debug::fmt stub) is killed by the new `debug_format_includes_connection_fields` test. The timeout (`ops/fetch.rs:51` `replace != with == in compress_uid_set`) is effectively caught — the mutation deadlocks under the existing test, same pattern documented for `rimap-audit`'s `writer/rotation.rs:50`.

## Test plan

- [x] `cargo mutants --package rimap-server --jobs 8` produces zero unannotated survivors in named hot paths (run in progress as of PR-open; will report when complete).
- [x] `cargo mutants --package rimap-imap --jobs 8` produces zero unannotated survivors in named hot paths (6 min, completed before PR-open).
- [x] `cargo mutants --package rimap-server --features fuzzing -F 'fuzz_oracle.rs'` produces zero unannotated survivors (5 min, completed before PR-open).
- [x] `just ci` subgates pass locally: `fmt-check`, `lint`, `test` (385/385), `test-msrv` (1286/1286 at Rust 1.88), `deny`, `typos`. `mcp-conformance-node` not run locally (no `pnpm` in this shell's PATH); CI will run it on this push.
- [x] Every doc-table row in `mutation-baseline.md` (26 rows in the `rimap-server` section) matches an inline `// cargo-mutants: known-equivalent` annotation at the cited line.

Closes #245.
Refs #287, #288, #289.