### PR TITLE
Trim local test runtime: hook scope + just test-fast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,8 +127,8 @@ repos:
   - repo: local
     hooks:
       - id: cargo-check
-        name: cargo check --workspace --all-targets --locked
-        entry: cargo check --workspace --all-targets --locked
+        name: cargo check --workspace --lib --bins --locked
+        entry: cargo check --workspace --lib --bins --locked
         language: system
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --workspace --all-targets --locked -- -D warnings
+        entry: cargo clippy --workspace --lib --bins --locked -- -D warnings
         language: system
         types: [rust]
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ just check           # fast compile-check (inner loop)
 just fmt             # format the workspace in place
 just fmt-check       # verify formatting without modifying
 just lint            # cargo clippy with -D warnings
-just test            # cargo nextest run --workspace
+just test-fast       # inner-loop unit tests (~4 s; skips heavy integration/proptest)
+just test            # full nextest workspace — run before pushing
 just test-msrv       # same as `test` but on the MSRV toolchain (1.88.0)
 just deny            # cargo deny check (advisories, licenses, bans, sources)
 just ci              # full local-CI equivalent — run this before pushing

--- a/docs/superpowers/plans/2026-05-20-local-test-runtime-trim.md
+++ b/docs/superpowers/plans/2026-05-20-local-test-runtime-trim.md
@@ -1,0 +1,567 @@
+# Local Test Runtime Trim — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut local commit/push hook compile cost and inner-loop test runtime by narrowing `--all-targets` to `--lib --bins` in two prek hooks and adding `just test-fast` (a nextest filter that skips the five heaviest test binaries).
+
+**Architecture:** Configuration-only changes across three files (`.pre-commit-config.yaml`, `justfile`, `AGENTS.md`). No Rust code, test code, or CI workflow changes. Verification is empirical (timing + behavior observation) rather than via unit tests, because the artifacts being changed are themselves the build/test tooling.
+
+**Tech Stack:** prek (pre-commit-in-Rust), cargo, cargo-nextest, just.
+
+**Spec:** [`docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md`](../specs/2026-05-20-local-test-runtime-trim-design.md). Read the spec before starting; the rationale for each flag and exclusion is there, not duplicated here.
+
+**Branch:** Work continues on `docs/local-test-runtime-trim-spec` (the branch that holds the spec commit). The branch name predates the renamed scope; that's fine — rename at PR time if desired.
+
+---
+
+## Pre-flight check
+
+Before starting, verify your workspace state matches the spec's assumptions.
+
+- [ ] **Pre-flight 1: Confirm branch and clean tree**
+
+Run:
+```bash
+git rev-parse --abbrev-ref HEAD
+git status -s
+```
+Expected: branch is `docs/local-test-runtime-trim-spec`; working tree is clean (the spec commit `bec7b0e` is already on this branch).
+
+- [ ] **Pre-flight 2: Confirm tooling is present**
+
+Run:
+```bash
+command -v just cargo cargo-nextest prek
+just --version && cargo --version && cargo nextest --version && prek --version
+```
+Expected: all four resolve and print versions. If `cargo-nextest` is missing, install with `cargo install --locked cargo-nextest`. If `prek` is missing, install per `justfile`'s `setup` target hints.
+
+- [ ] **Pre-flight 3: Confirm the five heavy binaries actually exist**
+
+Run:
+```bash
+cargo nextest list --workspace --locked --list-type binaries-only 2>&1 \
+  | grep -E '::(dovecot|e2e|e2e_wire|e2e_wire_cancellation|proptest_html_lookalike)$'
+```
+Expected: exactly five lines:
+```
+rimap-content::proptest_html_lookalike
+rimap-imap::dovecot
+rimap-server::e2e
+rimap-server::e2e_wire
+rimap-server::e2e_wire_cancellation
+```
+If any are missing or renamed, STOP and revisit the spec — the filter expression in Task 1 assumes these names. Update the filter and the spec together if needed.
+
+---
+
+## Task 1: Add `just test-fast` target
+
+**Why first:** This is the headline win (91.9 s → 4.2 s warm) and has no dependency on the hook changes. Ships independently if the hook tasks slip.
+
+**Files:**
+- Modify: `justfile` (insert after the existing `test:` target, around line 189)
+
+- [ ] **Step 1: Capture the baseline `just test` timing for the commit message**
+
+Run:
+```bash
+{ /usr/bin/time -f "baseline just test: %e s" just test ; } 2>&1 | tail -3
+```
+Expected: a line like `baseline just test: 90-130 s` (warm cache). Record this number; it goes in the commit message as evidence.
+
+If `just test` fails before producing a timing line (e.g., container daemon down), STOP and resolve the environment issue before continuing. The fast target's value claim relies on having a real baseline.
+
+- [ ] **Step 2: Add the `test-fast` target to the justfile**
+
+Open `justfile` and locate the existing `test` target (around line 187-189):
+```just
+# Unit and fast tests (no Proton Bridge).
+test: prune-containers
+    cargo nextest run --workspace --locked --no-tests=pass
+```
+
+Insert this new target immediately after it (before `# Verify the MSRV toolchain still builds and tests the workspace.`):
+```just
+# Inner-loop unit tests. Skips the five heaviest test binaries
+# (dovecot integration, e2e/e2e_wire MCP suites, and the slow HTML
+# lookalike proptest). Use this between `cargo check` cycles during
+# inner-loop iteration. Before pushing, run `just test` (or `just ci`)
+# for the full sweep. See
+# docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md.
+test-fast:
+    cargo nextest run --workspace --locked --no-tests=pass \
+        -E 'not (binary(dovecot) | binary(e2e) | binary(e2e_wire) | binary(e2e_wire_cancellation) | binary(proptest_html_lookalike))'
+```
+
+Note: `test-fast` deliberately does **not** depend on `prune-containers` — the fast tier does not spawn containers, so the prune step is unnecessary work.
+
+- [ ] **Step 3: Verify the just target parses**
+
+Run:
+```bash
+just --list
+```
+Expected: `test-fast` appears in the listing with its first-line comment as the description.
+
+- [ ] **Step 4: Verify the filter selects the expected test count**
+
+Run:
+```bash
+cargo nextest list --workspace --locked \
+  -E 'not (binary(dovecot) | binary(e2e) | binary(e2e_wire) | binary(e2e_wire_cancellation) | binary(proptest_html_lookalike))' 2>&1 \
+  | grep -c "::"
+```
+Expected: `1381` (or within ±20 if the test count has shifted since the spec was written; if it's drastically different, investigate before continuing).
+
+- [ ] **Step 5: Run `just test-fast` and time it**
+
+Run:
+```bash
+{ /usr/bin/time -f "just test-fast: %e s" just test-fast ; } 2>&1 | tail -3
+```
+Expected: all selected tests pass; total wall clock ≤ 10 s on a workstation, ≤ 30 s on a weak laptop. The line ends with `tests run: <N> passed, 0 skipped` where N is the count from Step 4.
+
+If any test fails, STOP. A failure here is unrelated to this change (these tests already pass in `just test`); investigate as a separate bug before proceeding.
+
+- [ ] **Step 6: Confirm the five excluded binaries did NOT run**
+
+Run:
+```bash
+just test-fast 2>&1 | grep -E "(dovecot|e2e_wire|e2e_wire_cancellation|::e2e |proptest_html_lookalike)" || echo "filter working: no excluded binary names appeared"
+```
+Expected: prints `filter working: no excluded binary names appeared`. If the grep matches anything, the filter is broken — re-verify the syntax against the nextest documentation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add justfile
+git commit -m "$(cat <<'EOF'
+feat(just): add `test-fast` for inner-loop unit tests
+
+Filters out the five heaviest nextest binaries (dovecot, e2e, e2e_wire,
+e2e_wire_cancellation, proptest_html_lookalike) which collectively
+account for ~97% of `just test` wall clock. Measured locally:
+`just test` warm = ~92 s; `just test-fast` warm = ~4 s. All ~1380 unit
+tests still run.
+
+Container-backed integration suites and the slow HTML lookalike proptest
+stay in `just test` and CI. No coverage lost; faster inner loop added.
+
+See docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 2: Document `just test-fast` in AGENTS.md
+
+**Why now:** Same logical change as Task 1; agents and human contributors discovering the command via documentation should find it the same day the target ships.
+
+**Files:**
+- Modify: `AGENTS.md` (the `## Development commands` code block, around line 49-62)
+
+- [ ] **Step 1: Update the commands list in `AGENTS.md`**
+
+Open `AGENTS.md` and locate the `## Development commands` section. The current block (lines 49-62) reads:
+
+```markdown
+```bash
+just setup           # one-time: install tooling, MSRV toolchain, prek hooks
+just check           # fast compile-check (inner loop)
+just fmt             # format the workspace in place
+just fmt-check       # verify formatting without modifying
+just lint            # cargo clippy with -D warnings
+just test            # cargo nextest run --workspace
+just test-msrv       # same as `test` but on the MSRV toolchain (1.88.0)
+just deny            # cargo deny check (advisories, licenses, bans, sources)
+just ci              # full local-CI equivalent — run this before pushing
+just hooks           # re-run prek on all files
+just test-injection  # adversarial email corpus (content pipeline, future)
+just test-integration  # Proton Bridge integration tests (gated, future)
+```
+```
+
+Replace the `just test` line and surrounding lines so the block reads:
+
+```markdown
+```bash
+just setup           # one-time: install tooling, MSRV toolchain, prek hooks
+just check           # fast compile-check (inner loop)
+just fmt             # format the workspace in place
+just fmt-check       # verify formatting without modifying
+just lint            # cargo clippy with -D warnings
+just test-fast       # inner-loop unit tests (~4 s; skips heavy integration/proptest)
+just test            # full nextest workspace — run before pushing
+just test-msrv       # same as `test` but on the MSRV toolchain (1.88.0)
+just deny            # cargo deny check (advisories, licenses, bans, sources)
+just ci              # full local-CI equivalent — run this before pushing
+just hooks           # re-run prek on all files
+just test-injection  # adversarial email corpus (content pipeline, future)
+just test-integration  # Proton Bridge integration tests (gated, future)
+```
+```
+
+The changes:
+1. Insert a new line `just test-fast       # inner-loop unit tests (~4 s; skips heavy integration/proptest)` immediately before the `just test` line.
+2. Change the comment on `just test` from `# cargo nextest run --workspace` to `# full nextest workspace — run before pushing`.
+
+Leave the rest of the block (including the `**If just ci passes locally, CI will pass.**` line above it) unchanged.
+
+- [ ] **Step 2: Verify the edit landed where intended**
+
+Run:
+```bash
+grep -n "test-fast\|just test " AGENTS.md | head -5
+```
+Expected (line numbers approximate):
+```
+55:just test-fast       # inner-loop unit tests (~4 s; skips heavy integration/proptest)
+56:just test            # full nextest workspace — run before pushing
+```
+
+- [ ] **Step 3: Verify typos hook is still happy**
+
+Run:
+```bash
+typos AGENTS.md
+```
+Expected: no output (exit 0). If typos flags anything in the new line, adjust wording until clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "$(cat <<'EOF'
+docs: list `just test-fast` in AGENTS.md commands
+
+Adds the new fast-tier test target to the documented inner-loop commands
+and clarifies that `just test` is the full sweep to run before pushing.
+EOF
+)"
+```
+
+---
+
+## Task 3: Narrow pre-commit clippy from `--all-targets` to `--lib --bins`
+
+**Why next:** Pre-commit fires more often than pre-push; landing this first gives the most immediate per-commit feedback that the change is working as intended.
+
+**Files:**
+- Modify: `.pre-commit-config.yaml` (the `cargo-clippy` hook entry, around line 56-62)
+
+- [ ] **Step 1: Capture the baseline warm clippy timing**
+
+Run:
+```bash
+# Warm the cache first
+cargo clippy --workspace --all-targets --locked -- -D warnings > /dev/null 2>&1
+# Then measure
+{ /usr/bin/time -f "baseline pre-commit clippy (warm): %e s" cargo clippy --workspace --all-targets --locked -- -D warnings ; } 2>&1 | tail -3
+```
+Expected: ~2-5 s on this hardware. Record for the commit message.
+
+- [ ] **Step 2: Edit `.pre-commit-config.yaml`**
+
+Open `.pre-commit-config.yaml`. The current `cargo-clippy` hook (lines 56-62) reads:
+
+```yaml
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --all-targets --locked -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-commit]
+```
+
+Change the `entry:` line so the block reads:
+
+```yaml
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --lib --bins --locked -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-commit]
+```
+
+Only `--all-targets` becomes `--lib --bins`. Do **not** change `--locked`, `--workspace`, `-D warnings`, or any other field.
+
+- [ ] **Step 3: Verify the new entry behaves identically on a clean tree**
+
+Run:
+```bash
+prek run cargo-clippy --all-files
+```
+Expected: prints `Passed` (or `cargo clippy.................................................................Passed`). If it prints `Failed`, the workspace has a real lint error in lib/bin code; resolve before continuing — this would have failed under the old configuration too.
+
+- [ ] **Step 4: Measure the new warm timing**
+
+Run:
+```bash
+# Warm
+cargo clippy --workspace --lib --bins --locked -- -D warnings > /dev/null 2>&1
+# Measure
+{ /usr/bin/time -f "narrowed pre-commit clippy (warm): %e s" cargo clippy --workspace --lib --bins --locked -- -D warnings ; } 2>&1 | tail -3
+```
+Expected: ~1-3 s. Should be at least as fast as the baseline (often noticeably faster on warm-repeat).
+
+- [ ] **Step 5: Confirm the hook still rejects a deliberate lint regression**
+
+In a separate scratch space (do **not** commit this), introduce a temporary clippy warning to a non-test file. For example, append to the end of `crates/rimap-server/src/lib.rs`:
+
+```rust
+#[allow(dead_code)]
+fn _scratch_unused() { let _x = 5_u8 as u32; }
+```
+
+(`unnecessary_cast` is a clippy default-warn lint.)
+
+Run:
+```bash
+prek run cargo-clippy --all-files
+```
+Expected: `Failed` with a clippy diagnostic mentioning `unnecessary_cast` (or similar). Then revert the scratch edit:
+
+```bash
+git checkout -- crates/rimap-server/src/lib.rs
+prek run cargo-clippy --all-files
+```
+Expected on second run: `Passed`.
+
+If the deliberate regression did **not** fail the hook, the `--lib --bins` scope is wrong; STOP and verify the file you edited is reachable from `--lib` or `--bins` (it must be one of those — that's the whole point).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "$(cat <<'EOF'
+chore(prek): narrow pre-commit clippy to --lib --bins
+
+Drops --all-targets from the pre-commit clippy hook. Test/example/bench
+compile + lint enforcement moves to CI (already runs the full
+--all-features --all-targets clippy on every push and PR).
+
+Warm-repeat: ~2.5 s → ~1.4 s on this hardware. Cold target/: ~23 s →
+~20 s. Proportionally larger improvements expected on lower-core-count
+laptops.
+
+See docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 4: Narrow pre-push check from `--all-targets` to `--lib --bins`
+
+**Files:**
+- Modify: `.pre-commit-config.yaml` (the `cargo-check` hook, around lines 129-135)
+
+- [ ] **Step 1: Capture the baseline warm timing (post-clippy)**
+
+Run:
+```bash
+# Pre-commit clippy --lib --bins (from Task 3) has already run, so target/
+# is in the right warm state for the post-clippy pre-push scenario.
+{ /usr/bin/time -f "baseline pre-push check (warm post-clippy): %e s" cargo check --workspace --all-targets --locked ; } 2>&1 | tail -3
+```
+Expected: ~1-4 s. Record for the commit message.
+
+- [ ] **Step 2: Edit `.pre-commit-config.yaml`**
+
+Open `.pre-commit-config.yaml`. The current `cargo-check` hook (lines 129-135) reads:
+
+```yaml
+      - id: cargo-check
+        name: cargo check --workspace --all-targets --locked
+        entry: cargo check --workspace --all-targets --locked
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Change the `name:` and `entry:` lines so the block reads:
+
+```yaml
+      - id: cargo-check
+        name: cargo check --workspace --lib --bins --locked
+        entry: cargo check --workspace --lib --bins --locked
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Both `name:` and `entry:` are updated so the hook's reported name matches what it actually runs. Do **not** change `language:`, `always_run:`, `pass_filenames:`, or `stages:` — those preserve the prior spec's invariants (the `always_run: true` decision is explained in the prior pre-push-hook-trim spec; don't revisit it here).
+
+- [ ] **Step 3: Verify the new entry passes**
+
+Run:
+```bash
+prek run cargo-check --hook-stage pre-push --all-files
+```
+Expected: `cargo check --workspace --lib --bins --locked....................Passed`. If `Failed`, a real compile error exists in lib/bin code; resolve before continuing.
+
+- [ ] **Step 4: Confirm `--locked` still rejects stale lockfile**
+
+Make a temporary edit that perturbs `Cargo.lock`. The safest way is to add a no-op `[patch]` entry to `Cargo.toml` that forces a lockfile recompute. **Skip this step if you're not confident you can revert cleanly** — the hook's `--locked` behavior was already exercised by the prior pre-push-hook-trim spec and hasn't changed here.
+
+If you do test:
+```bash
+# Save current Cargo.lock
+cp Cargo.lock /tmp/Cargo.lock.bak
+# Hand-edit Cargo.lock to perturb the [[package]] version of any dep slightly
+# (e.g., change one resolved version's checksum by one hex digit)
+# Then:
+prek run cargo-check --hook-stage pre-push --all-files
+# Expected: Failed, with cargo's "the lock file ... needs to be updated" error
+# Revert:
+cp /tmp/Cargo.lock.bak Cargo.lock
+rm /tmp/Cargo.lock.bak
+prek run cargo-check --hook-stage pre-push --all-files
+# Expected: Passed
+```
+
+- [ ] **Step 5: Measure the new warm timing**
+
+Run:
+```bash
+{ /usr/bin/time -f "narrowed pre-push check (warm post-clippy): %e s" cargo check --workspace --lib --bins --locked ; } 2>&1 | tail -3
+```
+Expected: ~1-3 s. Should be at least as fast as the baseline.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "$(cat <<'EOF'
+chore(prek): narrow pre-push cargo check to --lib --bins
+
+Drops --all-targets from the pre-push cargo-check hook to match Task 3's
+pre-commit clippy change. Test-target compile errors continue to be
+caught by `just test` locally and by CI on every push.
+
+Warm post-clippy: ~1.1 s → ~2 s (within noise). Cold target/: ~22 s →
+~19 s. Bigger relative win expected on weaker hardware.
+
+See docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 5: End-to-end verification and PR
+
+**Why last:** Confirms the three landed commits together still produce a clean local state, and that `just ci` and the prek hook bundle both pass before the push.
+
+**Files:** none modified in this task; all work is verification.
+
+- [ ] **Step 1: Confirm the branch state**
+
+Run:
+```bash
+git log --oneline main..HEAD
+```
+Expected: four commits on top of `main`:
+1. `bec7b0e docs: spec for local test-runtime trim (hook scope + just test-fast)` (already in place)
+2. `<sha> feat(just): add `test-fast` for inner-loop unit tests` (Task 1)
+3. `<sha> docs: list `just test-fast` in AGENTS.md commands` (Task 2)
+4. `<sha> chore(prek): narrow pre-commit clippy to --lib --bins` (Task 3)
+5. `<sha> chore(prek): narrow pre-push cargo check to --lib --bins` (Task 4)
+
+If the count is off, list and reconcile before continuing.
+
+- [ ] **Step 2: Run `prek run --all-files` to confirm every hook passes**
+
+Run:
+```bash
+prek run --all-files
+```
+Expected: every hook reports `Passed`. This covers pre-commit hooks against the whole tree (not just changed files), so it's the strongest local signal that the hook changes didn't break anything.
+
+If any hook fails, fix the underlying issue. If `cargo-clippy` fails specifically on test code, that's expected (it now lints only lib/bin); confirm by running:
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+```
+This is what CI runs. If CI's flags also fail, the test code has a real lint regression — fix it as a separate commit before merging.
+
+- [ ] **Step 3: Run `just test-fast` once more and time it**
+
+Run:
+```bash
+{ /usr/bin/time -f "final just test-fast: %e s" just test-fast ; } 2>&1 | tail -3
+```
+Expected: ≤ 10 s on this hardware, all tests pass.
+
+- [ ] **Step 4: Run `just test` to confirm full coverage still works**
+
+Run:
+```bash
+{ /usr/bin/time -f "final just test: %e s" just test ; } 2>&1 | tail -3
+```
+Expected: ~90-130 s warm, 1438 tests pass. Confirms the five "skipped in fast" binaries still run under `just test` itself.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin docs/local-test-runtime-trim-spec
+```
+If the push hangs or drops mid-transfer (the very symptom this spec addresses), apply the documented escape hatch:
+```bash
+GIT_SSH_COMMAND='ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=20' git push -u origin docs/local-test-runtime-trim-spec
+```
+Note this incident in the PR description so future readers see the cold-laptop case in the wild.
+
+- [ ] **Step 6: Open the PR**
+
+Use the GitHub CLI:
+```bash
+gh pr create --title "Trim local test runtime: hook scope + just test-fast" --body "$(cat <<'EOF'
+## Summary
+- Narrows pre-commit clippy and pre-push cargo check from `--workspace --all-targets --locked` to `--workspace --lib --bins --locked`. Test-target lint/compile enforcement moves to CI.
+- Adds `just test-fast`: a nextest filter that runs ~1380 unit tests in ~4 s (versus ~92 s for `just test`), skipping the five heaviest binaries (dovecot, e2e, e2e_wire, e2e_wire_cancellation, proptest_html_lookalike).
+- Documents the new command in AGENTS.md.
+
+## Why
+Local hook + test runtime had grown past the SSH idle window on cold target/ and past contributor patience on warm. Builds on (does not replace) the prior pre-push-hook-trim spec. See `docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md` for full measurement table and rationale.
+
+## Test plan
+- [x] `prek run --all-files` passes
+- [x] `just test-fast` runs and finishes in ≤ 10 s
+- [x] `just test` still runs the full 1438-test sweep
+- [x] CI runs `cargo clippy --workspace --all-targets --all-features --locked` (unchanged) on every push and PR, so test-code lint regressions are still caught before merge
+- [x] Pre-commit clippy still rejects a deliberate `unnecessary_cast` regression in lib code
+- [x] Pre-push cargo check still rejects a deliberate compile error in lib code
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Wait for CI and address any failures**
+
+CI runs the full `--all-targets --all-features` clippy and the full nextest workspace plus MSRV plus mcp-conformance. If anything fails, treat it as a pre-existing issue uncovered by the broader CI sweep (this change does not modify any code that CI tests). Resolve in this PR or split into a follow-up before merging.
+
+---
+
+## Out of scope reminders (do NOT do these in this plan)
+
+- Do **not** touch `.github/workflows/ci.yml`. CI keeps the full `--all-targets --all-features` sweep as the safety net.
+- Do **not** change `.config/nextest.toml`. The filter is at the call site in `justfile`.
+- Do **not** add or modify any `.rs` file. No test code refactor.
+- Do **not** install or configure `sccache`, `mold`, or any other build accelerator. Future spec if needed.
+- Do **not** touch `crates/rimap-server/src/mcp/fuzz_oracle.rs` or the `include_bytes!` schema path. Out-of-scope flag in the spec.
+- Do **not** trim or remove `just test-msrv`. Coverage decision, out of scope.
+
+## If something goes wrong
+
+- **`prek run cargo-clippy --all-files` fails after Task 3 edit:** Either there's a real lint error in lib/bin code (fix it, commit as a separate fix), or the YAML edit broke the hook structure (re-read the file, verify it's still valid YAML with `yq . .pre-commit-config.yaml` or `python -c 'import yaml; yaml.safe_load(open(".pre-commit-config.yaml"))'`).
+- **`just test-fast` selects zero tests or fails to parse:** The nextest filter syntax may have changed. Run `cargo nextest list --workspace --locked -E 'binary(dovecot)'` as a smoke test of the `binary()` predicate. If even that fails, the cargo-nextest version is incompatible — check `cargo nextest --version` against what's documented.
+- **A test that passed under `just test` fails under `just test-fast`:** The test depends on side effects from one of the excluded binaries. Investigate the dependency before working around it; if the dependency is real, the test belongs in the excluded set's surface and the filter needs adjustment.
+- **Push hangs on Step 5 of Task 5:** Expected on cold laptops; use the documented `GIT_SSH_COMMAND` keepalive (per the `project-push-ssh-keepalive` memory). Note in the PR description.

--- a/docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md
+++ b/docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md
@@ -1,0 +1,366 @@
+# Local Test Runtime Trim — Narrow Hook Compile Scope and Add `just test-fast`
+
+**Date:** 2026-05-20
+**Status:** Design approved; implementation pending
+**Scope:** Developer tooling only. No runtime code changes, no CI workflow
+changes, no test code refactor.
+**Builds on:** [`2026-05-15-pre-push-hook-trim-design.md`](2026-05-15-pre-push-hook-trim-design.md)
+
+## Problem
+
+Local commit/push hooks and the inner-loop test command have grown to the
+point where:
+
+1. `git push` regularly drops the ref transfer on cold target/, because
+   pre-push hooks exceed github.com's ~30 s SSH idle window. The prior
+   `pre-push-hook-trim` spec replaced `just test` at pre-push with
+   `cargo check --workspace --all-targets --locked`, which fixed the warm
+   case but explicitly flagged cold target/ as still-unsolved.
+2. `just test` takes 90–120 s warm on a 48-core / 250 GB workstation
+   (and proportionally worse on weaker laptops). Developers either skip
+   it before pushing (and find out from CI) or wait minutes per change.
+
+Empirical timings, measured 2026-05-20 on the maintainer's workstation
+(Fedora 43, 48 cores, 250 GB, warm `~/.cargo/registry`):
+
+| stage | warm (s) | cold (s) | warm-repeat (s) |
+|---|---|---|---|
+| pre-commit `cargo clippy --workspace --all-targets --locked -- -D warnings` | 2.5 | 23.2 | 2.5 |
+| pre-commit (fmt-check + shellcheck + shfmt + actionlint + zizmor + typos + branch + macros) | <1 total | <1 | <1 |
+| pre-push `cargo check --workspace --all-targets --locked` (no preceding clippy) | 4.0 | 21.7 | 1.1 |
+| pre-push `cargo deny check advisories bans` (advisory-db on disk) | 0.5 | 0.5 | 0.5 |
+| `just test` (`cargo nextest run --workspace --locked`) | 118.8 | n/a | 91.9 |
+| `just test-msrv` (MSRV check + nextest, MSRV target partially warm) | n/a | 140.6 | n/a |
+
+Cold-cache numbers on a 4–8-core developer laptop are typically 3–10×
+these — easily 60–180 s for cold `cargo check --workspace --all-targets`.
+That is the regime in which the SSH idle window blows.
+
+Per-test-binary breakdown of `just test`:
+
+| binary | sum-of-test-times (s) | test count | type |
+|---|---|---|---|
+| `rimap-imap::dovecot` | 332.5 | 43 | container |
+| `rimap-server::e2e_wire` | 34.1 | 5 | container |
+| `rimap-content::proptest_html_lookalike` | 33.4 | 3 | proptest |
+| `rimap-server::e2e_wire_cancellation` | 32.2 | 5 | container |
+| `rimap-server::e2e` | 17.2 | 1 | container |
+| everything else combined (~1350 tests) | ~13 | ~1350 | unit |
+
+≈ 97 % of `just test` wall clock is the five heavy binaries above. The
+other ~1350 unit tests run in single-digit seconds combined. nextest
+already caps container-backed binaries to 4 parallel threads via
+`.config/nextest.toml`, so further parallelism inside `just test` is not
+the lever.
+
+## Root cause
+
+Two distinct sources of avoidable cost.
+
+### 1. `--all-targets` in the hooks compiles test binaries the hooks never run
+
+Both pre-commit clippy and pre-push check use `--workspace --all-targets`.
+`--all-targets` expands to `--lib --bins --tests --examples --benches`.
+Neither hook executes tests; the test/example/bench artifacts exist
+only to ensure they compile.
+
+Measured impact of dropping `--all-targets` (same workstation,
+`cargo clean` between cold runs):
+
+| invocation | cold (s) | warm-repeat (s) |
+|---|---|---|
+| `cargo clippy --workspace --all-targets --locked -- -D warnings` | 23.2 | 2.5 |
+| `cargo clippy --workspace --lib --bins --locked -- -D warnings` | 19.7 | 1.4 |
+| `cargo check --workspace --all-targets --locked` | 21.7 | 1.1 (post-clippy) |
+| `cargo check --workspace --lib --bins --locked` | 19.4 | 2.1 (post-clippy with different flags) |
+
+The cold savings are smaller than naive volume math would suggest
+(~15 % here, not ~50 %), because dep-graph compilation dominates and
+parallelizes across this machine's 48 cores. On a 4–8-core laptop the
+relative savings should be larger — test binaries are the part that
+*stops* parallelizing first once core count runs out — but we can't
+measure that here directly. The warm-repeat win is real and consistent
+(~40–50 % faster).
+
+The bigger argument is correctness of intent: spending compile budget
+on test/example/bench artifacts at *commit* and *push* time is the
+wrong place to pay it. CI runs `cargo nextest run --workspace` on every
+push and PR, which is a strict superset of "test code compiles." The
+only thing the hook adds today is local feedback ~5 minutes earlier than
+the CI run, paid every commit/push.
+
+### 2. `just test` is dominated by container + proptest binaries that don't belong in the inner loop
+
+The five heavy binaries (dovecot, e2e, e2e_wire, e2e_wire_cancellation,
+proptest_html_lookalike) provide high-value coverage — Dovecot wire
+behavior, MCP e2e, HTML adversarial properties — but each test takes
+10–25 s of wall clock and the suite is dominated by them. They're the
+right thing to run on CI and before a push that touches their surface;
+they're the wrong thing to run after every two-line edit.
+
+The other ~1350 tests are pure unit tests with no external dependencies.
+They finish in <10 s on this hardware and would still finish in <30 s on
+a weak laptop. There is no fast-tier `just` target today, so developers
+either run `just test` (slow, often skipped) or no test at all.
+
+## Desired behavior
+
+After this change:
+
+1. **Pre-commit cold target/:** ≈ 20 s on this hardware (down from 23 s,
+   modest absolute gain), warm-repeat ≈ 1.4 s (down from 2.5 s).
+   Estimated proportionally larger savings on lower-core-count laptops.
+   Lint coverage for `--lib --bins` is unchanged; lint coverage for
+   `--tests --examples --benches` moves entirely to CI.
+2. **Pre-push cold target/:** ≈ 20 s on this hardware (down from 22 s),
+   warm (post-pre-commit) ≈ 2 s. SSH idle window comfortably honored in
+   the warm case; cold-laptop case marginally improved, with the
+   documented `GIT_SSH_COMMAND` keepalive remaining as the escape hatch
+   when needed.
+3. **Inner-loop tests:** `just test-fast` measured at 4.2 s warm here
+   (target: ≤ 10 s warm, ≤ 30 s on a weak laptop) versus 91.9 s for
+   `just test`. Runs the ~1380 unit tests; skips the five heavy
+   binaries.
+4. **Pre-push and CI test coverage:** Unchanged. `just test`, `just
+   test-msrv`, `just ci`, and the CI workflow all keep running the full
+   sweep. Nothing previously enforced loses coverage; we only add a
+   faster inner-loop alternative.
+
+Approach A's standalone value is modest on this hardware — the headline
+win is Approach B's inner-loop test command. A is still worth shipping
+in the same change because it's a single-line edit, scales better on
+weaker hardware, and tightens the alignment between hook intent ("did
+this commit break the build?") and hook scope.
+
+## Approach
+
+Two complementary, independent changes. Either could ship alone; both
+together is the goal.
+
+### A. Drop `--all-targets` from pre-commit clippy and pre-push check
+
+Single-file edit to `.pre-commit-config.yaml`:
+
+```yaml
+# Pre-commit: was
+- id: cargo-clippy
+  entry: cargo clippy --workspace --all-targets --locked -- -D warnings
+# Pre-commit: becomes
+- id: cargo-clippy
+  entry: cargo clippy --workspace --lib --bins --locked -- -D warnings
+
+# Pre-push: was
+- id: cargo-check
+  entry: cargo check --workspace --all-targets --locked
+# Pre-push: becomes
+- id: cargo-check
+  entry: cargo check --workspace --lib --bins --locked
+```
+
+`--lib --bins` is explicit rather than relying on cargo's default-target
+behavior so the hook command reads the same as the documented intent.
+
+#### Why `--lib --bins` and not `--lib` only
+
+The workspace has one binary target (`rusty-imap-mcp` in `rimap-server`)
+that contains the production main and clap CLI surface. A library-only
+check could miss CLI compile errors in `main.rs` — exactly the kind of
+mistake that should be caught at commit/push, not CI. The bin is small;
+including it is cheap.
+
+#### Why not also drop `--locked`
+
+`--locked` fails if `Cargo.lock` would be modified by the build. That's
+the lockfile-drift catch the prior spec called "exactly the right time."
+Kept verbatim.
+
+#### Why not narrow further with `-p <crate>` based on changed files
+
+Per-crate clippy invocations measured at 2.6–9.0 s warm each (sum: 43.1 s
+across the 8 crates) versus 2.5 s warm for the whole-workspace clippy.
+Per-crate invocations re-load and re-fingerprint dependencies from cargo's
+cache per invocation; workspace-level clippy amortizes that work once.
+Trying to scope clippy to "only the crates with changed files" would
+*slow down* warm cases and add scripting brittleness. Not worth it.
+
+#### Why not move clippy from pre-commit to pre-push
+
+Pre-commit is the right stage for lints: the developer is still in the
+local context that produced the warning, and the rebuild is incremental
+from inner-loop iteration. Moving clippy to pre-push compresses the
+"commit → push" interval (which the prior spec specifically widened) and
+costs cold compile latency exactly when the SSH window is at risk.
+
+### B. Add `just test-fast` for the inner loop
+
+Add a new `just` target backed by a nextest filter expression:
+
+```just
+# Fast unit-test loop. Skips container-backed integration suites and the
+# slowest property-test binary. Use this between `cargo check` cycles
+# during inner-loop iteration. Before pushing, run `just test` (or
+# `just ci`) for the full sweep.
+test-fast:
+    cargo nextest run --workspace --locked --no-tests=pass \
+        -E 'not (binary(dovecot) | binary(e2e) | binary(e2e_wire) | binary(e2e_wire_cancellation) | binary(proptest_html_lookalike))'
+```
+
+The filter excludes exactly the five binaries identified in the
+measurements. All other binaries (including `rimap-imap::proton`, which
+is fast despite being container-tagged, and the other proptest binaries
+`properties`, `mcp_wire_proptest`, `proptest_charset`, all sub-second)
+stay in `test-fast`.
+
+#### Why a nextest `-E` filter and not a nextest profile
+
+Profiles are the right tool when test behavior changes (retries, threads,
+timeouts). Here we want one switch — "skip the heavy five." A filter
+expression keeps the heavy/fast split visible at the call site in the
+justfile, doesn't require touching `.config/nextest.toml`, and behaves
+identically regardless of which profile is active.
+
+#### Why these five binaries and not "all container-backed" or "all proptest"
+
+Empirical, not categorical: these five each contribute ≥ 17 s of
+sum-of-test-times. `rimap-imap::proton` is container-tagged in the
+nextest config but the 20 tests in it run as a unit-test sweep of
+container support code (port reservation, project naming) — 0.69 s
+total. Excluding it would drop coverage with no speed benefit.
+`rimap-content::properties` and `rimap-server::mcp_wire_proptest` are
+proptest-shaped but cheap. The empirical rule is "binaries that cost
+more than a couple of seconds skip the fast tier"; that happens to
+correlate with `dovecot` + `e2e*` + `proptest_html_lookalike`.
+
+#### Why not also tune `PROPTEST_CASES` for `test-fast`
+
+`proptest_html_lookalike` could in principle be made faster by setting
+`PROPTEST_CASES=64` (versus the default 256) for the fast tier. We're
+choosing the simpler split — skip the binary entirely — because
+property tests at reduced case counts give a misleading "I ran the
+properties" signal. Either run them fully or don't; halfway is worse
+than either extreme.
+
+### Documentation update
+
+Update `AGENTS.md` to describe the three test commands:
+
+- `just test-fast` — inner-loop unit tests, ≤ 10 s warm. Run frequently.
+- `just test` — full nextest workspace including container and
+  proptest binaries. Run before pushing. Already documented; gets one
+  line clarifying that it's the "before push" sweep.
+- `just ci` — full local CI equivalent (test + test-msrv + deny +
+  mcp-conformance-node + typos). Run before sharing a PR or making a
+  large push. Already documented.
+
+The "Golden rule: if `just ci` passes locally, CI will pass" line in
+the existing development-commands section stays.
+
+## File layout
+
+- **Modified:** `.pre-commit-config.yaml` — two hook `entry:` lines.
+- **Modified:** `justfile` — add `test-fast` target.
+- **Modified:** `AGENTS.md` — add `just test-fast` to the commands list
+  in the development-commands section and clarify when to use each.
+- **No new files.** No new dependencies. No cargo or nextest config
+  changes. No CI workflow changes.
+
+## Testing
+
+Configuration change only; the hooks and `just` target are themselves
+the tests. Manual verification:
+
+1. **Pre-commit narrowed-clippy still catches lint regressions in lib/bin.**
+   Add a deliberate clippy warning to a non-test `.rs` file under
+   `crates/rimap-server/src/`, attempt `git commit`, observe the hook
+   fails with `-D warnings`.
+2. **Pre-commit no longer compiles test binaries.** With a warm target/,
+   delete `target/debug/deps/*-test-*` artifacts, run the hook, observe
+   no test binaries are rebuilt (verify with `find target/debug/deps
+   -newer .pre-commit-config.yaml -name '*-*'` post-hook).
+3. **Pre-push narrowed-check still catches lockfile drift.** Hand-edit
+   `Cargo.lock` to a stale state, attempt push, observe `cargo check
+   --locked` fails the hook.
+4. **Pre-push cold-cache timing.** `cargo clean && time git push`
+   (against a no-op branch or with `--dry-run` if available); expect
+   ≤ 15 s on this hardware. The prior spec's clean-push smoke test
+   (push without `GIT_SSH_COMMAND` keepalive, observe ref transfer
+   succeeds) continues to apply.
+5. **`just test-fast` test selection.** Run `just test-fast --list` (or
+   the nextest equivalent), verify none of the five excluded binaries
+   appear in the selected set.
+6. **`just test-fast` warm timing.** `just test-fast` after a warm
+   `just test`; expect ≤ 10 s wall clock on this hardware.
+7. **`just test` is unchanged.** Run `just test`, observe all 1438
+   tests still selected and pass.
+8. **CI is unchanged.** `just ci` continues to invoke the full sweep.
+   No `.github/workflows/` files modified.
+
+No automated regression suite for this change. The prior spec's note
+("`prek run --all-files` exercises the hook in CI's mcp-conformance /
+lint paths but doesn't simulate the network timing") continues to apply.
+
+## Risks and mitigations
+
+- **Test-target compile error slips past pre-commit.** Previously caught
+  by pre-commit clippy via `--all-targets`. Now caught only at CI (and
+  at `just test` if the developer runs it before push). Acceptable: CI
+  is a strict gate; the median test-target compile error is "I renamed
+  a public fn and forgot to update its test", which the developer will
+  hit the moment they run `just test` or `just test-fast` against the
+  changed crate. The other risk profile — a test in crate A breaks
+  because of an unrelated edit to crate B — is rare in this codebase
+  and CI catches it before merge.
+- **Developer runs only `just test-fast` and pushes without `just test`.**
+  Then a regression in dovecot/e2e/proptest_html_lookalike slips past
+  local validation; CI catches it. Same net outcome as today's
+  "developer skips `just test` entirely because it's slow." A faster
+  inner loop makes it more likely the developer runs *something*
+  rather than nothing.
+- **`--lib --bins` is too narrow and misses a real category of error.**
+  The workspace has no `[[example]]` targets and no `[[bench]]` targets
+  worth gating on. If those are added later, the spec author should
+  revisit whether they belong in the hook scope.
+- **Cold target/ on a weak laptop still blows the SSH idle window.**
+  The fix narrows compile scope by ~50 %, not by 100 %. A truly cold
+  laptop push may still exceed 30 s. Mitigations unchanged: documented
+  `GIT_SSH_COMMAND='ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=20'
+  git push ...` escape hatch from the `project-push-ssh-keepalive`
+  memory, or a permanent `~/.ssh/config` keepalive. Out of scope here.
+- **Container-backed test regression detected only at push time, not at
+  commit.** Same as today; `just test` was never wired into the hooks
+  after `2026-05-15-pre-push-hook-trim`. No change.
+- **nextest filter expression syntax changes.** Pinned to current
+  cargo-nextest CLI behavior. If the `-E 'binary(...)'` syntax changes,
+  the `just test-fast` target needs an update. This is the same risk
+  surface as any nextest invocation in the repo.
+
+## Out of scope
+
+- **`sccache` / `mold` / linker tuning.** Orthogonal; would shave cold
+  compile time across all stages, but does not address the "we compile
+  test binaries we never run" waste and does not address `just test`
+  test-execution time. Candidate for a future spec if cold-laptop pain
+  remains after this lands.
+- **CI workflow changes.** `.github/workflows/ci.yml` continues to run
+  the full sweep (`cargo nextest run --workspace --locked`,
+  `cargo clippy --workspace --all-targets --all-features --locked`,
+  msrv, mcp-conformance, e2e wire). The CI side is the safety net for
+  this spec's narrower local gates.
+- **Test code refactor / tiering via `#[cfg]` flags.** The fast tier is
+  achieved via a runtime nextest filter, not by gating tests at compile
+  time. No test code touched.
+- **`PROPTEST_CASES` tuning.** Mentioned above; rejected for honesty
+  reasons.
+- **Reducing the per-test cost of the container-backed binaries
+  themselves.** That's a separate concern (Dovecot fixture startup,
+  per-test session setup). Out of scope; covered partially by prior
+  specs (`2026-05-11-dovecot-port-race-design.md`,
+  `2026-05-13-dovecot-24-multiarch-fixture-design.md`).
+- **The `include_bytes!` rebuild quirk in
+  `crates/rimap-server/src/mcp/fuzz_oracle.rs:75`** that causes
+  `rimap-server` to re-check on every clippy invocation. ~1–2 s tax;
+  not worth bundling into this spec. Flag for follow-up.
+- **`just test-msrv` reduction.** The MSRV nextest run duplicates the
+  stable run (~90–140 s on top of `just test`). Removing or trimming it
+  would speed `just ci` substantially but is a coverage decision, not a
+  speed decision; out of scope here.

--- a/justfile
+++ b/justfile
@@ -188,6 +188,16 @@ prune-containers:
 test: prune-containers
     cargo nextest run --workspace --locked --no-tests=pass
 
+# Inner-loop unit tests. Skips the five heaviest test binaries
+# (dovecot integration, e2e/e2e_wire MCP suites, and the slow HTML
+# lookalike proptest). Use this between `cargo check` cycles during
+# inner-loop iteration. Before pushing, run `just test` (or `just ci`)
+# for the full sweep. See
+# docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md.
+test-fast:
+    cargo nextest run --workspace --locked --no-tests=pass \
+        -E 'not (binary(dovecot) | binary(e2e) | binary(e2e_wire) | binary(e2e_wire_cancellation) | binary(proptest_html_lookalike))'
+
 # Verify the MSRV toolchain still builds and tests the workspace.
 test-msrv:
     cargo +{{MSRV}} check --workspace --all-targets --all-features --locked


### PR DESCRIPTION
## Summary
- Narrows pre-commit clippy and pre-push cargo check from `--workspace --all-targets --locked` to `--workspace --lib --bins --locked`. Test-target lint/compile enforcement moves to CI.
- Adds `just test-fast`: a nextest filter that runs ~1380 unit tests in ~4 s (versus ~92 s for `just test`), skipping the five heaviest binaries (dovecot, e2e, e2e_wire, e2e_wire_cancellation, proptest_html_lookalike).
- Documents the new command in AGENTS.md.

## Why
Local hook + test runtime had grown past the SSH idle window on cold target/ and past contributor patience on warm. Builds on (does not replace) the prior pre-push-hook-trim spec. See [`docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md`](docs/superpowers/specs/2026-05-20-local-test-runtime-trim-design.md) for full measurement table and rationale.

## Local measurements (48-core workstation, warm cache)

| stage | before | after |
|---|---|---|
| pre-commit clippy (warm-repeat) | 2.58 s | 1.42 s |
| pre-push cargo check (warm post-clippy) | 3.81 s | 0.69 s |
| inner-loop tests | `just test` 91.93 s | `just test-fast` 4.52 s |

## Test plan
- [x] `prek run --all-files` passes (excluding the ts-typecheck hooks which require pnpm locally; unrelated to this branch)
- [x] `just test-fast` runs and finishes in ≤ 10 s (measured 4.52 s warm, 1381/1381 pass)
- [x] `just test` still runs the full 1438-test sweep (91.93 s warm, 1438/1438 pass)
- [x] CI runs `cargo clippy --workspace --all-targets --all-features --locked` (unchanged) on every push and PR, so test-code lint regressions are still caught before merge
- [x] Pre-commit clippy still rejects a deliberate `unnecessary_cast` regression in lib code (verified during Task 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)