### PR TITLE
docs: clarify infrastructure tools are not gateable by [security.tools]

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,7 @@ mark_read = "deny"                # deny even though draft-safe allows it
 
 #### Valid tool names
 
-All 24 tool capabilities recognized by `[security.tools]`:
+All 24 valid tool names for `[security.tools]`:
 
 | Tool name | Description | Default posture |
 |-----------|-------------|-----------------|
@@ -217,11 +217,17 @@ All 24 tool capabilities recognized by `[security.tools]`:
 | `rename_folder` | Rename existing folder | full+ |
 | `expunge` | Permanently delete marked messages | destructive |
 | `delete_folder` | Permanently delete folder | destructive |
-| `use_account` | Switch active account (multi-account only) | always available |
-| `list_accounts` | List configured accounts (multi-account only) | always available |
+| `use_account` | Switch active account (multi-account only) | always available (not gateable¹) |
+| `list_accounts` | List configured accounts (multi-account only) | always available (not gateable¹) |
 
 **Note:** "readonly+" means allowed in readonly and all higher postures.
 "draft-safe+" means allowed in draft-safe and all higher postures.
+
+¹ `use_account` and `list_accounts` are infrastructure tools, not
+posture-gated capabilities. They are always advertised and dispatchable,
+and `[security.tools]` cannot disable them. An `"allow"` or `"deny"`
+override targeting either name is accepted by config validation but has
+**no effect** at runtime — they remain available regardless.
 
 Sub-capabilities (`.advanced_query`, `.include_html`) are separate
 authorization gates within their parent tool. The parent tool name
@@ -234,6 +240,9 @@ sub-capability controls the escape hatch.
 - `"deny"` blocks the tool regardless of posture
 - An override matching the posture's default is a no-op (not an error)
 - Unknown tool names are rejected at config validation with `ERR_CONFIG`
+- Infrastructure tools (`use_account`, `list_accounts`) are not gated by
+  `[security.tools]`; overrides targeting them are accepted but have no
+  effect (see the note above)
 
 If you see `unknown tool name 'mark_as_read'`, check the spelling
 against the table above. The correct name is `mark_read`.


### PR DESCRIPTION
## What

Corrects the `[security.tools]` reference in `docs/configuration.md` to state that `use_account` and `list_accounts` cannot be disabled via `[security.tools]`.

## Why

The doc listed both tools as deniable (posture "always available") and said `"deny"` "blocks the tool regardless of posture." That is not true for these two infrastructure tools: `list_tools` advertises them unconditionally (`server.rs:345`) and dispatch routes them through `dispatch_infrastructure` without a posture-matrix check (`server.rs:212`/`:509`), so an `allow`/`deny` override is accepted by config validation but has no runtime effect. An operator following the docs to lock down account switching/listing would not actually get it.

This documents the limitation (option 2 in #311) rather than changing enforcement. The names stay valid — config does not reject them — so the existing "unknown tool name" guidance remains correct.

## Changes

- Table: `use_account`/`list_accounts` posture cell → `always available (not gateable¹)`.
- Footnote ¹: these are infrastructure tools; `[security.tools]` cannot disable them; an `allow`/`deny` override is accepted but has no runtime effect.
- "Override semantics": added a bullet stating overrides targeting them have no effect.
- Heading reworded `recognized by` → `valid tool names for`.

Docs-only change. Closes #311.