### PR TITLE
fix(rimap-content): gate HtmlResult re-export to match test_support cfg (#308)

### DIFF
--- a/crates/rimap-content/src/html/mod.rs
+++ b/crates/rimap-content/src/html/mod.rs
@@ -18,8 +18,10 @@ mod pipeline;
 mod sanitize;
 mod style_parse;
 
+#[cfg(any(test, feature = "test-support"))]
+pub use pipeline::HtmlResult;
+pub use pipeline::sanitize;
 pub(crate) use pipeline::{
     ElementIndex, HiddenMethod, MAX_ANCHOR_TEXT_SCAN, MAX_HIDDEN_HITS, MAX_HTML_BYTES,
     MAX_MISMATCH_HITS,
 };
-pub use pipeline::{HtmlResult, sanitize};


### PR DESCRIPTION
## Summary

Fixes #308.

The `pub use pipeline::{HtmlResult, sanitize}` re-export in `crates/rimap-content/src/html/mod.rs` emitted an `unused_imports` warning on default-feature builds (e.g. `cargo install`):

```
warning: unused import: `HtmlResult`
  --> crates/rimap-content/src/html/mod.rs:25:20
```

`HtmlResult`'s only consumer is `crate::test_support::HtmlResult` (`test_support.rs:32`), and the `test_support` module is gated on `#[cfg(any(test, feature = "test-support"))]` (`lib.rs:19`). When that gate is off, no consumer exists, so the re-export becomes unused.

The fix splits the re-export so:
- `pub use pipeline::sanitize` stays unconditional (consumed unconditionally by `parse::bodies`).
- `pub use pipeline::HtmlResult` is gated on the same `cfg` as its consumer.

The cfg is self-policing: future drift between the gates either re-emits the warning (consumer disappears) or fails compilation (consumer references a missing path) — failing loud in CI.

## Test plan

- [x] `cargo build -p rimap-content --release` (default features) — no warnings
- [x] `cargo build --release -p rimap-server` (reproduces the install path from #308) — no warnings
- [x] `cargo build -p rimap-content --features test-support` — clean
- [x] `cargo check -p rimap-content --tests` — clean
- [x] `cargo clippy -p rimap-content --all-targets --all-features -- -D warnings` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)