### PR TITLE
refactor(rimap-server): kill 2 [high] Codex findings on PR #293

### DIFF
--- a/crates/rimap-server/src/boot/discovery.rs
+++ b/crates/rimap-server/src/boot/discovery.rs
@@ -1,41 +1,90 @@
 //! One-shot special-use discovery at account boot.
 //!
-//! Runs `LIST "" "*"` once against a freshly-opened `Connection` and
-//! builds a `SpecialUseMap`. Called from the per-account boot path
-//! before `FolderGuard` is constructed so the guard's protected list
-//! can include discovered server-native folder names (e.g.
-//! `[Gmail]/Sent Mail`) in addition to the config-supplied literals.
+//! Classifies a folder list into a `SpecialUseMap`. Called from the
+//! per-account boot path before `FolderGuard` is constructed so the
+//! guard's protected list can include discovered server-native folder
+//! names (e.g. `[Gmail]/Sent Mail`) in addition to the config-supplied
+//! literals.
+//!
+//! The `LIST "" "*"` fetch lives at the caller so this function stays
+//! a pure mapping step exercisable by unit tests with synthetic
+//! `Folder` values — no live IMAP server required.
 //!
 //! Classification logic is unit-tested in `rimap_imap::special_use`;
 //! the live LIST path is covered by the Dovecot integration harness.
 
-use rimap_core::RimapError;
-use rimap_imap::{Connection, SpecialUseMap};
+use rimap_imap::{SpecialUseMap, types::Folder};
 
-/// Run one `LIST "*"` and classify the response into a `SpecialUseMap`.
+/// Classify a folder list into a `SpecialUseMap`.
 ///
-/// Discovery failures propagate — if we cannot enumerate folders at
-/// boot, the account is unusable regardless of what any downstream tool
-/// call does later, so returning the error early gives the operator a
-/// clean boot-time signal instead of a surprise on first compose.
-///
-/// # Errors
-///
-/// Returns `RimapError::Imap { ... }` when the underlying `LIST` call
-/// fails (transport error, server protocol error, auth expired, etc.).
-// cargo-mutants: known-equivalent (test-infrastructure gap) — the
-// `replace ... with Ok(Default::default())` stub returns an empty
-// SpecialUseMap, observably different from the populated map the
-// real implementation returns on a non-empty mailbox. Unit-testing
-// the mutation requires either a live IMAP server (covered by the
-// dovecot integration harness in `crates/rimap-server/tests/e2e.rs`
-// which is environment-gated and skipped by cargo-mutants runs that
-// have no Docker available) or a stub `Connection` that intercepts
-// `list_folders`. The latter would require either a new trait
-// boundary across `rimap-imap` or a refactor of this two-line
-// helper. Documented in `mutation-baseline.md` as a known coverage
-// gap pending future test-infrastructure work.
-pub async fn resolve_special_use(connection: &Connection) -> Result<SpecialUseMap, RimapError> {
-    let folders = connection.list_folders("*").await?;
-    Ok(SpecialUseMap::from_folders(&folders))
+/// Pure mapping over `&[Folder]` so tests can pin the
+/// classifier-output relationship without a live IMAP connection. The
+/// `LIST "" "*"` call that produces `folders` is the caller's job.
+#[must_use]
+pub fn resolve_special_use(folders: &[Folder]) -> SpecialUseMap {
+    SpecialUseMap::from_folders(folders)
+}
+
+#[cfg(test)]
+mod tests {
+    use rimap_imap::SpecialUse;
+    use rimap_imap::types::Folder;
+
+    use super::resolve_special_use;
+
+    fn folder(name: &str, special: Option<SpecialUse>) -> Folder {
+        Folder {
+            name: name.to_string(),
+            attributes: Vec::new(),
+            delimiter: Some('/'),
+            special_use: special,
+        }
+    }
+
+    #[test]
+    fn resolve_special_use_empty_input_returns_default_map() {
+        // Baseline: nothing to classify produces a fully-empty map.
+        // The unmutated function returns this for an empty input; the
+        // mutated form `with Default::default()` *also* returns this.
+        // The kill comes from the populated-input cases below, not this
+        // one — it stays as a sanity check that empty input does not
+        // panic.
+        let map = resolve_special_use(&[]);
+        assert_eq!(map.drafts(), None);
+        assert_eq!(map.sent(), None);
+        assert_eq!(map.trash(), None);
+    }
+
+    #[test]
+    fn resolve_special_use_gmail_drafts_populates_drafts_slot() {
+        // Kills `replace resolve_special_use -> SpecialUseMap with
+        // Default::default()`: the unmutated function classifies the
+        // `\Drafts` folder and returns `drafts() == Some("[Gmail]/Drafts")`,
+        // but the mutated stub returns an empty map with `drafts() ==
+        // None`. The single populated slot is enough to distinguish.
+        let folders = vec![folder("[Gmail]/Drafts", Some(SpecialUse::Drafts))];
+        let map = resolve_special_use(&folders);
+        assert_eq!(map.drafts(), Some("[Gmail]/Drafts"));
+        assert_eq!(map.sent(), None);
+        assert_eq!(map.trash(), None);
+    }
+
+    #[test]
+    fn resolve_special_use_mixed_special_use_populates_all_slots() {
+        // Pins the full classifier contract: Drafts, Sent, and Trash
+        // each route to their slot, and folders without `special_use`
+        // (`INBOX`, `Archive` without flag) do not occupy slots. A
+        // single mutation to swap slot routing or to drop one branch
+        // would observably change one of the asserted values.
+        let folders = vec![
+            folder("INBOX", None),
+            folder("[Gmail]/Drafts", Some(SpecialUse::Drafts)),
+            folder("[Gmail]/Sent Mail", Some(SpecialUse::Sent)),
+            folder("[Gmail]/Trash", Some(SpecialUse::Trash)),
+        ];
+        let map = resolve_special_use(&folders);
+        assert_eq!(map.drafts(), Some("[Gmail]/Drafts"));
+        assert_eq!(map.sent(), Some("[Gmail]/Sent Mail"));
+        assert_eq!(map.trash(), Some("[Gmail]/Trash"));
+    }
 }

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -430,11 +430,11 @@ async fn build_registry(
             ));
         let imap = Connection::new(conn_cfg, auth_sink.clone(), resolver);
 
-        let special_use = rimap_server::boot::discovery::resolve_special_use(&imap)
+        let folders = imap
+            .list_folders("*")
             .await
-            .with_context(|| {
-                format!("resolving special-use folders for account {}", id.as_str())
-            })?;
+            .with_context(|| format!("listing folders for account {}", id.as_str()))?;
+        let special_use = rimap_server::boot::discovery::resolve_special_use(&folders);
 
         // Expand the config-supplied protected-folders list with any
         // server-declared RFC 6154 names (e.g. Gmail's `[Gmail]/Sent Mail`).

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -28,7 +28,7 @@ use crate::boot::registry::{AccountRegistry, AccountState};
 use crate::mcp::dispatch::{PostureContext, rimap_error_to_breaker_reason};
 use crate::mcp::tool_catalog::TOOL_DEFS;
 use crate::mcp::tool_name::{
-    is_bare_simple_tool_name, is_legacy_single_account, refine_tool_name, split_tool_name,
+    is_legacy_single_account, refine_tool_name, split_tool_name, validate_bare_tool_namespace,
 };
 
 /// Core MCP server. Owns every resource the handler methods need.
@@ -469,26 +469,7 @@ impl ServerHandler for ImapMcpServer {
         // tools (use_account, list_accounts) remain valid bare forms
         // regardless. (#73)
         let accounts = self.registry.accounts();
-        // cargo-mutants: known-equivalent (test-infrastructure gap) —
-        // the `delete ! in <impl ServerHandler ...>::call_tool` mutation
-        // inverts the legacy-mode guard so legacy single-account
-        // deployments would reject bare tool names. The underlying
-        // predicate `is_legacy_single_account(accounts)` IS unit-tested
-        // (see `mcp::tool_name::tests::is_legacy_single_account_classifies_each_branch`),
-        // but exercising this composite branch through `call_tool`
-        // requires a `RequestContext<RoleServer>` for which rmcp
-        // exposes no public test constructor. Covered end-to-end by
-        // the dovecot harness; documented in `mutation-baseline.md`.
-        if !is_legacy_single_account(accounts) && is_bare_simple_tool_name(&request.name) {
-            return Err(ErrorData::invalid_params(
-                format!(
-                    "tool name must be namespaced in multi-account mode: \
-                     <account>.{}",
-                    &request.name,
-                ),
-                None,
-            ));
-        }
+        validate_bare_tool_namespace(is_legacy_single_account(accounts), &request.name)?;
 
         let mut args = request.arguments.unwrap_or_default();
 

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 use rimap_core::account::{AccountId, DEFAULT_ACCOUNT_NAME};
 use rimap_core::tool::ToolName;
+use rmcp::model::ErrorData;
 
 use crate::boot::registry::AccountState;
 
@@ -96,6 +97,26 @@ pub(crate) fn is_bare_simple_tool_name(raw: &str) -> bool {
     !matches!(tool, ToolName::UseAccount | ToolName::ListAccounts)
 }
 
+/// Enforce the multi-account namespace contract: in non-legacy
+/// (multi-account) mode, bare simple non-infrastructure tool names
+/// must be rejected with `INVALID_PARAMS`. Legacy single-account
+/// deployments and dotted/infrastructure tool names always pass.
+pub(super) fn validate_bare_tool_namespace(
+    legacy_single_account: bool,
+    raw_name: &str,
+) -> Result<(), ErrorData> {
+    if !legacy_single_account && is_bare_simple_tool_name(raw_name) {
+        return Err(ErrorData::invalid_params(
+            format!(
+                "tool name must be namespaced in multi-account mode: \
+                 <account>.{raw_name}",
+            ),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Split a possibly-namespaced MCP tool name into `(account, tool)`.
 ///
 /// Preserves sub-capability tool names that contain dots (e.g.
@@ -123,10 +144,16 @@ fn is_valid_account_prefix(s: &str) -> bool {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "tests use unwrap_err for assertions on namespace-validation errors"
+)]
 mod tests {
     use rimap_core::tool::ToolName;
 
-    use super::{is_bare_simple_tool_name, refine_tool_name, split_tool_name};
+    use super::{
+        is_bare_simple_tool_name, refine_tool_name, split_tool_name, validate_bare_tool_namespace,
+    };
 
     #[test]
     fn split_tool_name_bare() {
@@ -275,6 +302,56 @@ mod tests {
         two_accts.insert(default_state2.id.clone(), default_state2);
         two_accts.insert(personal_state.id.clone(), personal_state);
         assert!(!is_legacy_single_account(&two_accts));
+    }
+
+    #[test]
+    fn validate_bare_tool_namespace_truth_table() {
+        // Five cases cover every mutation surface on
+        // `validate_bare_tool_namespace`'s composite guard
+        // (`!legacy_single_account && is_bare_simple_tool_name(raw)`).
+        //
+        // Case 3 (multi-account + bare simple tool) specifically kills
+        // the `delete ! in <impl ServerHandler>::call_tool` mutation
+        // formerly annotated as a known-equivalent test-infrastructure
+        // gap — under the mutation the helper would return `Ok(())`
+        // and let the bare call through, but the unmutated function
+        // returns `Err(INVALID_PARAMS)`.
+
+        // Case 1: legacy mode + bare simple → Ok (legacy preserves
+        // bare names regardless of tool simplicity).
+        assert!(validate_bare_tool_namespace(true, "send_email").is_ok());
+
+        // Case 2: legacy mode + namespaced → Ok (dotted prefix is fine
+        // anywhere).
+        assert!(validate_bare_tool_namespace(true, "work.send_email").is_ok());
+
+        // Case 3: multi-account + bare simple → INVALID_PARAMS. Kills
+        // `delete !`: the mutated form `legacy_single_account && ...`
+        // returns `Ok(())` here (the legacy_single_account=false branch
+        // short-circuits the `&&`).
+        let err = validate_bare_tool_namespace(false, "send_email").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("multi-account mode"),
+            "message should explain the contract: {message}",
+            message = err.message,
+        );
+        assert!(
+            err.message.contains("send_email"),
+            "message should echo the tool name: {message}",
+            message = err.message,
+        );
+
+        // Case 4: multi-account + namespaced → Ok (the dotted form is
+        // exactly what the multi-account contract requires).
+        assert!(validate_bare_tool_namespace(false, "work.send_email").is_ok());
+
+        // Case 5: multi-account + infrastructure tool → Ok.
+        // `is_bare_simple_tool_name` returns false for `use_account` /
+        // `list_accounts`, so the composite short-circuits to `Ok(())`
+        // regardless of mode (infrastructure tools are always bare).
+        assert!(validate_bare_tool_namespace(false, "use_account").is_ok());
+        assert!(validate_bare_tool_namespace(false, "list_accounts").is_ok());
     }
 
     #[test]

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -139,14 +139,14 @@ a real test gap.
 ## `rimap-server`
 
 **Last refresh:** 2026-05-18.
-**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** 25 (all annotated as known-equivalent).
+**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** 24 (all annotated as known-equivalent).
 **Surviving mutants in best-effort paths (`cli/`, `tools/`, `main.rs`):** 55 (unannotated; documented as best-effort tier per spec §6 — see "best-effort paths" note below).
 
 Run summary (529 mutants total, 2026-05-18 baseline via `cargo
 mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60`
-on Linux): 281 caught, 107 missed (52 annotated below as hot-path
+on Linux): 282 caught, 106 missed (51 annotated below as hot-path
 known-equivalent across the main table and `### \`mcp/fuzz_oracle.rs\``
-subsection — 25 in hot paths and the rest documented under
+subsection — 24 in hot paths and the rest documented under
 `fuzz_oracle` or as best-effort tier), 3 timeouts, 138 unviable in
 22 minutes wall clock. The dev-host blocker captured in issue #289
 (cargo-mutants 27.0.0 + macOS-specific [#611](https://github.com/sourcefrog/cargo-mutants/issues/611))
@@ -197,7 +197,6 @@ triage is deferred to a follow-up issue; the spec's
 | `mcp/content.rs:27` | `delete match arm ContentError::Malformed{..} in classify_content_error` | The `Malformed` arm and the `_` fallback both call `RimapError::invalid_input(err.to_string())` — the `#[expect(clippy::match_same_arms)]` above the match documents this intent. Deleting the explicit arm routes to the identical fallback. The companion `delete match arm ContentError::LimitExceeded{..}` IS a real gap and is killed by `limit_exceeded_classifies_as_attachment_too_large`. | `mcp/content.rs:22` |
 | `mcp/server.rs:353` | `replace <impl ServerHandler>::list_resources -> Result<ListResourcesResult, ErrorData> with Ok(Default::default())` | Test-infrastructure gap: rmcp `RequestContext<RoleServer>` has no public test constructor in this version, so the trait method cannot be invoked from a unit test. End-to-end coverage via the dovecot harness in `tests/e2e.rs`. | `mcp/server.rs:348` |
 | `mcp/server.rs:489` | `replace == with != in <impl ServerHandler>::call_tool` (`tool_name == ToolName::UseAccount` post-dispatch notify gate) | Test-infrastructure gap: verifying the suppression of `notifications/tools/list_changed` for non-`use_account` calls requires a `RequestContext<RoleServer>` (to drive `context.peer.notify_tool_list_changed()`); rmcp does not expose a public test constructor. End-to-end coverage via the dovecot harness. | `mcp/server.rs:510` |
-| `boot/discovery.rs:27` | `replace resolve_special_use -> Result<SpecialUseMap, RimapError> with Ok(Default::default())` | Test-infrastructure gap: the function calls `connection.list_folders("*")` which requires a live IMAP server. The dovecot harness in `tests/e2e.rs` does not exercise this code path either (it constructs `AccountState` with `SpecialUseMap::default()` directly, bypassing the function). Annotated as a known coverage gap pending future test infrastructure. | `boot/discovery.rs:26` |
 
 ### `mcp/fuzz_oracle.rs` (behind `--features fuzzing`)
 

--- a/docs/superpowers/specs/test-strategy/mutation-baseline.md
+++ b/docs/superpowers/specs/test-strategy/mutation-baseline.md
@@ -139,14 +139,14 @@ a real test gap.
 ## `rimap-server`
 
 **Last refresh:** 2026-05-18.
-**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** 26 (all annotated as known-equivalent).
+**Surviving mutants in hot paths (`mcp/{dispatch,audit_envelope,tool_catalog,tool_name,wire_validator,preinit,server,response,content,error}.rs`, `boot/`; `fuzz_oracle.rs` covered separately below):** 25 (all annotated as known-equivalent).
 **Surviving mutants in best-effort paths (`cli/`, `tools/`, `main.rs`):** 55 (unannotated; documented as best-effort tier per spec §6 — see "best-effort paths" note below).
 
 Run summary (529 mutants total, 2026-05-18 baseline via `cargo
 mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60`
-on Linux): 280 caught, 108 missed (53 annotated below as hot-path
+on Linux): 281 caught, 107 missed (52 annotated below as hot-path
 known-equivalent across the main table and `### \`mcp/fuzz_oracle.rs\``
-subsection — 26 in hot paths and the rest documented under
+subsection — 25 in hot paths and the rest documented under
 `fuzz_oracle` or as best-effort tier), 3 timeouts, 138 unviable in
 22 minutes wall clock. The dev-host blocker captured in issue #289
 (cargo-mutants 27.0.0 + macOS-specific [#611](https://github.com/sourcefrog/cargo-mutants/issues/611))
@@ -196,7 +196,6 @@ triage is deferred to a follow-up issue; the spec's
 | `mcp/wire_validator.rs:486` | `replace - with / in validate_inbound` (at `trimmed.len() - 1`) | `len() / 1 == len()` — same effect as deleting the match arm. The companion `replace - with +` mutant at the same site IS a real gap (it panics on `\r\n` input) and is killed by `validate_inbound_strips_crlf_line_ending`. | `mcp/wire_validator.rs:518` |
 | `mcp/content.rs:27` | `delete match arm ContentError::Malformed{..} in classify_content_error` | The `Malformed` arm and the `_` fallback both call `RimapError::invalid_input(err.to_string())` — the `#[expect(clippy::match_same_arms)]` above the match documents this intent. Deleting the explicit arm routes to the identical fallback. The companion `delete match arm ContentError::LimitExceeded{..}` IS a real gap and is killed by `limit_exceeded_classifies_as_attachment_too_large`. | `mcp/content.rs:22` |
 | `mcp/server.rs:353` | `replace <impl ServerHandler>::list_resources -> Result<ListResourcesResult, ErrorData> with Ok(Default::default())` | Test-infrastructure gap: rmcp `RequestContext<RoleServer>` has no public test constructor in this version, so the trait method cannot be invoked from a unit test. End-to-end coverage via the dovecot harness in `tests/e2e.rs`. | `mcp/server.rs:348` |
-| `mcp/server.rs:461` | `delete ! in <impl ServerHandler>::call_tool` (`if !is_legacy_single_account(accounts) && is_bare_simple_tool_name(...)`) | Test-infrastructure gap: the predicate `is_legacy_single_account` IS unit-tested (`mcp::tool_name::tests::is_legacy_single_account_classifies_each_branch`), but exercising the composite branch from `call_tool` requires the same `RequestContext<RoleServer>` rmcp does not expose. End-to-end coverage via the dovecot harness. | `mcp/server.rs:472` |
 | `mcp/server.rs:489` | `replace == with != in <impl ServerHandler>::call_tool` (`tool_name == ToolName::UseAccount` post-dispatch notify gate) | Test-infrastructure gap: verifying the suppression of `notifications/tools/list_changed` for non-`use_account` calls requires a `RequestContext<RoleServer>` (to drive `context.peer.notify_tool_list_changed()`); rmcp does not expose a public test constructor. End-to-end coverage via the dovecot harness. | `mcp/server.rs:510` |
 | `boot/discovery.rs:27` | `replace resolve_special_use -> Result<SpecialUseMap, RimapError> with Ok(Default::default())` | Test-infrastructure gap: the function calls `connection.list_folders("*")` which requires a live IMAP server. The dovecot harness in `tests/e2e.rs` does not exercise this code path either (it constructs `AccountState` with `SpecialUseMap::default()` directly, bypassing the function). Annotated as a known coverage gap pending future test infrastructure. | `boot/discovery.rs:26` |
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #293. The Codex adversarial review on that branch returned `needs-attention` with two `[high]` findings, both flagging that an inline `// cargo-mutants: known-equivalent (test-infrastructure gap)` annotation was applied to a mutation that is in fact **non-equivalent and security-relevant**:

1. **`mcp/server.rs:472-482`** — `delete !` on the multi-account namespace guard. Under the mutation, multi-account deployments stop rejecting bare simple tool names (tenant/account isolation failure).
2. **`boot/discovery.rs:26-37`** — `replace resolve_special_use ... with Ok(Default::default())`. Under the mutation, server-native special-use folders (`[Gmail]/Sent Mail`, `[Gmail]/Drafts`, etc.) drop out of the FolderGuard protected list (weaker destructive/compose protection on provider-native names).

Both findings called for the annotation to come off and a deterministic test to take its place. Each commit handles one finding via a small structural refactor:

- **Commit 1** (`refactor(rimap-server): extract bare-tool namespace guard for unit testability`) — pulls the composite `!is_legacy_single_account(...) && is_bare_simple_tool_name(...)` guard out of `call_tool` into a sibling helper `validate_bare_tool_namespace` in `mcp/tool_name.rs`. Pure on `(bool, &str)`, so a 5-case truth-table test kills the `delete !` mutation without needing an rmcp `RequestContext<RoleServer>` constructor.
- **Commit 2** (`refactor(rimap-server): invert resolve_special_use I/O boundary`) — moves the `LIST "" "*"` call up to the single boot caller; `resolve_special_use` shrinks to a pure synchronous mapping `(&[Folder]) -> SpecialUseMap`. Three new cases (empty, single Gmail draft, mixed special-use) kill the stub mutation with synthetic `Folder` values.

`docs/superpowers/specs/test-strategy/mutation-baseline.md` loses both rows; the hot-path survivor count drops 26 → 24.

## Verification

- `cargo nextest run --package rimap-server --all-features --locked`: **389 tests pass** (was 386 on main; +3 for `resolve_special_use`, +1 for the namespace truth-table — the 5-case test asserts on the existing `is_legacy_single_account`/`is_bare_simple_tool_name` helpers).
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60` reverify:
  - **`delete ! in <impl ServerHandler>::call_tool`** — no longer in `missed.txt`; the structurally-equivalent `delete ! in validate_bare_tool_namespace` is in `caught.txt`.
  - **`replace resolve_special_use ... with Default::default()`** — in `caught.txt`.
  - Hot-path survivors = 24, doc rows = 24, **MATCH**.

## Test plan

- [x] Run `cargo nextest run --package rimap-server --all-features --locked` and confirm all tests pass.
- [x] Run `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and confirm no warnings.
- [x] Run `cargo mutants --package rimap-server --no-shuffle --jobs 8 --timeout 60` and confirm both prior `[high]` mutations are in `caught.txt`, not `missed.txt`.
- [ ] CI mcp-conformance-node passes on push.

Refs: Codex review on #293 (post-merge follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)