### PR TITLE
fix(rimap-server): serialize fetch_message date as RFC 3339 string

### DIFF
--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -71,15 +71,12 @@ pub struct FetchMessageUntrusted {
     pub cc: Vec<String>,
     /// `Reply-To` header.
     pub reply_to: Option<String>,
-    /// `Date` header. Serialized as a 9-element integer tuple:
-    /// `[year, ordinal, hour, minute, second, nanosecond,
-    ///   offset_whole_hours, offset_minutes_past_hour,
-    ///   offset_seconds_past_minute]`.
-    ///
-    /// Note: the `time` crate does not enable `serde-human-readable` in
-    /// this workspace, so `OffsetDateTime` always serializes as a tuple
-    /// regardless of the serializer's `is_human_readable()` flag.
-    #[schemars(schema_with = "offset_date_time_tuple_schema")]
+    /// `Date` header as an RFC 3339 / ISO 8601 timestamp in UTC, e.g.
+    /// `"2025-01-29T17:35:39Z"`; `null` when the header is absent. The
+    /// instant is normalized to UTC by the content pipeline, so the
+    /// offset is always `Z`. Mirrors `search`'s string-valued `date`.
+    #[serde(with = "time::serde::rfc3339::option")]
+    #[schemars(schema_with = "rfc3339_date_time_schema")]
     pub date: Option<time::OffsetDateTime>,
     /// MIME attachment parts found in the message.
     pub attachments: Vec<rimap_content::AttachmentMeta>,
@@ -161,40 +158,61 @@ pub async fn handle(
     .with_warnings(content.security_warnings))
 }
 
-/// JSON Schema for `time::OffsetDateTime` as serialized by the `time` crate
-/// without the `serde-human-readable` feature.
+/// JSON Schema for the RFC 3339 string form of `FetchMessageUntrusted::date`.
 ///
-/// The `time` crate serializes `OffsetDateTime` as a 9-element integer tuple:
-/// `[year, day_of_year, hour, minute, second, nanosecond,
-///   offset_whole_hours, offset_minutes_past_hour, offset_seconds_past_minute]`.
-/// This matches the actual wire bytes produced by `serde_json::to_string` when
-/// the workspace does not enable `serde-human-readable` on the `time` crate.
+/// The field serializes via `time::serde::rfc3339::option`, producing a UTC
+/// timestamp string (or `null`). A plain `["string", "null"]` schema validates
+/// identically under every JSON Schema draft.
 ///
-/// Used via `#[schemars(schema_with = "offset_date_time_tuple_schema")]` on
+/// This replaces the `time` crate's default integer-tuple serialization, whose
+/// schema required Draft 2020-12 `prefixItems` + `items: false`. Draft-07
+/// validators (e.g. Ajv, the default in the official TypeScript MCP SDK) ignore
+/// `prefixItems` and read `items: false` as "the array must be empty", rejecting
+/// every element of a valid timestamp tuple and failing structured-output
+/// validation.
+///
+/// Used via `#[schemars(schema_with = "rfc3339_date_time_schema")]` on
 /// `FetchMessageUntrusted::date`.
-fn offset_date_time_tuple_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+fn rfc3339_date_time_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
     use schemars::json_schema;
     json_schema!({
-        "type": ["array", "null"],
-        "description": concat!(
-            "time::OffsetDateTime as a 9-element integer tuple: ",
-            "[year, day_of_year, hour, minute, second, nanosecond, ",
-            "offset_whole_hours, offset_minutes_past_hour, ",
-            "offset_seconds_past_minute]. Null when the header is absent."
-        ),
-        "prefixItems": [
-            { "type": "integer", "description": "year" },
-            { "type": "integer", "description": "day_of_year (ordinal 1–366)" },
-            { "type": "integer", "description": "hour (0–23)" },
-            { "type": "integer", "description": "minute (0–59)" },
-            { "type": "integer", "description": "second (0–60)" },
-            { "type": "integer", "description": "nanosecond (0–999999999)" },
-            { "type": "integer", "description": "UTC offset: whole hours (-23–23)" },
-            { "type": "integer", "description": "UTC offset: minutes past hour (-59–59)" },
-            { "type": "integer", "description": "UTC offset: seconds past minute (-59–59)" }
-        ],
-        "minItems": 9,
-        "maxItems": 9,
-        "items": false
+        "type": ["string", "null"],
+        "format": "date-time"
     })
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    fn untrusted_with_date(date: Option<time::OffsetDateTime>) -> FetchMessageUntrusted {
+        FetchMessageUntrusted {
+            body_text: "hello".to_string(),
+            body_html: None,
+            subject: None,
+            from: None,
+            to: Vec::new(),
+            cc: Vec::new(),
+            reply_to: None,
+            date,
+            attachments: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn date_serializes_as_rfc3339_utc_string() {
+        // The content pipeline normalizes the Date header to UTC, so the
+        // RFC 3339 form always carries a `Z` offset and no fractional part
+        // for whole-second timestamps.
+        let dt = time::macros::datetime!(2025-01-29 17:35:39 UTC);
+        let value = serde_json::to_value(untrusted_with_date(Some(dt))).expect("serialize");
+        assert_eq!(value["date"], serde_json::json!("2025-01-29T17:35:39Z"));
+    }
+
+    #[test]
+    fn absent_date_serializes_as_null() {
+        let value = serde_json::to_value(untrusted_with_date(None)).expect("serialize");
+        assert_eq!(value["date"], serde_json::Value::Null);
+    }
 }

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
@@ -107,50 +107,10 @@
           "type": "array"
         },
         "date": {
-          "description": "`Date` header. Serialized as a 9-element integer tuple:\n`[year, ordinal, hour, minute, second, nanosecond,\n  offset_whole_hours, offset_minutes_past_hour,\n  offset_seconds_past_minute]`.\n\nNote: the `time` crate does not enable `serde-human-readable` in\nthis workspace, so `OffsetDateTime` always serializes as a tuple\nregardless of the serializer's `is_human_readable()` flag.",
-          "items": false,
-          "maxItems": 9,
-          "minItems": 9,
-          "prefixItems": [
-            {
-              "description": "year",
-              "type": "integer"
-            },
-            {
-              "description": "day_of_year (ordinal 1\u2013366)",
-              "type": "integer"
-            },
-            {
-              "description": "hour (0\u201323)",
-              "type": "integer"
-            },
-            {
-              "description": "minute (0\u201359)",
-              "type": "integer"
-            },
-            {
-              "description": "second (0\u201360)",
-              "type": "integer"
-            },
-            {
-              "description": "nanosecond (0\u2013999999999)",
-              "type": "integer"
-            },
-            {
-              "description": "UTC offset: whole hours (-23\u201323)",
-              "type": "integer"
-            },
-            {
-              "description": "UTC offset: minutes past hour (-59\u201359)",
-              "type": "integer"
-            },
-            {
-              "description": "UTC offset: seconds past minute (-59\u201359)",
-              "type": "integer"
-            }
-          ],
+          "description": "`Date` header as an RFC 3339 / ISO 8601 timestamp in UTC, e.g.\n`\"2025-01-29T17:35:39Z\"`; `null` when the header is absent. The\ninstant is normalized to UTC by the content pipeline, so the\noffset is always `Z`. Mirrors `search`'s string-valued `date`.",
+          "format": "date-time",
           "type": [
-            "array",
+            "string",
             "null"
           ]
         },

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -276,4 +276,82 @@ mod fixture_smoke_tests {
             );
         }
     }
+
+    /// Build a minimal, schema-valid `fetch_message` structured response
+    /// with `date` substituted into the untrusted payload. Required
+    /// fields mirror the published schema (`FetchMessageMeta`:
+    /// `folder`/`uid`/`size`/`truncated`; `FetchMessageUntrusted`:
+    /// `body_text`/`to`/`cc`/`date`/`attachments`).
+    fn fetch_message_payload(date: &Value) -> Value {
+        json!({
+            "meta": {
+                "folder": "INBOX",
+                "uid": 42u32,
+                "size": 1024u32,
+                "truncated": false,
+            },
+            "untrusted": {
+                "body_text": "hello",
+                "to": ["recipient@example.com"],
+                "cc": [],
+                "date": date.clone(),
+                "attachments": [],
+            },
+            "security_warnings": [],
+        })
+    }
+
+    /// Validate `payload` against the published `tool` schema under BOTH
+    /// the draft a strict MCP client uses (Draft-07 — the Ajv default in
+    /// the official TypeScript SDK) and the draft we advertise (2020-12).
+    ///
+    /// Forcing the draft is the entire point: `validator_for_tool_response`
+    /// auto-detects 2020-12 from the fixture's `$schema`, so it can never
+    /// reproduce how a Draft-07 client interprets the same schema. A field
+    /// that validates under 2020-12 but not Draft-07 (e.g. a `prefixItems`
+    /// tuple with `items:false`) sails past every other test and only
+    /// fails at a real client — which is exactly how the `date` tuple
+    /// regression escaped.
+    fn assert_validates_under_draft7_and_2020_12(tool: &'static str, payload: &Value) {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/rimap-tool-schemas")
+            .join(format!("{tool}.schema.json"));
+        let raw = std::fs::read_to_string(&path).expect("read tool schema fixture");
+        let schema: Value = serde_json::from_str(&raw).expect("parse tool schema fixture");
+        for draft in [jsonschema::Draft::Draft7, jsonschema::Draft::Draft202012] {
+            let validator = jsonschema::options()
+                .with_draft(draft)
+                .build(&schema)
+                .unwrap_or_else(|e| panic!("compile {tool} schema under {draft:?}: {e}"));
+            if !validator.is_valid(payload) {
+                let errors: Vec<String> = validator
+                    .iter_errors(payload)
+                    .map(|e| e.to_string())
+                    .collect();
+                panic!(
+                    "{tool} payload must validate under {draft:?}; errors:\n  {}\n\npayload: {payload}",
+                    errors.join("\n  ")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fetch_message_date_string_validates_under_draft7_and_2020_12() {
+        // Regression: `untrusted.date` was a 9-integer tuple described
+        // with Draft 2020-12 `prefixItems` + `items:false`. A Draft-07
+        // validator (Ajv default in the official TS MCP SDK) ignores
+        // `prefixItems` and reads `items:false` as "array must be empty",
+        // rejecting every element — the -32602 a real client hit.
+        // Serializing `date` as an RFC 3339 string validates identically
+        // under every draft.
+        let payload = fetch_message_payload(&json!("2025-01-29T17:35:39Z"));
+        assert_validates_under_draft7_and_2020_12("fetch_message", &payload);
+    }
+
+    #[test]
+    fn fetch_message_null_date_validates_under_draft7_and_2020_12() {
+        let payload = fetch_message_payload(&Value::Null);
+        assert_validates_under_draft7_and_2020_12("fetch_message", &payload);
+    }
 }


### PR DESCRIPTION
## What

`fetch_message`'s `untrusted.date` now serializes as an RFC 3339 / ISO 8601 UTC string (e.g. `"2025-01-29T17:35:39Z"`, or `null`) instead of a 9-element integer tuple.

## Why

`date` was a `time::OffsetDateTime`. Without the `time` crate's `serde-human-readable` feature it serializes as a 9-integer tuple, and the published output schema described that with Draft 2020-12 `prefixItems` + `items: false`. MCP clients that validate `structuredContent` with a Draft-07 validator (e.g. Ajv, the default in the official TypeScript SDK) ignore `prefixItems` and read `items: false` as "the array must be empty" — rejecting every element and failing the tool call with `-32602`. The data was well-formed; the schema dialect was the problem.

A string validates identically under every JSON Schema draft, matches `search`'s string-valued `date` and the audit crate's RFC 3339 timestamps, and is directly readable by callers. The value is already UTC-normalized upstream (`from_unix_timestamp`), so no offset information is lost.

## Changes

- `fetch_message.rs`: `#[serde(with = "time::serde::rfc3339::option")]`; replace the tuple schema helper with `{type:[string,null], format:date-time}`.
- Regenerate `fetch_message.schema.json`.
- Tests:
  - unit: `date` serializes as an RFC 3339 string, and `null` when absent.
  - fixture exercise: a realistic payload validates against the published schema under **both Draft-07 and Draft 2020-12**. The draft pin matters — the existing fixture validator auto-detects 2020-12 from `$schema`, so it could not have caught a Draft-07-only incompatibility.

## Verification

- New regression tests pass under both drafts (confirmed red against the old tuple schema first).
- New serialization unit tests pass.
- `wire_published_output_schema_matches_fixture` (byte-equality) passes.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.

## Related

An adversarial review of this branch surfaced an unrelated pre-existing issue (documented `[security.tools]` `deny` for `use_account`/`list_accounts` is not enforced), tracked separately in #311. Not addressed here.