### PR TITLE
docs: add per-tool enable/disable instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 .desloppify/
 docs/superpoweres/plans/
 
-# Phase 2 (Node) conformance suite — installed deps and coverage outputs
+# Conformance suite — installed deps and coverage outputs
 tests/mcp-conformance/node_modules/
 tests/mcp-conformance/coverage/
+
+# IBM Bob
+.bob/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,12 +189,54 @@ mark_read = "deny"                # deny even though draft-safe allows it
 "search.advanced_query" = "allow" # allow even though draft-safe denies it
 ```
 
-Valid tool names: `list_folders`, `search`, `search.advanced_query`,
-`fetch_message`, `fetch_message.include_html`, `list_attachments`,
-`download_attachment`, `mark_read`, `mark_unread`, `flag`, `unflag`,
-`add_label`, `remove_label`, `list_labels`, `move_message`,
-`create_draft`, `send_email`, `delete_message`, `create_folder`,
-`rename_folder`, `expunge`, `delete_folder`.
+#### Valid tool names
+
+All 24 tool capabilities recognized by `[security.tools]`:
+
+| Tool name | Description | Default posture |
+|-----------|-------------|-----------------|
+| `list_folders` | List IMAP folders | readonly+ |
+| `search` | Structured search (subject, from, to, dates, flags) | readonly+ |
+| `search.advanced_query` | Advanced search (body, text, bcc, headers) | full+ |
+| `fetch_message` | Fetch message (text parts only) | readonly+ |
+| `fetch_message.include_html` | Fetch message with HTML parts | full+ |
+| `list_attachments` | List message attachments | readonly+ |
+| `download_attachment` | Download attachment to sandbox | readonly+ |
+| `mark_read` | Mark message as read | draft-safe+ |
+| `mark_unread` | Mark message as unread | draft-safe+ |
+| `flag` | Add star/flag | draft-safe+ |
+| `unflag` | Remove star/flag | draft-safe+ |
+| `add_label` | Add label/tag | draft-safe+ |
+| `remove_label` | Remove label/tag | draft-safe+ |
+| `list_labels` | List available labels | readonly+ |
+| `move_message` | Move message to folder | draft-safe+ |
+| `create_draft` | Create draft with $PendingReview | draft-safe+ |
+| `send_email` | Send email via SMTP | full+ |
+| `delete_message` | Mark message as deleted | full+ |
+| `create_folder` | Create new folder | full+ |
+| `rename_folder` | Rename existing folder | full+ |
+| `expunge` | Permanently delete marked messages | destructive |
+| `delete_folder` | Permanently delete folder | destructive |
+| `use_account` | Switch active account (multi-account only) | always available |
+| `list_accounts` | List configured accounts (multi-account only) | always available |
+
+**Note:** "readonly+" means allowed in readonly and all higher postures.
+"draft-safe+" means allowed in draft-safe and all higher postures.
+
+Sub-capabilities (`.advanced_query`, `.include_html`) are separate
+authorization gates within their parent tool. The parent tool name
+(`search`, `fetch_message`) controls the base capability; the
+sub-capability controls the escape hatch.
+
+#### Override semantics
+
+- `"allow"` grants the tool regardless of posture
+- `"deny"` blocks the tool regardless of posture
+- An override matching the posture's default is a no-op (not an error)
+- Unknown tool names are rejected at config validation with `ERR_CONFIG`
+
+If you see `unknown tool name 'mark_as_read'`, check the spelling
+against the table above. The correct name is `mark_read`.
 
 ## `[limits]` section
 

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -143,6 +143,46 @@ Each account has independent:
 - Security posture
 
 One account's rate limit or circuit breaker state does not affect
+
+## Per-account per-tool overrides
+
+In multi-account configs, `[defaults.security.tools]` sets the baseline
+for all accounts. Per-account `[[accounts]].security.tools` overrides
+merge on top:
+
+```toml
+[defaults.security]
+posture = "draft-safe"
+
+[defaults.security.tools]
+mark_read = "deny"  # baseline: preserve unread state for all accounts
+
+[[accounts]]
+name = "work"
+# ... imap/smtp config ...
+# Inherits mark_read = "deny" from defaults
+
+[[accounts]]
+name = "personal"
+# ... imap/smtp config ...
+
+[accounts.security.tools]
+mark_read = "allow"  # override: personal account can mark read
+"search.advanced_query" = "allow"  # personal account can search bodies
+```
+
+**Merge semantics:**
+- Per-account overrides replace defaults for the same tool
+- Tools not mentioned in per-account inherit from defaults
+- Per-account posture (if set) replaces default posture
+- Per-account overrides apply on top of per-account posture
+
+In the example above:
+- `work` account: `mark_read` denied (inherited from defaults)
+- `personal` account: `mark_read` allowed (per-account override),
+  `search.advanced_query` allowed (per-account override)
+
+
 another.
 
 ## Backward compatibility

--- a/docs/postures.md
+++ b/docs/postures.md
@@ -66,6 +66,90 @@ mark_read = "deny"                # deny even though draft-safe allows it
 
 ## Tool advertisement
 
+
+### Common override patterns
+
+Real-world examples of per-tool overrides:
+
+#### Preserve unread state in draft-safe
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+mark_read = "deny"
+```
+
+Use case: Agent can search, fetch, and compose drafts, but cannot
+accidentally mark messages as read. Useful when the agent is triaging
+or summarizing without taking action.
+
+#### Enable advanced search in draft-safe
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+"search.advanced_query" = "allow"
+```
+
+Use case: Agent needs to search message bodies or headers but should
+not send email. The `advanced_query` escape hatch allows body/text/bcc
+searches while keeping `send_email` denied.
+
+**Security note:** Body search is classified as a "content oracle"
+because it scans untrusted adversarial message content. Enable only if
+you trust the agent not to exfiltrate search results.
+
+#### Block downloads in readonly
+
+```toml
+[security]
+posture = "readonly"
+
+[security.tools]
+download_attachment = "deny"
+```
+
+Use case: Agent can read message metadata and text but cannot write
+files to the sandbox. Useful for pure analysis workflows where
+attachment content is not needed.
+
+#### Allow HTML in draft-safe
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+"fetch_message.include_html" = "allow"
+```
+
+Use case: Agent needs to analyze HTML structure (e.g., detecting
+phishing via link/text mismatches) but should not send email. The
+`.include_html` sub-capability is gated separately because HTML
+parsing increases attack surface.
+
+**Security note:** HTML parts are sanitized but still carry higher
+risk than plain text. Enable only if the agent's task requires HTML.
+
+#### Deny sending in full posture
+
+```toml
+[security]
+posture = "full"
+
+[security.tools]
+send_email = "deny"
+```
+
+Use case: Agent can delete messages and manage folders but cannot send
+email. Useful when SMTP credentials are not available or when you want
+the agent to clean up the mailbox without outbound access.
+
+
 Tools denied by the effective matrix (posture + overrides) are **not
 advertised** via the MCP `list_tools` response. Denial is enforced at
 both discovery and dispatch (defense in depth).

--- a/docs/quickstart-gmail.md
+++ b/docs/quickstart-gmail.md
@@ -97,6 +97,33 @@ alongside Codex), see
 [Running multiple MCP clients](audit-log.md#running-multiple-mcp-clients)
 for the per-client configuration pattern.
 
+
+### Optional: Customize tool availability
+
+The default `draft-safe` posture allows most operations except sending,
+deleting, and advanced search. You can fine-tune this with per-tool
+overrides:
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+mark_read = "deny"                # preserve unread state
+"search.advanced_query" = "allow" # enable body/text search
+```
+
+Valid tool names and their default availability are listed in the
+[security postures](postures.md) documentation. Common patterns:
+
+- **Preserve unread state:** `mark_read = "deny"` in draft-safe
+- **Enable advanced search:** `"search.advanced_query" = "allow"` in draft-safe
+- **Block downloads:** `download_attachment = "deny"` in readonly
+
+See [configuration.md](configuration.md#per-tool-overrides) for the
+complete reference.
+
+
 ## Step 3: Store your credentials
 
 Store the App Password in your OS keychain. The `login` subcommand

--- a/docs/quickstart-proton-bridge.md
+++ b/docs/quickstart-proton-bridge.md
@@ -119,6 +119,33 @@ for the per-client configuration pattern.
 
 Proton Bridge uses a self-signed TLS certificate that is not in your
 system trust store. Pin the certificate fingerprint so the server can
+
+### Optional: Customize tool availability
+
+The default `draft-safe` posture allows most operations except sending,
+deleting, and advanced search. You can fine-tune this with per-tool
+overrides:
+
+```toml
+[security]
+posture = "draft-safe"
+
+[security.tools]
+mark_read = "deny"                # preserve unread state
+"search.advanced_query" = "allow" # enable body/text search
+```
+
+Valid tool names and their default availability are listed in the
+[security postures](postures.md) documentation. Common patterns:
+
+- **Preserve unread state:** `mark_read = "deny"` in draft-safe
+- **Enable advanced search:** `"search.advanced_query" = "allow"` in draft-safe
+- **Block downloads:** `download_attachment = "deny"` in readonly
+
+See [configuration.md](configuration.md#per-tool-overrides) for the
+complete reference.
+
+
 verify it.
 
 ### Recommended: capture via `--dry-run`


### PR DESCRIPTION
## Summary
- Document how to enable/disable individual MCP tools across the configuration docs (`docs/configuration.md`, `docs/postures.md`, `docs/multi-account.md`)
- Add per-tool enable/disable guidance to the Gmail and Proton Bridge quickstarts
- Tidy `.gitignore`: rename the conformance-suite comment and ignore `.bob/`

## Test Plan
- [ ] Docs-only change — no code affected; verify rendered Markdown reads correctly on GitHub