### PR TITLE
Expand searchable email fields in the search tool

### DIFF
--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -28,8 +28,8 @@ pub use crate::record::{
     ProcessEndReason, ProcessStart, Provenance, ResultSummary, ToolEnd, ToolStart, ToolStatus,
 };
 pub use crate::redact::{
-    FieldPolicy, RedactionSalt, RedactionSchema, Redactor, ToolRedactionSchema, hash_arguments,
-    redact, schemas,
+    FieldPolicy, RedactionSalt, RedactionSchema, Redactor, ToolRedactionSchema, VerbatimType,
+    hash_arguments, redact, schemas,
 };
 pub use crate::writer::provenance::ProvenanceBuffer;
 pub use crate::writer::self_check::{TrailingState, current_inode, read_trailing_state};

--- a/crates/rimap-audit/src/redact/mod.rs
+++ b/crates/rimap-audit/src/redact/mod.rs
@@ -289,34 +289,70 @@ fn list_folders_schema(tool: ToolName) -> RedactionSchema {
 // still records the byte length for unusual-payload detection.
 // Decision recorded in #22.
 fn search_schema(tool: ToolName) -> RedactionSchema {
-    use FieldPolicy::{Forbidden, RedactString, Verbatim};
+    use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
     RedactionSchema::new(
         tool,
         &[
             ("folder", Verbatim),
             ("limit", Verbatim),
-            ("include_seen", Verbatim),
+            ("offset", Verbatim),
+            ("larger", Verbatim),
+            ("smaller", Verbatim),
             ("since", Verbatim),
-            ("until", Verbatim),
+            ("before", Verbatim),
+            ("sent_since", Verbatim),
+            ("sent_before", Verbatim),
+            ("seen", Verbatim),
+            ("answered", Verbatim),
+            ("flagged", Verbatim),
+            ("draft", Verbatim),
+            ("has_attachment", Verbatim),
             ("from", RedactString),
             ("to", RedactString),
+            ("cc", RedactString),
+            ("bcc", RedactString),
             ("subject", RedactString),
             ("body", RedactString),
+            ("text", RedactString),
+            ("advanced_query", RedactString),
+            ("headers", SaltedHash),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
     )
 }
 
-// See [`search_schema`] for the RedactString rationale (#22).
+// Mirrors `search_schema` so a refinement-routing change cannot regress
+// redaction. See [`search_schema`] for the RedactString rationale (#22)
+// and the `headers` SaltedHash rationale.
 fn search_advanced_schema(tool: ToolName) -> RedactionSchema {
-    use FieldPolicy::{Forbidden, RedactString, Verbatim};
+    use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
     RedactionSchema::new(
         tool,
         &[
             ("folder", Verbatim),
             ("limit", Verbatim),
+            ("offset", Verbatim),
+            ("larger", Verbatim),
+            ("smaller", Verbatim),
+            ("since", Verbatim),
+            ("before", Verbatim),
+            ("sent_since", Verbatim),
+            ("sent_before", Verbatim),
+            ("seen", Verbatim),
+            ("answered", Verbatim),
+            ("flagged", Verbatim),
+            ("draft", Verbatim),
+            ("has_attachment", Verbatim),
+            ("from", RedactString),
+            ("to", RedactString),
+            ("cc", RedactString),
+            ("bcc", RedactString),
+            ("subject", RedactString),
+            ("body", RedactString),
+            ("text", RedactString),
             ("advanced_query", RedactString),
+            ("headers", SaltedHash),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -845,6 +881,139 @@ mod tests {
             schema.policies.get("message_count").copied(),
             Some(FieldPolicy::Verbatim),
         );
+    }
+
+    fn search_schema_for_tool(tool: ToolName) -> RedactionSchema {
+        let table = crate::redact::schemas();
+        table
+            .into_iter()
+            .find(|s| s.tool == tool)
+            .expect("schema exists for tool")
+    }
+
+    #[test]
+    fn search_schema_redacts_all_content_fields() {
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let out = r.apply(&json!({
+            "from": "alice@example.test",
+            "to": "bob@example.test",
+            "cc": "carol@example.test",
+            "bcc": "dave@example.test",
+            "subject": "hello world",
+            "body": "needle",
+            "text": "any-field-needle",
+            "advanced_query": "FROM alice",
+        }));
+        assert_eq!(out["from"], json!("<redacted:18>"));
+        assert_eq!(out["to"], json!("<redacted:16>"));
+        assert_eq!(out["cc"], json!("<redacted:18>"));
+        assert_eq!(out["bcc"], json!("<redacted:17>"));
+        assert_eq!(out["subject"], json!("<redacted:11>"));
+        assert_eq!(out["body"], json!("<redacted:6>"));
+        assert_eq!(out["text"], json!("<redacted:16>"));
+        assert_eq!(out["advanced_query"], json!("<redacted:10>"));
+    }
+
+    #[test]
+    fn search_schema_preserves_structural_fields() {
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let input = json!({
+            "folder": "INBOX",
+            "limit": 50,
+            "offset": 10,
+            "larger": 1000_u64,
+            "smaller": 5000_u64,
+            "since": "2026-01-01",
+            "before": "2026-12-31",
+            "sent_since": "2026-02-01",
+            "sent_before": "2026-11-30",
+            "seen": true,
+            "answered": false,
+            "flagged": true,
+            "draft": false,
+            "has_attachment": true,
+        });
+        let out = r.apply(&input);
+        // Every structural field round-trips with original JSON type/value.
+        assert_eq!(out, input);
+        // Spot-check that types are preserved (not stringified).
+        assert!(out["limit"].is_u64());
+        assert!(out["larger"].is_u64());
+        assert!(out["seen"].is_boolean());
+        assert!(out["folder"].is_string());
+        assert!(out["since"].is_string());
+    }
+
+    #[test]
+    fn search_schema_hashes_headers_array() {
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let headers_a = json!({
+            "headers": [
+                {"name": "X-Custom", "value": "alpha"},
+                {"name": "List-Id", "value": "<list@example.test>"},
+            ],
+        });
+        let headers_b = json!({
+            "headers": [
+                {"name": "X-Custom", "value": "beta"},
+            ],
+        });
+        let a1 = r.apply(&headers_a);
+        let a2 = r.apply(&headers_a);
+        let b = r.apply(&headers_b);
+        let hash_a = a1["headers"].as_str().expect("salted hash is a string");
+        assert!(hash_a.starts_with("salted:"));
+        assert_eq!(hash_a.len(), "salted:".len() + 16);
+        assert_eq!(a1["headers"], a2["headers"]);
+        assert_ne!(a1["headers"], b["headers"]);
+    }
+
+    #[test]
+    fn search_schema_drops_password_and_token() {
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let out = r.apply(&json!({
+            "folder": "INBOX",
+            "password": "hunter2",
+            "token": "abcdef",
+        }));
+        let map = out.as_object().expect("object output");
+        assert!(!map.contains_key("password"));
+        assert!(!map.contains_key("token"));
+        assert_eq!(out["folder"], json!("INBOX"));
+    }
+
+    #[test]
+    fn search_advanced_schema_matches_search_policy() {
+        let search = search_schema_for_tool(ToolName::Search);
+        let advanced = search_schema_for_tool(ToolName::SearchAdvanced);
+        let salt = salt();
+        let sample = json!({
+            "folder": "INBOX",
+            "limit": 25,
+            "answered": true,
+            "larger": 1024_u64,
+            "sent_since": "2026-03-01",
+            "from": "alice@example.test",
+            "cc": "carol@example.test",
+            "bcc": "dave@example.test",
+            "body": "needle",
+            "text": "scan-needle",
+            "advanced_query": "ALL",
+            "headers": [{"name": "X-Custom", "value": "x"}],
+            "password": "hunter2",
+            "token": "abcdef",
+        });
+        let from_search = Redactor::new(&search, &salt).apply(&sample);
+        let from_advanced = Redactor::new(&advanced, &salt).apply(&sample);
+        assert_eq!(from_search, from_advanced);
     }
 }
 

--- a/crates/rimap-audit/src/redact/mod.rs
+++ b/crates/rimap-audit/src/redact/mod.rs
@@ -1,7 +1,9 @@
 //! Structural argument redaction for audit records. Each tool declares a
 //! [`RedactionSchema`] that classifies its top-level argument fields:
 //!
-//! - [`FieldPolicy::Verbatim`] — structural fields copied into the record.
+//! - [`FieldPolicy::Verbatim`] — structural fields copied into the record
+//!   verbatim *if and only if* the JSON value matches the declared
+//!   [`VerbatimType`]. Type mismatches fall through to [`FieldPolicy::RedactString`].
 //! - [`FieldPolicy::RedactString`] — replaced with `"<redacted:N>"` where `N`
 //!   is the UTF-8 byte length of the original string.
 //! - [`FieldPolicy::SaltedHash`] — replaced with the first 16 hex chars of
@@ -23,14 +25,16 @@ use sha2::{Digest, Sha256};
 /// Per-field policy for the redaction pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldPolicy {
-    /// Copy the field's JSON value into the record unchanged. This policy
-    /// assumes the value has already passed the `rimap-content` mailbox-name
-    /// validator (no bare CR/LF, no NUL, no other ASCII control chars). The
-    /// invariant matters for downstream consumers of the audit JSONL who
-    /// pretty-print or grep the file: smuggled control bytes would surface
-    /// as confusing output, and a permissive JSONL re-parser could
-    /// re-introduce the bytes into a downstream sink.
-    Verbatim,
+    /// Copy the field's JSON value into the record if and only if it
+    /// matches the declared [`VerbatimType`]. Type-mismatched values
+    /// (e.g. a string supplied for a `U64` field) fall through to
+    /// [`Self::RedactString`] so a malicious or prompt-injected client
+    /// cannot smuggle arbitrary text into the audit log by mistyping a
+    /// "structural" field. `tool_start` is emitted before argument
+    /// deserialization runs, so the type check here is the only defense
+    /// against that vector. See [`Redactor::redact_string`] for the
+    /// fall-through output shape.
+    Verbatim(VerbatimType),
     /// Replace string values with `"<redacted:N>"`. Non-string values are
     /// replaced with `"<redacted:?>"`.
     RedactString,
@@ -42,6 +46,36 @@ pub enum FieldPolicy {
     /// via `tracing::warn!` and the field is dropped.
     Forbidden,
 }
+
+/// JSON-type expected by a [`FieldPolicy::Verbatim`] field. A mismatch
+/// falls through to [`FieldPolicy::RedactString`] inside [`Redactor::apply`]
+/// rather than copying the value into the audit log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerbatimType {
+    /// Any `Value::String`.
+    String,
+    /// `Value::String` capped at 32 bytes. Covers ISO 8601 date / date-time
+    /// shapes (`YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS+HH:MM`); the cap exists
+    /// to prevent a long blob from being persisted under a "date" field
+    /// when the JSON type alone matches. Strict ISO parsing stays in
+    /// `build_query`; the redactor's job is just to keep a blob out of
+    /// the log.
+    DateString,
+    /// `Value::Number` that fits in a `u64`.
+    U64,
+    /// `Value::Bool`.
+    Bool,
+    /// `Value::Array` whose every element fits in a `u64`.
+    U64Array,
+    /// `Value::Array` whose every element is a `Value::String`.
+    StringArray,
+}
+
+/// Length cap on [`VerbatimType::DateString`]. 32 bytes accommodates
+/// `YYYY-MM-DDTHH:MM:SS+HH:MM` (25) with room for fractional seconds
+/// (`.fff`) and a trailing zone suffix; longer values are treated as
+/// suspicious blobs.
+const DATE_STRING_MAX_BYTES: usize = 32;
 
 /// Declarative schema for one tool's arguments. Field names are top-level
 /// JSON object keys.
@@ -130,9 +164,14 @@ impl<'a> Redactor<'a> {
                 .copied()
                 .unwrap_or(FieldPolicy::RedactString);
             match policy {
-                FieldPolicy::Verbatim => {
-                    out.insert(name.clone(), value.clone());
-                }
+                FieldPolicy::Verbatim(vt) => match Self::verbatim_check(value, vt) {
+                    Some(v) => {
+                        out.insert(name.clone(), v);
+                    }
+                    None => {
+                        out.insert(name.clone(), Self::redact_string(value));
+                    }
+                },
                 FieldPolicy::RedactString => {
                     out.insert(name.clone(), Self::redact_string(value));
                 }
@@ -149,6 +188,32 @@ impl<'a> Redactor<'a> {
             }
         }
         Value::Object(out)
+    }
+
+    /// Return `Some(value.clone())` when `value` matches the JSON shape
+    /// implied by `vt`, otherwise `None`. Callers fall through to
+    /// [`Self::redact_string`] on `None` so a wrong-typed payload (e.g.
+    /// a string smuggled into a `U64` field) cannot reach the audit log
+    /// verbatim. See [`FieldPolicy::Verbatim`] for the threat-model
+    /// rationale.
+    fn verbatim_check(value: &Value, vt: VerbatimType) -> Option<Value> {
+        match vt {
+            VerbatimType::String => value.as_str().map(|_| value.clone()),
+            VerbatimType::DateString => value
+                .as_str()
+                .filter(|s| s.len() <= DATE_STRING_MAX_BYTES)
+                .map(|_| value.clone()),
+            VerbatimType::U64 => value.as_u64().map(|_| value.clone()),
+            VerbatimType::Bool => value.as_bool().map(|_| value.clone()),
+            VerbatimType::U64Array => value
+                .as_array()
+                .filter(|arr| arr.iter().all(serde_json::Value::is_u64))
+                .map(|_| value.clone()),
+            VerbatimType::StringArray => value
+                .as_array()
+                .filter(|arr| arr.iter().all(serde_json::Value::is_string))
+                .map(|_| value.clone()),
+        }
     }
 
     fn redact_string(value: &Value) -> Value {
@@ -290,23 +355,24 @@ fn list_folders_schema(tool: ToolName) -> RedactionSchema {
 // Decision recorded in #22.
 fn search_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
+    use VerbatimType::{Bool, DateString, String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("limit", Verbatim),
-            ("offset", Verbatim),
-            ("larger", Verbatim),
-            ("smaller", Verbatim),
-            ("since", Verbatim),
-            ("before", Verbatim),
-            ("sent_since", Verbatim),
-            ("sent_before", Verbatim),
-            ("seen", Verbatim),
-            ("answered", Verbatim),
-            ("flagged", Verbatim),
-            ("draft", Verbatim),
-            ("has_attachment", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("limit", Verbatim(U64)),
+            ("offset", Verbatim(U64)),
+            ("larger", Verbatim(U64)),
+            ("smaller", Verbatim(U64)),
+            ("since", Verbatim(DateString)),
+            ("before", Verbatim(DateString)),
+            ("sent_since", Verbatim(DateString)),
+            ("sent_before", Verbatim(DateString)),
+            ("seen", Verbatim(Bool)),
+            ("answered", Verbatim(Bool)),
+            ("flagged", Verbatim(Bool)),
+            ("draft", Verbatim(Bool)),
+            ("has_attachment", Verbatim(Bool)),
             ("from", RedactString),
             ("to", RedactString),
             ("cc", RedactString),
@@ -327,23 +393,24 @@ fn search_schema(tool: ToolName) -> RedactionSchema {
 // and the `headers` SaltedHash rationale.
 fn search_advanced_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
+    use VerbatimType::{Bool, DateString, String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("limit", Verbatim),
-            ("offset", Verbatim),
-            ("larger", Verbatim),
-            ("smaller", Verbatim),
-            ("since", Verbatim),
-            ("before", Verbatim),
-            ("sent_since", Verbatim),
-            ("sent_before", Verbatim),
-            ("seen", Verbatim),
-            ("answered", Verbatim),
-            ("flagged", Verbatim),
-            ("draft", Verbatim),
-            ("has_attachment", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("limit", Verbatim(U64)),
+            ("offset", Verbatim(U64)),
+            ("larger", Verbatim(U64)),
+            ("smaller", Verbatim(U64)),
+            ("since", Verbatim(DateString)),
+            ("before", Verbatim(DateString)),
+            ("sent_since", Verbatim(DateString)),
+            ("sent_before", Verbatim(DateString)),
+            ("seen", Verbatim(Bool)),
+            ("answered", Verbatim(Bool)),
+            ("flagged", Verbatim(Bool)),
+            ("draft", Verbatim(Bool)),
+            ("has_attachment", Verbatim(Bool)),
             ("from", RedactString),
             ("to", RedactString),
             ("cc", RedactString),
@@ -361,12 +428,13 @@ fn search_advanced_schema(tool: ToolName) -> RedactionSchema {
 
 fn fetch_message_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{Bool, String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("include_html", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("include_html", Verbatim(Bool)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -378,11 +446,12 @@ fn fetch_message_schema(tool: ToolName) -> RedactionSchema {
 /// `mark_read`, `mark_unread`.
 fn folder_uid_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -391,12 +460,13 @@ fn folder_uid_schema(tool: ToolName) -> RedactionSchema {
 
 fn download_attachment_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("part", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("part", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -405,12 +475,13 @@ fn download_attachment_schema(tool: ToolName) -> RedactionSchema {
 
 fn flag_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("flag", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("flag", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -419,12 +490,13 @@ fn flag_schema(tool: ToolName) -> RedactionSchema {
 
 fn move_message_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("destination", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("destination", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -433,11 +505,12 @@ fn move_message_schema(tool: ToolName) -> RedactionSchema {
 
 fn create_draft_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("in_reply_to_uid", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("in_reply_to_uid", Verbatim(U64)),
             ("to", SaltedHash),
             ("cc", SaltedHash),
             ("bcc", SaltedHash),
@@ -452,6 +525,7 @@ fn create_draft_schema(tool: ToolName) -> RedactionSchema {
 
 fn send_email_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, RedactString, SaltedHash, Verbatim};
+    use VerbatimType::{String as VtString, StringArray, U64};
     RedactionSchema::new(
         tool,
         &[
@@ -460,12 +534,12 @@ fn send_email_schema(tool: ToolName) -> RedactionSchema {
             ("bcc", SaltedHash),
             ("subject", RedactString),
             ("body", RedactString),
-            ("in_reply_to", Verbatim),
-            ("references", Verbatim),
-            ("message_id", Verbatim),
+            ("in_reply_to", Verbatim(VtString)),
+            ("references", Verbatim(StringArray)),
+            ("message_id", Verbatim(VtString)),
             ("smtp_response", RedactString),
-            ("sent_copy_uid", Verbatim),
-            ("folder", Verbatim),
+            ("sent_copy_uid", Verbatim(U64)),
+            ("folder", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -474,13 +548,14 @@ fn send_email_schema(tool: ToolName) -> RedactionSchema {
 
 fn delete_message_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("message_id", Verbatim),
-            ("destination", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("message_id", Verbatim(VtString)),
+            ("destination", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -489,12 +564,13 @@ fn delete_message_schema(tool: ToolName) -> RedactionSchema {
 
 fn expunge_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64, U64Array};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("expunged_count", Verbatim),
-            ("expunged_uids", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("expunged_count", Verbatim(U64)),
+            ("expunged_uids", Verbatim(U64Array)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -503,10 +579,11 @@ fn expunge_schema(tool: ToolName) -> RedactionSchema {
 
 fn create_folder_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::String as VtString;
     RedactionSchema::new(
         tool,
         &[
-            ("name", Verbatim),
+            ("name", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -515,11 +592,12 @@ fn create_folder_schema(tool: ToolName) -> RedactionSchema {
 
 fn rename_folder_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::String as VtString;
     RedactionSchema::new(
         tool,
         &[
-            ("old_name", Verbatim),
-            ("new_name", Verbatim),
+            ("old_name", Verbatim(VtString)),
+            ("new_name", Verbatim(VtString)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -528,11 +606,12 @@ fn rename_folder_schema(tool: ToolName) -> RedactionSchema {
 
 fn delete_folder_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, Verbatim};
+    use VerbatimType::{String as VtString, U64};
     RedactionSchema::new(
         tool,
         &[
-            ("name", Verbatim),
-            ("message_count", Verbatim),
+            ("name", Verbatim(VtString)),
+            ("message_count", Verbatim(U64)),
             ("password", Forbidden),
             ("token", Forbidden),
         ],
@@ -541,29 +620,36 @@ fn delete_folder_schema(tool: ToolName) -> RedactionSchema {
 
 fn add_remove_label_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::Verbatim;
+    use VerbatimType::{String as VtString, U64, U64Array};
     RedactionSchema::new(
         tool,
         &[
-            ("folder", Verbatim),
-            ("uid", Verbatim),
-            ("uids", Verbatim),
-            ("label", Verbatim),
+            ("folder", Verbatim(VtString)),
+            ("uid", Verbatim(U64)),
+            ("uids", Verbatim(U64Array)),
+            ("label", Verbatim(VtString)),
         ],
     )
 }
 
 fn list_labels_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::Verbatim;
-    RedactionSchema::new(tool, &[("folder", Verbatim), ("uid", Verbatim)])
+    use VerbatimType::{String as VtString, U64};
+    RedactionSchema::new(
+        tool,
+        &[("folder", Verbatim(VtString)), ("uid", Verbatim(U64))],
+    )
 }
 
 fn use_account_schema(tool: ToolName) -> RedactionSchema {
-    // `account` is redacted — NOT verbatim — because the handler's
-    // bidi/zero-width pre-check runs AFTER `tool_start` is emitted,
-    // so a spoofed name would otherwise land in the audit log verbatim.
-    // Operators reviewing audit records see `<redacted:N>`; the handler
-    // still returns `ERR_INVALID_INPUT` for spoofed input so downstream
-    // correlation via `tool_end.code` is unaffected (#111).
+    // `account` stays `RedactString` — NOT a typed `Verbatim(String)` —
+    // because the handler's bidi/zero-width pre-check runs AFTER
+    // `tool_start` is emitted. The typed Verbatim policies elsewhere in
+    // this module cover the "wrong JSON type smuggles a string into the
+    // log" vector, but a well-typed `Value::String` carrying spoofed
+    // bidi/zero-width codepoints would still pass the type check. The
+    // handler returns `ERR_INVALID_INPUT` for spoofed input so
+    // downstream correlation via `tool_end.code` is unaffected (#111).
     use FieldPolicy::RedactString;
     RedactionSchema::new(tool, &[("account", RedactString)])
 }
@@ -591,7 +677,9 @@ mod tests {
 
     use rimap_core::tool::ToolName;
 
-    use crate::redact::{FieldPolicy, RedactionSalt, RedactionSchema, Redactor, hash_arguments};
+    use crate::redact::{
+        FieldPolicy, RedactionSalt, RedactionSchema, Redactor, VerbatimType, hash_arguments,
+    };
 
     fn schema() -> RedactionSchema {
         RedactionSchema::new(
@@ -600,7 +688,7 @@ mod tests {
                 ("to", FieldPolicy::SaltedHash),
                 ("subject", FieldPolicy::RedactString),
                 ("body_text", FieldPolicy::RedactString),
-                ("in_reply_to_uid", FieldPolicy::Verbatim),
+                ("in_reply_to_uid", FieldPolicy::Verbatim(VerbatimType::U64)),
                 ("password", FieldPolicy::Forbidden),
             ],
         )
@@ -617,6 +705,207 @@ mod tests {
         let r = Redactor::new(&s, &salt);
         let out = r.apply(&json!({"in_reply_to_uid": 12345}));
         assert_eq!(out["in_reply_to_uid"], json!(12345));
+    }
+
+    #[test]
+    fn verbatim_u64_rejects_string_payload() {
+        // A client mistypes (or maliciously pokes) a structural u64 field
+        // with a string. The verbatim policy must NOT copy the raw string
+        // into the audit log; the value falls through to RedactString.
+        let canary = "u64-canary-leak";
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        for field in ["limit", "offset", "larger", "smaller"] {
+            let input = json!({ field: canary });
+            let out = r.apply(&input);
+            assert_eq!(
+                out[field],
+                json!(format!("<redacted:{}>", canary.len())),
+                "field {field} leaked a string payload verbatim",
+            );
+            let serialized = serde_json::to_string(&out).unwrap();
+            assert!(
+                !serialized.contains(canary),
+                "canary appeared in redacted output for field {field}: {serialized}",
+            );
+        }
+    }
+
+    #[test]
+    fn verbatim_bool_rejects_string_payload() {
+        let canary = "bool-canary-leak";
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        for field in ["seen", "answered", "flagged", "draft", "has_attachment"] {
+            let input = json!({ field: canary });
+            let out = r.apply(&input);
+            assert_eq!(
+                out[field],
+                json!(format!("<redacted:{}>", canary.len())),
+                "field {field} leaked a string payload verbatim",
+            );
+            let serialized = serde_json::to_string(&out).unwrap();
+            assert!(
+                !serialized.contains(canary),
+                "canary appeared in redacted output for field {field}: {serialized}",
+            );
+        }
+    }
+
+    #[test]
+    fn verbatim_date_string_rejects_oversized_value() {
+        // A 64-byte "date" string violates the 32-byte cap. Falls through
+        // to RedactString and the original bytes never reach the log.
+        let canary = "x".repeat(64);
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        for field in ["since", "before", "sent_since", "sent_before"] {
+            let input = json!({ field: canary.clone() });
+            let out = r.apply(&input);
+            assert_eq!(
+                out[field],
+                json!(format!("<redacted:{}>", canary.len())),
+                "oversized date field {field} leaked verbatim",
+            );
+        }
+    }
+
+    #[test]
+    fn verbatim_date_string_accepts_iso_dates() {
+        // Well-typed ISO date values stay verbatim — the 32-byte cap
+        // accommodates `YYYY-MM-DDTHH:MM:SS+HH:MM` and similar shapes.
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let input = json!({
+            "since": "2026-05-19",
+            "before": "2026-05-19T12:00:00+00:00",
+        });
+        let out = r.apply(&input);
+        assert_eq!(out["since"], json!("2026-05-19"));
+        assert_eq!(out["before"], json!("2026-05-19T12:00:00+00:00"));
+    }
+
+    #[test]
+    fn verbatim_u64_array_rejects_non_array() {
+        let canary = "array-canary-leak";
+        let schema = crate::redact::schemas()
+            .into_iter()
+            .find(|s| s.tool == ToolName::Expunge)
+            .expect("expunge schema exists");
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let out = r.apply(&json!({ "expunged_uids": canary }));
+        assert_eq!(
+            out["expunged_uids"],
+            json!(format!("<redacted:{}>", canary.len()))
+        );
+        let serialized = serde_json::to_string(&out).unwrap();
+        assert!(!serialized.contains(canary));
+    }
+
+    #[test]
+    fn verbatim_u64_array_rejects_mixed_element_types() {
+        let schema = crate::redact::schemas()
+            .into_iter()
+            .find(|s| s.tool == ToolName::Expunge)
+            .expect("expunge schema exists");
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let canary = "mixed-canary-leak";
+        let out = r.apply(&json!({ "expunged_uids": [1, canary, 3] }));
+        // Whole array is wrong-typed → falls through to RedactString,
+        // which for a non-string value emits `<redacted:?>`. The canary
+        // must NOT appear anywhere in the redacted output.
+        assert_eq!(out["expunged_uids"], json!("<redacted:?>"));
+        let serialized = serde_json::to_string(&out).unwrap();
+        assert!(
+            !serialized.contains(canary),
+            "canary leaked through array fall-through: {serialized}",
+        );
+    }
+
+    #[test]
+    fn verbatim_string_array_rejects_mixed_element_types() {
+        let schema = crate::redact::schemas()
+            .into_iter()
+            .find(|s| s.tool == ToolName::SendEmail)
+            .expect("send_email schema exists");
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let out = r.apply(&json!({ "references": ["<a@x>", 42, "<b@x>"] }));
+        assert_eq!(out["references"], json!("<redacted:?>"));
+    }
+
+    #[test]
+    fn verbatim_string_rejects_non_string() {
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+        let out = r.apply(&json!({"folder": 12345}));
+        // Number is not a string → falls through, gets `<redacted:?>`.
+        assert_eq!(out["folder"], json!("<redacted:?>"));
+    }
+
+    #[test]
+    fn search_canary_never_leaks_through_any_verbatim_field() {
+        // Codex adversarial-review regression: drive every Verbatim
+        // field on the search schema with a TYPE-MISMATCHED poison
+        // payload and verify the audit-record JSON never contains the
+        // canary. Per-field class:
+        //   * Verbatim(String)         → poison with an array (non-string).
+        //   * Verbatim(U64)            → poison with a string.
+        //   * Verbatim(Bool)           → poison with a string.
+        //   * Verbatim(DateString)     → poison with a string > 32 bytes
+        //                                AND poison with an array
+        //                                (cap and type both exercised).
+        // A well-typed but adversarial value (e.g. a short malformed
+        // string in a DateString field) is out of scope at the redactor
+        // layer; the plan keeps strict format parsing inside
+        // `build_query`.
+        let canary = "secret-leak-canary";
+        let oversized = "x".repeat(64) + canary;
+        let schema = search_schema_for_tool(ToolName::Search);
+        let salt = salt();
+        let r = Redactor::new(&schema, &salt);
+
+        let string_field_poisons: &[(&str, serde_json::Value)] = &[("folder", json!([canary]))];
+        let u64_field_poisons: &[(&str, serde_json::Value)] = &[
+            ("limit", json!(canary)),
+            ("offset", json!(canary)),
+            ("larger", json!(canary)),
+            ("smaller", json!(canary)),
+        ];
+        let bool_field_poisons: &[(&str, serde_json::Value)] = &[
+            ("seen", json!(canary)),
+            ("answered", json!(canary)),
+            ("flagged", json!(canary)),
+            ("draft", json!(canary)),
+            ("has_attachment", json!(canary)),
+        ];
+        let date_field_poisons: &[(&str, serde_json::Value)] = &[
+            ("since", json!(oversized)),
+            ("before", json!([canary])),
+            ("sent_since", json!(oversized)),
+            ("sent_before", json!([canary])),
+        ];
+        let all_cases = string_field_poisons
+            .iter()
+            .chain(u64_field_poisons)
+            .chain(bool_field_poisons)
+            .chain(date_field_poisons);
+        for (field, poison) in all_cases {
+            let input = json!({ *field: poison.clone() });
+            let out = r.apply(&input);
+            let serialized = serde_json::to_string(&out).unwrap();
+            assert!(
+                !serialized.contains(canary),
+                "canary leaked for field {field}: {serialized}",
+            );
+        }
     }
 
     #[test]
@@ -765,7 +1054,7 @@ mod tests {
             .expect("search schema exists");
         assert_eq!(
             schema.policies.get("folder").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
         );
         assert_eq!(
             schema.policies.get("body").copied(),
@@ -782,18 +1071,18 @@ mod tests {
             .expect("send_email schema exists");
         assert_eq!(
             schema.policies.get("in_reply_to").copied(),
-            Some(FieldPolicy::Verbatim),
-            "in_reply_to should be Verbatim per spec",
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
+            "in_reply_to should be Verbatim(String) per spec",
         );
         assert_eq!(
             schema.policies.get("references").copied(),
-            Some(FieldPolicy::Verbatim),
-            "references should be Verbatim per spec",
+            Some(FieldPolicy::Verbatim(VerbatimType::StringArray)),
+            "references should be Verbatim(StringArray) per spec",
         );
         assert_eq!(
             schema.policies.get("message_id").copied(),
-            Some(FieldPolicy::Verbatim),
-            "message_id result field should be Verbatim",
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
+            "message_id result field should be Verbatim(String)",
         );
         assert_eq!(
             schema.policies.get("smtp_response").copied(),
@@ -802,13 +1091,13 @@ mod tests {
         );
         assert_eq!(
             schema.policies.get("sent_copy_uid").copied(),
-            Some(FieldPolicy::Verbatim),
-            "sent_copy_uid should be Verbatim",
+            Some(FieldPolicy::Verbatim(VerbatimType::U64)),
+            "sent_copy_uid should be Verbatim(U64)",
         );
         assert_eq!(
             schema.policies.get("folder").copied(),
-            Some(FieldPolicy::Verbatim),
-            "folder (Sent) should be Verbatim",
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
+            "folder (Sent) should be Verbatim(String)",
         );
         assert!(
             !schema.policies.contains_key("in_reply_to_uid"),
@@ -845,11 +1134,11 @@ mod tests {
             .expect("delete_message schema exists");
         assert_eq!(
             schema.policies.get("message_id").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
         );
         assert_eq!(
             schema.policies.get("destination").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::String)),
         );
     }
 
@@ -862,11 +1151,11 @@ mod tests {
             .expect("expunge schema exists");
         assert_eq!(
             schema.policies.get("expunged_count").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::U64)),
         );
         assert_eq!(
             schema.policies.get("expunged_uids").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::U64Array)),
         );
     }
 
@@ -879,7 +1168,7 @@ mod tests {
             .expect("delete_folder schema exists");
         assert_eq!(
             schema.policies.get("message_count").copied(),
-            Some(FieldPolicy::Verbatim),
+            Some(FieldPolicy::Verbatim(VerbatimType::U64)),
         );
     }
 

--- a/crates/rimap-audit/tests/redact_properties.rs
+++ b/crates/rimap-audit/tests/redact_properties.rs
@@ -3,7 +3,9 @@
 #![expect(clippy::unwrap_used, reason = "tests")]
 
 use proptest::prelude::*;
-use rimap_audit::{FieldPolicy, RedactionSalt, RedactionSchema, Redactor, hash_arguments};
+use rimap_audit::{
+    FieldPolicy, RedactionSalt, RedactionSchema, Redactor, VerbatimType, hash_arguments,
+};
 use rimap_core::tool::ToolName;
 use serde_json::{Map, Value};
 
@@ -14,8 +16,8 @@ fn schema() -> RedactionSchema {
     RedactionSchema::new(
         ToolName::Search,
         &[
-            ("folder", FieldPolicy::Verbatim),
-            ("uid", FieldPolicy::Verbatim),
+            ("folder", FieldPolicy::Verbatim(VerbatimType::String)),
+            ("uid", FieldPolicy::Verbatim(VerbatimType::U64)),
             ("subject", FieldPolicy::RedactString),
             ("body", FieldPolicy::RedactString),
             ("to", FieldPolicy::SaltedHash),
@@ -139,5 +141,109 @@ proptest! {
         let a = r.apply(&input);
         let b = r.apply(&input);
         prop_assert_eq!(a, b);
+    }
+}
+
+// Schema fixture for the wrong-type Verbatim properties. Names mirror
+// the production search schema for U64/Bool/U64Array/StringArray
+// classes, so a future field addition won't silently skip a class.
+fn typed_verbatim_schema() -> RedactionSchema {
+    use FieldPolicy::Verbatim;
+    use VerbatimType::{Bool, StringArray, U64, U64Array};
+    RedactionSchema::new(
+        ToolName::Search,
+        &[
+            ("u64_field", Verbatim(U64)),
+            ("bool_field", Verbatim(Bool)),
+            ("u64_array_field", Verbatim(U64Array)),
+            ("string_array_field", Verbatim(StringArray)),
+        ],
+    )
+}
+
+proptest! {
+    // Adversarial-review regression (Codex high-severity finding): a
+    // string payload sent to ANY non-string Verbatim field must never
+    // survive into the redacted record. We check the whole serialized
+    // record for the canary and any sufficiently long substring of it
+    // so a partial overlap (e.g. only the length suffix landing in
+    // `<redacted:N>`) still fails the test.
+    #[test]
+    fn wrong_type_string_payload_never_leaks(
+        canary in "[^\u{0000}\\\\\"]{8,128}",
+        field_idx in 0_usize..4,
+    ) {
+        let fields = [
+            "u64_field",
+            "bool_field",
+            "u64_array_field",
+            "string_array_field",
+        ];
+        let field = fields[field_idx];
+        let s = typed_verbatim_schema();
+        let salt = salt();
+        let r = Redactor::new(&s, &salt);
+        let input = serde_json::json!({ field: canary.clone() });
+        let out = r.apply(&input);
+        let serialized = serde_json::to_string(&out).unwrap();
+        // The redacted record must not contain the canary itself…
+        prop_assert!(
+            !serialized.contains(&canary),
+            "canary leaked for field {field}: {serialized}",
+        );
+        // …nor any 8-char window of it (the plan's "substring ≥ 8 chars"
+        // criterion). For inputs ≥ 8 chars this is a stronger check than
+        // the full-string assertion above.
+        for window_start in 0..canary.len().saturating_sub(7) {
+            // Iterate by char boundary so multi-byte UTF-8 doesn't panic.
+            if !canary.is_char_boundary(window_start) {
+                continue;
+            }
+            let window: String = canary
+                .chars()
+                .skip(window_start)
+                .take(8)
+                .collect();
+            if window.len() < 8 {
+                break;
+            }
+            prop_assert!(
+                !serialized.contains(&window),
+                "8-char window {window:?} of canary leaked into redacted output for field {field}: {serialized}",
+            );
+        }
+    }
+
+    // Symmetric property: a well-typed payload to a typed-Verbatim field
+    // round-trips byte-identically. This guards against an over-eager
+    // type check that would re-redact valid input and break the audit
+    // shape for ordinary callers.
+    #[test]
+    fn well_typed_payload_passes_through_verbatim(
+        n in any::<u32>(),
+        b in any::<bool>(),
+        arr in proptest::collection::vec(any::<u32>(), 0..6),
+    ) {
+        let s = typed_verbatim_schema();
+        let salt = salt();
+        let r = Redactor::new(&s, &salt);
+        let input = serde_json::json!({
+            "u64_field": n,
+            "bool_field": b,
+            "u64_array_field": arr.clone(),
+            "string_array_field": ["a", "bc"],
+        });
+        let out = r.apply(&input);
+        prop_assert_eq!(out["u64_field"].as_u64(), Some(u64::from(n)));
+        prop_assert_eq!(out["bool_field"].as_bool(), Some(b));
+        let out_arr: Vec<u64> = out["u64_array_field"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        let expected: Vec<u64> = arr.into_iter().map(u64::from).collect();
+        prop_assert_eq!(out_arr, expected);
+        prop_assert_eq!(&out["string_array_field"], &serde_json::json!(["a", "bc"]));
     }
 }

--- a/crates/rimap-imap/src/ops/search.rs
+++ b/crates/rimap-imap/src/ops/search.rs
@@ -338,6 +338,19 @@ mod tests {
     }
 
     #[test]
+    fn structured_to_key_header_value_with_embedded_quote_is_escaped() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            headers: Some(vec![HeaderSearch {
+                name: "X-Tag".to_string(),
+                value: r#"a"b"#.to_string(),
+            }]),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(structured_to_key(&q).unwrap(), r#"HEADER X-Tag "a\"b""#);
+    }
+
+    #[test]
     fn structured_to_key_treats_empty_headers_vec_as_no_clause() {
         let q = StructuredQuery {
             headers: Some(Vec::new()),

--- a/crates/rimap-imap/src/ops/search.rs
+++ b/crates/rimap-imap/src/ops/search.rs
@@ -38,8 +38,32 @@ fn structured_to_key(q: &StructuredQuery) -> Result<String, ImapError> {
     if let Some(s) = &q.to {
         parts.push(format!("TO {}", quote(s)?));
     }
+    if let Some(s) = &q.cc {
+        parts.push(format!("CC {}", quote(s)?));
+    }
+    if let Some(s) = &q.bcc {
+        parts.push(format!("BCC {}", quote(s)?));
+    }
     if let Some(s) = &q.subject {
         parts.push(format!("SUBJECT {}", quote(s)?));
+    }
+    if let Some(s) = &q.body {
+        parts.push(format!("BODY {}", quote(s)?));
+    }
+    if let Some(s) = &q.text {
+        parts.push(format!("TEXT {}", quote(s)?));
+    }
+    if let Some(hs) = &q.headers {
+        for h in hs {
+            validate_header_name(&h.name)?;
+            parts.push(format!("HEADER {} {}", h.name, quote(&h.value)?));
+        }
+    }
+    if let Some(n) = q.larger {
+        parts.push(format!("LARGER {n}"));
+    }
+    if let Some(n) = q.smaller {
+        parts.push(format!("SMALLER {n}"));
     }
     if let Some(d) = q.since {
         parts.push(format!("SINCE {}", format_imap_date(d)));
@@ -47,9 +71,30 @@ fn structured_to_key(q: &StructuredQuery) -> Result<String, ImapError> {
     if let Some(d) = q.before {
         parts.push(format!("BEFORE {}", format_imap_date(d)));
     }
+    if let Some(d) = q.sent_since {
+        parts.push(format!("SENTSINCE {}", format_imap_date(d)));
+    }
+    if let Some(d) = q.sent_before {
+        parts.push(format!("SENTBEFORE {}", format_imap_date(d)));
+    }
     match q.seen {
         Some(true) => parts.push("SEEN".to_string()),
         Some(false) => parts.push("UNSEEN".to_string()),
+        None => {}
+    }
+    match q.answered {
+        Some(true) => parts.push("ANSWERED".to_string()),
+        Some(false) => parts.push("UNANSWERED".to_string()),
+        None => {}
+    }
+    match q.flagged {
+        Some(true) => parts.push("FLAGGED".to_string()),
+        Some(false) => parts.push("UNFLAGGED".to_string()),
+        None => {}
+    }
+    match q.draft {
+        Some(true) => parts.push("DRAFT".to_string()),
+        Some(false) => parts.push("UNDRAFT".to_string()),
         None => {}
     }
     if q.has_attachment {
@@ -83,6 +128,36 @@ fn quote(s: &str) -> Result<String, ImapError> {
     Ok(out)
 }
 
+/// Validate an RFC 5322 field name for use in a `HEADER` SEARCH clause.
+///
+/// Every byte must be in the printable ASCII range `33..=126`
+/// (`!`..`~`) and must not be `b':'` (which terminates a field name).
+/// This is stricter than the IMAP wire format requires but matches the
+/// shape of all real-world header names and blocks command injection
+/// via CR/LF/NUL or whitespace.
+///
+/// # Errors
+///
+/// Returns [`ImapError::InvalidInput`] with `field = "header name"` for
+/// any disallowed byte or an empty name.
+fn validate_header_name(name: &str) -> Result<(), ImapError> {
+    if name.is_empty() {
+        return Err(ImapError::InvalidInput {
+            field: "header name",
+            reason: "empty",
+        });
+    }
+    for b in name.bytes() {
+        if !(33..=126).contains(&b) || b == b':' {
+            return Err(ImapError::InvalidInput {
+                field: "header name",
+                reason: "must be printable ASCII without ':'",
+            });
+        }
+    }
+    Ok(())
+}
+
 fn format_imap_date(d: ::time::Date) -> String {
     // IMAP SEARCH dates use "DD-Mon-YYYY" with English month abbreviations.
     let month = match d.month() {
@@ -107,7 +182,7 @@ fn format_imap_date(d: ::time::Date) -> String {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{format_imap_date, quote, structured_to_key};
+    use super::{format_imap_date, quote, structured_to_key, validate_header_name};
     use crate::error::ImapError;
     use crate::types::StructuredQuery;
 
@@ -198,5 +273,201 @@ mod tests {
     #[test]
     fn quote_escapes_backslash_and_quote() {
         assert_eq!(quote(r#"a\b"c"#).unwrap(), r#""a\\b\"c""#);
+    }
+
+    #[test]
+    fn structured_to_key_emits_cc_and_bcc() {
+        let q = StructuredQuery {
+            cc: Some("alice@example.com".to_string()),
+            bcc: Some("bob@example.com".to_string()),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains(r#"CC "alice@example.com""#), "got {key}");
+        assert!(key.contains(r#"BCC "bob@example.com""#), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_body_and_text() {
+        let q = StructuredQuery {
+            body: Some("hello".to_string()),
+            text: Some("world".to_string()),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains(r#"BODY "hello""#), "got {key}");
+        assert!(key.contains(r#"TEXT "world""#), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_single_header() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            headers: Some(vec![HeaderSearch {
+                name: "List-Id".to_string(),
+                value: "rust-users".to_string(),
+            }]),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"HEADER List-Id "rust-users""#,
+        );
+    }
+
+    #[test]
+    fn structured_to_key_emits_multiple_headers_in_input_order() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            headers: Some(vec![
+                HeaderSearch {
+                    name: "List-Id".to_string(),
+                    value: "rust-users".to_string(),
+                },
+                HeaderSearch {
+                    name: "X-Mailer".to_string(),
+                    value: "thunderbird".to_string(),
+                },
+            ]),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"HEADER List-Id "rust-users" HEADER X-Mailer "thunderbird""#,
+        );
+    }
+
+    #[test]
+    fn structured_to_key_treats_empty_headers_vec_as_no_clause() {
+        let q = StructuredQuery {
+            headers: Some(Vec::new()),
+            ..StructuredQuery::default()
+        };
+        // Empty headers carries no filter intent — emitter must not
+        // produce any HEADER clause. With no other criteria the query
+        // collapses to ALL.
+        assert_eq!(structured_to_key(&q).unwrap(), "ALL");
+    }
+
+    #[test]
+    fn structured_to_key_emits_larger_and_smaller_numeric() {
+        let q = StructuredQuery {
+            larger: Some(1024),
+            smaller: Some(1_048_576),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("LARGER 1024"), "got {key}");
+        assert!(key.contains("SMALLER 1048576"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_sent_since_and_sent_before() {
+        let q = StructuredQuery {
+            sent_since: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::January, 1).unwrap(),
+            ),
+            sent_before: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::February, 1).unwrap(),
+            ),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("SENTSINCE 01-Jan-2026"), "got {key}");
+        assert!(key.contains("SENTBEFORE 01-Feb-2026"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_answered_flagged_draft_per_option() {
+        let q = StructuredQuery {
+            answered: Some(true),
+            flagged: Some(false),
+            draft: Some(true),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("ANSWERED"), "got {key}");
+        assert!(key.contains("UNFLAGGED"), "got {key}");
+        assert!(key.contains("DRAFT"), "got {key}");
+
+        let q = StructuredQuery {
+            answered: Some(false),
+            flagged: Some(true),
+            draft: Some(false),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("UNANSWERED"), "got {key}");
+        assert!(key.contains("FLAGGED"), "got {key}");
+        assert!(key.contains("UNDRAFT"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_combines_old_and_new_fields_in_emit_order() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            from: Some("alice@example.com".to_string()),
+            cc: Some("team@example.com".to_string()),
+            body: Some("ship it".to_string()),
+            headers: Some(vec![HeaderSearch {
+                name: "List-Id".to_string(),
+                value: "rust".to_string(),
+            }]),
+            larger: Some(2048),
+            sent_since: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::March, 15).unwrap(),
+            ),
+            answered: Some(true),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"FROM "alice@example.com" CC "team@example.com" BODY "ship it" HEADER List-Id "rust" LARGER 2048 SENTSINCE 15-Mar-2026 ANSWERED"#,
+        );
+    }
+
+    #[test]
+    fn validate_header_name_accepts_canonical_names() {
+        validate_header_name("Message-ID").unwrap();
+        validate_header_name("X-Foo").unwrap();
+        validate_header_name("List-Id").unwrap();
+        validate_header_name("Content-Type").unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "test failure path")]
+    fn validate_header_name_rejects_empty() {
+        let Err(ImapError::InvalidInput { field, reason }) = validate_header_name("") else {
+            panic!("expected InvalidInput error");
+        };
+        assert_eq!(field, "header name");
+        assert!(reason.contains("empty"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn validate_header_name_rejects_colon() {
+        assert!(validate_header_name("X-Foo:").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_space() {
+        assert!(validate_header_name("X Foo").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_crlf() {
+        assert!(validate_header_name("X-Foo\r\nBCC").is_err());
+        assert!(validate_header_name("X\rFoo").is_err());
+        assert!(validate_header_name("X\nFoo").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_nul() {
+        assert!(validate_header_name("X-Foo\0").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_high_bit_byte() {
+        assert!(validate_header_name("X-Föo").is_err());
     }
 }

--- a/crates/rimap-imap/src/types.rs
+++ b/crates/rimap-imap/src/types.rs
@@ -274,6 +274,11 @@ pub enum BodyStructure {
 
 /// SEARCH query — either a structured builder or a raw passthrough.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "StructuredQuery is the dominant variant; boxing it would \
+              require updating every call site for no runtime benefit"
+)]
 pub enum SearchQuery {
     /// Typed query built via `StructuredQuery`. This is the path all
     /// untrusted input (agent prompts, MCP tool arguments, HTTP requests)
@@ -298,6 +303,20 @@ pub enum SearchQuery {
     Raw(String),
 }
 
+/// A single `HEADER name value` SEARCH clause built into a
+/// [`StructuredQuery`]. The `name` must satisfy RFC 5322 field-name
+/// syntax (printable ASCII, no `:`); the `value` is quoted on emission
+/// and CR/LF/NUL bytes are rejected. Both are enforced when the
+/// query is compiled to an IMAP search key — see
+/// `crates/rimap-imap/src/ops/search.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderSearch {
+    /// RFC 5322 field name (e.g. `"List-Id"`, `"X-Spam-Score"`).
+    pub name: String,
+    /// Substring to match within the header value.
+    pub value: String,
+}
+
 /// Structured SEARCH builder. Empty builder = `ALL`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StructuredQuery {
@@ -316,6 +335,33 @@ pub struct StructuredQuery {
     /// Restrict to messages with attachments (`HAS_ATTACHMENT` heuristic;
     /// emitted as `BODY "Content-Disposition: attachment"`).
     pub has_attachment: bool,
+    /// Match `CC` header substring.
+    pub cc: Option<String>,
+    /// Match `BCC` header substring. (Content-oracle — gated to
+    /// `SearchAdvanced` at the MCP dispatch seam.)
+    pub bcc: Option<String>,
+    /// Match `BODY` substring (body parts only). Content-oracle.
+    pub body: Option<String>,
+    /// Match `TEXT` substring (headers OR body). Content-oracle.
+    pub text: Option<String>,
+    /// One or more `HEADER name value` clauses. Content-oracle when
+    /// non-empty.
+    pub headers: Option<Vec<HeaderSearch>>,
+    /// `LARGER N` (messages strictly greater than N octets).
+    pub larger: Option<u64>,
+    /// `SMALLER N` (messages strictly less than N octets).
+    pub smaller: Option<u64>,
+    /// `SENTSINCE` (inclusive lower bound by `Date:` header, not
+    /// INTERNALDATE — distinct from [`Self::since`]).
+    pub sent_since: Option<::time::Date>,
+    /// `SENTBEFORE` (exclusive upper bound by `Date:` header).
+    pub sent_before: Option<::time::Date>,
+    /// Restrict to messages with `\Answered`.
+    pub answered: Option<bool>,
+    /// Restrict to messages with `\Flagged`.
+    pub flagged: Option<bool>,
+    /// Restrict to messages with `\Draft`.
+    pub draft: Option<bool>,
 }
 
 /// FETCH item selection. `ENVELOPE`, `BODYSTRUCTURE`, `UID`, `FLAGS`, `SIZE`.

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -452,7 +452,7 @@ impl ServerHandler for ImapMcpServer {
         // a property of the *parsed* (parent) name, not the refined
         // sub-capability. Sub-capabilities (`SearchAdvanced`,
         // `FetchMessageHtml`) intentionally have no `TOOL_DEFS` entry
-        // (`crates/rimap-server/src/mcp/tool_catalog.rs:178`); they
+        // (see `tool_spec` in `crates/rimap-server/src/mcp/tool_catalog.rs`); they
         // share the parent's schema. Running this check on the
         // post-refinement name would short-circuit every refined
         // sub-capability call with RESOURCE_NOT_FOUND, defeating

--- a/crates/rimap-server/src/mcp/server.rs
+++ b/crates/rimap-server/src/mcp/server.rs
@@ -443,24 +443,33 @@ impl ServerHandler for ImapMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let (namespaced_account, bare_name) = split_tool_name(&request.name);
 
-        let tool_name = ToolName::from_str(bare_name)
+        let parsed_tool = ToolName::from_str(bare_name)
             .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
-        // Refine the tool name based on argument shape BEFORE DispatchGuard::pre_dispatch
-        // so the posture check covers sub-capabilities (FetchMessageHtml vs
-        // FetchMessage, SearchAdvanced vs Search) at a single seam rather
-        // than being re-checked inside every handler.
-        let tool_name = refine_tool_name(tool_name, request.arguments.as_ref());
 
-        // Reject tools that have no definition (not yet implemented).
-        // This prevents unimplemented v2 tools from consuming rate
-        // limiter tokens and producing misleading INTERNAL_ERROR.
-        if TOOL_DEFS.get(&tool_name).is_none() {
+        // Reject tools that have no MCP definition.
+        //
+        // This check answers "is this advertised tool implemented?" —
+        // a property of the *parsed* (parent) name, not the refined
+        // sub-capability. Sub-capabilities (`SearchAdvanced`,
+        // `FetchMessageHtml`) intentionally have no `TOOL_DEFS` entry
+        // (`crates/rimap-server/src/mcp/tool_catalog.rs:178`); they
+        // share the parent's schema. Running this check on the
+        // post-refinement name would short-circuit every refined
+        // sub-capability call with RESOURCE_NOT_FOUND, defeating
+        // `refine_tool_name` and bypassing `DispatchGuard::pre_dispatch`.
+        if TOOL_DEFS.get(&parsed_tool).is_none() {
             return Err(ErrorData::new(
                 McpCode::RESOURCE_NOT_FOUND,
                 format!("tool `{}` is not available", request.name),
                 None,
             ));
         }
+
+        // Refine the tool name based on argument shape AFTER the
+        // TOOL_DEFS check, so sub-capability promotion reaches
+        // DispatchGuard::pre_dispatch and the posture matrix governs
+        // the gated variant.
+        let tool_name = refine_tool_name(parsed_tool, request.arguments.as_ref());
 
         // Multi-account contract: bare simple tool names are only valid
         // in legacy single-account mode. In multi-account mode, clients

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -47,7 +47,7 @@ pub(super) fn refine_tool_name(
         {
             ToolName::FetchMessageHtml
         }
-        ToolName::Search if args.get("advanced_query").is_some() => ToolName::SearchAdvanced,
+        ToolName::Search if promotes_search_to_advanced(args) => ToolName::SearchAdvanced,
         ToolName::ListFolders
         | ToolName::Search
         | ToolName::SearchAdvanced
@@ -73,6 +73,28 @@ pub(super) fn refine_tool_name(
         | ToolName::UseAccount
         | ToolName::ListAccounts => base,
     }
+}
+
+/// Whether the `search` argument shape forces promotion to
+/// `SearchAdvanced`. Triggers on any content-oracle input:
+/// `advanced_query`, `body`, `text`, `bcc`, or a non-empty `headers`
+/// array. Envelope/flag fields (`cc`, `larger`, `sent_*`, `answered`,
+/// `flagged`, `draft`) do NOT promote — they map to IMAP-indexed
+/// metadata, not content scans, and stay under the low-posture
+/// `Search` seat.
+fn promotes_search_to_advanced(args: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if args.get("advanced_query").is_some()
+        || args.get("body").is_some()
+        || args.get("text").is_some()
+        || args.get("bcc").is_some()
+    {
+        return true;
+    }
+    // headers triggers only when present AND non-empty.
+    matches!(
+        args.get("headers").and_then(serde_json::Value::as_array),
+        Some(arr) if !arr.is_empty(),
+    )
 }
 
 /// Whether `raw` is a bare simple (undotted) tool name for a non-infrastructure
@@ -298,6 +320,77 @@ mod tests {
                 ToolName::Search => assert_eq!(refined, ToolName::SearchAdvanced),
                 other => assert_eq!(refined, other, "{other:?} unexpectedly refined"),
             }
+        }
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_body() {
+        let mut args = serde_json::Map::new();
+        args.insert("body".into(), serde_json::Value::String("hello".into()));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_text() {
+        let mut args = serde_json::Map::new();
+        args.insert("text".into(), serde_json::Value::String("anywhere".into()));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_bcc() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "bcc".into(),
+            serde_json::Value::String("blind@example.com".into()),
+        );
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_non_empty_headers() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "headers".into(),
+            serde_json::json!([{"name": "List-Id", "value": "rust"}]),
+        );
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_does_not_promote_on_empty_headers_array() {
+        let mut args = serde_json::Map::new();
+        args.insert("headers".into(), serde_json::json!([]));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::Search,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_does_not_promote_on_envelope_or_flag_fields() {
+        // cc/larger/sent_since/answered are NOT content-oracle inputs;
+        // they ride the existing low-posture Search seat.
+        for field in ["cc", "larger", "sent_since", "answered"] {
+            let mut args = serde_json::Map::new();
+            args.insert(field.into(), serde_json::json!("payload"));
+            assert_eq!(
+                refine_tool_name(ToolName::Search, Some(&args)),
+                ToolName::Search,
+                "{field} unexpectedly promoted",
+            );
         }
     }
 }

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -83,14 +83,31 @@ pub(super) fn refine_tool_name(
 /// metadata, not content scans, and stay under the low-posture
 /// `Search` seat.
 fn promotes_search_to_advanced(args: &serde_json::Map<String, serde_json::Value>) -> bool {
-    if args.get("advanced_query").is_some()
-        || args.get("body").is_some()
-        || args.get("text").is_some()
-        || args.get("bcc").is_some()
+    // Use as_str() rather than is_some() so explicit JSON null (e.g.
+    // {"body": null}) is treated as absent — serde deserializes
+    // Option<String> = null as None, and promoting a no-op filter to
+    // SearchAdvanced would produce a misleading PostureDenied.
+    if args
+        .get("advanced_query")
+        .and_then(serde_json::Value::as_str)
+        .is_some()
+        || args
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+        || args
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+        || args
+            .get("bcc")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
     {
         return true;
     }
-    // headers triggers only when present AND non-empty.
+    // headers triggers only when present AND non-empty (as_array filters
+    // non-array types automatically).
     matches!(
         args.get("headers").and_then(serde_json::Value::as_array),
         Some(arr) if !arr.is_empty(),
@@ -373,6 +390,19 @@ mod tests {
     fn refine_tool_name_does_not_promote_on_empty_headers_array() {
         let mut args = serde_json::Map::new();
         args.insert("headers".into(), serde_json::json!([]));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::Search,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_does_not_promote_on_explicit_null_body() {
+        // JSON {"body": null} must NOT promote: serde deserializes
+        // Option<String> = null as None, so the filter is a no-op
+        // and promotion would yield a misleading PostureDenied.
+        let mut args = serde_json::Map::new();
+        args.insert("body".into(), serde_json::Value::Null);
         assert_eq!(
             refine_tool_name(ToolName::Search, Some(&args)),
             ToolName::Search,

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -184,6 +184,7 @@ fn build_query(
         before,
         seen: input.seen,
         has_attachment: input.has_attachment.unwrap_or(false),
+        ..Default::default()
     }))
 }
 

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -548,6 +548,13 @@ mod tests {
     }
 
     #[test]
+    fn build_query_rejects_whitespace_bcc() {
+        let mut input = input_with_folder();
+        input.bcc = Some("   ".to_string());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
     fn build_query_rejects_empty_body() {
         let mut input = input_with_folder();
         input.body = Some(String::new());
@@ -565,6 +572,13 @@ mod tests {
     fn build_query_rejects_empty_text() {
         let mut input = input_with_folder();
         input.text = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_text() {
+        let mut input = input_with_folder();
+        input.text = Some("\t ".to_string());
         assert!(build(&input).is_err());
     }
 

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -23,6 +23,16 @@ use crate::mcp::response::ToolResponse;
 /// Maximum number of results per page.
 const MAX_LIMIT: usize = 100;
 
+/// One `HEADER name value` filter for the `search` tool. Converted to
+/// [`rimap_imap::types::HeaderSearch`] in `build_query`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HeaderInput {
+    /// RFC 5322 field name (e.g. `"List-Id"`).
+    pub name: String,
+    /// Substring to match within the header value.
+    pub value: String,
+}
+
 /// Input for the `search` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchInput {
@@ -32,14 +42,45 @@ pub struct SearchInput {
     pub from: Option<String>,
     /// Filter by `To` header substring.
     pub to: Option<String>,
+    /// Filter by `Cc` header substring.
+    pub cc: Option<String>,
+    /// Filter by `Bcc` header substring. Content-oracle — requires
+    /// `SearchAdvanced` posture (Full or Destructive).
+    pub bcc: Option<String>,
     /// Filter by `Subject` header substring.
     pub subject: Option<String>,
-    /// Messages since this ISO date (inclusive), e.g. "2026-01-01".
+    /// Substring search across body parts. Content-oracle — requires
+    /// `SearchAdvanced` posture.
+    pub body: Option<String>,
+    /// Substring search across headers OR body. Content-oracle —
+    /// requires `SearchAdvanced` posture.
+    pub text: Option<String>,
+    /// One or more `HEADER name value` filters. Content-oracle when
+    /// non-empty — requires `SearchAdvanced` posture.
+    pub headers: Option<Vec<HeaderInput>>,
+    /// Match messages strictly larger than this many octets.
+    pub larger: Option<u64>,
+    /// Match messages strictly smaller than this many octets.
+    pub smaller: Option<u64>,
+    /// Messages since this ISO date (inclusive) by INTERNALDATE,
+    /// e.g. "2026-01-01".
     pub since: Option<String>,
-    /// Messages before this ISO date (exclusive), e.g. "2026-02-01".
+    /// Messages before this ISO date (exclusive) by INTERNALDATE.
     pub before: Option<String>,
+    /// Messages since this ISO date (inclusive) by the message's
+    /// `Date:` header — distinct from `since` which uses INTERNALDATE.
+    pub sent_since: Option<String>,
+    /// Messages before this ISO date (exclusive) by the message's
+    /// `Date:` header — distinct from `before` which uses INTERNALDATE.
+    pub sent_before: Option<String>,
     /// Filter by seen/unseen status.
     pub seen: Option<bool>,
+    /// Filter by answered/unanswered status.
+    pub answered: Option<bool>,
+    /// Filter by flagged/unflagged status.
+    pub flagged: Option<bool>,
+    /// Filter by draft/non-draft status.
+    pub draft: Option<bool>,
     /// Filter for messages with attachments.
     pub has_attachment: Option<bool>,
     /// Raw IMAP SEARCH query (full posture only).

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -116,6 +116,10 @@ pub struct SearchResultEntry {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub to: Vec<String>,
     /// Cc addresses, sanitized. Omitted when empty.
+    ///
+    /// Note: `bcc` is intentionally absent — exposing BCC recipients
+    /// violates the privacy boundary enforced at the `SearchInput` and
+    /// output layers. See the spec's Privacy subsection.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cc: Vec<String>,
     /// RFC 2822 `Message-ID`, sanitized.
@@ -359,6 +363,16 @@ fn format_addresses(addrs: &[Address]) -> Vec<String> {
     addrs.iter().map(format_address).collect()
 }
 
+/// Apply the search-result envelope address pipeline: format each
+/// address as `"name <mailbox@host>"`, then route through
+/// `sanitize_for_output`. Returns an empty `Vec` when `addrs` is empty.
+fn sanitize_address_list(addrs: &[Address]) -> Vec<String> {
+    format_addresses(addrs)
+        .into_iter()
+        .map(|a| sanitize_for_output(&a))
+        .collect()
+}
+
 /// Format a flag for JSON output.
 fn format_flag(flag: &Flag) -> &str {
     match flag {
@@ -390,30 +404,9 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
             let raw = String::from_utf8_lossy(d);
             sanitize_for_output(&raw)
         });
-        let from = if env.from.is_empty() {
-            Vec::new()
-        } else {
-            format_addresses(&env.from)
-                .into_iter()
-                .map(|a| sanitize_for_output(&a))
-                .collect()
-        };
-        let to = if env.to.is_empty() {
-            Vec::new()
-        } else {
-            format_addresses(&env.to)
-                .into_iter()
-                .map(|a| sanitize_for_output(&a))
-                .collect()
-        };
-        let cc = if env.cc.is_empty() {
-            Vec::new()
-        } else {
-            format_addresses(&env.cc)
-                .into_iter()
-                .map(|a| sanitize_for_output(&a))
-                .collect()
-        };
+        let from = sanitize_address_list(&env.from);
+        let to = sanitize_address_list(&env.to);
+        let cc = sanitize_address_list(&env.cc);
         let message_id = env.message_id.as_ref().map(|mid| {
             let raw = String::from_utf8_lossy(mid.as_bytes());
             sanitize_for_output(&raw)
@@ -445,7 +438,7 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
 )]
 mod tests {
     use super::*;
-    use rimap_imap::types::{HeaderSearch, StructuredQuery};
+    use rimap_imap::types::{Address, Envelope, FetchedMessage, HeaderSearch, StructuredQuery};
 
     #[test]
     fn sanitize_strips_null_byte() {
@@ -656,8 +649,6 @@ mod tests {
             rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
         }
     }
-
-    use rimap_imap::types::{Address, Envelope, FetchedMessage};
 
     fn addr(name: &str, mailbox: &str, host: &str) -> Address {
         Address {

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -433,6 +433,7 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
 )]
 mod tests {
     use super::*;
+    use rimap_imap::types::{HeaderSearch, StructuredQuery};
 
     #[test]
     fn sanitize_strips_null_byte() {
@@ -481,8 +482,6 @@ mod tests {
         let input = "cafe\u{0301} naïve résumé 日本語";
         assert_eq!(sanitize_for_output(input), "café naïve résumé 日本語");
     }
-
-    use rimap_imap::types::{HeaderSearch, StructuredQuery};
 
     fn input_with_folder() -> SearchInput {
         SearchInput {
@@ -601,6 +600,22 @@ mod tests {
             name: "List-Id".to_string(),
             value: "  ".to_string(),
         }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_name_in_second_header() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![
+            HeaderInput {
+                name: "List-Id".to_string(),
+                value: "rust".to_string(),
+            },
+            HeaderInput {
+                name: String::new(),
+                value: "x".to_string(),
+            },
+        ]);
         assert!(build(&input).is_err());
     }
 

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -23,6 +23,12 @@ use crate::mcp::response::ToolResponse;
 /// Maximum number of results per page.
 const MAX_LIMIT: usize = 100;
 
+/// Maximum number of `HEADER` filters per search request. IMAP servers
+/// typically reject more than a handful in a single SEARCH command;
+/// the cap also bounds CPU spent in `build_query`'s per-entry validation
+/// for adversarial inputs.
+const MAX_HEADERS: usize = 32;
+
 /// One `HEADER name value` filter for the `search` tool. Converted to
 /// [`rimap_imap::types::HeaderSearch`] in `build_query`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -231,6 +237,11 @@ fn build_query(input: &SearchInput) -> Result<SearchQuery, rimap_core::RimapErro
     let headers = match &input.headers {
         Some(v) if v.is_empty() => None,
         Some(v) => {
+            if v.len() > MAX_HEADERS {
+                return Err(rimap_core::RimapError::invalid_input(format!(
+                    "headers array exceeds maximum of {MAX_HEADERS} entries"
+                )));
+            }
             let mut converted = Vec::with_capacity(v.len());
             for h in v {
                 if h.name.trim().is_empty() {
@@ -358,18 +369,13 @@ fn format_address(addr: &Address) -> String {
     }
 }
 
-/// Format addresses list.
-fn format_addresses(addrs: &[Address]) -> Vec<String> {
-    addrs.iter().map(format_address).collect()
-}
-
 /// Apply the search-result envelope address pipeline: format each
 /// address as `"name <mailbox@host>"`, then route through
 /// `sanitize_for_output`. Returns an empty `Vec` when `addrs` is empty.
 fn sanitize_address_list(addrs: &[Address]) -> Vec<String> {
-    format_addresses(addrs)
-        .into_iter()
-        .map(|a| sanitize_for_output(&a))
+    addrs
+        .iter()
+        .map(|a| sanitize_for_output(&format_address(a)))
         .collect()
 }
 
@@ -636,6 +642,23 @@ mod tests {
             },
         ]);
         assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_headers_array_over_cap() {
+        let mut input = input_with_folder();
+        let too_many: Vec<HeaderInput> = (0..=MAX_HEADERS)
+            .map(|i| HeaderInput {
+                name: format!("X-Test-{i}"),
+                value: "v".to_string(),
+            })
+            .collect();
+        input.headers = Some(too_many);
+        let err = build(&input).unwrap_err();
+        assert!(
+            err.to_string().contains("headers array exceeds maximum"),
+            "expected over-cap error, got: {err}",
+        );
     }
 
     #[test]

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -50,13 +50,13 @@ pub struct SearchInput {
     /// Filter by `Subject` header substring.
     pub subject: Option<String>,
     /// Substring search across body parts. Content-oracle — requires
-    /// `SearchAdvanced` posture.
+    /// `SearchAdvanced` posture (Full or Destructive).
     pub body: Option<String>,
     /// Substring search across headers OR body. Content-oracle —
-    /// requires `SearchAdvanced` posture.
+    /// requires `SearchAdvanced` posture (Full or Destructive).
     pub text: Option<String>,
     /// One or more `HEADER name value` filters. Content-oracle when
-    /// non-empty — requires `SearchAdvanced` posture.
+    /// non-empty — requires `SearchAdvanced` posture (Full or Destructive).
     pub headers: Option<Vec<HeaderInput>>,
     /// Match messages strictly larger than this many octets.
     pub larger: Option<u64>,

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -157,7 +157,7 @@ pub async fn handle(
 ) -> Result<ToolResponse<SearchMeta, SearchUntrusted>, rimap_core::RimapError> {
     crate::tools::validation::validate_folder_input("folder", &input.folder)?;
 
-    let query = build_query(account, &input)?;
+    let query = build_query(&input)?;
 
     let uids = Box::pin(account.imap.search(&input.folder, query)).await?;
     let total_matched = uids.len();
@@ -201,10 +201,7 @@ pub async fn handle(
 
 /// Build a `SearchQuery` from the input. The `SearchAdvanced` posture
 /// check happens upstream in `refine_tool_name` + `DispatchGuard::pre_dispatch`.
-fn build_query(
-    _account: &AccountState,
-    input: &SearchInput,
-) -> Result<SearchQuery, rimap_core::RimapError> {
+fn build_query(input: &SearchInput) -> Result<SearchQuery, rimap_core::RimapError> {
     if let Some(raw) = &input.advanced_query {
         if raw.bytes().any(|b| b == b'\r' || b == b'\n' || b == b'\0') {
             return Err(rimap_core::RimapError::invalid_input(
@@ -214,8 +211,53 @@ fn build_query(
         return Ok(SearchQuery::Raw(raw.clone()));
     }
 
+    // Reject empty/whitespace-only string filters at the MCP boundary —
+    // the IMAP server happily executes broad scans like `BODY ""` and
+    // the existing quote() only blocks CR/LF/NUL.
+    let cc = require_non_empty("cc", input.cc.as_deref())?;
+    let bcc = require_non_empty("bcc", input.bcc.as_deref())?;
+    let body = require_non_empty("body", input.body.as_deref())?;
+    let text = require_non_empty("text", input.text.as_deref())?;
+
+    // Empty headers vec carries no filter intent — normalize to None
+    // so the emitter does not have to special-case it.
+    let headers = match &input.headers {
+        Some(v) if v.is_empty() => None,
+        Some(v) => {
+            let mut converted = Vec::with_capacity(v.len());
+            for h in v {
+                if h.name.trim().is_empty() {
+                    return Err(rimap_core::RimapError::invalid_input(
+                        "headers[].name must not be empty or whitespace-only",
+                    ));
+                }
+                if h.value.trim().is_empty() {
+                    return Err(rimap_core::RimapError::invalid_input(
+                        "headers[].value must not be empty or whitespace-only",
+                    ));
+                }
+                converted.push(rimap_imap::types::HeaderSearch {
+                    name: h.name.clone(),
+                    value: h.value.clone(),
+                });
+            }
+            Some(converted)
+        }
+        None => None,
+    };
+
     let since = input.since.as_deref().map(parse_iso_date).transpose()?;
     let before = input.before.as_deref().map(parse_iso_date).transpose()?;
+    let sent_since = input
+        .sent_since
+        .as_deref()
+        .map(parse_iso_date)
+        .transpose()?;
+    let sent_before = input
+        .sent_before
+        .as_deref()
+        .map(parse_iso_date)
+        .transpose()?;
 
     Ok(SearchQuery::Structured(StructuredQuery {
         from: input.from.clone(),
@@ -225,8 +267,38 @@ fn build_query(
         before,
         seen: input.seen,
         has_attachment: input.has_attachment.unwrap_or(false),
-        ..Default::default()
+        cc,
+        bcc,
+        body,
+        text,
+        headers,
+        larger: input.larger,
+        smaller: input.smaller,
+        sent_since,
+        sent_before,
+        answered: input.answered,
+        flagged: input.flagged,
+        draft: input.draft,
     }))
+}
+
+/// Reject empty/whitespace-only string filters. Returns `Ok(None)` for
+/// `None`, `Ok(Some(s.to_string()))` for a non-trimmed-empty value, and
+/// `Err(RimapError::invalid_input)` otherwise. The `field` label flows
+/// straight into the error message.
+fn require_non_empty(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<String>, rimap_core::RimapError> {
+    let Some(s) = value else {
+        return Ok(None);
+    };
+    if s.trim().is_empty() {
+        return Err(rimap_core::RimapError::invalid_input(format!(
+            "{field} must not be empty or whitespace-only"
+        )));
+    }
+    Ok(Some(s.to_string()))
 }
 
 /// Parse an ISO 8601 date string ("YYYY-MM-DD") into a `time::Date`.
@@ -353,6 +425,12 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests"
+)]
 mod tests {
     use super::*;
 
@@ -402,5 +480,204 @@ mod tests {
         // Other already-precomposed characters pass through unchanged.
         let input = "cafe\u{0301} naïve résumé 日本語";
         assert_eq!(sanitize_for_output(input), "café naïve résumé 日本語");
+    }
+
+    use rimap_imap::types::{HeaderSearch, StructuredQuery};
+
+    fn input_with_folder() -> SearchInput {
+        SearchInput {
+            folder: "INBOX".to_string(),
+            from: None,
+            to: None,
+            cc: None,
+            bcc: None,
+            subject: None,
+            body: None,
+            text: None,
+            headers: None,
+            larger: None,
+            smaller: None,
+            since: None,
+            before: None,
+            sent_since: None,
+            sent_before: None,
+            seen: None,
+            answered: None,
+            flagged: None,
+            draft: None,
+            has_attachment: None,
+            advanced_query: None,
+            limit: None,
+            offset: None,
+        }
+    }
+
+    fn build(
+        input: &SearchInput,
+    ) -> Result<rimap_imap::types::SearchQuery, rimap_core::RimapError> {
+        super::build_query(input)
+    }
+
+    #[test]
+    fn build_query_rejects_empty_cc() {
+        let mut input = input_with_folder();
+        input.cc = Some(String::new());
+        let err = build(&input).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("cc"),
+            "expected cc-empty error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_cc() {
+        let mut input = input_with_folder();
+        input.cc = Some("   ".to_string());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_bcc() {
+        let mut input = input_with_folder();
+        input.bcc = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_body() {
+        let mut input = input_with_folder();
+        input.body = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_body() {
+        let mut input = input_with_folder();
+        input.body = Some("\t ".to_string());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_text() {
+        let mut input = input_with_folder();
+        input.text = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_header_name() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: String::new(),
+            value: "x".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_header_name() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "   ".to_string(),
+            value: "x".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_header_value() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: String::new(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_header_value() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: "  ".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_accepts_empty_headers_array_as_no_filter() {
+        let mut input = input_with_folder();
+        input.headers = Some(Vec::new());
+        let q = build(&input).expect("empty headers vec is accepted");
+        match q {
+            rimap_imap::types::SearchQuery::Structured(s) => {
+                assert!(s.headers.is_none(), "headers should be normalized to None");
+            }
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        }
+    }
+
+    #[test]
+    fn build_query_threads_cc_into_structured_query() {
+        let mut input = input_with_folder();
+        input.cc = Some("alice@example.com".to_string());
+        let q = build(&input).unwrap();
+        match q {
+            rimap_imap::types::SearchQuery::Structured(s) => {
+                assert_eq!(s.cc.as_deref(), Some("alice@example.com"));
+            }
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        }
+    }
+
+    #[test]
+    fn build_query_threads_all_new_fields_into_structured_query() {
+        let mut input = input_with_folder();
+        input.cc = Some("c@example.com".to_string());
+        input.bcc = Some("b@example.com".to_string());
+        input.body = Some("hi".to_string());
+        input.text = Some("anywhere".to_string());
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: "rust".to_string(),
+        }]);
+        input.larger = Some(1024);
+        input.smaller = Some(2_048_000);
+        input.sent_since = Some("2026-01-01".to_string());
+        input.sent_before = Some("2026-02-01".to_string());
+        input.answered = Some(true);
+        input.flagged = Some(false);
+        input.draft = Some(true);
+        let q = build(&input).unwrap();
+        let s: StructuredQuery = match q {
+            rimap_imap::types::SearchQuery::Structured(s) => s,
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        };
+        assert_eq!(s.cc.as_deref(), Some("c@example.com"));
+        assert_eq!(s.bcc.as_deref(), Some("b@example.com"));
+        assert_eq!(s.body.as_deref(), Some("hi"));
+        assert_eq!(s.text.as_deref(), Some("anywhere"));
+        let hs = s.headers.expect("headers");
+        assert_eq!(hs.len(), 1);
+        assert_eq!(
+            hs[0],
+            HeaderSearch {
+                name: "List-Id".to_string(),
+                value: "rust".to_string()
+            }
+        );
+        assert_eq!(s.larger, Some(1024));
+        assert_eq!(s.smaller, Some(2_048_000));
+        assert_eq!(
+            s.sent_since,
+            Some(::time::Date::from_calendar_date(2026, ::time::Month::January, 1).unwrap()),
+        );
+        assert_eq!(
+            s.sent_before,
+            Some(::time::Date::from_calendar_date(2026, ::time::Month::February, 1).unwrap()),
+        );
+        assert_eq!(s.answered, Some(true));
+        assert_eq!(s.flagged, Some(false));
+        assert_eq!(s.draft, Some(true));
     }
 }

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -115,6 +115,9 @@ pub struct SearchResultEntry {
     /// To addresses, sanitized. Omitted when empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub to: Vec<String>,
+    /// Cc addresses, sanitized. Omitted when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
     /// RFC 2822 `Message-ID`, sanitized.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
@@ -378,7 +381,7 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
         .as_ref()
         .map(|f| f.iter().map(|flag| format_flag(flag).to_string()).collect());
 
-    let (subject, date, from, to, message_id) = if let Some(env) = &msg.envelope {
+    let (subject, date, from, to, cc, message_id) = if let Some(env) = &msg.envelope {
         let subject = env.subject_raw.as_ref().map(|s| {
             let raw = String::from_utf8_lossy(s);
             sanitize_for_output(&raw)
@@ -403,13 +406,21 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
                 .map(|a| sanitize_for_output(&a))
                 .collect()
         };
+        let cc = if env.cc.is_empty() {
+            Vec::new()
+        } else {
+            format_addresses(&env.cc)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect()
+        };
         let message_id = env.message_id.as_ref().map(|mid| {
             let raw = String::from_utf8_lossy(mid.as_bytes());
             sanitize_for_output(&raw)
         });
-        (subject, date, from, to, message_id)
+        (subject, date, from, to, cc, message_id)
     } else {
-        (None, None, Vec::new(), Vec::new(), None)
+        (None, None, Vec::new(), Vec::new(), Vec::new(), None)
     };
 
     SearchResultEntry {
@@ -420,6 +431,7 @@ fn format_search_result(msg: &FetchedMessage) -> SearchResultEntry {
         date,
         from,
         to,
+        cc,
         message_id,
     }
 }
@@ -643,6 +655,106 @@ mod tests {
             }
             rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
         }
+    }
+
+    use rimap_imap::types::{Address, Envelope, FetchedMessage};
+
+    fn addr(name: &str, mailbox: &str, host: &str) -> Address {
+        Address {
+            name: if name.is_empty() {
+                None
+            } else {
+                Some(name.as_bytes().to_vec())
+            },
+            adl: None,
+            mailbox: Some(mailbox.as_bytes().to_vec()),
+            host: Some(host.as_bytes().to_vec()),
+        }
+    }
+
+    fn uid(n: u32) -> rimap_imap::types::Uid {
+        use std::num::NonZeroU32;
+        rimap_imap::types::Uid::from(NonZeroU32::new(n).expect("non-zero"))
+    }
+
+    fn fetched_with_envelope(env: Envelope) -> FetchedMessage {
+        FetchedMessage {
+            uid: uid(42),
+            envelope: Some(env),
+            bodystructure: None,
+            flags: None,
+            size: None,
+        }
+    }
+
+    #[test]
+    fn format_search_result_populates_cc_from_envelope() {
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![addr("Carol", "carol", "example.com")],
+            bcc: vec![],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        assert_eq!(entry.cc, vec!["Carol <carol@example.com>"]);
+    }
+
+    #[test]
+    fn format_search_result_returns_empty_cc_when_envelope_omits_it() {
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![],
+            bcc: vec![],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        assert!(entry.cc.is_empty());
+
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("\"cc\""),
+            "empty cc must be skipped on serialize; got {json}",
+        );
+    }
+
+    #[test]
+    fn format_search_result_never_emits_bcc_even_when_envelope_has_it() {
+        // Privacy boundary: bcc must NOT appear in SearchResultEntry in
+        // any posture. format_search_result must ignore env.bcc.
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![],
+            bcc: vec![addr("Blind", "blind", "example.com")],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("bcc"),
+            "bcc key must not appear in serialized SearchResultEntry; got {json}",
+        );
+        assert!(
+            !json.contains("blind@example.com"),
+            "bcc address must not leak via any other field; got {json}",
+        );
     }
 
     #[test]

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -304,10 +304,21 @@ async fn assert_search(harness: &mut Harness) -> u32 {
     assert!(uid > 0);
 
     // Exercise the new `cc` input field. The seeded message has no
-    // Cc header (verified in fixtures.rs::multipart_with_attachment),
-    // so this asserts that the wire path round-trips the new field
-    // and the IMAP server honors the `CC` SEARCH key (returning zero
-    // matches).
+    // Cc header (see fixtures.rs::multipart_with_attachment), so this
+    // asserts that the wire path round-trips the new field and the
+    // IMAP server honors the `CC` SEARCH key (returning zero matches).
+    //
+    // Coverage caveat: a regression that silently drops the `cc` arg
+    // would also produce zero matches (the IMAP query would degrade
+    // to ALL on an inbox with one message that doesn't match other
+    // criteria). The wire-format direction itself is pinned by the
+    // unit tests:
+    //   - rimap-server build_query_threads_cc_into_structured_query
+    //   - rimap-imap structured_to_key_emits_cc_and_bcc
+    // Together those guarantee the field reaches the IMAP key; this
+    // e2e check adds proof that Dovecot accepts the resulting
+    // command. A positive-case e2e (seed a message with a Cc header)
+    // is a worthwhile follow-up but is deferred from this PR.
     let cc_body = call_tool(
         harness,
         "draftsafe.search",

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -302,6 +302,24 @@ async fn assert_search(harness: &mut Harness) -> u32 {
     let uid_u64 = messages[0]["uid"].as_u64().expect("uid is integer");
     let uid = u32::try_from(uid_u64).expect("uid fits u32");
     assert!(uid > 0);
+
+    // Exercise the new `cc` input field. The seeded message has no
+    // Cc header (verified in fixtures.rs::multipart_with_attachment),
+    // so this asserts that the wire path round-trips the new field
+    // and the IMAP server honors the `CC` SEARCH key (returning zero
+    // matches).
+    let cc_body = call_tool(
+        harness,
+        "draftsafe.search",
+        json!({ "folder": "INBOX", "cc": "noone@example.com" }),
+    )
+    .await;
+    assert_eq!(
+        cc_body["meta"]["total_matched"].as_u64(),
+        Some(0),
+        "cc filter against unseeded address must yield zero hits: {cc_body}",
+    );
+
     uid
 }
 

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -646,6 +646,31 @@ async fn assert_readonly_denial(harness: &mut Harness) {
         Some(POSTURE_DENIAL_CODE),
         "posture-denial wire code drifted; got {resp}",
     );
+
+    // Regression coverage for the sub-capability dispatch order bug.
+    // refine_tool_name promotes Search -> SearchAdvanced when
+    // `advanced_query` is set; the TOOL_DEFS check must run on the
+    // parsed (parent) name so the refined name reaches DispatchGuard
+    // and returns PostureDenied (not RESOURCE_NOT_FOUND).
+    let advanced_denial = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "readonly.search",
+                "arguments": {"folder": "INBOX", "advanced_query": "FROM x"},
+            }),
+        )
+        .await;
+    assert!(
+        advanced_denial["error"].is_object(),
+        "expected error envelope for readonly.search advanced_query, got {advanced_denial}",
+    );
+    assert_eq!(
+        advanced_denial["error"]["code"].as_i64(),
+        Some(POSTURE_DENIAL_CODE),
+        "readonly.search advanced_query must be posture-denied (sub-capability \
+         dispatch reaches DispatchGuard); got {advanced_denial}",
+    );
 }
 
 /// Verify audit records from the readonly posture denial test.
@@ -714,6 +739,40 @@ fn assert_readonly_audit_records(audit_path: &std::path::Path) {
         "readonly.move_message tool_end must record account=\"readonly\": {records:#?}",
     );
     assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
+
+    // Denial path: search_advanced pair, account="readonly" (advanced_query
+    // sub-capability, denied by DispatchGuard after the reordered
+    // TOOL_DEFS check). The audit writer logs the *refined* tool name
+    // (SearchAdvanced.as_str() == "search.advanced_query"), not "search".
+    let s_starts: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "search.advanced_query")
+        .collect();
+    assert_eq!(
+        s_starts.len(),
+        1,
+        "expected exactly one search.advanced_query tool_start"
+    );
+    assert_eq!(
+        s_starts[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_start must record account=\"readonly\": {records:#?}",
+    );
+    let s_ends: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "search.advanced_query")
+        .collect();
+    assert_eq!(
+        s_ends.len(),
+        1,
+        "expected exactly one search.advanced_query tool_end"
+    );
+    assert_eq!(
+        s_ends[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_end must record account=\"readonly\": {records:#?}",
+    );
+    assert_eq!(s_ends[0]["start_seq"], s_starts[0]["seq"]);
 }
 
 async fn seed_multipart_message(dovecot: &DovecotHarness) {

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -317,8 +317,7 @@ async fn assert_search(harness: &mut Harness) -> u32 {
     //   - rimap-imap structured_to_key_emits_cc_and_bcc
     // Together those guarantee the field reaches the IMAP key; this
     // e2e check adds proof that Dovecot accepts the resulting
-    // command. A positive-case e2e (seed a message with a Cc header)
-    // is a worthwhile follow-up but is deferred from this PR.
+    // command.
     let cc_body = call_tool(
         harness,
         "draftsafe.search",
@@ -792,8 +791,10 @@ fn assert_readonly_audit_records(audit_path: &std::path::Path) {
     );
     assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
 
-    // Denial path: TWO search.advanced_query pairs — advanced_query (Task 3)
-    // and body (Task 10), both refine to SearchAdvanced.
+    // Denial path: TWO search.advanced_query pairs, account="readonly".
+    // One from advanced_query, one from body — both refine to
+    // SearchAdvanced and serialize as "search.advanced_query" in the
+    // audit log. Each pair shares start_seq via the dispatch envelope.
     assert_readonly_audit_search_pairs(&records);
 }
 

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -740,7 +740,7 @@ fn assert_readonly_audit_records(audit_path: &std::path::Path) {
     );
     assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
 
-    // Denial path: search_advanced pair, account="readonly" (advanced_query
+    // Denial path: search.advanced_query pair, account="readonly" (advanced_query
     // sub-capability, denied by DispatchGuard after the reordered
     // TOOL_DEFS check). The audit writer logs the *refined* tool name
     // (SearchAdvanced.as_str() == "search.advanced_query"), not "search".
@@ -773,6 +773,9 @@ fn assert_readonly_audit_records(audit_path: &std::path::Path) {
         "readonly.search tool_end must record account=\"readonly\": {records:#?}",
     );
     assert_eq!(s_ends[0]["start_seq"], s_starts[0]["seq"]);
+    // NOTE(Task 10): if body promotion adds a second search.advanced_query
+    // denial, bump both == 1 above to == 2 and consider extracting an
+    // assert_audit_pair(records, tool, account, expected_count) helper.
 }
 
 async fn seed_multipart_message(dovecot: &DovecotHarness) {

--- a/crates/rimap-server/tests/e2e_wire.rs
+++ b/crates/rimap-server/tests/e2e_wire.rs
@@ -700,6 +700,29 @@ async fn assert_readonly_denial(harness: &mut Harness) {
         "readonly.search advanced_query must be posture-denied (sub-capability \
          dispatch reaches DispatchGuard); got {advanced_denial}",
     );
+
+    // The new `body` input is a content-oracle; refine_tool_name
+    // promotes Search -> SearchAdvanced, which the posture matrix
+    // denies under Readonly. Pin the wire error to the posture-denial
+    // code so silent drift in refinement OR the matrix surfaces here.
+    let body_denial = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "readonly.search",
+                "arguments": {"folder": "INBOX", "body": "hello"},
+            }),
+        )
+        .await;
+    assert!(
+        body_denial["error"].is_object(),
+        "expected error envelope for readonly.search body, got {body_denial}",
+    );
+    assert_eq!(
+        body_denial["error"]["code"].as_i64(),
+        Some(POSTURE_DENIAL_CODE),
+        "readonly.search body must be posture-denied; got {body_denial}",
+    );
 }
 
 /// Verify audit records from the readonly posture denial test.
@@ -769,42 +792,59 @@ fn assert_readonly_audit_records(audit_path: &std::path::Path) {
     );
     assert_eq!(mm_ends[0]["start_seq"], mm_starts[0]["seq"]);
 
-    // Denial path: search.advanced_query pair, account="readonly" (advanced_query
-    // sub-capability, denied by DispatchGuard after the reordered
-    // TOOL_DEFS check). The audit writer logs the *refined* tool name
-    // (SearchAdvanced.as_str() == "search.advanced_query"), not "search".
+    // Denial path: TWO search.advanced_query pairs — advanced_query (Task 3)
+    // and body (Task 10), both refine to SearchAdvanced.
+    assert_readonly_audit_search_pairs(&records);
+}
+
+/// Assert the two `search.advanced_query` audit pairs produced by the
+/// readonly denial test (one from `advanced_query`, one from `body` — both
+/// refine to `SearchAdvanced` and serialize as `"search.advanced_query"`).
+fn assert_readonly_audit_search_pairs(records: &[Value]) {
     let s_starts: Vec<&Value> = records
         .iter()
         .filter(|r| r["kind"] == "tool_start" && r["tool"] == "search.advanced_query")
         .collect();
     assert_eq!(
         s_starts.len(),
-        1,
-        "expected exactly one search.advanced_query tool_start"
+        2,
+        "expected exactly two search.advanced_query tool_start \
+         (advanced_query + body): {records:#?}",
     );
-    assert_eq!(
-        s_starts[0]["account"].as_str(),
-        Some("readonly"),
-        "readonly.search tool_start must record account=\"readonly\": {records:#?}",
-    );
+    for s in &s_starts {
+        assert_eq!(
+            s["account"].as_str(),
+            Some("readonly"),
+            "readonly.search tool_start must record account=\"readonly\": {records:#?}",
+        );
+    }
     let s_ends: Vec<&Value> = records
         .iter()
         .filter(|r| r["kind"] == "tool_end" && r["tool"] == "search.advanced_query")
         .collect();
     assert_eq!(
         s_ends.len(),
-        1,
-        "expected exactly one search.advanced_query tool_end"
+        2,
+        "expected exactly two search.advanced_query tool_end: {records:#?}",
     );
-    assert_eq!(
-        s_ends[0]["account"].as_str(),
-        Some("readonly"),
-        "readonly.search tool_end must record account=\"readonly\": {records:#?}",
-    );
-    assert_eq!(s_ends[0]["start_seq"], s_starts[0]["seq"]);
-    // NOTE(Task 10): if body promotion adds a second search.advanced_query
-    // denial, bump both == 1 above to == 2 and consider extracting an
-    // assert_audit_pair(records, tool, account, expected_count) helper.
+    for e in &s_ends {
+        assert_eq!(
+            e["account"].as_str(),
+            Some("readonly"),
+            "readonly.search tool_end must record account=\"readonly\": {records:#?}",
+        );
+    }
+    // Each tool_end's start_seq must match a tool_start's seq.
+    let start_seqs: std::collections::HashSet<&Value> =
+        s_starts.iter().map(|s| &s["seq"]).collect();
+    for e in &s_ends {
+        let start_seq = &e["start_seq"];
+        assert!(
+            start_seqs.contains(start_seq),
+            "tool_end start_seq {start_seq} should match a \
+             tool_start seq from {start_seqs:?}",
+        );
+    }
 }
 
 async fn seed_multipart_message(dovecot: &DovecotHarness) {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -3,6 +3,13 @@
     "SearchResultEntry": {
       "description": "A single message entry in a `search` untrusted payload.",
       "properties": {
+        "cc": {
+          "description": "Cc addresses, sanitized. Omitted when empty.\n\nNote: `bcc` is intentionally absent \u2014 exposing BCC recipients\nviolates the privacy boundary enforced at the `SearchInput` and\noutput layers. See the spec's Privacy subsection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "date": {
           "description": "Date header, sanitized.",
           "type": [

--- a/docs/superpowers/plans/2026-05-18-expand-search-fields-impl.md
+++ b/docs/superpowers/plans/2026-05-18-expand-search-fields-impl.md
@@ -1,0 +1,2096 @@
+# Expand searchable email fields — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 12 new structured SEARCH fields (`cc`, `bcc`, `body`, `text`, `headers`, `larger`, `smaller`, `sent_since`, `sent_before`, `answered`, `flagged`, `draft`) plus `cc` on the search result envelope, with content-oracle inputs gated to `SearchAdvanced` and empty-string filters rejected at the MCP boundary.
+
+**Architecture:** Two-layer extension. `rimap-imap` gains a public `HeaderSearch` value type plus extra `StructuredQuery` fields; its `structured_to_key` emits the new IMAP keys with a `validate_header_name` helper for RFC 5322 field-name syntax. `rimap-server` extends `SearchInput`/`SearchResultEntry`, threads inputs through `build_query` with empty-string rejection, populates `cc` on output from the already-fetched envelope, and extends the `refine_tool_name` predicate so `body`/`text`/non-empty `headers`/`bcc` promote `Search` → `SearchAdvanced` (denied under Readonly/DraftSafe by the existing posture matrix).
+
+**Tech Stack:** Rust 2021 (workspace), `time` crate for dates, `schemars` for JSON Schema derivation, `serde` for wire serialization, `cargo test` for unit/integration tests, `cargo clippy --all-targets --all-features -- -D warnings` for lint, Dovecot Docker container fixture for e2e.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-expand-search-fields-design.md` (commit `32facf9`).
+
+**Branch:** `feat/expand-search-fields` (already checked out; original spec commit `2ffa9a0` and revision `32facf9` already on it).
+
+---
+
+## File Structure
+
+**Modified:**
+- `crates/rimap-imap/src/types.rs` — extend `StructuredQuery`; add `HeaderSearch` public struct.
+- `crates/rimap-imap/src/ops/search.rs` — extend `structured_to_key`; add `validate_header_name`; add unit tests.
+- `crates/rimap-server/src/mcp/tool_name.rs` — extend `refine_tool_name` predicate; add unit tests.
+- `crates/rimap-server/src/tools/retrieval/search.rs` — extend `SearchInput` (add `HeaderInput` schemars-aware sibling type), extend `SearchResultEntry` with `cc`, thread inputs through `build_query` with empty-string rejection, populate `cc` in `format_search_result`; add unit tests.
+- `crates/rimap-server/tests/e2e_wire.rs` — add one positive case (`cc` filter against Dovecot) and one negative case (`body` under `readonly` posture returns `PostureDenied`).
+- `crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json` — regenerated via `scripts/regen-tool-schemas.sh` after `SearchInput`/`SearchResultEntry` changes land.
+
+**No new files.**
+
+---
+
+## Pre-flight checks
+
+- [ ] **Step P1: Confirm branch and clean working tree**
+
+```bash
+cd /Users/dave/src/rusty-imap-mcp
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: clean working tree on `feat/expand-search-fields`. If a different branch or dirty tree, stop and ask.
+
+- [ ] **Step P2: Confirm baseline tests pass**
+
+```bash
+cargo test -p rimap-imap --lib structured_to_key
+cargo test -p rimap-server --lib refine_tool_name
+```
+
+Expected: all pass (the pre-existing tests at `crates/rimap-imap/src/ops/search.rs:114-201` and `crates/rimap-server/src/mcp/tool_name.rs:175-302`).
+
+If any baseline test fails, STOP — investigate before adding scope.
+
+---
+
+## Task 1: Add `HeaderSearch` and extend `StructuredQuery` (rimap-imap types)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/types.rs:302-319`
+
+This task only changes data shape — no behavior. Tests come with Task 2.
+
+- [ ] **Step 1.1: Add the `HeaderSearch` struct**
+
+Insert immediately before the `StructuredQuery` definition (currently at `crates/rimap-imap/src/types.rs:302`). The doc comment mirrors the existing tone in the file.
+
+```rust
+/// A single `HEADER name value` SEARCH clause built into a
+/// [`StructuredQuery`]. The `name` must satisfy RFC 5322 field-name
+/// syntax (printable ASCII, no `:`); the `value` is quoted on emission
+/// and CR/LF/NUL bytes are rejected. Both are enforced when the
+/// query is compiled to an IMAP search key — see
+/// `crates/rimap-imap/src/ops/search.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderSearch {
+    /// RFC 5322 field name (e.g. `"List-Id"`, `"X-Spam-Score"`).
+    pub name: String,
+    /// Substring to match within the header value.
+    pub value: String,
+}
+```
+
+- [ ] **Step 1.2: Extend `StructuredQuery`**
+
+Replace the existing `StructuredQuery` struct definition (at `crates/rimap-imap/src/types.rs:302-319`) with the extended version below. Keep the existing fields in their original order; append the new fields after `has_attachment`.
+
+```rust
+/// Structured SEARCH builder. Empty builder = `ALL`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StructuredQuery {
+    /// Match `FROM` substring.
+    pub from: Option<String>,
+    /// Match `TO` substring.
+    pub to: Option<String>,
+    /// Match `SUBJECT` substring.
+    pub subject: Option<String>,
+    /// `SINCE` (inclusive lower bound by INTERNALDATE).
+    pub since: Option<::time::Date>,
+    /// `BEFORE` (exclusive upper bound by INTERNALDATE).
+    pub before: Option<::time::Date>,
+    /// Restrict to messages with `\Seen`.
+    pub seen: Option<bool>,
+    /// Restrict to messages with attachments (`HAS_ATTACHMENT` heuristic;
+    /// emitted as `BODY "Content-Disposition: attachment"`).
+    pub has_attachment: bool,
+    /// Match `CC` header substring.
+    pub cc: Option<String>,
+    /// Match `BCC` header substring. (Content-oracle — gated to
+    /// `SearchAdvanced` at the MCP dispatch seam.)
+    pub bcc: Option<String>,
+    /// Match `BODY` substring (body parts only). Content-oracle.
+    pub body: Option<String>,
+    /// Match `TEXT` substring (headers OR body). Content-oracle.
+    pub text: Option<String>,
+    /// One or more `HEADER name value` clauses. Content-oracle when
+    /// non-empty.
+    pub headers: Option<Vec<HeaderSearch>>,
+    /// `LARGER N` (messages strictly greater than N octets).
+    pub larger: Option<u64>,
+    /// `SMALLER N` (messages strictly less than N octets).
+    pub smaller: Option<u64>,
+    /// `SENTSINCE` (inclusive lower bound by `Date:` header, not
+    /// INTERNALDATE — distinct from [`Self::since`]).
+    pub sent_since: Option<::time::Date>,
+    /// `SENTBEFORE` (exclusive upper bound by `Date:` header).
+    pub sent_before: Option<::time::Date>,
+    /// Restrict to messages with `\Answered`.
+    pub answered: Option<bool>,
+    /// Restrict to messages with `\Flagged`.
+    pub flagged: Option<bool>,
+    /// Restrict to messages with `\Draft`.
+    pub draft: Option<bool>,
+}
+```
+
+- [ ] **Step 1.3: Confirm the crate still compiles**
+
+```bash
+cargo check -p rimap-imap --all-targets
+```
+
+Expected: compiles clean. `StructuredQuery::default()` will still work because all new fields are `Option` / `bool` defaults.
+
+- [ ] **Step 1.4: Run the existing search tests to confirm zero regression**
+
+```bash
+cargo test -p rimap-imap --lib search
+```
+
+Expected: all pre-existing tests pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add crates/rimap-imap/src/types.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-imap): add HeaderSearch + StructuredQuery search fields
+
+Extend StructuredQuery with cc, bcc, body, text, headers (Vec<HeaderSearch>),
+larger, smaller, sent_since, sent_before, answered, flagged, draft.
+Add public HeaderSearch { name, value } struct for HEADER clauses.
+
+No behavior change — emitter extensions and validation in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Emit the new IMAP keys + `validate_header_name` (rimap-imap ops)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/ops/search.rs`
+
+- [ ] **Step 2.1: Write the failing tests for new keys**
+
+Append the following test functions inside the existing `#[cfg(test)] mod tests` block at `crates/rimap-imap/src/ops/search.rs:107-202`, immediately before the closing `}` of the module.
+
+```rust
+    #[test]
+    fn structured_to_key_emits_cc_and_bcc() {
+        let q = StructuredQuery {
+            cc: Some("alice@example.com".to_string()),
+            bcc: Some("bob@example.com".to_string()),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains(r#"CC "alice@example.com""#), "got {key}");
+        assert!(key.contains(r#"BCC "bob@example.com""#), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_body_and_text() {
+        let q = StructuredQuery {
+            body: Some("hello".to_string()),
+            text: Some("world".to_string()),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains(r#"BODY "hello""#), "got {key}");
+        assert!(key.contains(r#"TEXT "world""#), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_single_header() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            headers: Some(vec![HeaderSearch {
+                name: "List-Id".to_string(),
+                value: "rust-users".to_string(),
+            }]),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"HEADER List-Id "rust-users""#,
+        );
+    }
+
+    #[test]
+    fn structured_to_key_emits_multiple_headers_in_input_order() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            headers: Some(vec![
+                HeaderSearch {
+                    name: "List-Id".to_string(),
+                    value: "rust-users".to_string(),
+                },
+                HeaderSearch {
+                    name: "X-Mailer".to_string(),
+                    value: "thunderbird".to_string(),
+                },
+            ]),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"HEADER List-Id "rust-users" HEADER X-Mailer "thunderbird""#,
+        );
+    }
+
+    #[test]
+    fn structured_to_key_treats_empty_headers_vec_as_no_clause() {
+        let q = StructuredQuery {
+            headers: Some(Vec::new()),
+            ..StructuredQuery::default()
+        };
+        // Empty headers carries no filter intent — emitter must not
+        // produce any HEADER clause. With no other criteria the query
+        // collapses to ALL.
+        assert_eq!(structured_to_key(&q).unwrap(), "ALL");
+    }
+
+    #[test]
+    fn structured_to_key_emits_larger_and_smaller_numeric() {
+        let q = StructuredQuery {
+            larger: Some(1024),
+            smaller: Some(1_048_576),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("LARGER 1024"), "got {key}");
+        assert!(key.contains("SMALLER 1048576"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_sent_since_and_sent_before() {
+        let q = StructuredQuery {
+            sent_since: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::January, 1).unwrap(),
+            ),
+            sent_before: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::February, 1).unwrap(),
+            ),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("SENTSINCE 01-Jan-2026"), "got {key}");
+        assert!(key.contains("SENTBEFORE 01-Feb-2026"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_emits_answered_flagged_draft_per_option() {
+        let q = StructuredQuery {
+            answered: Some(true),
+            flagged: Some(false),
+            draft: Some(true),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("ANSWERED"), "got {key}");
+        assert!(key.contains("UNFLAGGED"), "got {key}");
+        assert!(key.contains("DRAFT"), "got {key}");
+
+        let q = StructuredQuery {
+            answered: Some(false),
+            flagged: Some(true),
+            draft: Some(false),
+            ..StructuredQuery::default()
+        };
+        let key = structured_to_key(&q).unwrap();
+        assert!(key.contains("UNANSWERED"), "got {key}");
+        assert!(key.contains("FLAGGED"), "got {key}");
+        assert!(key.contains("UNDRAFT"), "got {key}");
+    }
+
+    #[test]
+    fn structured_to_key_combines_old_and_new_fields_in_emit_order() {
+        use crate::types::HeaderSearch;
+        let q = StructuredQuery {
+            from: Some("alice@example.com".to_string()),
+            cc: Some("team@example.com".to_string()),
+            body: Some("ship it".to_string()),
+            headers: Some(vec![HeaderSearch {
+                name: "List-Id".to_string(),
+                value: "rust".to_string(),
+            }]),
+            larger: Some(2048),
+            sent_since: Some(
+                ::time::Date::from_calendar_date(2026, ::time::Month::March, 15).unwrap(),
+            ),
+            answered: Some(true),
+            ..StructuredQuery::default()
+        };
+        assert_eq!(
+            structured_to_key(&q).unwrap(),
+            r#"FROM "alice@example.com" CC "team@example.com" BODY "ship it" HEADER List-Id "rust" LARGER 2048 SENTSINCE 15-Mar-2026 ANSWERED"#,
+        );
+    }
+
+    #[test]
+    fn validate_header_name_accepts_canonical_names() {
+        validate_header_name("Message-ID").unwrap();
+        validate_header_name("X-Foo").unwrap();
+        validate_header_name("List-Id").unwrap();
+        validate_header_name("Content-Type").unwrap();
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "test failure path")]
+    fn validate_header_name_rejects_empty() {
+        let Err(ImapError::InvalidInput { field, reason }) = validate_header_name("") else {
+            panic!("expected InvalidInput error");
+        };
+        assert_eq!(field, "header name");
+        assert!(reason.contains("empty"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn validate_header_name_rejects_colon() {
+        assert!(validate_header_name("X-Foo:").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_space() {
+        assert!(validate_header_name("X Foo").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_crlf() {
+        assert!(validate_header_name("X-Foo\r\nBCC").is_err());
+        assert!(validate_header_name("X\rFoo").is_err());
+        assert!(validate_header_name("X\nFoo").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_nul() {
+        assert!(validate_header_name("X-Foo\0").is_err());
+    }
+
+    #[test]
+    fn validate_header_name_rejects_high_bit_byte() {
+        assert!(validate_header_name("X-Föo").is_err());
+    }
+```
+
+The test for `validate_header_name` references a function that does not exist yet — that is the failing-test driver for Steps 2.2 and 2.3.
+
+- [ ] **Step 2.2: Run the tests and confirm they fail**
+
+```bash
+cargo test -p rimap-imap --lib search 2>&1 | tail -40
+```
+
+Expected: compile error from `validate_header_name` not being defined.
+
+- [ ] **Step 2.3: Add the `validate_header_name` helper**
+
+Insert the following function immediately after `quote()` (currently at `crates/rimap-imap/src/ops/search.rs:67-84`) and before `format_imap_date()`.
+
+```rust
+/// Validate an RFC 5322 field name for use in a `HEADER` SEARCH clause.
+///
+/// Every byte must be in the printable ASCII range `33..=126`
+/// (`!`..`~`) and must not be `b':'` (which terminates a field name).
+/// This is stricter than the IMAP wire format requires but matches the
+/// shape of all real-world header names and blocks command injection
+/// via CR/LF/NUL or whitespace.
+///
+/// # Errors
+///
+/// Returns [`ImapError::InvalidInput`] with `field = "header name"` for
+/// any disallowed byte or an empty name.
+fn validate_header_name(name: &str) -> Result<(), ImapError> {
+    if name.is_empty() {
+        return Err(ImapError::InvalidInput {
+            field: "header name",
+            reason: "empty",
+        });
+    }
+    for b in name.bytes() {
+        if !(33..=126).contains(&b) || b == b':' {
+            return Err(ImapError::InvalidInput {
+                field: "header name",
+                reason: "must be printable ASCII without ':'",
+            });
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2.4: Extend `structured_to_key` to emit the new keys**
+
+Replace the body of `structured_to_key` (currently at `crates/rimap-imap/src/ops/search.rs:33-65`) with the extended version below. The emit order matters — the combined test in Step 2.1 pins it.
+
+```rust
+fn structured_to_key(q: &StructuredQuery) -> Result<String, ImapError> {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(s) = &q.from {
+        parts.push(format!("FROM {}", quote(s)?));
+    }
+    if let Some(s) = &q.to {
+        parts.push(format!("TO {}", quote(s)?));
+    }
+    if let Some(s) = &q.cc {
+        parts.push(format!("CC {}", quote(s)?));
+    }
+    if let Some(s) = &q.bcc {
+        parts.push(format!("BCC {}", quote(s)?));
+    }
+    if let Some(s) = &q.subject {
+        parts.push(format!("SUBJECT {}", quote(s)?));
+    }
+    if let Some(s) = &q.body {
+        parts.push(format!("BODY {}", quote(s)?));
+    }
+    if let Some(s) = &q.text {
+        parts.push(format!("TEXT {}", quote(s)?));
+    }
+    if let Some(hs) = &q.headers {
+        for h in hs {
+            validate_header_name(&h.name)?;
+            parts.push(format!("HEADER {} {}", h.name, quote(&h.value)?));
+        }
+    }
+    if let Some(n) = q.larger {
+        parts.push(format!("LARGER {n}"));
+    }
+    if let Some(n) = q.smaller {
+        parts.push(format!("SMALLER {n}"));
+    }
+    if let Some(d) = q.since {
+        parts.push(format!("SINCE {}", format_imap_date(d)));
+    }
+    if let Some(d) = q.before {
+        parts.push(format!("BEFORE {}", format_imap_date(d)));
+    }
+    if let Some(d) = q.sent_since {
+        parts.push(format!("SENTSINCE {}", format_imap_date(d)));
+    }
+    if let Some(d) = q.sent_before {
+        parts.push(format!("SENTBEFORE {}", format_imap_date(d)));
+    }
+    match q.seen {
+        Some(true) => parts.push("SEEN".to_string()),
+        Some(false) => parts.push("UNSEEN".to_string()),
+        None => {}
+    }
+    match q.answered {
+        Some(true) => parts.push("ANSWERED".to_string()),
+        Some(false) => parts.push("UNANSWERED".to_string()),
+        None => {}
+    }
+    match q.flagged {
+        Some(true) => parts.push("FLAGGED".to_string()),
+        Some(false) => parts.push("UNFLAGGED".to_string()),
+        None => {}
+    }
+    match q.draft {
+        Some(true) => parts.push("DRAFT".to_string()),
+        Some(false) => parts.push("UNDRAFT".to_string()),
+        None => {}
+    }
+    if q.has_attachment {
+        // Heuristic: scan the message body for the literal Content-Disposition
+        // header. False negatives for unusual capitalization or nested MIME
+        // structures are accepted — see StructuredQuery::has_attachment doc.
+        parts.push("BODY \"Content-Disposition: attachment\"".to_string());
+    }
+    if parts.is_empty() {
+        return Ok("ALL".to_string());
+    }
+    Ok(parts.join(" "))
+}
+```
+
+- [ ] **Step 2.5: Import `validate_header_name` in the test module**
+
+The test module's `use super::{...}` already pulls in private items via `super::`. Update the `use` line at `crates/rimap-imap/src/ops/search.rs:110` from:
+
+```rust
+    use super::{format_imap_date, quote, structured_to_key};
+```
+
+to:
+
+```rust
+    use super::{format_imap_date, quote, structured_to_key, validate_header_name};
+```
+
+- [ ] **Step 2.6: Run the tests and confirm they pass**
+
+```bash
+cargo test -p rimap-imap --lib search
+```
+
+Expected: every test in the search module passes, including the new ones from Step 2.1 and the pre-existing ones.
+
+- [ ] **Step 2.7: Lint the crate**
+
+```bash
+cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/search.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-imap): emit CC/BCC/BODY/TEXT/HEADER/LARGER/SMALLER/SENT*/flag keys
+
+Extend structured_to_key to render every new StructuredQuery field as
+its RFC 3501 SEARCH key. Add validate_header_name helper (RFC 5322
+field-name byte check: printable ASCII, no ':'). HEADER clauses run
+through both validate_header_name and the existing quote() escape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Fix sub-capability dispatch order (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/server.rs:444-463`
+- Modify: `crates/rimap-server/tests/e2e_wire.rs` (extend `assert_readonly_denial` + `assert_readonly_audit_records`)
+
+**Why this task exists:** A preexisting bug in `call_tool` makes refined sub-capabilities unreachable. The current order is `refine_tool_name` → `TOOL_DEFS.get(&refined_name).is_none()`, but `TOOL_DEFS` intentionally excludes sub-capability variants (`SearchAdvanced`, `FetchMessageHtml`) per `crates/rimap-server/src/mcp/tool_catalog.rs:178`. The check therefore returns `RESOURCE_NOT_FOUND` for any refined call, short-circuiting `DispatchGuard::pre_dispatch` (and its posture matrix). Nothing in HEAD exercises `advanced_query` or `include_html=true` end-to-end at the wire level (`grep` for those fields in `tests/` finds only schema fixtures), so the bug has gone undetected. Task 4 expands the refined surface — without this fix, Task 10's posture-denial test would observe `RESOURCE_NOT_FOUND` instead of `PostureDenied`, and every new content-oracle path would be unreachable.
+
+The fix: the `TOOL_DEFS` check answers "is this advertised MCP tool implemented?" — a question about the *parsed* (parent) name, not the refined sub-capability. Move the check above `refine_tool_name`.
+
+- [ ] **Step 3.1: Add a wire regression test for the existing `advanced_query` sub-capability**
+
+This test fails today (returns `RESOURCE_NOT_FOUND`, code `-32002`) and passes after Step 3.2 lands (returns `PostureDenied`, code `-32001`). It pins the fix and shields against future regressions on the existing sub-capability paths.
+
+Append the following inside `assert_readonly_denial` at `crates/rimap-server/tests/e2e_wire.rs:627-649`, after the existing `move_message` assertion block:
+
+```rust
+    // Regression coverage for the sub-capability dispatch order bug.
+    // refine_tool_name promotes Search -> SearchAdvanced when
+    // `advanced_query` is set; the TOOL_DEFS check must run on the
+    // parsed (parent) name so the refined name reaches DispatchGuard
+    // and returns PostureDenied (not RESOURCE_NOT_FOUND).
+    let advanced_denial = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "readonly.search",
+                "arguments": {"folder": "INBOX", "advanced_query": "FROM x"},
+            }),
+        )
+        .await;
+    assert!(
+        advanced_denial["error"].is_object(),
+        "expected error envelope for readonly.search advanced_query, got {advanced_denial}",
+    );
+    assert_eq!(
+        advanced_denial["error"]["code"].as_i64(),
+        Some(POSTURE_DENIAL_CODE),
+        "readonly.search advanced_query must be posture-denied (sub-capability \
+         dispatch reaches DispatchGuard); got {advanced_denial}",
+    );
+```
+
+- [ ] **Step 3.2: Run the test and confirm it fails today**
+
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo test -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial -- --nocapture 2>&1 | tail -40
+```
+
+Expected: the new assertion fails. The error envelope's `code` is `-32002` (`RESOURCE_NOT_FOUND`) instead of `-32001` (`POSTURE_DENIAL_CODE`). This is the bug.
+
+If Docker is unavailable, skip the loud failure and proceed to Step 3.3 — the unit-level evidence in `tool_catalog.rs:178` and `server.rs:452-457` is sufficient to justify the fix.
+
+- [ ] **Step 3.3: Reorder the check in `call_tool`**
+
+In `crates/rimap-server/src/mcp/server.rs:444-463`, replace:
+
+```rust
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (namespaced_account, bare_name) = split_tool_name(&request.name);
+
+        let tool_name = ToolName::from_str(bare_name)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+        // Refine the tool name based on argument shape BEFORE DispatchGuard::pre_dispatch
+        // so the posture check covers sub-capabilities (FetchMessageHtml vs
+        // FetchMessage, SearchAdvanced vs Search) at a single seam rather
+        // than being re-checked inside every handler.
+        let tool_name = refine_tool_name(tool_name, request.arguments.as_ref());
+
+        // Reject tools that have no definition (not yet implemented).
+        // This prevents unimplemented v2 tools from consuming rate
+        // limiter tokens and producing misleading INTERNAL_ERROR.
+        if TOOL_DEFS.get(&tool_name).is_none() {
+            return Err(ErrorData::new(
+                McpCode::RESOURCE_NOT_FOUND,
+                format!("tool `{}` is not available", request.name),
+                None,
+            ));
+        }
+```
+
+with:
+
+```rust
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (namespaced_account, bare_name) = split_tool_name(&request.name);
+
+        let parsed_tool = ToolName::from_str(bare_name)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+
+        // Reject tools that have no MCP definition.
+        //
+        // This check answers "is this advertised tool implemented?" —
+        // a property of the *parsed* (parent) name, not the refined
+        // sub-capability. Sub-capabilities (`SearchAdvanced`,
+        // `FetchMessageHtml`) intentionally have no `TOOL_DEFS` entry
+        // (`crates/rimap-server/src/mcp/tool_catalog.rs:178`); they
+        // share the parent's schema. Running this check on the
+        // post-refinement name would short-circuit every refined
+        // sub-capability call with RESOURCE_NOT_FOUND, defeating
+        // `refine_tool_name` and bypassing `DispatchGuard::pre_dispatch`.
+        if TOOL_DEFS.get(&parsed_tool).is_none() {
+            return Err(ErrorData::new(
+                McpCode::RESOURCE_NOT_FOUND,
+                format!("tool `{}` is not available", request.name),
+                None,
+            ));
+        }
+
+        // Refine the tool name based on argument shape AFTER the
+        // TOOL_DEFS check, so sub-capability promotion reaches
+        // DispatchGuard::pre_dispatch and the posture matrix governs
+        // the gated variant.
+        let tool_name = refine_tool_name(parsed_tool, request.arguments.as_ref());
+```
+
+The remainder of `call_tool` (the bare-name multi-account check, infrastructure-bypass branch, account resolution, dispatch) is unchanged — every downstream use of `tool_name` continues to see the refined variant.
+
+- [ ] **Step 3.4: Update `assert_readonly_audit_records` to expect the new pair**
+
+The added wire test in Step 3.1 triggers a third audit pair (`tool=search` start + end, account `readonly`). Append the following inside `assert_readonly_audit_records` at `crates/rimap-server/tests/e2e_wire.rs:652-717`, after the existing `move_message` block:
+
+```rust
+    // Denial path: search pair, account="readonly" (advanced_query
+    // sub-capability, denied by DispatchGuard after the reordered
+    // TOOL_DEFS check).
+    let s_starts: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "search")
+        .collect();
+    assert_eq!(s_starts.len(), 1, "expected exactly one search tool_start");
+    assert_eq!(
+        s_starts[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_start must record account=\"readonly\": {records:#?}",
+    );
+    let s_ends: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "search")
+        .collect();
+    assert_eq!(s_ends.len(), 1, "expected exactly one search tool_end");
+    assert_eq!(
+        s_ends[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_end must record account=\"readonly\": {records:#?}",
+    );
+    assert_eq!(s_ends[0]["start_seq"], s_starts[0]["seq"]);
+```
+
+If the audit writer logs `search_advanced` instead of `search` after refinement, change both `r["tool"] == "search"` matches to `r["tool"] == "search_advanced"`. Verify empirically once via:
+
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo test -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial -- --nocapture 2>&1 | grep -E '"tool":|"kind":' | head -20
+```
+
+Note: Task 10 adds another `search` denial pair (for `body`). If Task 10 lands after this task, update both audit-record assertions to expect a count of `2` instead of `1` (or fold the assertion into a single block that counts the sum). The simplest pattern is to expect `s_starts.len() >= 1` here and adjust Task 10's audit block to do the same. The plan keeps the strict `== 1` form so a regression surfaces; Task 10's commit must update this count to match.
+
+- [ ] **Step 3.5: Run the test and confirm it now passes**
+
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo test -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial 2>&1 | tail -30
+```
+
+Expected: passes when Docker is available.
+
+- [ ] **Step 3.6: Lint**
+
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/server.rs crates/rimap-server/tests/e2e_wire.rs
+git commit -m "$(cat <<'EOF'
+fix(rimap-server): run TOOL_DEFS check before refine_tool_name
+
+call_tool refined the tool name before checking TOOL_DEFS, but
+sub-capability variants (SearchAdvanced, FetchMessageHtml) are
+intentionally absent from TOOL_DEFS — they share the parent's
+schema. The check therefore short-circuited every refined call with
+RESOURCE_NOT_FOUND, bypassing DispatchGuard::pre_dispatch and the
+posture matrix. Reorder the check to run on the parsed (parent)
+name, then refine.
+
+Adds wire-level regression coverage: readonly.search +
+advanced_query must now return PostureDenied (-32001), not
+RESOURCE_NOT_FOUND (-32002).
+
+This is a prerequisite for the content-oracle search fields landing
+in subsequent commits — body/text/bcc/non-empty-headers refine to
+SearchAdvanced and depend on the same dispatch path being live.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Extend `refine_tool_name` predicate (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/tool_name.rs`
+
+- [ ] **Step 4.1: Write the failing posture refinement tests**
+
+Append the following test functions inside the existing `#[cfg(test)] mod tests` block at `crates/rimap-server/src/mcp/tool_name.rs:125-303`, immediately before the closing `}` of the module.
+
+```rust
+    #[test]
+    fn refine_tool_name_promotes_search_on_body() {
+        let mut args = serde_json::Map::new();
+        args.insert("body".into(), serde_json::Value::String("hello".into()));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_text() {
+        let mut args = serde_json::Map::new();
+        args.insert("text".into(), serde_json::Value::String("anywhere".into()));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_bcc() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "bcc".into(),
+            serde_json::Value::String("blind@example.com".into()),
+        );
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_promotes_search_on_non_empty_headers() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "headers".into(),
+            serde_json::json!([{"name": "List-Id", "value": "rust"}]),
+        );
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::SearchAdvanced,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_does_not_promote_on_empty_headers_array() {
+        let mut args = serde_json::Map::new();
+        args.insert("headers".into(), serde_json::json!([]));
+        assert_eq!(
+            refine_tool_name(ToolName::Search, Some(&args)),
+            ToolName::Search,
+        );
+    }
+
+    #[test]
+    fn refine_tool_name_does_not_promote_on_envelope_or_flag_fields() {
+        // cc/larger/sent_since/answered are NOT content-oracle inputs;
+        // they ride the existing low-posture Search seat.
+        for field in ["cc", "larger", "sent_since", "answered"] {
+            let mut args = serde_json::Map::new();
+            args.insert(field.into(), serde_json::json!("payload"));
+            assert_eq!(
+                refine_tool_name(ToolName::Search, Some(&args)),
+                ToolName::Search,
+                "{field} unexpectedly promoted",
+            );
+        }
+    }
+```
+
+- [ ] **Step 4.2: Run the tests and confirm they fail**
+
+```bash
+cargo test -p rimap-server --lib refine_tool_name 2>&1 | tail -30
+```
+
+Expected: the four "promotes" assertions fail (the predicate currently only triggers on `advanced_query`), the two "does not promote" assertions pass.
+
+- [ ] **Step 4.3: Extend the predicate**
+
+Replace the `ToolName::Search` arm of the match in `refine_tool_name` (at `crates/rimap-server/src/mcp/tool_name.rs:50`):
+
+```rust
+        ToolName::Search if args.get("advanced_query").is_some() => ToolName::SearchAdvanced,
+```
+
+with the multi-condition form below. Keep the rest of the match unchanged.
+
+```rust
+        ToolName::Search if promotes_search_to_advanced(args) => ToolName::SearchAdvanced,
+```
+
+Then insert the helper just below `refine_tool_name` (after the closing `}` at line 76, before `is_bare_simple_tool_name`):
+
+```rust
+/// Whether the `search` argument shape forces promotion to
+/// `SearchAdvanced`. Triggers on any content-oracle input:
+/// `advanced_query`, `body`, `text`, `bcc`, or a non-empty `headers`
+/// array. Envelope/flag fields (`cc`, `larger`, `sent_*`, `answered`,
+/// `flagged`, `draft`) do NOT promote — they map to IMAP-indexed
+/// metadata, not content scans, and stay under the low-posture
+/// `Search` seat.
+fn promotes_search_to_advanced(args: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if args.get("advanced_query").is_some()
+        || args.get("body").is_some()
+        || args.get("text").is_some()
+        || args.get("bcc").is_some()
+    {
+        return true;
+    }
+    // headers triggers only when present AND non-empty.
+    matches!(
+        args.get("headers").and_then(serde_json::Value::as_array),
+        Some(arr) if !arr.is_empty(),
+    )
+}
+```
+
+Note: `matches!` is normally avoided per the global Rust style guide, but the global rule says "explicit destructuring catches field changes" — for a single-shape JSON array check there is no struct to destructure. The arm above is local and well-scoped; if a reviewer prefers `if let Some(arr) = ... { !arr.is_empty() } else { false }`, that's fine too.
+
+- [ ] **Step 4.4: Run the tests and confirm they pass**
+
+```bash
+cargo test -p rimap-server --lib refine_tool_name
+```
+
+Expected: every refinement test passes, including the pre-existing `refine_tool_name_promotes_sub_capabilities` and `refine_tool_name_is_identity_for_all_other_variants`.
+
+- [ ] **Step 4.5: Lint**
+
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/tool_name.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): promote Search to SearchAdvanced on content-oracle args
+
+Extend refine_tool_name so body, text, bcc, or non-empty headers
+trigger the same Search -> SearchAdvanced promotion that advanced_query
+already does. DispatchGuard then denies these under Readonly/DraftSafe
+via the existing posture matrix — no new gating layer.
+
+Envelope/flag fields (cc, larger, sent_*, answered, flagged, draft)
+keep the low-posture Search seat: they map to IMAP-indexed metadata,
+not content scans.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Extend `SearchInput` + add `HeaderInput` (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs:27-51`
+
+Shape-only change. `build_query` threading happens in Task 6; the file will still compile after this task because the new fields are unused (allowed by Rust on plain struct fields).
+
+- [ ] **Step 5.1: Add the `HeaderInput` sibling type**
+
+Insert immediately before `SearchInput` (currently at `crates/rimap-server/src/tools/retrieval/search.rs:27`):
+
+```rust
+/// One `HEADER name value` filter for the `search` tool. Converted to
+/// [`rimap_imap::types::HeaderSearch`] in `build_query`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HeaderInput {
+    /// RFC 5322 field name (e.g. `"List-Id"`).
+    pub name: String,
+    /// Substring to match within the header value.
+    pub value: String,
+}
+```
+
+- [ ] **Step 5.2: Extend `SearchInput`**
+
+Replace the existing `SearchInput` struct definition (at `crates/rimap-server/src/tools/retrieval/search.rs:27-51`) with the extended version below. Append the new fields after the existing ones; keep `advanced_query`, `limit`, `offset` last.
+
+```rust
+/// Input for the `search` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchInput {
+    /// IMAP folder to search in.
+    pub folder: String,
+    /// Filter by `From` header substring.
+    pub from: Option<String>,
+    /// Filter by `To` header substring.
+    pub to: Option<String>,
+    /// Filter by `Cc` header substring.
+    pub cc: Option<String>,
+    /// Filter by `Bcc` header substring. Content-oracle — requires
+    /// `SearchAdvanced` posture (Full or Destructive).
+    pub bcc: Option<String>,
+    /// Filter by `Subject` header substring.
+    pub subject: Option<String>,
+    /// Substring search across body parts. Content-oracle — requires
+    /// `SearchAdvanced` posture.
+    pub body: Option<String>,
+    /// Substring search across headers OR body. Content-oracle —
+    /// requires `SearchAdvanced` posture.
+    pub text: Option<String>,
+    /// One or more `HEADER name value` filters. Content-oracle when
+    /// non-empty — requires `SearchAdvanced` posture.
+    pub headers: Option<Vec<HeaderInput>>,
+    /// Match messages strictly larger than this many octets.
+    pub larger: Option<u64>,
+    /// Match messages strictly smaller than this many octets.
+    pub smaller: Option<u64>,
+    /// Messages since this ISO date (inclusive) by INTERNALDATE,
+    /// e.g. "2026-01-01".
+    pub since: Option<String>,
+    /// Messages before this ISO date (exclusive) by INTERNALDATE.
+    pub before: Option<String>,
+    /// Messages since this ISO date (inclusive) by the message's
+    /// `Date:` header — distinct from `since` which uses INTERNALDATE.
+    pub sent_since: Option<String>,
+    /// Messages before this ISO date (exclusive) by the message's
+    /// `Date:` header — distinct from `before` which uses INTERNALDATE.
+    pub sent_before: Option<String>,
+    /// Filter by seen/unseen status.
+    pub seen: Option<bool>,
+    /// Filter by answered/unanswered status.
+    pub answered: Option<bool>,
+    /// Filter by flagged/unflagged status.
+    pub flagged: Option<bool>,
+    /// Filter by draft/non-draft status.
+    pub draft: Option<bool>,
+    /// Filter for messages with attachments.
+    pub has_attachment: Option<bool>,
+    /// Raw IMAP SEARCH query (full posture only).
+    pub advanced_query: Option<String>,
+    /// Max results to return (default 100, max 100).
+    pub limit: Option<usize>,
+    /// Offset into the result set (default 0).
+    pub offset: Option<usize>,
+}
+```
+
+- [ ] **Step 5.3: Confirm the crate still compiles**
+
+```bash
+cargo check -p rimap-server --all-targets
+```
+
+Expected: compiles clean. (New fields are unused but Rust does not warn on unread struct fields when the struct is `pub` and used externally.)
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/search.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): extend SearchInput with new search filter fields
+
+Add cc, bcc, body, text, headers (Vec<HeaderInput>), larger, smaller,
+sent_since, sent_before, answered, flagged, draft to SearchInput.
+Add HeaderInput sibling type with schemars/serde derives.
+
+Shape-only change — build_query threading and empty-string rejection
+land in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Thread new inputs through `build_query` + empty-string rejection (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs` (extend `build_query` at line 163; add unit tests in the existing `#[cfg(test)] mod tests` block)
+
+- [ ] **Step 6.0: Add a module-level clippy exemption to the test module**
+
+The existing `crates/rimap-server/src/tools/retrieval/search.rs` test module (at lines 313-364) has no clippy attributes — its current tests only use `assert!` / `assert_eq!`. The new tests in Steps 6.1 and 7.1 use `unwrap`, `expect`, and `panic!`, which the workspace lints (`unwrap_used = "deny"`, `panic = "deny"`, `expect_used = "warn"` → fatal under `-D warnings`) would reject.
+
+Mirror the pattern already used in `crates/rimap-imap/src/ops/search.rs:108` (`#[expect(clippy::unwrap_used, reason = "tests")]` directly above `mod tests`). Insert above the existing `#[cfg(test)]` at `crates/rimap-server/src/tools/retrieval/search.rs:313`:
+
+```rust
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+```
+
+(Replace the existing `#[cfg(test)]\nmod tests {` with the multi-attribute form above.)
+
+- [ ] **Step 6.1: Write the failing unit tests**
+
+Append the following inside the existing `#[cfg(test)] mod tests` block at `crates/rimap-server/src/tools/retrieval/search.rs:313-364`, immediately before its closing `}`.
+
+```rust
+    use rimap_imap::types::{HeaderSearch, StructuredQuery};
+
+    fn input_with_folder() -> SearchInput {
+        SearchInput {
+            folder: "INBOX".to_string(),
+            from: None,
+            to: None,
+            cc: None,
+            bcc: None,
+            subject: None,
+            body: None,
+            text: None,
+            headers: None,
+            larger: None,
+            smaller: None,
+            since: None,
+            before: None,
+            sent_since: None,
+            sent_before: None,
+            seen: None,
+            answered: None,
+            flagged: None,
+            draft: None,
+            has_attachment: None,
+            advanced_query: None,
+            limit: None,
+            offset: None,
+        }
+    }
+
+    fn build(input: &SearchInput) -> Result<rimap_imap::types::SearchQuery, rimap_core::RimapError> {
+        // build_query's `_account` parameter is unused; pass a zero-sized
+        // placeholder via an unsafe-free workaround would require
+        // touching AccountState plumbing. Easier: call build_query
+        // through a thin local wrapper that pretends to have an account.
+        // Since `_account: &AccountState` is unused in the body, we
+        // construct a minimal AccountState only if absolutely required.
+        // For these tests we exercise build_query indirectly via the
+        // pure validation paths exposed below; if that proves awkward,
+        // extract the validation into a free helper and test that
+        // directly.
+        let _ = input;
+        unimplemented!("see Step 6.2 — wire to build_query once it accepts &SearchInput only")
+    }
+
+    #[test]
+    fn build_query_rejects_empty_cc() {
+        let mut input = input_with_folder();
+        input.cc = Some(String::new());
+        let err = build(&input).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("cc"),
+            "expected cc-empty error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_cc() {
+        let mut input = input_with_folder();
+        input.cc = Some("   ".to_string());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_bcc() {
+        let mut input = input_with_folder();
+        input.bcc = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_body() {
+        let mut input = input_with_folder();
+        input.body = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_body() {
+        let mut input = input_with_folder();
+        input.body = Some("\t ".to_string());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_text() {
+        let mut input = input_with_folder();
+        input.text = Some(String::new());
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_header_name() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: String::new(),
+            value: "x".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_header_name() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "   ".to_string(),
+            value: "x".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_empty_header_value() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: String::new(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_rejects_whitespace_header_value() {
+        let mut input = input_with_folder();
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: "  ".to_string(),
+        }]);
+        assert!(build(&input).is_err());
+    }
+
+    #[test]
+    fn build_query_accepts_empty_headers_array_as_no_filter() {
+        let mut input = input_with_folder();
+        input.headers = Some(Vec::new());
+        let q = build(&input).expect("empty headers vec is accepted");
+        match q {
+            rimap_imap::types::SearchQuery::Structured(s) => {
+                assert!(s.headers.is_none(), "headers should be normalized to None");
+            }
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        }
+    }
+
+    #[test]
+    fn build_query_threads_cc_into_structured_query() {
+        let mut input = input_with_folder();
+        input.cc = Some("alice@example.com".to_string());
+        let q = build(&input).unwrap();
+        match q {
+            rimap_imap::types::SearchQuery::Structured(s) => {
+                assert_eq!(s.cc.as_deref(), Some("alice@example.com"));
+            }
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        }
+    }
+
+    #[test]
+    fn build_query_threads_all_new_fields_into_structured_query() {
+        let mut input = input_with_folder();
+        input.cc = Some("c@example.com".to_string());
+        input.bcc = Some("b@example.com".to_string());
+        input.body = Some("hi".to_string());
+        input.text = Some("anywhere".to_string());
+        input.headers = Some(vec![HeaderInput {
+            name: "List-Id".to_string(),
+            value: "rust".to_string(),
+        }]);
+        input.larger = Some(1024);
+        input.smaller = Some(2_048_000);
+        input.sent_since = Some("2026-01-01".to_string());
+        input.sent_before = Some("2026-02-01".to_string());
+        input.answered = Some(true);
+        input.flagged = Some(false);
+        input.draft = Some(true);
+        let q = build(&input).unwrap();
+        let s: StructuredQuery = match q {
+            rimap_imap::types::SearchQuery::Structured(s) => s,
+            rimap_imap::types::SearchQuery::Raw(r) => panic!("unexpected raw: {r}"),
+        };
+        assert_eq!(s.cc.as_deref(), Some("c@example.com"));
+        assert_eq!(s.bcc.as_deref(), Some("b@example.com"));
+        assert_eq!(s.body.as_deref(), Some("hi"));
+        assert_eq!(s.text.as_deref(), Some("anywhere"));
+        let hs = s.headers.expect("headers");
+        assert_eq!(hs.len(), 1);
+        assert_eq!(hs[0], HeaderSearch { name: "List-Id".to_string(), value: "rust".to_string() });
+        assert_eq!(s.larger, Some(1024));
+        assert_eq!(s.smaller, Some(2_048_000));
+        assert_eq!(
+            s.sent_since,
+            Some(::time::Date::from_calendar_date(2026, ::time::Month::January, 1).unwrap()),
+        );
+        assert_eq!(
+            s.sent_before,
+            Some(::time::Date::from_calendar_date(2026, ::time::Month::February, 1).unwrap()),
+        );
+        assert_eq!(s.answered, Some(true));
+        assert_eq!(s.flagged, Some(false));
+        assert_eq!(s.draft, Some(true));
+    }
+```
+
+The tests reference a `build(&input)` helper that does not exist yet, and the `_account: &AccountState` parameter on `build_query` blocks direct testing. Step 6.2 refactors `build_query` to remove that block.
+
+- [ ] **Step 6.2: Refactor `build_query` to drop the unused `_account` parameter**
+
+Confirm `_account` is currently unused by reading `crates/rimap-server/src/tools/retrieval/search.rs:163-188` — it is, the parameter is prefixed `_`. Change the signature so the tests can call it directly.
+
+At `crates/rimap-server/src/tools/retrieval/search.rs:163-188`, replace:
+
+```rust
+fn build_query(
+    _account: &AccountState,
+    input: &SearchInput,
+) -> Result<SearchQuery, rimap_core::RimapError> {
+```
+
+with:
+
+```rust
+fn build_query(input: &SearchInput) -> Result<SearchQuery, rimap_core::RimapError> {
+```
+
+Then update the single caller in `handle()` (at `crates/rimap-server/src/tools/retrieval/search.rs:119`):
+
+```rust
+    let query = build_query(account, &input)?;
+```
+
+becomes:
+
+```rust
+    let query = build_query(&input)?;
+```
+
+- [ ] **Step 6.3: Update the test `build` helper to call `build_query` directly**
+
+In the new test code from Step 6.1, replace the `build` function with a one-liner:
+
+```rust
+    fn build(input: &SearchInput) -> Result<rimap_imap::types::SearchQuery, rimap_core::RimapError> {
+        super::build_query(input)
+    }
+```
+
+- [ ] **Step 6.4: Run the tests and confirm they fail**
+
+```bash
+cargo test -p rimap-server --lib search 2>&1 | tail -40
+```
+
+Expected: every new test fails (the existing `build_query` still ignores the new fields and has no empty-string rejection).
+
+- [ ] **Step 6.5: Extend `build_query`**
+
+Replace the entire body of `build_query` (the version with the signature now from Step 6.2) with:
+
+```rust
+fn build_query(input: &SearchInput) -> Result<SearchQuery, rimap_core::RimapError> {
+    if let Some(raw) = &input.advanced_query {
+        if raw.bytes().any(|b| b == b'\r' || b == b'\n' || b == b'\0') {
+            return Err(rimap_core::RimapError::invalid_input(
+                "advanced_query contains forbidden control bytes",
+            ));
+        }
+        return Ok(SearchQuery::Raw(raw.clone()));
+    }
+
+    // Reject empty/whitespace-only string filters at the MCP boundary —
+    // the IMAP server happily executes broad scans like `BODY ""` and
+    // the existing quote() only blocks CR/LF/NUL.
+    let cc = require_non_empty("cc", input.cc.as_deref())?;
+    let bcc = require_non_empty("bcc", input.bcc.as_deref())?;
+    let body = require_non_empty("body", input.body.as_deref())?;
+    let text = require_non_empty("text", input.text.as_deref())?;
+
+    // Empty headers vec carries no filter intent — normalize to None
+    // so the emitter does not have to special-case it.
+    let headers = match &input.headers {
+        Some(v) if v.is_empty() => None,
+        Some(v) => {
+            let mut converted = Vec::with_capacity(v.len());
+            for h in v {
+                if h.name.trim().is_empty() {
+                    return Err(rimap_core::RimapError::invalid_input(
+                        "headers[].name must not be empty or whitespace-only",
+                    ));
+                }
+                if h.value.trim().is_empty() {
+                    return Err(rimap_core::RimapError::invalid_input(
+                        "headers[].value must not be empty or whitespace-only",
+                    ));
+                }
+                converted.push(rimap_imap::types::HeaderSearch {
+                    name: h.name.clone(),
+                    value: h.value.clone(),
+                });
+            }
+            Some(converted)
+        }
+        None => None,
+    };
+
+    let since = input.since.as_deref().map(parse_iso_date).transpose()?;
+    let before = input.before.as_deref().map(parse_iso_date).transpose()?;
+    let sent_since = input.sent_since.as_deref().map(parse_iso_date).transpose()?;
+    let sent_before = input.sent_before.as_deref().map(parse_iso_date).transpose()?;
+
+    Ok(SearchQuery::Structured(StructuredQuery {
+        from: input.from.clone(),
+        to: input.to.clone(),
+        subject: input.subject.clone(),
+        since,
+        before,
+        seen: input.seen,
+        has_attachment: input.has_attachment.unwrap_or(false),
+        cc,
+        bcc,
+        body,
+        text,
+        headers,
+        larger: input.larger,
+        smaller: input.smaller,
+        sent_since,
+        sent_before,
+        answered: input.answered,
+        flagged: input.flagged,
+        draft: input.draft,
+    }))
+}
+
+/// Reject empty/whitespace-only string filters. Returns `Ok(None)` for
+/// `None`, `Ok(Some(s.to_string()))` for a non-trimmed-empty value, and
+/// `Err(RimapError::invalid_input)` otherwise. The `field` label flows
+/// straight into the error message.
+fn require_non_empty(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<String>, rimap_core::RimapError> {
+    let Some(s) = value else {
+        return Ok(None);
+    };
+    if s.trim().is_empty() {
+        return Err(rimap_core::RimapError::invalid_input(format!(
+            "{field} must not be empty or whitespace-only"
+        )));
+    }
+    Ok(Some(s.to_string()))
+}
+```
+
+The header loop inlines its own trim check rather than calling `require_non_empty`, because `require_non_empty` returns `Result<Option<String>, _>` and unwrapping the inner `Option` after a known-Some input would need `.expect(...)`, which trips `clippy::expect_used = "warn"` in non-test code. Inline trim checks keep the helper signature clean and avoid the lint.
+
+- [ ] **Step 6.6: Run the tests and confirm they pass**
+
+```bash
+cargo test -p rimap-server --lib search
+```
+
+Expected: every test passes, including all new rejection / threading tests and the pre-existing sanitize tests.
+
+- [ ] **Step 6.7: Lint**
+
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/search.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): thread new search fields through build_query
+
+Pass cc, bcc, body, text, headers (with empty-array -> None
+normalization), larger, smaller, sent_since, sent_before, answered,
+flagged, draft into the StructuredQuery built for each search call.
+Reject empty/whitespace-only string filters with
+RimapError::invalid_input at the MCP boundary.
+
+Drop the unused _account parameter from build_query so the validation
+logic is unit-testable without an AccountState fixture.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add `cc` to `SearchResultEntry` + populate from envelope
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs:54-80,259-311`
+
+- [ ] **Step 7.1: Write the failing output tests**
+
+Append inside the existing `#[cfg(test)] mod tests` block at `crates/rimap-server/src/tools/retrieval/search.rs`:
+
+```rust
+    use rimap_imap::types::{Address, Envelope, FetchedMessage};
+
+    fn addr(name: &str, mailbox: &str, host: &str) -> Address {
+        Address {
+            name: if name.is_empty() { None } else { Some(name.as_bytes().to_vec()) },
+            adl: None,
+            mailbox: Some(mailbox.as_bytes().to_vec()),
+            host: Some(host.as_bytes().to_vec()),
+        }
+    }
+
+    fn fetched_with_envelope(env: Envelope) -> FetchedMessage {
+        FetchedMessage {
+            uid: rimap_imap::types::tests::uid(42),
+            envelope: Some(env),
+            bodystructure: None,
+            flags: None,
+            size: None,
+        }
+    }
+
+    #[test]
+    fn format_search_result_populates_cc_from_envelope() {
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![addr("Carol", "carol", "example.com")],
+            bcc: vec![],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        assert_eq!(entry.cc, vec!["Carol <carol@example.com>"]);
+    }
+
+    #[test]
+    fn format_search_result_returns_empty_cc_when_envelope_omits_it() {
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![],
+            bcc: vec![],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        assert!(entry.cc.is_empty());
+
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("\"cc\""),
+            "empty cc must be skipped on serialize; got {json}",
+        );
+    }
+
+    #[test]
+    fn format_search_result_never_emits_bcc_even_when_envelope_has_it() {
+        // Privacy boundary: bcc must NOT appear in SearchResultEntry in
+        // any posture. format_search_result must ignore env.bcc.
+        let env = Envelope {
+            date: None,
+            subject_raw: None,
+            from: vec![],
+            sender: vec![],
+            reply_to: vec![],
+            to: vec![],
+            cc: vec![],
+            bcc: vec![addr("Blind", "blind", "example.com")],
+            in_reply_to: None,
+            message_id: None,
+        };
+        let entry = format_search_result(&fetched_with_envelope(env));
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("bcc"),
+            "bcc key must not appear in serialized SearchResultEntry; got {json}",
+        );
+        assert!(
+            !json.contains("blind@example.com"),
+            "bcc address must not leak via any other field; got {json}",
+        );
+    }
+```
+
+The first two tests fail to compile (no `cc` field on `SearchResultEntry`); the third compiles only after the first two are addressed.
+
+Note: `rimap_imap::types::tests::uid` is the test-only constructor exposed at `crates/rimap-imap/src/types.rs:557-559`; it is `pub(crate)` inside `mod tests`, which is `pub(crate) mod`. To use it from `rimap-server` tests it must either be exposed under a `test-support` feature or rebuilt locally. Check accessibility with:
+
+```bash
+grep -n "pub(crate) mod tests\|pub mod tests\|pub fn uid" /Users/dave/src/rusty-imap-mcp/crates/rimap-imap/src/types.rs
+```
+
+If `pub(crate) mod tests` keeps `uid` inside the crate, rebuild it locally in the test module (no feature flag needed). The test module already has `#[cfg(test)]` so `expect` is allowed:
+
+```rust
+    #[expect(clippy::expect_used, reason = "tests")]
+    fn uid(n: u32) -> rimap_imap::types::Uid {
+        use std::num::NonZeroU32;
+        rimap_imap::types::Uid::from(NonZeroU32::new(n).expect("non-zero"))
+    }
+```
+
+Then call `uid(42)` instead of `rimap_imap::types::tests::uid(42)`. If the surrounding test module is already wrapped in `#[expect(clippy::expect_used, reason = "tests")]` at the `mod` level, drop the per-item attribute.
+
+- [ ] **Step 7.2: Run and confirm failure**
+
+```bash
+cargo test -p rimap-server --lib search 2>&1 | tail -30
+```
+
+Expected: compile error on missing `cc` field on `SearchResultEntry`.
+
+- [ ] **Step 7.3: Add the `cc` field to `SearchResultEntry`**
+
+In the `SearchResultEntry` struct (at `crates/rimap-server/src/tools/retrieval/search.rs:54-80`), insert immediately after the `to` field (currently at lines 75-76):
+
+```rust
+    /// Cc addresses, sanitized. Omitted when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
+```
+
+- [ ] **Step 7.4: Populate `cc` in `format_search_result`**
+
+In `format_search_result` (at `crates/rimap-server/src/tools/retrieval/search.rs:259-311`), update the envelope destructuring tuple to include `cc`. The current pattern is `(subject, date, from, to, message_id)`; extend to `(subject, date, from, to, cc, message_id)`.
+
+Replace the `let (subject, date, from, to, message_id) = ...` block with:
+
+```rust
+    let (subject, date, from, to, cc, message_id) = if let Some(env) = &msg.envelope {
+        let subject = env.subject_raw.as_ref().map(|s| {
+            let raw = String::from_utf8_lossy(s);
+            sanitize_for_output(&raw)
+        });
+        let date = env.date.as_ref().map(|d| {
+            let raw = String::from_utf8_lossy(d);
+            sanitize_for_output(&raw)
+        });
+        let from = if env.from.is_empty() {
+            Vec::new()
+        } else {
+            format_addresses(&env.from)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect()
+        };
+        let to = if env.to.is_empty() {
+            Vec::new()
+        } else {
+            format_addresses(&env.to)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect()
+        };
+        let cc = if env.cc.is_empty() {
+            Vec::new()
+        } else {
+            format_addresses(&env.cc)
+                .into_iter()
+                .map(|a| sanitize_for_output(&a))
+                .collect()
+        };
+        let message_id = env.message_id.as_ref().map(|mid| {
+            let raw = String::from_utf8_lossy(mid.as_bytes());
+            sanitize_for_output(&raw)
+        });
+        (subject, date, from, to, cc, message_id)
+    } else {
+        (None, None, Vec::new(), Vec::new(), Vec::new(), None)
+    };
+```
+
+And update the `SearchResultEntry` constructor at the bottom of `format_search_result`:
+
+```rust
+    SearchResultEntry {
+        uid: msg.uid.get(),
+        size,
+        flags,
+        subject,
+        date,
+        from,
+        to,
+        cc,
+        message_id,
+    }
+```
+
+`env.bcc` is intentionally not read — see the spec's *Privacy* subsection.
+
+- [ ] **Step 7.5: Run the tests and confirm they pass**
+
+```bash
+cargo test -p rimap-server --lib search
+```
+
+Expected: every test passes.
+
+- [ ] **Step 7.6: Lint**
+
+```bash
+cargo clippy -p rimap-server --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/search.rs
+git commit -m "$(cat <<'EOF'
+feat(rimap-server): add cc to SearchResultEntry (bcc intentionally not)
+
+Populate SearchResultEntry.cc from env.cc using the same
+sanitize_for_output pipeline as from/to. env.bcc is intentionally not
+read — privacy boundary documented in the spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Regenerate the tool-schema fixture
+
+**Files:**
+- Regenerate: `crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json` (and any sibling files the regen script touches).
+
+This is mechanical — the script in `scripts/regen-tool-schemas.sh` rebuilds every fixture from the live Rust types.
+
+- [ ] **Step 8.1: Run the regen script**
+
+```bash
+./scripts/regen-tool-schemas.sh
+```
+
+Expected: script exits 0; `git diff --stat crates/rimap-server/tests/fixtures/rimap-tool-schemas/` shows changes to at least `search.schema.json`.
+
+- [ ] **Step 8.2: Sanity-check the diff**
+
+```bash
+git --no-pager diff crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json | head -120
+```
+
+Expected (manual checklist):
+- New properties in the input schema: `cc`, `bcc`, `body`, `text`, `headers`, `larger`, `smaller`, `sent_since`, `sent_before`, `answered`, `flagged`, `draft`.
+- New `$defs/HeaderInput` block with `name` and `value` properties.
+- New property `cc` on `SearchResultEntry`.
+- NO new `bcc` property on `SearchResultEntry` — privacy boundary.
+
+If `bcc` appears on `SearchResultEntry`, STOP — return to Task 7 and remove the leak before continuing.
+
+- [ ] **Step 8.3: Run the dump-tool-catalog smoke test**
+
+```bash
+cargo test -p rimap-server --test dump_tool_catalog
+```
+
+Expected: passes. (This test only counts tool defs and verifies `inputSchema.type == "object"`; it does not diff against the fixture, but a compilation failure in `dump-tool-schemas` would surface here.)
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+git commit -m "$(cat <<'EOF'
+chore(rimap-server): regen search.schema.json for expanded fields
+
+Picks up the new SearchInput fields (cc, bcc, body, text, headers,
+larger, smaller, sent_since, sent_before, answered, flagged, draft)
+and the new SearchResultEntry.cc output field. bcc remains absent
+from SearchResultEntry by design.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: E2E wire test — `cc` filter against Dovecot
+
+**Files:**
+- Modify: `crates/rimap-server/tests/e2e_wire.rs:284-306` (extend `assert_search`).
+
+The existing `wire_e2e_full_session_draft_safe` test seeds one message, runs `search` with `subject: "e2e-wire-test-smoke"`, and asserts a hit. Extend it with a second call that filters by `cc` and asserts the same hit (or a deliberate non-hit) plus the new `cc` output field.
+
+- [ ] **Step 9.1: Inspect the seed message's CC address**
+
+```bash
+grep -n "Cc:\|cc:\|multipart_with_attachment\|fn multipart" /Users/dave/src/rusty-imap-mcp/crates/rimap-server/tests/support/dovecot/fixtures.rs
+```
+
+If the seed message has no `Cc:` header, add one in the seed fixture OR pick a CC filter that the existing message satisfies. The intent of this step is to identify a CC value that the seeded message already has — adjust the test to that value rather than mutate the fixture (smaller blast radius).
+
+If no CC is present in the seed, the test's `cc` assertion should target the negative case: `cc: "noone@example.com"` returns `total_matched == 0`. That still exercises the wire-format path for the new field.
+
+- [ ] **Step 9.2: Extend `assert_search`**
+
+Append the following at the end of `assert_search` (just before the `uid` return at `crates/rimap-server/tests/e2e_wire.rs:305`).
+
+```rust
+    // Exercise the new `cc` input field. The seeded message has no
+    // Cc header (verified in Step 9.1), so this asserts that the
+    // wire path round-trips the new field and the IMAP server
+    // honors the `CC` SEARCH key (returning zero matches).
+    let cc_body = call_tool(
+        harness,
+        "draftsafe.search",
+        json!({ "folder": "INBOX", "cc": "noone@example.com" }),
+    )
+    .await;
+    assert_eq!(
+        cc_body["meta"]["total_matched"].as_u64(),
+        Some(0),
+        "cc filter against unseeded address must yield zero hits: {cc_body}",
+    );
+```
+
+If Step 9.1 shows the seed actually has a `Cc:` header (the spec only mentions CC adoption on output and the existing fixture may already include a recipient), adapt the assertion to match the seeded CC value and assert `total_matched >= 1` plus that the first result entry's `cc` array contains the seeded address.
+
+- [ ] **Step 9.3: Run the test**
+
+```bash
+cargo test -p rimap-server --test e2e_wire wire_e2e_full_session_draft_safe -- --nocapture 2>&1 | tail -40
+```
+
+Expected: passes if Docker is available. If Docker is unavailable, the test silently skips — set `RIMAP_REQUIRE_DOCKER=1` to make the skip loud while iterating locally.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add crates/rimap-server/tests/e2e_wire.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): e2e wire-format check for cc search filter
+
+Extend assert_search to issue a second search with the new `cc` field
+against the seeded message and assert the IMAP server honors it.
+Locks in the wire-shape round-trip for the new field.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: E2E wire test — `body` under Readonly returns PostureDenied
+
+**Files:**
+- Modify: `crates/rimap-server/tests/e2e_wire.rs:627-649` (extend `assert_readonly_denial`).
+
+The existing `wire_e2e_readonly_posture_denial` test verifies `move_message` is denied. Extend it to also verify `search` with `body` is denied — exercising the new `refine_tool_name` promotion path end-to-end.
+
+- [ ] **Step 10.1: Extend `assert_readonly_denial`**
+
+Append at the end of `assert_readonly_denial` (at `crates/rimap-server/tests/e2e_wire.rs:627-649`):
+
+```rust
+    // The new `body` input is a content-oracle; refine_tool_name
+    // promotes Search -> SearchAdvanced, which the posture matrix
+    // denies under Readonly. Pin the wire error to the posture-denial
+    // code so silent drift in refinement OR the matrix surfaces here.
+    let body_denial = harness
+        .request(
+            "tools/call",
+            json!({
+                "name": "readonly.search",
+                "arguments": {"folder": "INBOX", "body": "hello"},
+            }),
+        )
+        .await;
+    assert!(
+        body_denial["error"].is_object(),
+        "expected error envelope for readonly.search body, got {body_denial}",
+    );
+    assert_eq!(
+        body_denial["error"]["code"].as_i64(),
+        Some(POSTURE_DENIAL_CODE),
+        "readonly.search body must be posture-denied; got {body_denial}",
+    );
+```
+
+- [ ] **Step 10.2: Consider the audit-record assertions**
+
+`assert_readonly_audit_records` (at `crates/rimap-server/tests/e2e_wire.rs:652-717`) counts `move_message` audit pairs. The new `search` denial will produce an additional pair under `tool=search`. Either:
+
+(a) Add a third block to `assert_readonly_audit_records` that asserts exactly one `tool=search` start/end pair with `account=readonly`, mirroring the `move_message` block, OR
+
+(b) Leave the audit assertions as-is (they only count `move_message` records and never assert "no other records present"; adding another tool call does not break them).
+
+Pick (a) — the audit-record block is the strongest cross-check that posture denial flows through the audit writer with the right account scoping. The version below mirrors the existing `move_message` block exactly.
+
+Append at the end of `assert_readonly_audit_records`:
+
+```rust
+    // Denial path: search pair, account="readonly".
+    let s_starts: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_start" && r["tool"] == "search")
+        .collect();
+    assert_eq!(s_starts.len(), 1, "expected exactly one search tool_start");
+    assert_eq!(
+        s_starts[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_start must record account=\"readonly\": {records:#?}",
+    );
+    let s_ends: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["kind"] == "tool_end" && r["tool"] == "search")
+        .collect();
+    assert_eq!(s_ends.len(), 1, "expected exactly one search tool_end");
+    assert_eq!(
+        s_ends[0]["account"].as_str(),
+        Some("readonly"),
+        "readonly.search tool_end must record account=\"readonly\": {records:#?}",
+    );
+    assert_eq!(s_ends[0]["start_seq"], s_starts[0]["seq"]);
+```
+
+If the audit records use a different `tool` value for refined sub-capabilities (e.g. `tool=search_advanced` after refinement), update the filter accordingly. Verify by running the test once and inspecting the audit JSONL:
+
+```bash
+RIMAP_REQUIRE_DOCKER=1 cargo test -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial -- --nocapture 2>&1 | grep -E '"tool":|"kind":' | head -20
+```
+
+If the `tool` field reads `search_advanced` instead of `search`, change both `r["tool"] == "search"` strings above to `r["tool"] == "search_advanced"`.
+
+- [ ] **Step 10.3: Run the test**
+
+```bash
+cargo test -p rimap-server --test e2e_wire wire_e2e_readonly_posture_denial 2>&1 | tail -40
+```
+
+Expected: passes when Docker is available.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add crates/rimap-server/tests/e2e_wire.rs
+git commit -m "$(cat <<'EOF'
+test(rimap-server): e2e posture denial for body search under Readonly
+
+Pin the wire-format error envelope for `readonly.search` with `body`:
+refine_tool_name promotes to SearchAdvanced, DispatchGuard denies under
+Readonly, and the audit writer records the matching tool_start/tool_end
+pair scoped to account=readonly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Full-workspace verification
+
+- [ ] **Step 11.1: Run the full workspace test suite**
+
+```bash
+cargo test --workspace --all-features --locked
+```
+
+Expected: all tests pass. Docker-gated tests silently skip if Docker is unavailable; that's fine for local iteration but a Linux CI run should hit them.
+
+- [ ] **Step 11.2: Run the full workspace clippy**
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 11.3: Confirm formatting**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no diff. Run `cargo fmt --all` to auto-fix if there's drift.
+
+- [ ] **Step 11.4: Run `cargo deny`**
+
+```bash
+cargo deny check
+```
+
+Expected: no advisories, license, or ban violations. This is part of the pre-push hook, so it must pass before the push step.
+
+- [ ] **Step 11.5: Verify the commit history**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: ten new commits on top of `32facf9`:
+1. Task 1 commit (rimap-imap types)
+2. Task 2 commit (rimap-imap emitter)
+3. Task 3 commit (sub-capability dispatch order fix + advanced_query regression test)
+4. Task 4 commit (refine_tool_name)
+5. Task 5 commit (SearchInput shape)
+6. Task 6 commit (build_query threading + validation)
+7. Task 7 commit (SearchResultEntry.cc)
+8. Task 8 commit (schema regen)
+9. Task 9 commit (e2e cc)
+10. Task 10 commit (e2e body posture denial)
+
+(The two earlier commits — `2ffa9a0` spec and `32facf9` spec revision — remain in place at the base of the feature.)
+
+- [ ] **Step 11.6: Push to origin and open the PR**
+
+This step is interactive — confirm with the user before running.
+
+```bash
+git push -u origin feat/expand-search-fields
+```
+
+If the push exits 0 with no ref transferred (the known SSH-idle issue documented in the user's memory), retry once. If a second push silently succeeds without transferring, surface the issue rather than re-trying in a loop.
+
+Then open the PR with:
+
+```bash
+gh pr create --title "Expand searchable email fields in the search tool" --body "$(cat <<'EOF'
+## Summary
+
+- Adds 12 structured SEARCH fields to the `search` MCP tool (`cc`, `bcc`, `body`, `text`, `headers`, `larger`, `smaller`, `sent_since`, `sent_before`, `answered`, `flagged`, `draft`).
+- Content-oracle inputs (`body`, `text`, non-empty `headers`, `bcc`) promote `Search` → `SearchAdvanced` via `refine_tool_name`; existing posture matrix denies them under Readonly/DraftSafe.
+- Adds `cc` to `SearchResultEntry` from the already-fetched envelope. `bcc` is intentionally not exposed on output (privacy boundary documented in the spec).
+- Rejects empty/whitespace-only string filters at the MCP boundary.
+- Fixes a preexisting bug in `call_tool` where refined sub-capability variants (`SearchAdvanced`, `FetchMessageHtml`) were rejected with `RESOURCE_NOT_FOUND` before reaching the posture matrix. The `TOOL_DEFS` lookup now runs on the parsed (parent) name; refinement runs after.
+
+Spec: `docs/superpowers/specs/2026-05-18-expand-search-fields-design.md`.
+
+## Test plan
+
+- [x] `cargo test --workspace --all-features --locked` passes locally.
+- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
+- [x] `cargo fmt --all -- --check` clean.
+- [x] `cargo deny check` clean.
+- [x] `scripts/regen-tool-schemas.sh` produces the committed `search.schema.json`.
+- [x] Docker-gated `wire_e2e_full_session_draft_safe` exercises the new `cc` field; `wire_e2e_readonly_posture_denial` exercises both the `body` and `advanced_query` posture denial paths.
+EOF
+)"
+```
+
+---
+
+## Risks during execution
+
+- **Test-helper visibility for `Uid`.** `rimap_imap::types::tests::uid` is `pub(crate)`; tests outside the crate must reconstruct it locally (Step 7.1 covers this). If a `test-support` feature exists on `rimap-imap`, prefer that over local reconstruction.
+- **`build_query` refactor (Step 6.2).** Dropping the `_account` parameter is a small public-ish API change inside the file; it only has one caller (`handle`) so the blast radius is local. If any other crate imports `build_query`, surface that before changing.
+- **Audit `tool` field for promoted dispatch (Step 10.2).** The audit writer may log either `search` or `search_advanced` after refinement; verify empirically before pinning the test.
+- **Pre-push SSH keepalive (Step 11.6).** Per the user's memory, cold-cache pushes can exit 0 without transferring refs. Verify the ref landed (`git ls-remote origin feat/expand-search-fields`) before claiming the push succeeded.
+- **Docker availability.** E2E tests silently skip without Docker; the value of Tasks 3, 9, and 10 depends on Docker being up at execution time. If Docker is unavailable locally, flag that the e2e signal is missing rather than declaring the task complete. (Task 3's reorder fix can still be reasoned about from the unit-level evidence — see Step 3.2.)
+- **Audit-record counts in `assert_readonly_audit_records`.** Tasks 3 and 10 each add a new `search` denial pair. Task 3 lands first with a strict `== 1` assertion; Task 10 must update both `s_starts.len() == 1` and `s_ends.len() == 1` to `== 2` (or relax to `>= 1`). The plan keeps strict counts so a regression surfaces, but the implementer needs to remember to update Task 3's assertion when Task 10 lands.
+
+---
+
+## Out of scope (do not implement)
+
+- BCC visibility on output in any posture.
+- `DELETED`/`UNDELETED`, `OR`/`NOT`/`KEYWORD`, `OLDER`/`YOUNGER` SEARCH keys.
+- Fuzz/mutation baseline expansion for the new keys (issue #289).
+- Rate limiting or cost accounting for content-oracle searches under SearchAdvanced.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `cc` input — Task 1 (struct), Task 2 (emit), Task 5 (input), Task 6 (thread).
+- `bcc` input + posture promotion — Task 1, Task 2, Task 4 (promote), Task 5, Task 6.
+- `body` input + posture promotion — Task 1, Task 2, Task 4, Task 5, Task 6, Task 10 (e2e denial).
+- `text` input + posture promotion — Task 1, Task 2, Task 4, Task 5, Task 6.
+- `headers` input + posture promotion (non-empty only) — Task 1, Task 2 (with `validate_header_name`), Task 4 (non-empty check), Task 5 (`HeaderInput`), Task 6 (empty-array normalization).
+- `larger`/`smaller` inputs — Task 1, Task 2, Task 5, Task 6.
+- `sent_since`/`sent_before` inputs (ISO date parsing) — Task 1 (`time::Date`), Task 2, Task 5 (`Option<String>`), Task 6 (parse).
+- `answered`/`flagged`/`draft` inputs — Task 1, Task 2, Task 5, Task 6.
+- `cc` on `SearchResultEntry` — Task 7.
+- `bcc` NOT on `SearchResultEntry` — Task 7 (negative test), Task 8 (schema check).
+- Empty/whitespace string rejection — Task 6 (per-field tests).
+- `headers: []` normalized to `None` — Task 6 (test + implementation), Task 2 (emitter still passes empty-vec test).
+- `validate_header_name` — Task 2.
+- Refinement triggers covered — Task 4.
+- Refinement non-triggers covered — Task 4 (low-posture fields don't promote, empty headers don't promote).
+- Sub-capability dispatch reaches posture matrix — Task 3 (dispatch reorder + `advanced_query` regression e2e), Task 10 (`body` e2e).
+- E2E `cc` wire round-trip — Task 9.
+- E2E posture denial wire path — Task 3 (existing `advanced_query`), Task 10 (new `body`).
+- Schema regen — Task 8.
+- File-level summary — all five files in the spec's File-level summary are touched, plus `crates/rimap-server/src/mcp/server.rs` (Task 3 dispatch reorder, not in the spec's File-level summary because the bug was unknown at spec time).
+- Lint-policy compliance for new tests — Task 6 adds module-level `#[expect(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "tests")]` to the `crates/rimap-server/src/tools/retrieval/search.rs` test module before inserting the new tests; Task 7 reuses that exemption.
+
+**Placeholder scan:** no TBD/TODO/FIXME; every step contains the actual code or an exact command.
+
+**Type consistency:**
+- `HeaderSearch` (rimap-imap) and `HeaderInput` (rimap-server) are deliberately distinct types — the conversion happens in `build_query`. Field names match (`name`, `value`).
+- `StructuredQuery` field names match between the struct definition (Task 1), the emitter (Task 2), and the threading code (Task 6).
+- `SearchResultEntry.cc: Vec<String>` (Task 7) matches the test assertions (Task 7 tests) and the schema regen check (Task 8).
+- `require_non_empty` returns `Result<Option<String>, RimapError>` consistently in Step 6.5.
+- `POSTURE_DENIAL_CODE` already exists in `e2e_wire.rs:544`; Tasks 3 and 10 reuse it.

--- a/docs/superpowers/specs/2026-05-18-expand-search-fields-design.md
+++ b/docs/superpowers/specs/2026-05-18-expand-search-fields-design.md
@@ -15,25 +15,32 @@ keys (`BCC`, `BODY`, `TEXT`, generic `HEADER`, size bounds, sent-date bounds,
 flag predicates) have the same problem.
 
 This change adds the common RFC 3501 SEARCH keys to the structured path so
-agents can express ordinary filters without crossing the posture line. The
-new keys ride the existing `Search` posture, which is allowed in all four
-postures.
+agents can express ordinary filters without unnecessary escalation. The
+envelope/flag keys (`cc`, `larger`, `smaller`, `sent_since`, `sent_before`,
+`answered`, `flagged`, `draft`) ride the existing `Search` posture and are
+allowed in all four postures. The content-oracle keys (`body`, `text`,
+generic `headers`, `bcc`) promote the dispatch to `SearchAdvanced` and are
+denied under `Readonly` and `DraftSafe`, matching the existing
+`advanced_query` boundary.
 
-The CC and BCC headers are also added to the per-message response so an
-agent that filters by `cc: "alice"` can see who else was CC'd without a
-follow-up `fetch_message` call.
+CC is also added to the per-message response so an agent that filters by
+`cc: "alice"` can see who else was CC'd without a follow-up
+`fetch_message` call. BCC is intentionally not added to the response — see
+*Privacy* below.
 
 ## Goals
 
 - Add `cc`, `bcc`, `body`, `text`, `headers`, `larger`, `smaller`,
   `sent_since`, `sent_before`, `answered`, `flagged`, `draft` to
   `SearchInput` and `StructuredQuery`.
-- Add `cc` and `bcc` to `SearchResultEntry`, populated from the envelope
-  already fetched by the search handler.
-- Preserve existing posture semantics (structured search stays under
-  `Search`; raw passthrough stays under `SearchAdvanced`).
+- Add `cc` (but not `bcc`) to `SearchResultEntry`, populated from the
+  envelope already fetched by the search handler.
+- Gate the content-oracle inputs (`body`, `text`, `headers`, `bcc`) to
+  the `SearchAdvanced` posture by extending the existing
+  `refine_tool_name` predicate. Other new fields stay under `Search`.
 - Preserve existing security boundaries (CR/LF/NUL injection blocked,
-  header names validated as RFC 5322 field-name tokens).
+  header names validated as RFC 5322 field-name tokens, empty/whitespace
+  string filters rejected at the MCP boundary).
 
 ## Non-goals
 
@@ -63,33 +70,86 @@ Two thin extensions, no new modules.
 **`rimap-server`**
 
 - `crates/rimap-server/src/tools/retrieval/search.rs`: extend `SearchInput`
-  and `SearchResultEntry`; thread the new inputs through `build_query`;
-  populate `cc`/`bcc` in `format_search_result` from the envelope already
-  fetched.
+  and `SearchResultEntry` (adding `cc` only on the output); thread the new
+  inputs through `build_query`; populate `cc` in `format_search_result`
+  from the envelope already fetched. Reject empty/whitespace-only string
+  filters before constructing the `StructuredQuery`.
+- `crates/rimap-server/src/mcp/tool_name.rs`: extend the
+  `refine_tool_name` predicate so that any of `body`, `text`, a
+  non-empty `headers`, or `bcc` promotes `Search` to `SearchAdvanced`
+  (in addition to the existing `advanced_query` trigger).
 
-Posture matrix (`crates/rimap-core/src/posture_matrix.rs:16-17`) is
-unchanged. All new fields are quoted/validated, so structured search
-keeps its universal-posture status.
+### Posture split
+
+The posture matrix in `crates/rimap-core/src/posture_matrix.rs:14-22`
+keeps its current shape:
+
+- `Search` — `[true, true, true, true]` (allowed in every posture).
+- `SearchAdvanced` — `[false, false, true, true]` (denied under
+  `Readonly` and `DraftSafe`).
+
+`DispatchGuard::pre_dispatch` (`crates/rimap-authz/src/guard.rs:40-44`)
+already enforces this; no change there. The new fields split across the
+two postures as follows.
+
+**Stays under low-posture `Search`** — envelope/flag predicates that map
+to IMAP-indexed metadata, no content scan:
+
+- `cc`, `larger`, `smaller`, `sent_since`, `sent_before`, `answered`,
+  `flagged`, `draft`.
+
+**Promotes to `SearchAdvanced`** — content-oracle predicates that scan
+header values or body bytes the server may otherwise refuse to index for
+low-trust clients, matching the existing treatment of `advanced_query`:
+
+- `body`, `text`, `headers` (any non-empty array), `bcc`.
+
+The promotion happens in `refine_tool_name`
+(`crates/rimap-server/src/mcp/tool_name.rs:31-76`) by extending the
+existing predicate. The current line
+`ToolName::Search if args.get("advanced_query").is_some() => ToolName::SearchAdvanced`
+becomes a multi-condition check: presence of `advanced_query` OR `body`
+OR `text` OR a non-empty `headers` array OR `bcc`. The dispatch seam then
+runs the existing `SearchAdvanced` posture check; no new gating layer is
+added.
+
+`headers: Some([])` (an explicitly empty array) does NOT promote — a
+present-but-empty array carries no filter intent and is normalized to
+`None` by `build_query`.
+
+### Privacy
+
+BCC is exposed as an input filter (gated to `SearchAdvanced`) but is
+intentionally not exposed in `SearchResultEntry` in any posture. No
+existing MCP tool returns BCC: `fetch_message`
+(`crates/rimap-server/src/tools/retrieval/fetch_message.rs:53-84`) and
+`ContentMeta` (`crates/rimap-content/src/output.rs:38-66`) both surface
+only `to` and `cc`. Adding `bcc` to search output would create a new
+disclosure surface for blind-recipient metadata that is particularly
+sensitive on `Sent` and `Drafts` folders. Future BCC-on-output work is
+out of scope for this change and would require its own posture / capability
+decision.
 
 ### Input fields
 
 Each new field is `Option<...>` and is AND-combined into the existing
-structured query. Empty/`None` is ignored, matching the existing pattern.
+structured query. `None` is ignored. Empty or whitespace-only string
+filters are rejected at the MCP boundary — see *Validation and security*.
 
-| Field         | Type                       | IMAP key emitted             | Notes                                                            |
-|---------------|----------------------------|------------------------------|------------------------------------------------------------------|
-| `cc`          | `Option<String>`           | `CC "<v>"`                   | Quoted via existing `quote()`; CR/LF/NUL rejected                |
-| `bcc`         | `Option<String>`           | `BCC "<v>"`                  | Same                                                             |
-| `body`        | `Option<String>`           | `BODY "<v>"`                 | Substring in body parts                                          |
-| `text`        | `Option<String>`           | `TEXT "<v>"`                 | Substring in headers OR body                                     |
-| `headers`     | `Option<Vec<HeaderSearch>>`| `HEADER <name> "<v>"` per entry | `name` validated; `value` quoted                              |
-| `larger`      | `Option<u64>`              | `LARGER <n>`                 | Numeric token, no quoting                                        |
-| `smaller`     | `Option<u64>`              | `SMALLER <n>`                | Numeric token, no quoting                                        |
-| `sent_since`  | `Option<String>` (ISO date)| `SENTSINCE DD-Mon-YYYY`      | Uses message `Date:` header (not INTERNALDATE)                   |
-| `sent_before` | `Option<String>` (ISO date)| `SENTBEFORE DD-Mon-YYYY`     | Same                                                             |
-| `answered`    | `Option<bool>`             | `ANSWERED` / `UNANSWERED`    | Mirrors existing `seen`                                          |
-| `flagged`     | `Option<bool>`             | `FLAGGED` / `UNFLAGGED`      | Same                                                             |
-| `draft`       | `Option<bool>`             | `DRAFT` / `UNDRAFT`          | Same                                                             |
+| Field         | Type                       | IMAP key emitted             | Posture            | Notes                                                            |
+|---------------|----------------------------|------------------------------|--------------------|------------------------------------------------------------------|
+| `cc`          | `Option<String>`           | `CC "<v>"`                   | `Search`           | Quoted via existing `quote()`; CR/LF/NUL rejected                |
+| `bcc`         | `Option<String>`           | `BCC "<v>"`                  | `SearchAdvanced`   | Same; promotes dispatch (content-oracle)                         |
+| `body`        | `Option<String>`           | `BODY "<v>"`                 | `SearchAdvanced`   | Substring in body parts; promotes dispatch                       |
+| `text`        | `Option<String>`           | `TEXT "<v>"`                 | `SearchAdvanced`   | Substring in headers OR body; promotes dispatch                  |
+| `headers`     | `Option<Vec<HeaderSearch>>`| `HEADER <name> "<v>"` per entry | `SearchAdvanced` (when non-empty) | `name` validated; `value` quoted; empty array does not promote |
+| `larger`      | `Option<u64>`              | `LARGER <n>`                 | `Search`           | Numeric token, no quoting                                        |
+| `smaller`     | `Option<u64>`              | `SMALLER <n>`                | `Search`           | Numeric token, no quoting                                        |
+| `sent_since`  | `Option<String>` (ISO date)| `SENTSINCE DD-Mon-YYYY`      | `Search`           | Uses message `Date:` header (not INTERNALDATE)                   |
+| `sent_before` | `Option<String>` (ISO date)| `SENTBEFORE DD-Mon-YYYY`     | `Search`           | Same                                                             |
+| `answered`    | `Option<bool>`             | `ANSWERED` / `UNANSWERED`    | `Search`           | Mirrors existing `seen`                                          |
+| `flagged`     | `Option<bool>`             | `FLAGGED` / `UNFLAGGED`      | `Search`           | Same                                                             |
+| `draft`       | `Option<bool>`             | `DRAFT` / `UNDRAFT`          | `Search`           | Same                                                             |
 
 `HeaderSearch`:
 
@@ -106,34 +166,57 @@ INTERNALDATE — these are different and an agent must pick the right one.
 
 ### Output fields
 
-`SearchResultEntry` gains:
+`SearchResultEntry` gains a single field:
 
 ```rust
 #[serde(default, skip_serializing_if = "Vec::is_empty")]
 pub cc: Vec<String>,
-#[serde(default, skip_serializing_if = "Vec::is_empty")]
-pub bcc: Vec<String>,
 ```
 
-Populated by `format_search_result` from `env.cc` and `env.bcc`
-(the envelope is already fetched). Same `sanitize_for_output` pipeline as
-`from`/`to`. No extra IMAP traffic.
+Populated by `format_search_result` from `env.cc` (the envelope is
+already fetched). Same `sanitize_for_output` pipeline as `from`/`to`. No
+extra IMAP traffic.
+
+`bcc` is intentionally omitted from the output struct — see *Privacy*
+above. `format_search_result` does not read `env.bcc`.
 
 ### Validation and security
 
-1. **Header name** (new): byte-level check in `structured_to_key` before
+1. **Empty-string rejection** (new): in `build_query`
+   (`crates/rimap-server/src/tools/retrieval/search.rs`), every new
+   string filter is checked before constructing `StructuredQuery`. The
+   rule is `s.trim().is_empty()` → reject with
+   `RimapError::invalid_input("<field-name> must not be empty or whitespace-only")`.
+   This covers `cc`, `bcc`, `body`, `text`, and every
+   `headers[i].name` / `headers[i].value`. Without this gate the
+   existing `quote()` (`crates/rimap-imap/src/ops/search.rs:67-84`)
+   only rejects CR/LF/NUL, so `""` would pass through and the IMAP
+   server would happily execute broad scans like `BODY ""` or
+   `HEADER X-Foo ""`.
+
+   `headers: Some(vec![])` (a present-but-empty array) is normalized to
+   `None` rather than rejected — an empty array carries no filter
+   intent.
+2. **Header name** (new): byte-level check in `structured_to_key` before
    emitting `HEADER`. Every byte must be in `33..=126` and not `b':'`.
    Empty names rejected. Failure returns `ImapError::InvalidInput { field:
    "header name", reason: ... }`, surfaced as
-   `RimapError::invalid_input` by the existing call path.
-2. **Header value**: routed through the existing `quote()` which already
+   `RimapError::invalid_input` by the existing call path. This runs in
+   addition to the MCP-boundary empty-string check above.
+3. **Header value**: routed through the existing `quote()` which already
    rejects CR/LF/NUL. No new code path.
-3. **`larger`/`smaller`**: `u64`, formatted with `{}`. Numeric token; no
+4. **`larger`/`smaller`**: `u64`, formatted with `{}`. Numeric token; no
    quoting needed.
-4. **`sent_since`/`sent_before`**: parsed by the existing
+5. **`sent_since`/`sent_before`**: parsed by the existing
    `parse_iso_date`; formatted by `format_imap_date`. Same error type and
    error path as `since`/`before`.
-5. **Raw branch unchanged**: `advanced_query` path is not touched.
+6. **Posture enforcement**: content-oracle inputs (`body`, `text`,
+   non-empty `headers`, `bcc`) promote the dispatched tool to
+   `SearchAdvanced` via `refine_tool_name`, so
+   `DispatchGuard::pre_dispatch` rejects them with
+   `Authz { code: PostureDenied }` under `Readonly` and `DraftSafe`.
+   See *Posture split*.
+7. **Raw branch unchanged**: `advanced_query` path is not touched.
 
 ### MCP schema and tool catalog
 
@@ -165,18 +248,55 @@ Add unit tests alongside the existing ones in `ops/search.rs`:
 Add unit tests alongside the existing ones in
 `tools/retrieval/search.rs`:
 
-- `format_search_result` populates `cc`/`bcc` from an envelope containing
-  CC and BCC addresses.
-- `format_search_result` returns empty `cc`/`bcc` when the envelope omits
-  them (verifies the skip-serialize-on-empty behavior).
+- `format_search_result` populates `cc` from an envelope containing CC
+  addresses.
+- `format_search_result` returns empty `cc` when the envelope omits it
+  (verifies the skip-serialize-on-empty behavior).
+- `format_search_result` does NOT read `env.bcc` — assert that an
+  envelope with BCC addresses produces a `SearchResultEntry` whose
+  serialized JSON contains no `bcc` key.
 - `build_query` wires each new `SearchInput` field into the corresponding
   `StructuredQuery` field — table-driven if it stays clean.
+
+### Posture refinement (`mcp/tool_name.rs`)
+
+Extend `refine_tool_name_promotes_sub_capabilities` (or add a sibling
+test) at `crates/rimap-server/src/mcp/tool_name.rs:175`:
+
+- One assertion per promotion trigger: `body`, `text`, `headers: [{...}]`
+  (non-empty), `bcc` — each promotes `ToolName::Search` to
+  `ToolName::SearchAdvanced`.
+- One assertion that low-posture fields (`cc`, `larger`, `sent_since`,
+  `answered`) do NOT promote — base `Search` is returned.
+- One assertion that `headers: []` (an explicit empty array) does NOT
+  promote.
+
+### Posture denial (E2E)
+
+Extend the existing posture-denied wire-test scaffolding in
+`crates/rimap-server/tests/e2e_wire.rs`:
+
+- Calling `search` with `body: Some("hello")` under `Readonly` posture
+  returns `Authz { code: PostureDenied }` — exercises the
+  `refine_tool_name` + `DispatchGuard::pre_dispatch` path end-to-end.
+
+### Empty-string rejection (unit)
+
+In `crates/rimap-server/src/tools/retrieval/search.rs`:
+
+- One rejection assertion per field — `cc`, `bcc`, `body`, `text`,
+  `headers[].name`, `headers[].value` — for both `""` and `"   "` —
+  asserting `RimapError::Authz { code: InvalidInput, ... }`.
+- One assertion that `headers: Some(vec![])` produces a
+  `StructuredQuery` that emits no `HEADER` clause (i.e. is treated as
+  `None`) and is accepted.
 
 ### Snapshot regeneration
 
 Regenerate the `dump_tool_catalog` snapshot for the `search` tool's input
 and output schema. The regen is the verification that `JsonSchema`
-picked up every new field.
+picked up every new input field and that `bcc` is absent from the
+`SearchResultEntry` schema.
 
 ### E2E
 
@@ -210,9 +330,14 @@ body contains `CC "..."`.
   `HeaderSearch`.
 - `crates/rimap-imap/src/ops/search.rs` — extend `structured_to_key`;
   add `validate_header_name`; add unit tests.
+- `crates/rimap-server/src/mcp/tool_name.rs` — extend the
+  `refine_tool_name` predicate so `body`, `text`, non-empty `headers`,
+  or `bcc` promote `Search` to `SearchAdvanced`; add unit tests.
 - `crates/rimap-server/src/tools/retrieval/search.rs` — extend
-  `SearchInput` and `SearchResultEntry`; thread fields through
-  `build_query`; populate `cc`/`bcc` in `format_search_result`; add
-  unit tests.
+  `SearchInput` and `SearchResultEntry` (output: `cc` only); thread
+  fields through `build_query`; reject empty/whitespace-only string
+  filters; populate `cc` in `format_search_result`; add unit tests.
 - `crates/rimap-server/tests/dump_tool_catalog.rs` snapshot — regen.
-- `crates/rimap-server/tests/e2e_wire.rs` — one additive case.
+- `crates/rimap-server/tests/e2e_wire.rs` — add one additive case for
+  `cc` wire-format and one posture-denied case for `body` under
+  `Readonly`.

--- a/docs/superpowers/specs/2026-05-18-expand-search-fields-design.md
+++ b/docs/superpowers/specs/2026-05-18-expand-search-fields-design.md
@@ -1,0 +1,218 @@
+# Expand searchable email fields in the `search` tool
+
+- **Date**: 2026-05-18
+- **Status**: Approved (brainstorm)
+- **Scope**: `crates/rimap-imap` (`StructuredQuery`, `ops/search`), `crates/rimap-server` (`tools/retrieval/search.rs`)
+
+## Motivation
+
+The MCP `search` tool exposes a narrow subset of RFC 3501 SEARCH keys: `from`,
+`to`, `subject`, `since`, `before`, `seen`, `has_attachment`. An agent attempting
+to filter by `CC:` has no structured option and must escalate to
+`advanced_query`, which is gated behind the `SearchAdvanced` posture and is
+unavailable in the two lower postures. Several other common
+keys (`BCC`, `BODY`, `TEXT`, generic `HEADER`, size bounds, sent-date bounds,
+flag predicates) have the same problem.
+
+This change adds the common RFC 3501 SEARCH keys to the structured path so
+agents can express ordinary filters without crossing the posture line. The
+new keys ride the existing `Search` posture, which is allowed in all four
+postures.
+
+The CC and BCC headers are also added to the per-message response so an
+agent that filters by `cc: "alice"` can see who else was CC'd without a
+follow-up `fetch_message` call.
+
+## Goals
+
+- Add `cc`, `bcc`, `body`, `text`, `headers`, `larger`, `smaller`,
+  `sent_since`, `sent_before`, `answered`, `flagged`, `draft` to
+  `SearchInput` and `StructuredQuery`.
+- Add `cc` and `bcc` to `SearchResultEntry`, populated from the envelope
+  already fetched by the search handler.
+- Preserve existing posture semantics (structured search stays under
+  `Search`; raw passthrough stays under `SearchAdvanced`).
+- Preserve existing security boundaries (CR/LF/NUL injection blocked,
+  header names validated as RFC 5322 field-name tokens).
+
+## Non-goals
+
+- `DELETED`/`UNDELETED` — rarely useful on modern servers that expunge.
+- `OR`/`NOT`/`KEYWORD` combinators — composition belongs in
+  `advanced_query`.
+- `OLDER`/`YOUNGER` (RFC 5032 `WITHIN` extension) — capability-gated;
+  defer until requested.
+- Fuzz/mutation baseline additions for the new keys — they mirror existing
+  paths already covered by the issue-289 baselines.
+
+## Design
+
+### Architecture
+
+Two thin extensions, no new modules.
+
+**`rimap-imap`**
+
+- `crates/rimap-imap/src/types.rs`: extend `StructuredQuery` with the new
+  fields; add a public `HeaderSearch { name: String, value: String }`
+  struct.
+- `crates/rimap-imap/src/ops/search.rs`: extend `structured_to_key` to
+  emit the new keys; add a `validate_header_name` helper enforcing RFC
+  5322 field-name syntax.
+
+**`rimap-server`**
+
+- `crates/rimap-server/src/tools/retrieval/search.rs`: extend `SearchInput`
+  and `SearchResultEntry`; thread the new inputs through `build_query`;
+  populate `cc`/`bcc` in `format_search_result` from the envelope already
+  fetched.
+
+Posture matrix (`crates/rimap-core/src/posture_matrix.rs:16-17`) is
+unchanged. All new fields are quoted/validated, so structured search
+keeps its universal-posture status.
+
+### Input fields
+
+Each new field is `Option<...>` and is AND-combined into the existing
+structured query. Empty/`None` is ignored, matching the existing pattern.
+
+| Field         | Type                       | IMAP key emitted             | Notes                                                            |
+|---------------|----------------------------|------------------------------|------------------------------------------------------------------|
+| `cc`          | `Option<String>`           | `CC "<v>"`                   | Quoted via existing `quote()`; CR/LF/NUL rejected                |
+| `bcc`         | `Option<String>`           | `BCC "<v>"`                  | Same                                                             |
+| `body`        | `Option<String>`           | `BODY "<v>"`                 | Substring in body parts                                          |
+| `text`        | `Option<String>`           | `TEXT "<v>"`                 | Substring in headers OR body                                     |
+| `headers`     | `Option<Vec<HeaderSearch>>`| `HEADER <name> "<v>"` per entry | `name` validated; `value` quoted                              |
+| `larger`      | `Option<u64>`              | `LARGER <n>`                 | Numeric token, no quoting                                        |
+| `smaller`     | `Option<u64>`              | `SMALLER <n>`                | Numeric token, no quoting                                        |
+| `sent_since`  | `Option<String>` (ISO date)| `SENTSINCE DD-Mon-YYYY`      | Uses message `Date:` header (not INTERNALDATE)                   |
+| `sent_before` | `Option<String>` (ISO date)| `SENTBEFORE DD-Mon-YYYY`     | Same                                                             |
+| `answered`    | `Option<bool>`             | `ANSWERED` / `UNANSWERED`    | Mirrors existing `seen`                                          |
+| `flagged`     | `Option<bool>`             | `FLAGGED` / `UNFLAGGED`      | Same                                                             |
+| `draft`       | `Option<bool>`             | `DRAFT` / `UNDRAFT`          | Same                                                             |
+
+`HeaderSearch`:
+
+```rust
+pub struct HeaderSearch {
+    pub name: String,
+    pub value: String,
+}
+```
+
+The `SearchInput` docstring will call out that `sent_*` filters use the
+message's `Date:` header while `since`/`before` use the server's
+INTERNALDATE — these are different and an agent must pick the right one.
+
+### Output fields
+
+`SearchResultEntry` gains:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub cc: Vec<String>,
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub bcc: Vec<String>,
+```
+
+Populated by `format_search_result` from `env.cc` and `env.bcc`
+(the envelope is already fetched). Same `sanitize_for_output` pipeline as
+`from`/`to`. No extra IMAP traffic.
+
+### Validation and security
+
+1. **Header name** (new): byte-level check in `structured_to_key` before
+   emitting `HEADER`. Every byte must be in `33..=126` and not `b':'`.
+   Empty names rejected. Failure returns `ImapError::InvalidInput { field:
+   "header name", reason: ... }`, surfaced as
+   `RimapError::invalid_input` by the existing call path.
+2. **Header value**: routed through the existing `quote()` which already
+   rejects CR/LF/NUL. No new code path.
+3. **`larger`/`smaller`**: `u64`, formatted with `{}`. Numeric token; no
+   quoting needed.
+4. **`sent_since`/`sent_before`**: parsed by the existing
+   `parse_iso_date`; formatted by `format_imap_date`. Same error type and
+   error path as `since`/`before`.
+5. **Raw branch unchanged**: `advanced_query` path is not touched.
+
+### MCP schema and tool catalog
+
+`SearchInput` and `SearchResultEntry` derive `JsonSchema`. The tool
+descriptor regenerates automatically. The `dump_tool_catalog` snapshot
+under `crates/rimap-server/tests/dump_tool_catalog.rs` must be regenerated
+and committed — this is what agents see and the reviewable surface of the
+change.
+
+## Testing
+
+### `rimap-imap` (where `structured_to_key` lives)
+
+Add unit tests alongside the existing ones in `ops/search.rs`:
+
+- One test per new field rendering to the expected key.
+- `headers: [{name: "List-Id", value: "rust-users"}]` → `HEADER List-Id
+  "rust-users"`.
+- Multiple headers AND together in input order: `headers: [a, b]` → two
+  `HEADER ...` clauses in order.
+- One combined test mixing several new fields with existing fields to
+  lock in field ordering.
+- `validate_header_name` accepts canonical names (`Message-ID`, `X-Foo`)
+  and rejects: empty, contains `:`, contains space, contains CR/LF/NUL,
+  contains a high-bit byte.
+
+### `rimap-server` (handler + formatter)
+
+Add unit tests alongside the existing ones in
+`tools/retrieval/search.rs`:
+
+- `format_search_result` populates `cc`/`bcc` from an envelope containing
+  CC and BCC addresses.
+- `format_search_result` returns empty `cc`/`bcc` when the envelope omits
+  them (verifies the skip-serialize-on-empty behavior).
+- `build_query` wires each new `SearchInput` field into the corresponding
+  `StructuredQuery` field — table-driven if it stays clean.
+
+### Snapshot regeneration
+
+Regenerate the `dump_tool_catalog` snapshot for the `search` tool's input
+and output schema. The regen is the verification that `JsonSchema`
+picked up every new field.
+
+### E2E
+
+One additive case in `crates/rimap-server/tests/e2e_wire.rs` exercising
+`cc: "..."` against the mock IMAP server, asserting the IMAP command
+body contains `CC "..."`.
+
+### Out of scope
+
+- Fuzz/mutation baseline expansion for the new keys (per issue #289
+  notes, full local cargo-mutants runs are unsafe on this host;
+  baselines refresh on the regular schedule).
+
+## Risks
+
+- **Schema growth**: the `search` MCP descriptor roughly doubles in
+  field count. The contract is purely additive — every new field is
+  `Option`/`Vec` — so older agents continue to work unchanged. No
+  version bump required.
+- **`sent_*` vs `since`/`before` confusion**: the two pairs of date
+  filters use different message attributes (Date: header vs
+  INTERNALDATE). The `SearchInput` docstrings will distinguish them
+  explicitly.
+- **Server compatibility**: every emitted key is RFC 3501 core. No
+  capability negotiation needed; the change should work against every
+  server already tested.
+
+## File-level summary
+
+- `crates/rimap-imap/src/types.rs` — extend `StructuredQuery`; add
+  `HeaderSearch`.
+- `crates/rimap-imap/src/ops/search.rs` — extend `structured_to_key`;
+  add `validate_header_name`; add unit tests.
+- `crates/rimap-server/src/tools/retrieval/search.rs` — extend
+  `SearchInput` and `SearchResultEntry`; thread fields through
+  `build_query`; populate `cc`/`bcc` in `format_search_result`; add
+  unit tests.
+- `crates/rimap-server/tests/dump_tool_catalog.rs` snapshot — regen.
+- `crates/rimap-server/tests/e2e_wire.rs` — one additive case.

--- a/fuzz/fuzz_targets/audit_jsonl.rs
+++ b/fuzz/fuzz_targets/audit_jsonl.rs
@@ -51,7 +51,7 @@ fuzz_target!(|data: &[u8]| {
                 .get(name.as_str())
                 .copied()
                 .unwrap_or(rimap_audit::FieldPolicy::RedactString);
-            if matches!(policy, rimap_audit::FieldPolicy::Verbatim) {
+            if matches!(policy, rimap_audit::FieldPolicy::Verbatim(_)) {
                 continue;
             }
             let serde_json::Value::String(s_in) = value_in else {


### PR DESCRIPTION
## Summary

Adds 12 new structured RFC 3501 SEARCH keys to the MCP `search` tool plus `cc` on the per-message response. Content-oracle inputs gate at the existing `SearchAdvanced` posture. Also fixes a preexisting dispatch-order bug surfaced during plan review.

**New search inputs:**
- Envelope/flag (low-posture `Search`): `cc`, `larger`, `smaller`, `sent_since`, `sent_before`, `answered`, `flagged`, `draft`.
- Content-oracle (promote to `SearchAdvanced`): `body`, `text`, `headers` (when non-empty), `bcc`.

**New output:** `cc` field on `SearchResultEntry` (sanitized addresses, omitted when empty). `bcc` is intentionally not exposed — see *Privacy* below.

**Validation:** empty or whitespace-only string filters are rejected at the MCP boundary with `RimapError::invalid_input`. `headers: []` is normalized to `None`.

## Preexisting bug fix (Task 3)

A Codex adversarial review of the implementation plan surfaced a preexisting bug in `call_tool`: refinement to a sub-capability (`SearchAdvanced`, `FetchMessageHtml`) ran **before** the `TOOL_DEFS.get(...).is_none()` check, but `TOOL_DEFS` intentionally excludes those variants. The check therefore short-circuited every refined call with `RESOURCE_NOT_FOUND`, bypassing `DispatchGuard::pre_dispatch` and the posture matrix. Nothing in HEAD exercised `advanced_query` or `include_html=true` end-to-end, so the bug had gone undetected.

Reordered to: parse → `TOOL_DEFS` check on parent → refine → dispatch. Wire regression test added for `readonly.search + advanced_query` → `PostureDenied` (was `RESOURCE_NOT_FOUND`). The fix is a prerequisite for the new content-oracle fields routing correctly through posture enforcement.

**Side effect:** `include_html=true` posture denials now return `PostureDenied` rather than `RESOURCE_NOT_FOUND`. The fix code path is shared; no dedicated e2e test was added for that branch (worth a follow-up).

## Privacy boundary (no BCC on output)

BCC stays an input-side filter (gated to `SearchAdvanced`). It is never returned in `search` output, in any posture. Defense in depth at four layers:
- Output struct shape: no `bcc` field on `SearchResultEntry`.
- `format_search_result` does not read `env.bcc`.
- Schema fixture (`search.schema.json`): `bcc` absent from `SearchResultEntry`.
- Dedicated test (`format_search_result_never_emits_bcc_even_when_envelope_has_it`) asserts neither `"bcc"` JSON key nor the BCC address string appears in serialized output.

`fetch_message` and `ContentMeta` likewise surface only `to`/`cc`; this PR preserves that invariant. Future BCC-on-output work would require its own posture/capability decision.

## Test plan

- [x] `cargo test --workspace --all-features --locked` — 1,333 passed, 0 failed (Docker available; Dovecot e2e tests ran live, not skipped).
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — 0 warnings.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo deny check` — clean.
- [x] `scripts/regen-tool-schemas.sh` — `search.schema.json` regenerated; `bcc` absent from `SearchResultEntry`.
- [x] Wire-level regression coverage:
  - `wire_e2e_full_session_draft_safe` exercises `cc` filter (negative case — seed has no Cc).
  - `wire_e2e_readonly_posture_denial` exercises `body` and `advanced_query` posture denials (both serialize as `search.advanced_query` in audit log; assertion uses HashSet linkage on `start_seq`).
- [x] Unit-level coverage:
  - `rimap-imap`: 16 new tests for `structured_to_key` emit paths + `validate_header_name` (RFC 5322 byte check).
  - `rimap-server`: 6 new `refine_tool_name` tests (including JSON-null handling) + 13 `build_query` tests (rejection + normalization + threading) + 3 `format_search_result` tests (cc populate, empty skip, BCC absence).

## Spec and plan

- Spec: `docs/superpowers/specs/2026-05-18-expand-search-fields-design.md` (revised post-adversarial-review at commit `32facf9`).
- Plan: `docs/superpowers/plans/2026-05-18-expand-search-fields-impl.md` (committed at `9b3bc46`).

## Deliberately deferred (out of scope; tracked as follow-ups)

- Positive-case `cc` e2e (requires seeding a Cc-bearing Dovecot fixture; comment in `assert_search` points at the unit-test wire-format guards).
- `include_html=true` wire-level e2e for the parallel posture-denial fix.
- `from`/`to`/`subject` empty-string rejection (pre-existing asymmetry; not a regression).
- `has_attachment: bool` vs `Option<bool>` asymmetry between `StructuredQuery` and `SearchInput` layers (pre-existing).
- `ImapError::InvalidInput { reason: &'static str }` widening to carry dynamic context (pre-existing constraint).
- Input-schema fixture (`SearchInput` JSON Schema is currently emitted at runtime via `dump-tool-catalog` but not snapshotted; a fixture would catch silent `#[serde(skip)]`-style regressions).

## Commit history

18 commits on top of the plan commit `9b3bc46`. Each task landed as a feature/test commit plus zero-to-one fixup commit responding to spec or code-quality review. The history is traceable; squash-on-merge is fine if preferred for main-branch cleanliness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)