### PR TITLE
feat(export_messages): bulk raw mbox export tool (default-disabled)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "hex",
  "infer",
  "jsonschema",
+ "libc",
  "mail-builder",
  "mail-parser",
  "predicates",

--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -1324,6 +1324,39 @@ mod tests {
         let from_advanced = Redactor::new(&advanced, &salt).apply(&sample);
         assert_eq!(from_search, from_advanced);
     }
+
+    #[test]
+    fn export_messages_schema_redacts_paths_keeps_identifiers() {
+        let salt = salt();
+        let schema = crate::redact::schemas()
+            .into_iter()
+            .find(|s| s.tool == ToolName::ExportMessages)
+            .expect("export_messages schema exists");
+        let args = json!({
+            "folder": "INBOX",
+            "uids": [101_u64, 102_u64],
+            "expected_uidvalidity": 12345_u64,
+            "dest_dir": "/home/user/secret-dir",
+            "filename": "private-series",
+            "password": "hunter2",
+            "token": "s3cr3t-token"
+        });
+        let out = Redactor::new(&schema, &salt).apply(&args);
+        // Structural fields are preserved verbatim.
+        assert_eq!(out["folder"], json!("INBOX"));
+        assert_eq!(out["expected_uidvalidity"], json!(12345_u64));
+        // Requested UID set is recorded verbatim (recoverable for audit).
+        assert_eq!(out["uids"], json!([101_u64, 102_u64]));
+        // dest_dir / filename must not appear verbatim.
+        let serialized = serde_json::to_string(&out).unwrap();
+        assert!(!serialized.contains("/home/user/secret-dir"));
+        assert!(!serialized.contains("private-series"));
+        // password / token are Forbidden — keys must be absent.
+        assert!(!serialized.contains("hunter2"));
+        assert!(!out.as_object().unwrap().contains_key("password"));
+        assert!(!serialized.contains("s3cr3t-token"));
+        assert!(!out.as_object().unwrap().contains_key("token"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -321,6 +321,7 @@ impl ToolRedactionSchema for ToolName {
             Self::FetchMessage | Self::FetchMessageHtml => fetch_message_schema(self),
             Self::ListAttachments | Self::MarkRead | Self::MarkUnread => folder_uid_schema(self),
             Self::DownloadAttachment => download_attachment_schema(self),
+            Self::ExportMessages => export_messages_schema(self),
             Self::Flag | Self::Unflag => flag_schema(self),
             Self::MoveMessage => move_message_schema(self),
             Self::CreateDraft => create_draft_schema(self),
@@ -467,6 +468,25 @@ fn download_attachment_schema(tool: ToolName) -> RedactionSchema {
             ("folder", Verbatim(VtString)),
             ("uid", Verbatim(U64)),
             ("part", Verbatim(VtString)),
+            ("password", Forbidden),
+            ("token", Forbidden),
+        ],
+    )
+}
+
+fn export_messages_schema(tool: ToolName) -> RedactionSchema {
+    use FieldPolicy::{Forbidden, RedactString, Verbatim};
+    use VerbatimType::{Bool, String as VtString, U64, U64Array};
+    RedactionSchema::new(
+        tool,
+        &[
+            ("folder", Verbatim(VtString)),
+            ("uids", Verbatim(U64Array)),
+            ("expected_uidvalidity", Verbatim(U64)),
+            ("max_total_bytes", Verbatim(U64)),
+            ("allow_partial", Verbatim(Bool)),
+            ("dest_dir", RedactString),
+            ("filename", RedactString),
             ("password", Forbidden),
             ("token", Forbidden),
         ],

--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -67,6 +67,17 @@ pub enum VerbatimType {
     Bool,
     /// `Value::Array` whose every element fits in a `u64`.
     U64Array,
+    /// `Value::Array` whose every element fits in a `u64` *and* whose length
+    /// does not exceed the embedded cap. Over-cap or wrong-typed arrays fall
+    /// through to [`FieldPolicy::RedactString`] (emitting `<redacted:?>`)
+    /// instead of being copied verbatim.
+    ///
+    /// Use this — not [`Self::U64Array`] — for *caller-supplied* UID arrays
+    /// that the handler itself rejects above the same cap. `tool_start` is
+    /// emitted before argument deserialization runs, so without the cap a
+    /// rejected oversize request would still be cloned and persisted verbatim,
+    /// amplifying audit-log and memory use.
+    U64ArrayMax(usize),
     /// `Value::Array` whose every element is a `Value::String`.
     StringArray,
 }
@@ -208,6 +219,10 @@ impl<'a> Redactor<'a> {
             VerbatimType::U64Array => value
                 .as_array()
                 .filter(|arr| arr.iter().all(serde_json::Value::is_u64))
+                .map(|_| value.clone()),
+            VerbatimType::U64ArrayMax(max) => value
+                .as_array()
+                .filter(|arr| arr.len() <= max && arr.iter().all(serde_json::Value::is_u64))
                 .map(|_| value.clone()),
             VerbatimType::StringArray => value
                 .as_array()
@@ -474,14 +489,22 @@ fn download_attachment_schema(tool: ToolName) -> RedactionSchema {
     )
 }
 
+/// Upper bound on the `uids` array copied verbatim into `tool_start` for
+/// `export_messages`. Mirrors the handler's `MAX_EXPORT_UIDS` validation cap
+/// (`crates/rimap-server/src/tools/retrieval/export_messages.rs`). The audit
+/// envelope redacts arguments *before* the handler runs that validation, so
+/// without this cap a rejected oversize request would still be cloned and
+/// persisted verbatim. Over-cap arrays fall through to `RedactString`.
+const EXPORT_UIDS_REDACT_CAP: usize = 100;
+
 fn export_messages_schema(tool: ToolName) -> RedactionSchema {
     use FieldPolicy::{Forbidden, RedactString, Verbatim};
-    use VerbatimType::{Bool, String as VtString, U64, U64Array};
+    use VerbatimType::{Bool, String as VtString, U64, U64ArrayMax};
     RedactionSchema::new(
         tool,
         &[
             ("folder", Verbatim(VtString)),
-            ("uids", Verbatim(U64Array)),
+            ("uids", Verbatim(U64ArrayMax(EXPORT_UIDS_REDACT_CAP))),
             ("expected_uidvalidity", Verbatim(U64)),
             ("max_total_bytes", Verbatim(U64)),
             ("allow_partial", Verbatim(Bool)),
@@ -1356,6 +1379,43 @@ mod tests {
         assert!(!out.as_object().unwrap().contains_key("password"));
         assert!(!serialized.contains("s3cr3t-token"));
         assert!(!out.as_object().unwrap().contains_key("token"));
+    }
+
+    #[test]
+    fn export_messages_schema_caps_oversize_uid_array() {
+        // Codex adversarial-review regression: the audit envelope redacts
+        // arguments BEFORE the handler's 100-UID validation runs. An array
+        // over the cap must NOT be copied verbatim into `tool_start` — it
+        // falls through to RedactString so a rejected oversize request cannot
+        // bloat the audit log. A <=cap array still round-trips verbatim.
+        let salt = salt();
+        let schema = crate::redact::schemas()
+            .into_iter()
+            .find(|s| s.tool == ToolName::ExportMessages)
+            .expect("export_messages schema exists");
+        let r = Redactor::new(&schema, &salt);
+
+        // 101 numeric UIDs — one past the cap. A distinctive sentinel value
+        // lets us prove the array bytes never reach the redacted output.
+        let sentinel: u64 = 999_888_777;
+        let mut oversize: Vec<serde_json::Value> = (1..=100_u64).map(|n| json!(n)).collect();
+        oversize.push(json!(sentinel));
+        let out = r.apply(&json!({ "uids": serde_json::Value::Array(oversize) }));
+        assert_eq!(
+            out["uids"],
+            json!("<redacted:?>"),
+            "oversize uid array must fall through to RedactString",
+        );
+        let serialized = serde_json::to_string(&out).unwrap();
+        assert!(
+            !serialized.contains(&sentinel.to_string()),
+            "oversize uid array leaked verbatim into audit output: {serialized}",
+        );
+
+        // Exactly at the cap (100) still passes through verbatim.
+        let at_cap: Vec<serde_json::Value> = (1..=100_u64).map(|n| json!(n)).collect();
+        let out = r.apply(&json!({ "uids": serde_json::Value::Array(at_cap.clone()) }));
+        assert_eq!(out["uids"], serde_json::Value::Array(at_cap));
     }
 }
 

--- a/crates/rimap-authz/src/matrix.rs
+++ b/crates/rimap-authz/src/matrix.rs
@@ -137,6 +137,7 @@ mod tests {
             ToolName::CreateFolder,
             ToolName::RenameFolder,
             ToolName::DeleteFolder,
+            ToolName::ExportMessages,
         ] {
             assert!(!base_allows(Posture::Readonly, t), "{t} should be denied");
         }
@@ -153,6 +154,7 @@ mod tests {
             ToolName::CreateFolder,
             ToolName::RenameFolder,
             ToolName::DeleteFolder,
+            ToolName::ExportMessages,
         ];
         for t in &denied {
             assert!(!base_allows(Posture::DraftSafe, *t), "{t} expected denied");
@@ -167,7 +169,11 @@ mod tests {
 
     #[test]
     fn base_full_allows_except_destructive() {
-        let denied = [ToolName::Expunge, ToolName::DeleteFolder];
+        let denied = [
+            ToolName::Expunge,
+            ToolName::DeleteFolder,
+            ToolName::ExportMessages,
+        ];
         for t in ToolName::all() {
             if t.is_infrastructure() {
                 assert!(
@@ -195,6 +201,11 @@ mod tests {
                 assert!(
                     !base_allows(Posture::Destructive, t),
                     "{t} infrastructure tool should not be in posture matrix"
+                );
+            } else if t == ToolName::ExportMessages {
+                assert!(
+                    !base_allows(Posture::Destructive, t),
+                    "export_messages is default-deny at every base posture"
                 );
             } else {
                 assert!(
@@ -277,6 +288,11 @@ mod tests {
                     !allowed,
                     "{tool} infrastructure tool should be denied in matrix"
                 );
+            } else if *tool == ToolName::ExportMessages {
+                assert!(
+                    !allowed,
+                    "export_messages is default-deny at every base posture"
+                );
             } else {
                 assert!(allowed, "{tool} should be allowed at destructive");
             }
@@ -287,5 +303,22 @@ mod tests {
     fn posture_accessor_returns_construction_value() {
         let m = EffectiveMatrix::build(Posture::DraftSafe, &BTreeMap::new());
         assert_eq!(m.posture(), Posture::DraftSafe);
+    }
+
+    #[test]
+    fn export_messages_denied_by_default_enabled_only_by_override() {
+        // No override: denied at every posture.
+        for p in Posture::all() {
+            let m = EffectiveMatrix::build(p, &BTreeMap::new());
+            assert!(
+                m.check(ToolName::ExportMessages).is_err(),
+                "export_messages must be default-denied at {p:?}"
+            );
+        }
+        // Explicit allow override enables it.
+        let mut overrides = BTreeMap::new();
+        overrides.insert(ToolName::ExportMessages, Verdict::Allow);
+        let m = EffectiveMatrix::build(Posture::Readonly, &overrides);
+        assert!(m.check(ToolName::ExportMessages).is_ok());
     }
 }

--- a/crates/rimap-config/src/validate/compose.rs
+++ b/crates/rimap-config/src/validate/compose.rs
@@ -112,12 +112,32 @@ fn validate_multi_inner(config: MultiAccountConfig) -> Result<ValidatedMultiConf
 
     paths::validate_audit_config(&config.audit)?;
     paths::validate_paths_multi(&config.audit, &config.attachments)?;
+    paths::validate_export_download_root(
+        &config.attachments,
+        export_messages_enabled(accounts.values()),
+    )?;
 
     Ok(ValidatedMultiConfig {
         accounts,
         audit: config.audit,
         attachments: config.attachments,
     })
+}
+
+/// Whether `export_messages` is effectively enabled for any account.
+///
+/// `export_messages` is base-DENY across every posture (see the posture
+/// matrix), so it is enabled only when an account carries an explicit
+/// `Allow` override in `[security.tools]`. The download root is a global
+/// setting, so a single enabled account is enough to require a private
+/// root.
+fn export_messages_enabled<'a>(accounts: impl Iterator<Item = &'a ValidatedAccountConfig>) -> bool {
+    for account in accounts {
+        if account.tool_overrides.get(&ToolName::ExportMessages) == Some(&Verdict::Allow) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Convert a legacy flat config into a `ValidatedMultiConfig` with a
@@ -139,6 +159,10 @@ pub fn validate_legacy_as_multi(config: Config) -> Result<ValidatedMultiConfig, 
     })?;
     paths::validate_audit_config(&config.audit)?;
     paths::validate_paths_multi(&config.audit, &config.attachments)?;
+    paths::validate_export_download_root(
+        &config.attachments,
+        export_messages_enabled(std::iter::once(&account)),
+    )?;
 
     let mut accounts = BTreeMap::new();
     accounts.insert(id, account);
@@ -954,5 +978,100 @@ allowed_base_dir = "{}"
                 ..
             }
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // export_messages private-download-root enforcement (Unix only)
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn set_mode(path: &std::path::Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_messages_enabled_with_world_writable_root_fails() {
+        let audit_dir = TempDir::new().unwrap();
+        let download_dir = TempDir::new().unwrap();
+        set_mode(download_dir.path(), 0o777);
+
+        let mut cfg = base_config(audit_dir.path());
+        cfg.attachments = AttachmentsConfig {
+            download_dir: download_dir.path().to_string_lossy().into_owned(),
+        };
+        cfg.security
+            .tools
+            .insert("export_messages".into(), Verdict::Allow);
+
+        let err = validate(cfg).unwrap_err();
+        let ConfigError::PathNotWritable { reason, .. } = &err else {
+            panic!("expected PathNotWritable, got {err:?}");
+        };
+        assert!(reason.contains("group/world-writable"), "reason: {reason}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_messages_enabled_with_private_root_passes() {
+        let audit_dir = TempDir::new().unwrap();
+        let download_dir = TempDir::new().unwrap();
+        set_mode(download_dir.path(), 0o700);
+
+        let mut cfg = base_config(audit_dir.path());
+        cfg.attachments = AttachmentsConfig {
+            download_dir: download_dir.path().to_string_lossy().into_owned(),
+        };
+        cfg.security
+            .tools
+            .insert("export_messages".into(), Verdict::Allow);
+
+        validate(cfg).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_messages_disabled_does_not_check_world_writable_root() {
+        let audit_dir = TempDir::new().unwrap();
+        let download_dir = TempDir::new().unwrap();
+        set_mode(download_dir.path(), 0o777);
+
+        let mut cfg = base_config(audit_dir.path());
+        cfg.attachments = AttachmentsConfig {
+            download_dir: download_dir.path().to_string_lossy().into_owned(),
+        };
+
+        validate(cfg).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn multi_account_export_messages_enabled_with_world_writable_root_fails() {
+        // Drives the multi-account entry point (`validate_multi` ->
+        // `validate_multi_inner`) so the export private-root check stays
+        // wired to that path, not just the legacy wrapper.
+        let audit_dir = TempDir::new().unwrap();
+        let download_dir = TempDir::new().unwrap();
+        set_mode(download_dir.path(), 0o777);
+
+        let mut exporter = raw_account("work");
+        let mut tools = std::collections::BTreeMap::new();
+        tools.insert("export_messages".into(), Verdict::Allow);
+        exporter.security = Some(SecurityConfig {
+            tools,
+            ..SecurityConfig::default()
+        });
+
+        let mut cfg = base_multi_config(audit_dir.path(), vec![exporter, raw_account("personal")]);
+        cfg.attachments = AttachmentsConfig {
+            download_dir: download_dir.path().to_string_lossy().into_owned(),
+        };
+
+        let err = validate_multi(cfg).unwrap_err();
+        let ConfigError::PathNotWritable { reason, .. } = &err else {
+            panic!("expected PathNotWritable, got {err:?}");
+        };
+        assert!(reason.contains("group/world-writable"), "reason: {reason}");
     }
 }

--- a/crates/rimap-config/src/validate/paths.rs
+++ b/crates/rimap-config/src/validate/paths.rs
@@ -38,6 +38,64 @@ pub(super) fn validate_paths_multi(
     Ok(())
 }
 
+/// Fail-closed precondition for `export_messages`: when the tool is
+/// enabled, the configured download root must be server-private (not
+/// group- or world-writable).
+///
+/// `export_messages` writes a raw, unsanitized mbox into the download
+/// sandbox. Because the export is an unredacted raw-message oracle, the
+/// design requires the download root be writable only by the server
+/// (write authority separated from the consuming agent). This turns that
+/// requirement into a hard startup check: enabling the tool with a
+/// group/world-writable download root rejects the config.
+///
+/// The check fires only when `export_enabled` is true and a download root
+/// is configured (a non-empty `attachments.download_dir`). An empty
+/// `download_dir` means per-session tempdir, which the server creates with
+/// private permissions and is out of operator control. On non-Unix
+/// platforms the permission concept does not apply and the check is a
+/// no-op.
+pub(super) fn validate_export_download_root(
+    attachments: &AttachmentsConfig,
+    export_enabled: bool,
+) -> Result<(), ConfigError> {
+    if !export_enabled || attachments.download_dir.is_empty() {
+        return Ok(());
+    }
+    check_export_download_root_private(Path::new(&attachments.download_dir))
+}
+
+#[cfg(unix)]
+fn check_export_download_root_private(download_root: &Path) -> Result<(), ConfigError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let mode = std::fs::metadata(download_root)
+        .map_err(|e| ConfigError::PathNotWritable {
+            path: download_root.to_path_buf(),
+            reason: format!("cannot stat download root: {e}"),
+        })?
+        .permissions()
+        .mode();
+    // 0o022 = group-write (0o020) | other-write (0o002)
+    if mode & 0o022 != 0 {
+        return Err(ConfigError::PathNotWritable {
+            path: download_root.to_path_buf(),
+            reason: format!(
+                "export_messages is enabled but the download root is \
+                 group/world-writable (mode {:o}); export_messages requires \
+                 a server-private download root",
+                mode & 0o777,
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn check_export_download_root_private(_download_root: &Path) -> Result<(), ConfigError> {
+    Ok(())
+}
+
 /// Compute the default audit base when `audit.allowed_base_dir` is unset.
 /// Returns `$XDG_STATE_HOME/rusty-imap-mcp/` on platforms where
 /// `directories::ProjectDirs` resolves; returns `None` otherwise (which
@@ -231,5 +289,58 @@ mod tests {
             Some(base_tmp.path().to_path_buf()),
         );
         assert!(enforce_audit_containment(&audit).is_ok());
+    }
+
+    #[cfg(unix)]
+    fn attachments_with(download_dir: &Path) -> AttachmentsConfig {
+        AttachmentsConfig {
+            download_dir: download_dir.to_string_lossy().into_owned(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn set_mode(path: &Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_world_writable_rejected_when_enabled() {
+        let tmp = TempDir::new().unwrap();
+        set_mode(tmp.path(), 0o777);
+        let attachments = attachments_with(tmp.path());
+        let err = validate_export_download_root(&attachments, true).unwrap_err();
+        let ConfigError::PathNotWritable { reason, .. } = &err else {
+            panic!("expected PathNotWritable, got {err:?}");
+        };
+        assert!(reason.contains("group/world-writable"), "reason: {reason}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_private_accepted_when_enabled() {
+        let tmp = TempDir::new().unwrap();
+        set_mode(tmp.path(), 0o700);
+        let attachments = attachments_with(tmp.path());
+        assert!(validate_export_download_root(&attachments, true).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_world_writable_ignored_when_disabled() {
+        let tmp = TempDir::new().unwrap();
+        set_mode(tmp.path(), 0o777);
+        let attachments = attachments_with(tmp.path());
+        assert!(validate_export_download_root(&attachments, false).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_empty_download_dir_skips_check() {
+        let attachments = AttachmentsConfig {
+            download_dir: String::new(),
+        };
+        assert!(validate_export_download_root(&attachments, true).is_ok());
     }
 }

--- a/crates/rimap-core/src/posture_matrix.rs
+++ b/crates/rimap-core/src/posture_matrix.rs
@@ -9,9 +9,9 @@ use crate::tool::ToolName;
 
 /// Compile-time truth table. `true` = allowed by base posture.
 ///
-/// Layout: outer by [`ToolName`] (22 tools),
+/// Layout: outer by [`ToolName`] (23 tools),
 /// inner `[readonly, draft_safe, full, destructive]`.
-pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 22] = [
+pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 23] = [
     (ToolName::ListFolders, [true, true, true, true]),
     (ToolName::Search, [true, true, true, true]),
     (ToolName::SearchAdvanced, [false, false, true, true]),
@@ -19,6 +19,9 @@ pub const POSTURE_MATRIX: [(ToolName, [bool; 4]); 22] = [
     (ToolName::FetchMessageHtml, [false, false, true, true]),
     (ToolName::ListAttachments, [true, true, true, true]),
     (ToolName::DownloadAttachment, [true, true, true, true]),
+    // export_messages: default-DENY at every posture. Reachable only via
+    // an explicit [security.tools].export_messages = "allow" override.
+    (ToolName::ExportMessages, [false, false, false, false]),
     (ToolName::MarkRead, [false, true, true, true]),
     (ToolName::MarkUnread, [false, true, true, true]),
     (ToolName::Flag, [false, true, true, true]),

--- a/crates/rimap-core/src/tool.rs
+++ b/crates/rimap-core/src/tool.rs
@@ -28,6 +28,10 @@ pub enum ToolName {
     ListAttachments,
     /// `download_attachment`
     DownloadAttachment,
+    /// `export_messages` — bulk raw export of multiple UIDs to a
+    /// `git am`-able mbox in the download sandbox. Default-denied in the
+    /// base posture matrix; enabled only via `[security.tools]`.
+    ExportMessages,
     /// `mark_read`
     MarkRead,
     /// `mark_unread`
@@ -80,6 +84,7 @@ impl ToolName {
             Self::FetchMessageHtml => "fetch_message.include_html",
             Self::ListAttachments => "list_attachments",
             Self::DownloadAttachment => "download_attachment",
+            Self::ExportMessages => "export_messages",
             Self::MarkRead => "mark_read",
             Self::MarkUnread => "mark_unread",
             Self::Flag => "flag",
@@ -127,6 +132,7 @@ impl ToolName {
             | Self::FetchMessageHtml
             | Self::ListAttachments
             | Self::DownloadAttachment
+            | Self::ExportMessages
             | Self::MarkRead
             | Self::MarkUnread
             | Self::Flag
@@ -160,6 +166,7 @@ impl ToolName {
             | Self::FetchMessageHtml
             | Self::ListAttachments
             | Self::DownloadAttachment
+            | Self::ExportMessages
             | Self::MarkRead
             | Self::MarkUnread
             | Self::Flag
@@ -194,6 +201,7 @@ impl ToolName {
             | Self::FetchMessageHtml
             | Self::ListAttachments
             | Self::DownloadAttachment
+            | Self::ExportMessages
             | Self::MarkRead
             | Self::MarkUnread
             | Self::Flag
@@ -283,10 +291,15 @@ impl ToolName {
 
             // Non-idempotent, non-destructive mutations. `CreateFolder`
             // also falls here: same name fails the second call per IMAP
-            // semantics.
-            Self::MoveMessage | Self::CreateDraft | Self::RenameFolder | Self::CreateFolder => {
-                (false, false, false, true)
-            }
+            // semantics. `ExportMessages` writes a new sandbox file per
+            // call (write_attachment de-dups, never overwrites) and reads
+            // from IMAP, so it is non-idempotent + open-world like the
+            // rest of this group.
+            Self::MoveMessage
+            | Self::CreateDraft
+            | Self::RenameFolder
+            | Self::CreateFolder
+            | Self::ExportMessages => (false, false, false, true),
 
             // Destructive, irreversible.
             Self::SendEmail | Self::DeleteMessage | Self::Expunge | Self::DeleteFolder => {
@@ -350,9 +363,9 @@ mod tests {
     use strum::IntoEnumIterator;
 
     #[test]
-    fn all_has_exactly_twenty_four_variants() {
-        assert_eq!(ToolName::all().len(), 24);
-        assert_eq!(ToolName::iter().count(), 24);
+    fn all_has_exactly_twenty_five_variants() {
+        assert_eq!(ToolName::all().len(), 25);
+        assert_eq!(ToolName::iter().count(), 25);
     }
 
     #[test]
@@ -501,5 +514,25 @@ mod annotation_tests {
         assert!(h.idempotent, "same UID+part_id yields identical bytes");
         assert!(!h.destructive, "no irreversible server-side mutation");
         assert!(h.open_world, "fetches from the IMAP server");
+    }
+
+    #[test]
+    fn export_messages_is_non_idempotent_open_world_write() {
+        // Pins ExportMessages to (read_only, destructive, idempotent,
+        // open_world) = (false, false, false, true). Without this, a future
+        // edit could silently fold the variant into a different
+        // annotation_hints match arm (e.g. the idempotent
+        // download_attachment group) and change the advertised hints.
+        let h = ToolName::ExportMessages.annotation_hints();
+        assert!(
+            !h.read_only,
+            "export_messages writes a sandbox file; must not advertise read_only_hint",
+        );
+        assert!(!h.destructive, "no irreversible server-side mutation");
+        assert!(
+            !h.idempotent,
+            "writes a new artifact per call; not idempotent"
+        );
+        assert!(h.open_world, "reads from the IMAP server");
     }
 }

--- a/crates/rimap-imap/src/connection/dispatch.rs
+++ b/crates/rimap-imap/src/connection/dispatch.rs
@@ -116,7 +116,10 @@ impl Connection {
         .await
     }
 
-    /// `SEARCH` against `folder`. Returns matching UIDs.
+    /// `SEARCH` against `folder`. Returns matching UIDs paired with the
+    /// UIDVALIDITY observed by the same read-only SELECT (`None` if the
+    /// server omitted it). Thread the value into `export_messages`'
+    /// `expected_uidvalidity`.
     ///
     /// # Errors
     /// Propagates timeout, connection-lost, or protocol errors from the
@@ -125,7 +128,7 @@ impl Connection {
         &self,
         folder: &str,
         query: crate::types::SearchQuery,
-    ) -> Result<Vec<crate::types::Uid>, ImapError> {
+    ) -> Result<(Vec<crate::types::Uid>, Option<u32>), ImapError> {
         self.with_session("search", async |session| {
             crate::ops::search::search(session, folder, query).await
         })
@@ -159,8 +162,8 @@ impl Connection {
 
     /// Fetch the full `BODY[]` of `uid` from `folder`. Returns raw bytes
     /// (no MIME parsing — Sprint 4's `rimap-content` owns that). Drops
-    /// the connection on size-limit overflow OR connection loss so the
-    /// half-consumed response state never leaks to the next op.
+    /// the connection on size-limit overflow, connection loss, or timeout,
+    /// so the half-consumed response state never leaks to the next op.
     ///
     /// # Pre-flight size check
     ///
@@ -175,14 +178,25 @@ impl Connection {
     /// remains as defense-in-depth because servers can lie about
     /// `RFC822.SIZE`.
     ///
+    /// # UIDVALIDITY guard
+    ///
+    /// When `expected_uidvalidity` is `Some(v)`, BOTH internal read-only
+    /// SELECTs (the `RFC822.SIZE` preflight and the `BODY.PEEK[]` fetch)
+    /// verify the folder's current UIDVALIDITY against `v`, fail-closed: a
+    /// mismatch returns `ImapError::UidValidityChanged` and an omitted
+    /// server value returns `ImapError::UidValidityUnavailable`. Pass
+    /// `None` to skip the guard.
+    ///
     /// # Errors
     /// Propagates `ImapError::SizeLimit` if the body exceeds the configured
-    /// `max_fetch_body_bytes`, plus the usual timeout / protocol /
-    /// connection-lost errors.
+    /// `max_fetch_body_bytes`, `ImapError::UidValidityChanged` /
+    /// `ImapError::UidValidityUnavailable` on a failed guard, plus the usual
+    /// timeout / protocol / connection-lost errors.
     pub async fn fetch_body(
         &self,
         folder: &str,
         uid: crate::types::Uid,
+        expected_uidvalidity: Option<u32>,
     ) -> Result<Vec<u8>, ImapError> {
         let dur = self.inner.cfg.command_timeout;
         let limit = self.inner.cfg.max_fetch_body_bytes;
@@ -194,29 +208,35 @@ impl Connection {
                     .ok_or(ImapError::Protocol(async_imap::error::Error::Bad(
                         "session invariant violated: guard is None after session()".to_string(),
                     )))?;
-            let server_size = crate::ops::fetch::preflight_fetch_size(session, folder, uid).await?;
+            let server_size =
+                crate::ops::fetch::preflight_fetch_size(session, folder, uid, expected_uidvalidity)
+                    .await?;
             crate::ops::fetch::preflight_size_check(server_size, limit)?;
-            crate::ops::fetch::fetch_body(session, folder, uid, limit).await
+            crate::ops::fetch::fetch_body(session, folder, uid, limit, expected_uidvalidity).await
         })
         .await;
-        // Drop the cached session on EITHER ConnectionLost OR SizeLimit.
-        // SizeLimit means we aborted mid-stream, so the IMAP response
+        // Drop the cached session on ConnectionLost, SizeLimit, OR Timeout.
+        // SizeLimit and Timeout both abort mid-stream, so the IMAP response
         // state is half-consumed and the session cannot be reused.
+        // UidValidityUnavailable is fail-closed but the session is healthy
+        // (only mailbox identity is unverifiable), so it stays non-invalidating.
         // The match here lists every ImapError variant explicitly because
         // workspace lints ban `_ =>` wildcards.
         let should_invalidate = match &result {
-            Err(ImapError::ConnectionLost | ImapError::SizeLimit { .. }) => true,
+            Err(
+                ImapError::ConnectionLost | ImapError::SizeLimit { .. } | ImapError::Timeout { .. },
+            ) => true,
             Err(
                 ImapError::Tls { .. }
                 | ImapError::TlsHandshake(_)
                 | ImapError::Starttls { .. }
                 | ImapError::Connect(_)
-                | ImapError::Timeout { .. }
                 | ImapError::Auth { .. }
                 | ImapError::Protocol(_)
                 | ImapError::InvalidInput { .. }
                 | ImapError::BatchTooLarge { .. }
                 | ImapError::UidValidityChanged { .. }
+                | ImapError::UidValidityUnavailable { .. }
                 | ImapError::Audit { .. },
             )
             | Ok(_) => false,

--- a/crates/rimap-imap/src/connection/mod.rs
+++ b/crates/rimap-imap/src/connection/mod.rs
@@ -187,6 +187,12 @@ impl Connection {
         &self.inner.cfg.username
     }
 
+    /// Maximum bytes a single `fetch_body` will accept (config cap).
+    #[must_use]
+    pub fn max_fetch_body_bytes(&self) -> u64 {
+        self.inner.cfg.max_fetch_body_bytes
+    }
+
     /// Acquire the session lock; lazy-connect if needed. The returned guard
     /// holds the tokio mutex; drop it before any other method on `Connection`.
     pub(crate) async fn session(
@@ -375,6 +381,12 @@ mod tests {
                     folder: "INBOX".to_string(),
                     expected: 100,
                     actual: 101,
+                },
+                "ERR_UID_VALIDITY_CHANGED",
+            ),
+            (
+                ImapError::UidValidityUnavailable {
+                    folder: "INBOX".to_string(),
                 },
                 "ERR_UID_VALIDITY_CHANGED",
             ),

--- a/crates/rimap-imap/src/error.rs
+++ b/crates/rimap-imap/src/error.rs
@@ -81,6 +81,14 @@ pub enum ImapError {
         /// The UIDVALIDITY value the server reported.
         actual: u32,
     },
+    /// A guarded fetch required UIDVALIDITY but the server omitted it.
+    /// Distinct from `UidValidityChanged` (which carries a concrete
+    /// mismatch); here the guard simply could not be verified.
+    #[error("server omitted UIDVALIDITY for folder {folder} on a guarded fetch")]
+    UidValidityUnavailable {
+        /// The folder that was selected.
+        folder: String,
+    },
     /// Audit-subsystem failure during a tool call. The IMAP transport may
     /// be healthy; this variant exists so audit-write failures stay
     /// distinguishable from network failures in metrics and observability.
@@ -198,7 +206,9 @@ impl ImapError {
             Self::SizeLimit { .. } => ErrorCode::AttachmentTooLarge,
             Self::Protocol(_) => ErrorCode::ImapProtocol,
             Self::InvalidInput { .. } | Self::BatchTooLarge { .. } => ErrorCode::InvalidInput,
-            Self::UidValidityChanged { .. } => ErrorCode::UidValidityChanged,
+            Self::UidValidityChanged { .. } | Self::UidValidityUnavailable { .. } => {
+                ErrorCode::UidValidityChanged
+            }
             Self::Audit { .. } => ErrorCode::Internal,
         }
     }
@@ -212,6 +222,10 @@ impl From<ImapError> for RimapError {
         // through the generic `Imap` arm. Both arms preserve the
         // original `ImapError` as a `#[source]` so reporters that walk
         // `error.source().chain()` see consistent depth.
+        // UidValidityUnavailable has no concrete mismatch to surface, so it
+        // intentionally flows through the generic Imap arm below — same
+        // client-visible code() (UidValidityChanged) but no structured
+        // expected/actual fields.
         if let ImapError::UidValidityChanged {
             folder,
             expected,

--- a/crates/rimap-imap/src/ops/fetch.rs
+++ b/crates/rimap-imap/src/ops/fetch.rs
@@ -103,6 +103,29 @@ pub(crate) fn check_uidvalidity(
     }
 }
 
+/// Like [`check_uidvalidity`] but **fail-closed**: when `expected` is set,
+/// an absent observed UIDVALIDITY is an error, not a warning.
+pub(crate) fn require_uidvalidity(
+    folder: &str,
+    expected: Option<u32>,
+    observed: Option<u32>,
+) -> Result<(), ImapError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    match observed {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(ImapError::UidValidityChanged {
+            folder: folder.to_owned(),
+            expected,
+            actual,
+        }),
+        None => Err(ImapError::UidValidityUnavailable {
+            folder: folder.to_owned(),
+        }),
+    }
+}
+
 pub(crate) async fn fetch(
     session: &mut ImapSession,
     folder: &str,
@@ -190,11 +213,10 @@ pub(crate) async fn fetch_body(
     folder: &str,
     uid: Uid,
     limit: u64,
+    expected_uidvalidity: Option<u32>,
 ) -> Result<Vec<u8>, ImapError> {
-    session
-        .examine(folder)
-        .await
-        .map_err(super::folders::map_err)?;
+    let selected = super::folders::select(session, folder, true).await?;
+    require_uidvalidity(folder, expected_uidvalidity, selected.uid_validity)?;
 
     let mut stream = session
         .uid_fetch(uid.get().to_string(), "BODY.PEEK[]")
@@ -256,11 +278,10 @@ pub(crate) async fn preflight_fetch_size(
     session: &mut ImapSession,
     folder: &str,
     uid: Uid,
+    expected_uidvalidity: Option<u32>,
 ) -> Result<Option<u32>, ImapError> {
-    session
-        .examine(folder)
-        .await
-        .map_err(super::folders::map_err)?;
+    let selected = super::folders::select(session, folder, true).await?;
+    require_uidvalidity(folder, expected_uidvalidity, selected.uid_validity)?;
 
     let mut stream = session
         .uid_fetch(uid.get().to_string(), "RFC822.SIZE")
@@ -444,7 +465,7 @@ fn convert_flag(f: &async_imap::types::Flag<'_>) -> crate::types::Flag {
 mod tests {
     use super::{
         MAX_BODYSTRUCTURE_DEPTH, check_uidvalidity, compress_uid_set, convert_bs_inner,
-        preflight_size_check, project_size,
+        preflight_size_check, project_size, require_uidvalidity,
     };
     use crate::error::ImapError;
     use crate::types::tests::uid;
@@ -803,6 +824,23 @@ mod tests {
     fn check_uidvalidity_server_omitted_is_not_error() {
         // Server omitted UIDVALIDITY (None) → warn and proceed, no error.
         check_uidvalidity("INBOX", Some(42), None).unwrap();
+    }
+
+    #[test]
+    fn require_uidvalidity_strict() {
+        // expected=None: no-op (download_attachment path).
+        assert!(require_uidvalidity("INBOX", None, None).is_ok());
+        assert!(require_uidvalidity("INBOX", None, Some(7)).is_ok());
+        // expected=Some: match ok, mismatch and ABSENT both error.
+        assert!(require_uidvalidity("INBOX", Some(7), Some(7)).is_ok());
+        assert!(matches!(
+            require_uidvalidity("INBOX", Some(7), Some(8)),
+            Err(crate::error::ImapError::UidValidityChanged { .. })
+        ));
+        assert!(matches!(
+            require_uidvalidity("INBOX", Some(7), None),
+            Err(crate::error::ImapError::UidValidityUnavailable { .. })
+        ));
     }
 
     // NOTE: The round-trip parser in this proptest is a SIMPLIFIED model.

--- a/crates/rimap-imap/src/ops/search.rs
+++ b/crates/rimap-imap/src/ops/search.rs
@@ -10,13 +10,11 @@ pub(crate) async fn search(
     session: &mut ImapSession,
     folder: &str,
     query: SearchQuery,
-) -> Result<Vec<Uid>, ImapError> {
-    // Caller should have sent SELECT via the public API; this is a defensive
-    // re-EXAMINE to keep the search scoped to the requested folder.
-    session
-        .examine(folder)
-        .await
-        .map_err(super::folders::map_err)?;
+) -> Result<(Vec<Uid>, Option<u32>), ImapError> {
+    // Read-only SELECT (EXAMINE) so the UID set and its UIDVALIDITY come
+    // from the same selected-mailbox operation.
+    let selected = super::folders::select(session, folder, true).await?;
+    let uid_validity = selected.uid_validity;
 
     let key = match query {
         SearchQuery::Structured(s) => structured_to_key(&s)?,
@@ -27,7 +25,10 @@ pub(crate) async fn search(
         .uid_search(&key)
         .await
         .map_err(super::folders::map_err)?;
-    Ok(uids.into_iter().filter_map(Uid::new).collect())
+    Ok((
+        uids.into_iter().filter_map(Uid::new).collect(),
+        uid_validity,
+    ))
 }
 
 fn structured_to_key(q: &StructuredQuery) -> Result<String, ImapError> {

--- a/crates/rimap-imap/tests/error_mapping.rs
+++ b/crates/rimap-imap/tests/error_mapping.rs
@@ -74,6 +74,16 @@ fn connect_io_error_maps_to_err_connection_lost() {
 }
 
 #[test]
+fn uid_validity_unavailable_maps_to_err_uid_validity_changed() {
+    let err = ImapError::UidValidityUnavailable {
+        folder: "INBOX".to_string(),
+    };
+    let rimap: RimapError = err.into();
+    assert_eq!(rimap.code(), ErrorCode::UidValidityChanged);
+    assert!(rimap.source().is_some());
+}
+
+#[test]
 fn audit_variant_maps_to_internal_error_code() {
     let err = ImapError::Audit {
         op: "emit_auth",

--- a/crates/rimap-imap/tests/integration/dovecot.rs
+++ b/crates/rimap-imap/tests/integration/dovecot.rs
@@ -193,7 +193,7 @@ async fn case_06_search_structured_subject_match() {
         subject: Some("Sprint 3 plain text fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
+    let (uids, _) = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(
         !uids.is_empty(),
         "expected at least one UID for the seeded subject"
@@ -208,7 +208,7 @@ async fn case_07_search_raw_passthrough() {
         return;
     };
     let q = SearchQuery::Raw("HEADER \"X-Test\" \"marker\"".to_string());
-    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
+    let (uids, _) = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(
         !uids.is_empty(),
         "expected at least one UID for X-Test: marker"
@@ -226,7 +226,7 @@ async fn case_08_fetch_envelope_and_bodystructure() {
         subject: Some("Sprint 3 multipart fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
+    let (uids, _) = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(!uids.is_empty());
     let spec = FetchSpec {
         envelope: true,
@@ -258,9 +258,13 @@ async fn case_09_fetch_body_under_limit() {
         subject: Some("Sprint 3 plain text fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
+    let (uids, _) = Box::pin(h.connection.search("INBOX", q)).await.unwrap();
     assert!(!uids.is_empty());
-    let body = h.connection.fetch_body("INBOX", uids[0]).await.unwrap();
+    let body = h
+        .connection
+        .fetch_body("INBOX", uids[0], None)
+        .await
+        .unwrap();
     assert!(!body.is_empty());
     assert!(body.len() < 5_000, "fixture is small");
 }
@@ -305,8 +309,8 @@ async fn case_10_fetch_body_over_limit_drops_connection() {
         subject: Some("Sprint 3 multipart fixture".to_string()),
         ..StructuredQuery::default()
     });
-    let uids = Box::pin(conn.search("INBOX", q)).await.unwrap();
-    let result = conn.fetch_body("INBOX", uids[0]).await;
+    let (uids, _) = Box::pin(conn.search("INBOX", q)).await.unwrap();
+    let result = conn.fetch_body("INBOX", uids[0], None).await;
     match result {
         Err(ImapError::SizeLimit { limit }) => assert_eq!(limit, 10),
         #[expect(clippy::panic, reason = "test failure path")]
@@ -357,7 +361,7 @@ async fn case_12_store_add_seen_flag() {
         .unwrap();
 
     // Search for it.
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("store-seen".to_string()),
@@ -414,7 +418,7 @@ async fn case_13_store_remove_seen_flag() {
         .await
         .unwrap();
 
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("store-unseen".to_string()),
@@ -511,7 +515,7 @@ async fn case_15_append_message_to_inbox() {
     assert_eq!(result.uid, None);
 
     // Verify the message is in INBOX by searching for it.
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("append-test".to_string()),
@@ -553,7 +557,7 @@ async fn case_16_move_message_between_folders() {
         .await
         .unwrap();
 
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("move-test".to_string()),
@@ -575,7 +579,7 @@ async fn case_16_move_message_between_folders() {
     assert_eq!(outcome.results[0].old_uid, uid);
 
     // Verify the message is gone from INBOX.
-    let after_uids = Box::pin(h.connection.search(
+    let (after_uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("move-test".to_string()),
@@ -590,7 +594,7 @@ async fn case_16_move_message_between_folders() {
     );
 
     // Verify the message is in Archive.
-    let archive_uids = Box::pin(h.connection.search(
+    let (archive_uids, _) = Box::pin(h.connection.search(
         "Archive",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("move-test".to_string()),
@@ -619,7 +623,7 @@ async fn case_17_delete_message() {
         .unwrap();
 
     // Find the appended message
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("delete-test".to_string()),
@@ -643,7 +647,7 @@ async fn case_17_delete_message() {
     assert!(result.moved_to_trash);
 
     // Verify it's gone from INBOX
-    let after = Box::pin(h.connection.search(
+    let (after, _) = Box::pin(h.connection.search(
         "INBOX",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("delete-test".to_string()),
@@ -674,7 +678,7 @@ async fn case_18_expunge() {
         .unwrap();
 
     // Find it
-    let uids = Box::pin(h.connection.search(
+    let (uids, _) = Box::pin(h.connection.search(
         "Trash",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("expunge-test".to_string()),
@@ -707,7 +711,7 @@ async fn case_18_expunge() {
     assert!(count > 0, "should expunge at least one message");
 
     // Verify it's gone
-    let after = Box::pin(h.connection.search(
+    let (after, _) = Box::pin(h.connection.search(
         "Trash",
         rimap_imap::types::SearchQuery::Structured(rimap_imap::types::StructuredQuery {
             subject: Some("expunge-test".to_string()),

--- a/crates/rimap-imap/tests/integration/proton.rs
+++ b/crates/rimap-imap/tests/integration/proton.rs
@@ -110,9 +110,10 @@ async fn proton_bridge_connect_and_fetch_one_envelope() {
     };
     let conn = build_connection(&cfg);
     let _ = conn.select("INBOX", true).await.unwrap();
-    let uids = Box::pin(conn.search("INBOX", rimap_imap::types::SearchQuery::Raw("ALL".into())))
-        .await
-        .unwrap();
+    let (uids, _) =
+        Box::pin(conn.search("INBOX", rimap_imap::types::SearchQuery::Raw("ALL".into())))
+            .await
+            .unwrap();
     assert!(!uids.is_empty(), "expected at least one message in INBOX");
     let spec = FetchSpec {
         envelope: true,

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -94,6 +94,12 @@ tempfile = { workspace = true }
 # remains for integration-test consumers; cargo dedupes the version.
 jsonschema = { workspace = true, optional = true }
 
+# Used only for the `O_NOFOLLOW` open flag in the attachment sandbox writer
+# (`tools::retrieval::sandbox`). Referenced as a plain constant — no `unsafe`
+# (the workspace forbids it). Unix-only; non-Unix builds use a fail-closed stub.
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }

--- a/crates/rimap-server/src/cli/dump_tool_schemas.rs
+++ b/crates/rimap-server/src/cli/dump_tool_schemas.rs
@@ -43,6 +43,7 @@ fn build_schemas() -> BTreeMap<&'static str, Value> {
         },
         retrieval::{
             download_attachment::{DownloadAttachmentMeta, DownloadAttachmentUntrusted},
+            export_messages::ExportMessagesMeta,
             fetch_message::{FetchMessageMeta, FetchMessageUntrusted},
             list_attachments::{ListAttachmentsMeta, ListAttachmentsUntrusted},
             search::{SearchMeta, SearchUntrusted},
@@ -70,6 +71,7 @@ fn build_schemas() -> BTreeMap<&'static str, Value> {
     out.insert("create_folder", tool_envelope::<CreateFolderMeta, ()>());
     out.insert("rename_folder", tool_envelope::<RenameFolderMeta, ()>());
     out.insert("delete_folder", tool_envelope::<DeleteFolderMeta, ()>());
+    out.insert("export_messages", tool_envelope::<ExportMessagesMeta, ()>());
 
     // meta + untrusted tools
     out.insert("search", tool_envelope::<SearchMeta, SearchUntrusted>());
@@ -134,6 +136,7 @@ mod tests {
             "create_folder",
             "rename_folder",
             "delete_folder",
+            "export_messages",
             "search",
             "fetch_message",
             "list_attachments",
@@ -150,8 +153,8 @@ mod tests {
 
         assert_eq!(
             parsed.len(),
-            22,
-            "expected exactly 22 tool schemas, found {}",
+            23,
+            "expected exactly 23 tool schemas, found {}",
             parsed.len()
         );
     }

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -132,7 +132,7 @@ impl ImapMcpServer {
             delete_message, expunge, flags, folder_management, labels, move_message,
         };
         use crate::tools::retrieval::{
-            download_attachment, fetch_message, list_attachments, search,
+            download_attachment, export_messages, fetch_message, list_attachments, search,
         };
         let resp = match tool {
             ToolName::ListFolders => ser(Box::pin(list_folders::handle(account)).await?)?,
@@ -160,6 +160,9 @@ impl ImapMcpServer {
             }
             ToolName::DownloadAttachment => {
                 ser(Box::pin(download_attachment::handle(account, parse_args(args)?)).await?)?
+            }
+            ToolName::ExportMessages => {
+                ser(Box::pin(export_messages::handle(account, parse_args(args)?)).await?)?
             }
             ToolName::CreateDraft => {
                 ser(Box::pin(create_draft::handle(account, parse_args(args)?)).await?)?
@@ -245,6 +248,7 @@ impl ImapMcpServer {
                     | ToolName::FetchMessageHtml
                     | ToolName::ListAttachments
                     | ToolName::DownloadAttachment
+                    | ToolName::ExportMessages
                     | ToolName::MarkRead
                     | ToolName::MarkUnread
                     | ToolName::Flag

--- a/crates/rimap-server/src/mcp/tool_catalog.rs
+++ b/crates/rimap-server/src/mcp/tool_catalog.rs
@@ -103,6 +103,7 @@ fn output_schema(name: ToolName) -> Option<serde_json::Map<String, serde_json::V
         },
         retrieval::{
             download_attachment::{DownloadAttachmentMeta, DownloadAttachmentUntrusted},
+            export_messages::ExportMessagesMeta,
             fetch_message::{FetchMessageMeta, FetchMessageUntrusted},
             list_attachments::{ListAttachmentsMeta, ListAttachmentsUntrusted},
             search::{SearchMeta, SearchUntrusted},
@@ -123,6 +124,7 @@ fn output_schema(name: ToolName) -> Option<serde_json::Map<String, serde_json::V
         ToolName::DownloadAttachment => {
             envelope_schema::<ToolResponse<DownloadAttachmentMeta, DownloadAttachmentUntrusted>>()
         }
+        ToolName::ExportMessages => envelope_schema::<ToolResponse<ExportMessagesMeta, ()>>(),
         ToolName::MarkRead | ToolName::MarkUnread | ToolName::Flag | ToolName::Unflag => {
             envelope_schema::<ToolResponse<FlagsMeta, ()>>()
         }
@@ -148,7 +150,7 @@ fn output_schema(name: ToolName) -> Option<serde_json::Map<String, serde_json::V
 /// (e.g. `SearchAdvanced`, `FetchMessageHtml`).
 #[expect(
     clippy::too_many_lines,
-    reason = "single match over 24 ToolName variants; splitting would create two parallel matches"
+    reason = "single match over 25 ToolName variants; splitting would create two parallel matches"
 )]
 fn tool_spec(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::admin::accounts::UseAccountInput;
@@ -163,6 +165,7 @@ fn tool_spec(name: ToolName) -> Option<ToolSpec> {
     use crate::tools::mailbox::labels::{LabelInput, ListLabelsInput};
     use crate::tools::mailbox::move_message::MoveMessageInput;
     use crate::tools::retrieval::download_attachment::DownloadAttachmentInput;
+    use crate::tools::retrieval::export_messages::ExportMessagesInput;
     use crate::tools::retrieval::fetch_message::FetchMessageInput;
     use crate::tools::retrieval::list_attachments::ListAttachmentsInput;
     use crate::tools::retrieval::search::SearchInput;
@@ -191,6 +194,13 @@ fn tool_spec(name: ToolName) -> Option<ToolSpec> {
             "Download Attachment",
             "Download an attachment to the sandbox directory",
             envelope_schema::<DownloadAttachmentInput>(),
+        ),
+        ToolName::ExportMessages => (
+            "Export Messages",
+            "Export multiple messages by UID as a single git am-able mbox \
+             file in the download sandbox. Discover UIDs with `search` and \
+             pass its uid_validity. Disabled unless enabled in [security.tools].",
+            envelope_schema::<ExportMessagesInput>(),
         ),
         ToolName::MarkRead => (
             "Mark Messages Read",
@@ -513,7 +523,7 @@ mod tests {
         // `ToolName → (MetaType, UntrustedType)` tables disagree. The wire
         // test `wire_published_output_schema_matches_fixture` only
         // exercises 2 tools in the zero-account harness; this unit test
-        // covers all 22 without docker.
+        // covers all 23 without docker.
         use std::path::Path;
         for def in ToolName::all()
             .into_iter()

--- a/crates/rimap-server/src/mcp/tool_name.rs
+++ b/crates/rimap-server/src/mcp/tool_name.rs
@@ -56,6 +56,7 @@ pub(super) fn refine_tool_name(
         | ToolName::FetchMessageHtml
         | ToolName::ListAttachments
         | ToolName::DownloadAttachment
+        | ToolName::ExportMessages
         | ToolName::MarkRead
         | ToolName::MarkUnread
         | ToolName::Flag

--- a/crates/rimap-server/src/tools/compose/message_builder.rs
+++ b/crates/rimap-server/src/tools/compose/message_builder.rs
@@ -202,7 +202,7 @@ pub(crate) async fn apply_threading_headers<'a>(
     let folder = in_reply_to_folder.unwrap_or("INBOX");
     let uid = rimap_imap::types::Uid::from(reply_uid);
 
-    let raw = account.imap.fetch_body(folder, uid).await?;
+    let raw = account.imap.fetch_body(folder, uid, None).await?;
     let headers = rimap_content::extract_threading_headers(&raw);
 
     let Some(msg_id) = headers.message_id else {

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -105,7 +105,7 @@ pub async fn handle(
     let dest =
         sandbox::resolve_dest_dir_async(input.dest_dir, Arc::clone(&account.download_dir)).await?;
 
-    let raw = account.imap.fetch_body(&input.folder, uid).await?;
+    let raw = account.imap.fetch_body(&input.folder, uid, None).await?;
 
     let parts = crate::mcp::content::walk_attachment_parts_async(raw).await?;
 

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -1,12 +1,15 @@
 //! `export_messages` tool handler: bulk raw export of multiple UIDs to a
 //! single `git am`-able mbox file in the download sandbox.
 
-use rimap_imap::types::Uid;
+use std::sync::Arc;
+
+use rimap_imap::types::{FetchSpec, Uid};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::boot::registry::AccountState;
 use crate::mcp::response::ToolResponse;
+use crate::tools::retrieval::sandbox;
 
 /// Hard ceiling on the aggregate export size, regardless of the
 /// caller-supplied `max_total_bytes`.
@@ -105,7 +108,6 @@ const MAX_EXPORT_UIDS: usize = 100;
 ///
 /// `RimapError::Authz { code: InvalidInput }` for an empty list or one
 /// exceeding [`MAX_EXPORT_UIDS`].
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 fn validate_uids(uids: Vec<core::num::NonZeroU32>) -> Result<Vec<Uid>, rimap_core::RimapError> {
     if uids.is_empty() {
         return Err(rimap_core::RimapError::invalid_input(
@@ -128,7 +130,6 @@ fn validate_uids(uids: Vec<core::num::NonZeroU32>) -> Result<Vec<Uid>, rimap_cor
 }
 
 /// Clamp the caller-supplied aggregate byte budget to the hard ceiling.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 fn clamp_total_bytes(requested: Option<u64>) -> u64 {
     requested.map_or(MAX_EXPORT_TOTAL_BYTES, |n| n.min(MAX_EXPORT_TOTAL_BYTES))
 }
@@ -144,7 +145,6 @@ const MBOX_SEPARATOR: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1
 ///
 /// Callers must pass non-empty message bodies; an empty body would emit a
 /// bare separator with no content. Task 7's handler validates this upstream.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
     let mut out = Vec::new();
     for msg in messages {
@@ -214,7 +214,6 @@ fn line_is_from(line: &[u8]) -> bool {
 /// `RimapError::Authz { code: InvalidInput }` if the prefix is empty after
 /// trimming, longer than 64 bytes, or contains any character outside the
 /// grammar.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 fn sanitize_filename_prefix(prefix: Option<&str>) -> Result<String, rimap_core::RimapError> {
     let Some(raw) = prefix else {
         return Ok("messages".to_string());
@@ -238,23 +237,351 @@ fn sanitize_filename_prefix(prefix: Option<&str>) -> Result<String, rimap_core::
     Ok(trimmed.to_string())
 }
 
+/// The IMAP operations `export_messages` depends on. The handler calls this
+/// trait instead of `account.imap` directly so the orchestration — that every
+/// body fetch carries the pinned `expected_uidvalidity`, and that any
+/// body-fetch error is fatal-with-no-artifact — is deterministically testable
+/// against a hand-written fake without a live server.
+pub(crate) trait ExportSource {
+    /// Preflight: for each requested uid that exists, the `(uid, RFC822.SIZE)`
+    /// pair (size `None` when the server omitted it), plus the folder's
+    /// observed UIDVALIDITY (`None` when the server omitted it).
+    ///
+    /// # Errors
+    ///
+    /// Propagates IMAP failures (including a UIDVALIDITY mismatch).
+    async fn fetch_sizes(
+        &self,
+        folder: &str,
+        uids: &[Uid],
+        expected_uidvalidity: u32,
+    ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError>;
+
+    /// Fetch one message body, guarded by `expected_uidvalidity`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates IMAP failures; the handler treats every error as fatal.
+    async fn fetch_one_body(
+        &self,
+        folder: &str,
+        uid: Uid,
+        expected_uidvalidity: u32,
+    ) -> Result<Vec<u8>, rimap_core::RimapError>;
+}
+
+impl ExportSource for AccountState {
+    async fn fetch_sizes(
+        &self,
+        folder: &str,
+        uids: &[Uid],
+        expected_uidvalidity: u32,
+    ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError> {
+        let (msgs, uid_validity) = self
+            .imap
+            .fetch(
+                folder,
+                uids,
+                FetchSpec {
+                    size: true,
+                    ..FetchSpec::default()
+                },
+                Some(expected_uidvalidity),
+            )
+            .await?;
+        let sizes = msgs.iter().map(|m| (m.uid.get(), m.size)).collect();
+        Ok((sizes, uid_validity))
+    }
+
+    async fn fetch_one_body(
+        &self,
+        folder: &str,
+        uid: Uid,
+        expected_uidvalidity: u32,
+    ) -> Result<Vec<u8>, rimap_core::RimapError> {
+        Ok(self
+            .imap
+            .fetch_body(folder, uid, Some(expected_uidvalidity))
+            .await?)
+    }
+}
+
 /// Execute the `export_messages` tool.
+///
+/// Validates input, resolves the sandbox destination, then delegates the
+/// preflight/fetch/build/write orchestration to [`run_export`] over the
+/// account's [`ExportSource`].
 ///
 /// # Errors
 ///
-/// Returns `RimapError::Internal` — not yet implemented (filled in Task 7).
-#[expect(
-    clippy::unused_async,
-    reason = "inert handler; dispatch awaits this future and the real \
-              implementation (Task 7) performs IMAP I/O"
-)]
+/// - `RimapError::Authz { code: InvalidInput }` for an empty/over-cap UID
+///   list or an unsafe `filename`.
+/// - `RimapError::UidValidityChanged` if the folder's UIDVALIDITY no longer
+///   matches `expected_uidvalidity`.
+/// - `RimapError::Authz { code: InvalidInput }` (all-or-nothing default)
+///   listing failed UIDs when `allow_partial` is false and any UID fails.
+/// - `RimapError::Imap { ... }` for connection-dropping fetch failures.
+/// - `RimapError::Internal` for filesystem/hashing failures.
 pub async fn handle(
-    _account: &AccountState,
-    _input: ExportMessagesInput,
+    account: &AccountState,
+    input: ExportMessagesInput,
 ) -> Result<ToolResponse<ExportMessagesMeta, ()>, rimap_core::RimapError> {
-    Err(rimap_core::RimapError::Internal(
-        "export_messages not yet implemented".into(),
-    ))
+    crate::tools::validation::validate_folder_input("folder", &input.folder)?;
+
+    let prefix = sanitize_filename_prefix(input.filename.as_deref())?;
+    let uids = validate_uids(input.uids)?;
+    let budget = clamp_total_bytes(input.max_total_bytes);
+    let allow_partial = input.allow_partial.unwrap_or(false);
+    let expected = input.expected_uidvalidity.get();
+    let per_msg_cap = account.imap.max_fetch_body_bytes();
+
+    let dest =
+        sandbox::resolve_dest_dir_async(input.dest_dir, Arc::clone(&account.download_dir)).await?;
+
+    let plan = RunPlan {
+        folder: input.folder,
+        dest,
+        prefix,
+        uids,
+        expected,
+        budget,
+        per_msg_cap,
+        allow_partial,
+    };
+    run_export(account, plan).await
+}
+
+/// Inputs to [`run_export`], grouped so the orchestrator stays within the
+/// positional-parameter limit.
+pub(crate) struct RunPlan {
+    pub folder: String,
+    pub dest: std::path::PathBuf,
+    pub prefix: String,
+    pub uids: Vec<Uid>,
+    pub expected: u32,
+    pub budget: u64,
+    pub per_msg_cap: u64,
+    pub allow_partial: bool,
+}
+
+/// The size/identity bounds threaded through the preflight and fetch loop:
+/// the pinned UIDVALIDITY, the per-message body cap, and the aggregate byte
+/// budget. Grouped so the helpers stay within the positional-parameter limit.
+#[derive(Debug, Clone, Copy)]
+struct FetchLimits {
+    expected: u32,
+    per_msg_cap: u64,
+    budget: u64,
+}
+
+/// Preflight → classify+fetch → frame → write. Generic over [`ExportSource`]
+/// so handler wiring is testable against a fake. `dest` is the already-resolved
+/// sandbox directory.
+///
+/// # Errors
+///
+/// See [`handle`]. Notably: a missing UIDVALIDITY in the preflight, an
+/// over-budget eligible-size sum or framed output, an all-or-nothing abort, and
+/// any body-fetch error are all returned `Err` before anything is written.
+pub(crate) async fn run_export(
+    source: &impl ExportSource,
+    plan: RunPlan,
+) -> Result<ToolResponse<ExportMessagesMeta, ()>, rimap_core::RimapError> {
+    let RunPlan {
+        folder,
+        dest,
+        prefix,
+        uids,
+        expected,
+        budget,
+        per_msg_cap,
+        allow_partial,
+    } = plan;
+
+    let limits = FetchLimits {
+        expected,
+        per_msg_cap,
+        budget,
+    };
+
+    let size_by_uid = preflight_sizes(source, &folder, &uids, limits).await?;
+
+    let outcomes = fetch_bodies(source, &folder, &uids, &size_by_uid, limits).await?;
+
+    let (complete, bodies, succeeded, failed) = match plan_outcome(outcomes, allow_partial) {
+        Outcome::Abort { failed } => {
+            let failed_uids: Vec<String> = failed.iter().map(|f| f.uid.to_string()).collect();
+            return Err(rimap_core::RimapError::invalid_input(format!(
+                "export incomplete (set allow_partial=true to override); failed UIDs: {}",
+                failed_uids.join(", ")
+            )));
+        }
+        Outcome::Proceed {
+            complete,
+            bodies,
+            succeeded,
+            failed,
+        } => (complete, bodies, succeeded, failed),
+    };
+
+    let mbox = build_mbox(&bodies);
+    let total_bytes = mbox.len() as u64;
+    // Authoritative budget check on the *framed* output: mboxrd separators,
+    // From-line escaping, and terminal padding add bytes beyond the raw bodies
+    // counted during fetch. Reject before writing anything.
+    if total_bytes > budget {
+        return Err(rimap_core::RimapError::invalid_input(
+            "framed mbox exceeds max_total_bytes",
+        ));
+    }
+    let sha256 = sandbox::sha256_hex(&mbox);
+
+    let suffix = if complete { "mbox" } else { "partial.mbox" };
+    let token = export_token();
+    let filename = format!("{prefix}-{token}.{suffix}");
+    let written = sandbox::write_attachment_async(dest, filename, mbox).await?;
+    let written = written.to_string_lossy().to_string();
+
+    let (path, partial_path) = if complete {
+        (Some(written), None)
+    } else {
+        (None, Some(written))
+    };
+
+    Ok(ToolResponse::meta_only(ExportMessagesMeta {
+        folder,
+        complete,
+        path,
+        partial_path,
+        sha256,
+        message_count: succeeded.len(),
+        total_bytes,
+        // `expected`, not the preflight-observed value: the guarded fetch
+        // fail-closes on any UIDVALIDITY mismatch/omission (preflight rejects
+        // None; fetch/fetch_body error on mismatch), so observed == expected is
+        // provable whenever we reach the manifest.
+        uid_validity: expected,
+        succeeded,
+        failed,
+    }))
+}
+
+/// Preflight: fetch reported sizes, reject an absent UIDVALIDITY, and run the
+/// advisory eligible-sum budget pre-check. Returns a `uid -> reported size`
+/// map (absence from the map means the UID is not present in the folder).
+///
+/// # Errors
+///
+/// Propagates IMAP failures; returns `InvalidInput` when the server omits
+/// UIDVALIDITY or the eligible reported-size sum exceeds `budget`.
+async fn preflight_sizes(
+    source: &impl ExportSource,
+    folder: &str,
+    uids: &[Uid],
+    limits: FetchLimits,
+) -> Result<std::collections::BTreeMap<u32, Option<u32>>, rimap_core::RimapError> {
+    let (sizes, uid_validity_opt) = source.fetch_sizes(folder, uids, limits.expected).await?;
+    // The shared guard only *warns* on an omitted UIDVALIDITY; export refuses
+    // to run unguarded, so reject an absent value.
+    if uid_validity_opt.is_none() {
+        return Err(rimap_core::RimapError::invalid_input(
+            "server omitted UIDVALIDITY; export_messages requires it to guard the mailbox",
+        ));
+    }
+
+    let mut size_by_uid: std::collections::BTreeMap<u32, Option<u32>> =
+        std::collections::BTreeMap::new();
+    for (uid, size) in sizes {
+        size_by_uid.insert(uid, size);
+    }
+
+    // Advisory aggregate pre-check, summed over ONLY the UIDs that may be
+    // written — present and within the per-message cap. Excluding NotFound and
+    // known-Oversize UIDs means they cannot block an `allow_partial` export of
+    // the writable messages. (A present-but-size-unknown UID counts 0 here; the
+    // running actual-bytes check during fetch is its real guard.) The framed
+    // size check later is the final authority.
+    let eligible_sum: u64 = uids
+        .iter()
+        .filter_map(|u| match size_by_uid.get(&u.get()) {
+            Some(Some(sz)) if u64::from(*sz) <= limits.per_msg_cap => Some(u64::from(*sz)),
+            _ => None,
+        })
+        .sum();
+    if eligible_sum > limits.budget {
+        return Err(rimap_core::RimapError::invalid_input(
+            "export exceeds max_total_bytes",
+        ));
+    }
+    Ok(size_by_uid)
+}
+
+/// Classify + fetch in caller order. Missing and known-oversize UIDs are
+/// per-UID failures resolved at preflight (no body fetch). `running` is the
+/// authoritative bound on *actual* transferred bytes — the reported-size
+/// pre-check can be defeated by a server that omits/under-reports RFC822.SIZE,
+/// so abort the moment real bytes exceed the budget.
+///
+/// # Errors
+///
+/// ANY body-fetch error is fatal — never downgraded to a per-UID failure.
+/// Per-UID absence/oversize is already resolved at preflight, so a UID that
+/// reaches the body fetch is known-present and in-bounds; an error here
+/// (UIDVALIDITY change/omission, `SizeLimit`, `Timeout`, connection loss, or a
+/// BODY-stream protocol error) means the session or the returned bytes are
+/// untrustworthy. Aborting prevents a corrupt/stale body landing in an
+/// artifact. Also returns `InvalidInput` if the running actual-byte total
+/// exceeds `budget`.
+async fn fetch_bodies(
+    source: &impl ExportSource,
+    folder: &str,
+    uids: &[Uid],
+    size_by_uid: &std::collections::BTreeMap<u32, Option<u32>>,
+    limits: FetchLimits,
+) -> Result<Vec<FetchOutcome>, rimap_core::RimapError> {
+    let mut outcomes = Vec::with_capacity(uids.len());
+    let mut running: u64 = 0;
+    for uid in uids {
+        let n = uid.get();
+        // Preflight-driven per-UID decision (pure, unit-tested). Skips never
+        // attempt a body fetch, so oversize never triggers SizeLimit.
+        if let UidPlan::Skip(reason) =
+            classify_uid(size_by_uid.get(&n).copied(), limits.per_msg_cap)
+        {
+            outcomes.push(FetchOutcome {
+                uid: n,
+                result: Err(reason),
+            });
+            continue;
+        }
+        let body = source.fetch_one_body(folder, *uid, limits.expected).await?;
+        running = running.saturating_add(body.len() as u64);
+        if running > limits.budget {
+            return Err(rimap_core::RimapError::invalid_input(
+                "export exceeds max_total_bytes",
+            ));
+        }
+        outcomes.push(FetchOutcome {
+            uid: n,
+            result: Ok(body),
+        });
+    }
+    Ok(outcomes)
+}
+
+/// Short token making concurrent exports' filenames distinct. Uses wall-clock
+/// nanos plus a process-local counter so two exports in the same instant still
+/// differ; `write_attachment`'s de-dup is the correctness backstop.
+fn export_token() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos:016x}{seq:04x}")
 }
 
 /// Per-UID fetch result fed into [`plan_outcome`].
@@ -264,7 +591,6 @@ pub(crate) struct FetchOutcome {
 }
 
 /// Decision produced by [`plan_outcome`].
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 pub(crate) enum Outcome {
     /// Default all-or-nothing path with failures: write nothing, error out.
     Abort { failed: Vec<FailedUid> },
@@ -280,7 +606,6 @@ pub(crate) enum Outcome {
 /// Partition per-UID outcomes into an export decision. With failures and
 /// `allow_partial == false`, returns [`Outcome::Abort`]; otherwise
 /// [`Outcome::Proceed`] with `complete == failed.is_empty()`.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 fn plan_outcome(outcomes: Vec<FetchOutcome>, allow_partial: bool) -> Outcome {
     let mut bodies = Vec::new();
     let mut succeeded = Vec::new();
@@ -325,7 +650,6 @@ pub(crate) enum UidPlan {
 /// The `Option<Option<u32>>` signature intentionally encodes three distinct
 /// states: absent, present-size-unknown, and present-size-known. A custom enum
 /// would be clearer but would require plumbing changes in Task 6's IMAP fetch.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
 #[expect(
     clippy::option_option,
     reason = "three-state encoding: absent / present-unknown / present-known"
@@ -669,5 +993,211 @@ mod build_mbox_tests {
             out.push(&b[start..]);
         }
         out
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::expect_used, reason = "tests")]
+mod source_seam_tests {
+    use super::{ExportSource, RunPlan, run_export};
+    use core::num::NonZeroU32;
+    use rimap_imap::types::Uid;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    fn uid(n: u32) -> Uid {
+        Uid::from(NonZeroU32::new(n).unwrap())
+    }
+
+    /// A single seeded body for the happy fake.
+    struct Seeded {
+        uid: u32,
+        body: Vec<u8>,
+    }
+
+    /// Hand-written fake `ExportSource`. `bodies` seeds the present UIDs (in any
+    /// order) with their raw bytes; `uid_validity` is what the preflight
+    /// reports; `body_error`, when set, makes EVERY `fetch_one_body` fail with a
+    /// freshly-built clone of that error. `seen_expected` records the `expected`
+    /// each fetch was called with so tests can assert it never drifts.
+    struct FakeSource {
+        bodies: Vec<Seeded>,
+        uid_validity: Option<u32>,
+        body_error: Option<fn() -> rimap_core::RimapError>,
+        seen_expected: RefCell<Vec<u32>>,
+    }
+
+    impl FakeSource {
+        fn happy(bodies: Vec<Seeded>, uid_validity: u32) -> Self {
+            Self {
+                bodies,
+                uid_validity: Some(uid_validity),
+                body_error: None,
+                seen_expected: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn failing(uid_validity: u32, body_error: fn() -> rimap_core::RimapError) -> Self {
+            Self {
+                bodies: vec![Seeded {
+                    uid: 1,
+                    body: b"Subject: x\r\n\r\nbody\r\n".to_vec(),
+                }],
+                uid_validity: Some(uid_validity),
+                body_error: Some(body_error),
+                seen_expected: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ExportSource for FakeSource {
+        async fn fetch_sizes(
+            &self,
+            _folder: &str,
+            uids: &[Uid],
+            _expected: u32,
+        ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError> {
+            let requested: std::collections::BTreeSet<u32> = uids.iter().map(|u| u.get()).collect();
+            let sizes = self
+                .bodies
+                .iter()
+                .filter(|s| requested.contains(&s.uid))
+                .map(|s| (s.uid, Some(u32::try_from(s.body.len()).unwrap())))
+                .collect();
+            Ok((sizes, self.uid_validity))
+        }
+
+        async fn fetch_one_body(
+            &self,
+            _folder: &str,
+            uid: Uid,
+            expected: u32,
+        ) -> Result<Vec<u8>, rimap_core::RimapError> {
+            self.seen_expected.borrow_mut().push(expected);
+            if let Some(make_err) = self.body_error {
+                return Err(make_err());
+            }
+            let found = self
+                .bodies
+                .iter()
+                .find(|s| s.uid == uid.get())
+                .expect("fetch_one_body called for an unseeded uid");
+            Ok(found.body.clone())
+        }
+    }
+
+    fn plan(dest: PathBuf, uids: Vec<Uid>, expected: u32, allow_partial: bool) -> RunPlan {
+        RunPlan {
+            folder: "INBOX".to_string(),
+            dest,
+            prefix: "messages".to_string(),
+            uids,
+            expected,
+            budget: super::MAX_EXPORT_TOTAL_BYTES,
+            per_msg_cap: 5_242_880,
+            allow_partial,
+        }
+    }
+
+    fn dir_is_empty(dir: &std::path::Path) -> bool {
+        std::fs::read_dir(dir).expect("read_dir").next().is_none()
+    }
+
+    #[tokio::test]
+    async fn happy_path_writes_artifact_and_pins_expected_on_every_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = FakeSource::happy(
+            vec![
+                Seeded {
+                    uid: 7,
+                    body: b"Subject: a\r\n\r\nalpha\r\n".to_vec(),
+                },
+                Seeded {
+                    uid: 9,
+                    body: b"Subject: b\r\n\r\nbeta\r\n".to_vec(),
+                },
+            ],
+            4242,
+        );
+        let resp = run_export(
+            &fake,
+            plan(tmp.path().to_path_buf(), vec![uid(7), uid(9)], 4242, false),
+        )
+        .await
+        .expect("export should succeed");
+
+        let meta = &resp.meta;
+        assert!(meta.complete);
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.uid_validity, 4242);
+        // succeeded preserves caller (mbox) order.
+        let order: Vec<u32> = meta.succeeded.iter().map(|s| s.uid).collect();
+        assert_eq!(order, vec![7, 9]);
+        let path = meta.path.as_deref().expect("complete export has path");
+        assert!(meta.partial_path.is_none());
+        let on_disk = std::fs::read(path).expect("artifact exists");
+        assert_eq!(super::sandbox::sha256_hex(&on_disk), meta.sha256);
+        // Every body fetch carried the same pinned UIDVALIDITY.
+        assert_eq!(*fake.seen_expected.borrow(), vec![4242, 4242]);
+    }
+
+    async fn assert_body_error_aborts_with_no_artifact(make_err: fn() -> rimap_core::RimapError) {
+        for allow_partial in [false, true] {
+            let tmp = tempfile::tempdir().unwrap();
+            let fake = FakeSource::failing(4242, make_err);
+            let result = run_export(
+                &fake,
+                plan(tmp.path().to_path_buf(), vec![uid(1)], 4242, allow_partial),
+            )
+            .await;
+            assert!(
+                result.is_err(),
+                "body error must abort (allow_partial={allow_partial})"
+            );
+            assert!(
+                dir_is_empty(tmp.path()),
+                "no artifact may be written on a body-fetch error \
+                 (allow_partial={allow_partial})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn uid_validity_changed_body_error_aborts_no_artifact() {
+        assert_body_error_aborts_with_no_artifact(|| {
+            rimap_core::RimapError::from(rimap_imap::ImapError::UidValidityChanged {
+                folder: "INBOX".to_string(),
+                expected: 4242,
+                actual: 9999,
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn uid_validity_unavailable_body_error_aborts_no_artifact() {
+        assert_body_error_aborts_with_no_artifact(|| {
+            rimap_core::RimapError::from(rimap_imap::ImapError::UidValidityUnavailable {
+                folder: "INBOX".to_string(),
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn timeout_body_error_aborts_no_artifact() {
+        assert_body_error_aborts_with_no_artifact(|| {
+            rimap_core::RimapError::from(rimap_imap::ImapError::Timeout { op: "fetch_body" })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn size_limit_body_error_aborts_no_artifact() {
+        assert_body_error_aborts_with_no_artifact(|| {
+            rimap_core::RimapError::from(rimap_imap::ImapError::SizeLimit { limit: 1024 })
+        })
+        .await;
     }
 }

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -143,8 +143,9 @@ const MBOX_SEPARATOR: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1
 /// every line matching `^>*From ` is escaped with one extra leading `>`;
 /// CRLF is preserved verbatim.
 ///
-/// Callers must pass non-empty message bodies; an empty body would emit a
-/// bare separator with no content. Task 7's handler validates this upstream.
+/// Callers pass already-fetched, non-empty message bodies. The handler never calls this
+/// with an empty slice (it short-circuits a zero-success export before building), and
+/// per-body emptiness isn't expected from a real BODY.PEEK[] fetch.
 fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
     let mut out = Vec::new();
     for msg in messages {
@@ -436,16 +437,21 @@ pub(crate) async fn run_export(
     }
     let sha256 = sandbox::sha256_hex(&mbox);
 
-    let suffix = if complete { "mbox" } else { "partial.mbox" };
-    let token = export_token();
-    let filename = format!("{prefix}-{token}.{suffix}");
-    let written = sandbox::write_attachment_async(dest, filename, mbox).await?;
-    let written = written.to_string_lossy().to_string();
-
-    let (path, partial_path) = if complete {
-        (Some(written), None)
+    // Nothing succeeded (only reachable with allow_partial=true and all UIDs
+    // failed): report the failures, write no empty artifact.
+    let (path, partial_path) = if succeeded.is_empty() {
+        (None, None)
     } else {
-        (None, Some(written))
+        let suffix = if complete { "mbox" } else { "partial.mbox" };
+        let token = export_token();
+        let filename = format!("{prefix}-{token}.{suffix}");
+        let written = sandbox::write_attachment_async(dest, filename, mbox).await?;
+        let written = written.to_string_lossy().to_string();
+        if complete {
+            (Some(written), None)
+        } else {
+            (None, Some(written))
+        }
     };
 
     Ok(ToolResponse::meta_only(ExportMessagesMeta {
@@ -999,6 +1005,7 @@ mod build_mbox_tests {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 #[expect(clippy::expect_used, reason = "tests")]
+#[expect(clippy::panic, reason = "tests")]
 mod source_seam_tests {
     use super::{ExportSource, RunPlan, run_export};
     use core::num::NonZeroU32;
@@ -1199,6 +1206,89 @@ mod source_seam_tests {
             rimap_core::RimapError::from(rimap_imap::ImapError::SizeLimit { limit: 1024 })
         })
         .await;
+    }
+
+    /// A fake that reports NO UIDs as present (empty size list), simulating
+    /// a mailbox where every requested UID is absent.
+    struct AllAbsentSource {
+        uid_validity: u32,
+    }
+
+    impl ExportSource for AllAbsentSource {
+        async fn fetch_sizes(
+            &self,
+            _folder: &str,
+            _uids: &[Uid],
+            _expected: u32,
+        ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError> {
+            // Return an empty size list: every requested UID is not present.
+            Ok((vec![], Some(self.uid_validity)))
+        }
+
+        async fn fetch_one_body(
+            &self,
+            _folder: &str,
+            _uid: Uid,
+            _expected: u32,
+        ) -> Result<Vec<u8>, rimap_core::RimapError> {
+            // Should never be called: all UIDs are classified NotFound at preflight.
+            panic!("fetch_one_body must not be called when all UIDs are absent");
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_success_partial_writes_no_artifact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = AllAbsentSource { uid_validity: 1234 };
+
+        let result = run_export(
+            &fake,
+            plan(
+                tmp.path().to_path_buf(),
+                vec![uid(10), uid(20), uid(30)],
+                1234,
+                true, // allow_partial=true: every-UID-failed is "allowed"
+            ),
+        )
+        .await;
+
+        let resp = result.expect("zero-success partial must return Ok");
+        let meta = &resp.meta;
+
+        assert!(
+            !meta.complete,
+            "complete must be false when nothing succeeded"
+        );
+        assert!(
+            meta.path.is_none(),
+            "path must be None (no complete artifact)"
+        );
+        assert!(
+            meta.partial_path.is_none(),
+            "partial_path must be None (no empty artifact written)"
+        );
+        assert_eq!(meta.message_count, 0, "message_count must be 0");
+        assert_eq!(meta.total_bytes, 0, "total_bytes must be 0");
+        assert_eq!(meta.failed.len(), 3, "all 3 UIDs must appear in failed");
+        for f in &meta.failed {
+            assert_eq!(
+                f.reason,
+                super::ExportFailReason::NotFound,
+                "uid {} must be NotFound",
+                f.uid
+            );
+        }
+        let failed_uids: Vec<u32> = meta.failed.iter().map(|f| f.uid).collect();
+        assert!(
+            failed_uids.contains(&10) && failed_uids.contains(&20) && failed_uids.contains(&30),
+            "failed list must include all requested UIDs: {failed_uids:?}"
+        );
+
+        // No artifact may be written.
+        assert!(
+            dir_is_empty(tmp.path()),
+            "dest dir must be empty — no 0-byte artifact written"
+        );
     }
 }
 

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -94,6 +94,72 @@ pub struct ExportMessagesMeta {
     pub failed: Vec<FailedUid>,
 }
 
+/// Pinned mboxrd separator. `git am`/`mailsplit` use it only as a delimiter
+/// and take real authorship from each message's own `From:` header.
+const MBOX_SEPARATOR: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1970\n";
+
+/// Assemble raw RFC822 messages into a single mboxrd byte buffer suitable
+/// for `git am`. Each message is preceded by [`MBOX_SEPARATOR`] at column 0;
+/// every line matching `^>*From ` is escaped with one extra leading `>`;
+/// CRLF is preserved verbatim.
+///
+/// Callers must pass non-empty message bodies; an empty body would emit a
+/// bare separator with no content. Task 7's handler validates this upstream.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for msg in messages {
+        // Ensure the previous message ended with a line feed so this
+        // separator starts at column 0.
+        if let Some(&last) = out.last()
+            && last != b'\n'
+        {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(MBOX_SEPARATOR);
+        escape_from_lines_into(&mut out, msg);
+    }
+    // Trailing newline for a well-formed final message.
+    if let Some(&last) = out.last()
+        && last != b'\n'
+    {
+        out.push(b'\n');
+    }
+    out
+}
+
+/// Append `msg` to `out`, escaping each `^>*From ` line with one extra `>`.
+fn escape_from_lines_into(out: &mut Vec<u8>, msg: &[u8]) {
+    let mut line_start = 0;
+    for i in 0..msg.len() {
+        if msg[i] == b'\n' {
+            write_mbox_line(out, &msg[line_start..=i]);
+            line_start = i + 1;
+        }
+    }
+    if line_start < msg.len() {
+        write_mbox_line(out, &msg[line_start..]);
+    }
+}
+
+/// Append `line` to `out`, prefixing it with `>` when it matches `^>*From `.
+fn write_mbox_line(out: &mut Vec<u8>, line: &[u8]) {
+    if line_is_from(line) {
+        out.push(b'>');
+    }
+    out.extend_from_slice(line);
+}
+
+/// Whether `line` (from column 0) matches `^>*From ` — any run of `>` then
+/// the literal `From `.
+fn line_is_from(line: &[u8]) -> bool {
+    let mut j = 0;
+    while j < line.len() && line[j] == b'>' {
+        j += 1;
+    }
+    line[j..].starts_with(b"From ")
+}
+
 /// Execute the `export_messages` tool.
 ///
 /// # Errors
@@ -111,4 +177,127 @@ pub async fn handle(
     Err(rimap_core::RimapError::Internal(
         "export_messages not yet implemented".into(),
     ))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod build_mbox_tests {
+    use super::build_mbox;
+
+    const SEP: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1970\n";
+
+    #[test]
+    fn single_message_gets_separator_and_trailing_newline() {
+        let out = build_mbox(&[b"Subject: hi\r\n\r\nbody".to_vec()]);
+        assert!(out.starts_with(SEP), "missing leading separator");
+        assert!(out.ends_with(b"\n"), "must end with newline");
+        assert!(out.ends_with(b"body\n"));
+    }
+
+    #[test]
+    fn missing_terminal_newline_padded_before_next_separator() {
+        // First message has no trailing newline; the second separator must
+        // still start at column 0.
+        let out = build_mbox(&[
+            b"a: 1\r\n\r\nno-newline".to_vec(),
+            b"b: 2\r\n\r\nx\n".to_vec(),
+        ]);
+        let text = String::from_utf8(out).unwrap();
+        // Exactly two separators, each at the start of a line.
+        let seps: Vec<_> = text.match_indices("From mboxrd@").collect();
+        assert_eq!(seps.len(), 2);
+        for (idx, _) in &seps {
+            assert!(
+                *idx == 0 || text.as_bytes()[idx - 1] == b'\n',
+                "separator not at col 0"
+            );
+        }
+    }
+
+    #[test]
+    fn escapes_every_from_line_including_nested_and_header_position() {
+        let msg = b"From the desk of X\r\n>From already escaped\r\nFrom \r\nnormal\n".to_vec();
+        let out = build_mbox(&[msg]);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains(">From the desk of X"));
+        assert!(text.contains(">>From already escaped"));
+        assert!(text.contains(">From \r\n"));
+        assert!(text.contains("\nnormal"));
+    }
+
+    #[test]
+    fn preserves_crlf_verbatim_in_body() {
+        let out = build_mbox(&[b"H: 1\r\n\r\nline1\r\nline2\r\n".to_vec()]);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("line1\r\nline2\r\n"));
+    }
+
+    #[test]
+    fn split_back_round_trips_messages() {
+        // Build, then split on separator lines and un-escape; must equal inputs.
+        let inputs = vec![
+            b"A: 1\r\n\r\nFrom space\r\nbody1\r\n".to_vec(),
+            b"B: 2\r\n\r\nbody2\n".to_vec(),
+        ];
+        let mbox = build_mbox(&inputs);
+        let recovered = split_and_unescape(&mbox);
+        assert_eq!(recovered.len(), inputs.len());
+        // Compare ignoring a single trailing newline build_mbox may add.
+        for (got, want) in recovered.iter().zip(inputs.iter()) {
+            assert_eq!(trim_one_trailing_nl(got), trim_one_trailing_nl(want));
+        }
+    }
+
+    fn trim_one_trailing_nl(b: &[u8]) -> &[u8] {
+        b.strip_suffix(b"\n").unwrap_or(b)
+    }
+
+    // Test-only inverse of build_mbox's framing: split on separator lines,
+    // strip one leading '>' from each `^>+From ` line.
+    fn split_and_unescape(mbox: &[u8]) -> Vec<Vec<u8>> {
+        let mut parts: Vec<Vec<u8>> = Vec::new();
+        let mut cur: Option<Vec<u8>> = None;
+        for line in split_keep_newlines(mbox) {
+            if line == SEP {
+                if let Some(c) = cur.take() {
+                    parts.push(c);
+                }
+                cur = Some(Vec::new());
+            } else if let Some(c) = cur.as_mut() {
+                c.extend_from_slice(&unescape_line(line));
+            }
+        }
+        if let Some(c) = cur.take() {
+            parts.push(c);
+        }
+        parts
+    }
+
+    fn unescape_line(line: &[u8]) -> Vec<u8> {
+        // If line is `>+From `, drop one leading '>'.
+        let mut j = 0;
+        while j < line.len() && line[j] == b'>' {
+            j += 1;
+        }
+        if j >= 1 && line[j..].starts_with(b"From ") {
+            line[1..].to_vec()
+        } else {
+            line.to_vec()
+        }
+    }
+
+    fn split_keep_newlines(b: &[u8]) -> Vec<&[u8]> {
+        let mut out = Vec::new();
+        let mut start = 0;
+        for i in 0..b.len() {
+            if b[i] == b'\n' {
+                out.push(&b[start..=i]);
+                start = i + 1;
+            }
+        }
+        if start < b.len() {
+            out.push(&b[start..]);
+        }
+        out
+    }
 }

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -257,6 +257,184 @@ pub async fn handle(
     ))
 }
 
+/// Per-UID fetch result fed into [`plan_outcome`].
+pub(crate) struct FetchOutcome {
+    pub uid: u32,
+    pub result: Result<Vec<u8>, ExportFailReason>,
+}
+
+/// Decision produced by [`plan_outcome`].
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+pub(crate) enum Outcome {
+    /// Default all-or-nothing path with failures: write nothing, error out.
+    Abort { failed: Vec<FailedUid> },
+    /// Write the bodies (in order) and report the manifest.
+    Proceed {
+        complete: bool,
+        bodies: Vec<Vec<u8>>,
+        succeeded: Vec<ExportedUid>,
+        failed: Vec<FailedUid>,
+    },
+}
+
+/// Partition per-UID outcomes into an export decision. With failures and
+/// `allow_partial == false`, returns [`Outcome::Abort`]; otherwise
+/// [`Outcome::Proceed`] with `complete == failed.is_empty()`.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+fn plan_outcome(outcomes: Vec<FetchOutcome>, allow_partial: bool) -> Outcome {
+    let mut bodies = Vec::new();
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+    for o in outcomes {
+        match o.result {
+            Ok(body) => {
+                succeeded.push(ExportedUid {
+                    uid: o.uid,
+                    size_bytes: body.len(),
+                });
+                bodies.push(body);
+            }
+            Err(reason) => failed.push(FailedUid { uid: o.uid, reason }),
+        }
+    }
+    if !failed.is_empty() && !allow_partial {
+        return Outcome::Abort { failed };
+    }
+    Outcome::Proceed {
+        complete: failed.is_empty(),
+        bodies,
+        succeeded,
+        failed,
+    }
+}
+
+/// What to do with one requested UID, decided from its preflight size entry.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum UidPlan {
+    /// Resolved at preflight without a body fetch (`NotFound` / `Oversize`).
+    Skip(ExportFailReason),
+    /// Present and in-bounds: fetch the body.
+    Fetch,
+}
+
+/// Classify a UID from its preflight size entry (`None` = absent from the
+/// folder; `Some(None)` = present, size unknown; `Some(Some(n))` = present,
+/// reported size `n`). Pure, so the security-critical NotFound/Oversize
+/// decision is unit-testable without a live IMAP server.
+///
+/// The `Option<Option<u32>>` signature intentionally encodes three distinct
+/// states: absent, present-size-unknown, and present-size-known. A custom enum
+/// would be clearer but would require plumbing changes in Task 6's IMAP fetch.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+#[expect(
+    clippy::option_option,
+    reason = "three-state encoding: absent / present-unknown / present-known"
+)]
+fn classify_uid(reported: Option<Option<u32>>, per_msg_cap: u64) -> UidPlan {
+    match reported {
+        None => UidPlan::Skip(ExportFailReason::NotFound),
+        Some(Some(sz)) if u64::from(sz) > per_msg_cap => UidPlan::Skip(ExportFailReason::Oversize),
+        Some(Some(_) | None) => UidPlan::Fetch,
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic,
+    reason = "tests use panic! for assertion failures in match arms"
+)]
+mod outcome_tests {
+    use super::{ExportFailReason, FetchOutcome, Outcome, plan_outcome};
+
+    fn ok(uid: u32, body: &[u8]) -> FetchOutcome {
+        FetchOutcome {
+            uid,
+            result: Ok(body.to_vec()),
+        }
+    }
+    fn err(uid: u32, reason: ExportFailReason) -> FetchOutcome {
+        FetchOutcome {
+            uid,
+            result: Err(reason),
+        }
+    }
+
+    #[test]
+    fn all_success_is_complete() {
+        let out = plan_outcome(vec![ok(1, b"a"), ok(2, b"b")], false);
+        match out {
+            Outcome::Proceed {
+                complete,
+                bodies,
+                succeeded,
+                failed,
+            } => {
+                assert!(complete);
+                assert_eq!(bodies.len(), 2);
+                assert_eq!(succeeded.len(), 2);
+                assert!(failed.is_empty());
+                assert_eq!(succeeded[0].uid, 1);
+                assert_eq!(succeeded[1].uid, 2);
+                assert_eq!(bodies[0], b"a");
+                assert_eq!(bodies[1], b"b");
+            }
+            Outcome::Abort { .. } => panic!("expected Proceed"),
+        }
+    }
+
+    #[test]
+    fn failure_without_allow_partial_aborts() {
+        let out = plan_outcome(vec![ok(1, b"a"), err(2, ExportFailReason::NotFound)], false);
+        match out {
+            Outcome::Abort { failed } => {
+                assert_eq!(failed.len(), 1);
+                assert_eq!(failed[0].uid, 2);
+            }
+            Outcome::Proceed { .. } => panic!("expected Abort"),
+        }
+    }
+
+    #[test]
+    fn failure_with_allow_partial_proceeds_incomplete() {
+        let out = plan_outcome(vec![ok(1, b"a"), err(2, ExportFailReason::Oversize)], true);
+        match out {
+            Outcome::Proceed {
+                complete,
+                bodies,
+                succeeded,
+                failed,
+            } => {
+                assert!(!complete);
+                assert_eq!(bodies.len(), 1);
+                assert_eq!(succeeded.len(), 1);
+                assert_eq!(failed.len(), 1);
+            }
+            Outcome::Abort { .. } => panic!("expected Abort"),
+        }
+    }
+
+    #[test]
+    fn classify_uid_cases() {
+        use super::{ExportFailReason, UidPlan, classify_uid};
+        assert_eq!(
+            classify_uid(None, 100),
+            UidPlan::Skip(ExportFailReason::NotFound)
+        );
+        assert_eq!(
+            classify_uid(Some(Some(200)), 100),
+            UidPlan::Skip(ExportFailReason::Oversize)
+        );
+        assert_eq!(classify_uid(Some(Some(50)), 100), UidPlan::Fetch);
+        assert_eq!(classify_uid(Some(None), 100), UidPlan::Fetch); // present, size unknown
+        // Exact boundary: size == cap is in-bounds (Fetch); one over is Oversize.
+        assert_eq!(classify_uid(Some(Some(100)), 100), UidPlan::Fetch);
+        assert_eq!(
+            classify_uid(Some(Some(101)), 100),
+            UidPlan::Skip(ExportFailReason::Oversize)
+        );
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod input_tests {

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -1201,3 +1201,85 @@ mod source_seam_tests {
         .await;
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::expect_used, reason = "tests")]
+mod git_am_tests {
+    use super::build_mbox;
+    use std::process::Command;
+
+    fn git(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            // Isolate from host config so commit.gpgsign / global hooks /
+            // templates / init.defaultBranch cannot spuriously fail git am.
+            // The identity env vars above are load-bearing once global
+            // user.name/email is suppressed.
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git runs")
+    }
+
+    /// Emits CRLF (`\r\n`) line endings deliberately, mirroring raw RFC822
+    /// bytes; the format string mixes `\r\n` with line-continuation backslashes.
+    fn patch(n: u32, body_extra: &str) -> Vec<u8> {
+        // A minimal git-format-patch-style message: From/Subject/Date headers,
+        // then a unified diff creating file_<n>.txt.
+        format!(
+            "From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001\r\n\
+             From: Dev <dev@example.com>\r\n\
+             Date: Mon, 1 Jan 2024 0{n}:00:00 +0000\r\n\
+             Subject: [PATCH {n}/2] add file {n}{body_extra}\r\n\
+             \r\n\
+             ---\r\n \
+             file_{n}.txt | 1 +\r\n \
+             1 file changed, 1 insertion(+)\r\n\
+             \r\n\
+             diff --git a/file_{n}.txt b/file_{n}.txt\r\n\
+             new file mode 100644\r\n\
+             index 0000000..0000001\r\n\
+             --- /dev/null\r\n\
+             +++ b/file_{n}.txt\r\n\
+             @@ -0,0 +1 @@\r\n\
+             +content {n}\r\n\
+             -- \r\n\
+             2.40.0\r\n"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn git_am_applies_generated_mbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        assert!(git(&["init", "-q"], repo).status.success());
+
+        // A spurious `From `-leading line in the message (here in the header
+        // region) must be escaped by build_mbox, or git's mbox splitter would
+        // wrongly split the series there.
+        let mbox = build_mbox(&[patch(1, "\r\nFrom the author: note"), patch(2, "")]);
+        let mbox_path = repo.join("series.mbox");
+        std::fs::write(&mbox_path, &mbox).unwrap();
+
+        let out = git(&["am", mbox_path.to_str().unwrap()], repo);
+        assert!(
+            out.status.success(),
+            "git am failed: {}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+
+        let log = git(&["rev-list", "--count", "HEAD"], repo);
+        let count = String::from_utf8_lossy(&log.stdout).trim().to_string();
+        assert_eq!(count, "2", "expected 2 commits from a 2-patch series");
+        assert!(repo.join("file_1.txt").exists());
+        assert!(repo.join("file_2.txt").exists());
+    }
+}

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -160,6 +160,45 @@ fn line_is_from(line: &[u8]) -> bool {
     line[j..].starts_with(b"From ")
 }
 
+/// Sanitize the advisory `filename` prefix to a safe single basename, or
+/// return the default `"messages"` when absent.
+///
+/// Uses a conservative **allowlist** grammar — `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`
+/// — because the prefix ends up in the `path` returned to the agent and the
+/// documented flow is `git am <path>`. The allowlist rejects path separators,
+/// `..` traversal, shell metacharacters, whitespace, quotes, and all non-ASCII
+/// (so bidi / zero-width / tag display-spoofing codepoints cannot appear), and
+/// the alphanumeric-first rule rejects leading `.`/`-`.
+///
+/// # Errors
+///
+/// `RimapError::Authz { code: InvalidInput }` if the prefix is empty after
+/// trimming, longer than 64 bytes, or contains any character outside the
+/// grammar.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+fn sanitize_filename_prefix(prefix: Option<&str>) -> Result<String, rimap_core::RimapError> {
+    let Some(raw) = prefix else {
+        return Ok("messages".to_string());
+    };
+    let trimmed = raw.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed.len() <= 64
+        && trimmed
+            .bytes()
+            .next()
+            .is_some_and(|b| b.is_ascii_alphanumeric())
+        && trimmed
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if !valid {
+        return Err(rimap_core::RimapError::invalid_input(
+            "filename prefix must match [A-Za-z0-9][A-Za-z0-9._-]{0,63} \
+             (conservative ASCII basename)",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
 /// Execute the `export_messages` tool.
 ///
 /// # Errors
@@ -177,6 +216,73 @@ pub async fn handle(
     Err(rimap_core::RimapError::Internal(
         "export_messages not yet implemented".into(),
     ))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod sanitize_tests {
+    use super::sanitize_filename_prefix;
+
+    #[test]
+    fn default_when_absent() {
+        assert_eq!(sanitize_filename_prefix(None).unwrap(), "messages");
+    }
+
+    #[test]
+    fn accepts_plain_basename() {
+        assert_eq!(
+            sanitize_filename_prefix(Some("dpdk-series")).unwrap(),
+            "dpdk-series"
+        );
+    }
+
+    #[test]
+    fn rejects_everything_outside_the_allowlist() {
+        for bad in [
+            "../escape",
+            "/abs/path",
+            "a/b",
+            "a\\b",
+            "",
+            "  ",
+            "a\u{0}b",
+            "a\nb", // separators/control
+            "a;b",
+            "a b",
+            "a'b",
+            "a\"b",
+            "a$b",
+            "a|b",
+            "a&b",
+            "a`b", // shell metachars/spaces/quotes
+            "-lead",
+            ".hidden", // leading dash/dot
+            "a\u{202E}b",
+            "a\u{200B}b",
+            "a\u{E0001}b", // bidi / zero-width / tag
+        ] {
+            assert!(
+                sanitize_filename_prefix(Some(bad)).is_err(),
+                "should reject {bad:?}"
+            );
+        }
+        // Overlong (> 64 chars) is rejected.
+        let long = "a".repeat(65);
+        assert!(sanitize_filename_prefix(Some(&long)).is_err());
+        // Exactly 64 chars is the accepted boundary.
+        let max = "a".repeat(64);
+        assert!(sanitize_filename_prefix(Some(&max)).is_ok());
+    }
+
+    #[test]
+    fn accepts_conservative_ascii_basenames() {
+        for ok in ["messages", "dpdk-series", "patch_set.v2", "AB12"] {
+            assert!(
+                sanitize_filename_prefix(Some(ok)).is_ok(),
+                "should accept {ok:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -1,0 +1,114 @@
+//! `export_messages` tool handler: bulk raw export of multiple UIDs to a
+//! single `git am`-able mbox file in the download sandbox.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::boot::registry::AccountState;
+use crate::mcp::response::ToolResponse;
+
+/// Hard ceiling on the aggregate export size, regardless of the
+/// caller-supplied `max_total_bytes`.
+pub const MAX_EXPORT_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Input for the `export_messages` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub struct ExportMessagesInput {
+    /// IMAP folder containing the messages.
+    pub folder: String,
+    /// UIDs to export, in mbox (patch) order. Non-empty, max 100, de-duped.
+    pub uids: Vec<core::num::NonZeroU32>,
+    /// UIDVALIDITY observed when the UID list was discovered (e.g. from
+    /// `search`). Required: pins mailbox identity across search→export.
+    #[serde(deserialize_with = "crate::tools::lenient_int::deserialize_nonzero_u32")]
+    #[schemars(schema_with = "crate::tools::lenient_int::schema_nonzero_u32")]
+    pub expected_uidvalidity: core::num::NonZeroU32,
+    /// Optional destination directory. Must be within the download root.
+    pub dest_dir: Option<String>,
+    /// Optional advisory basename prefix (sanitized).
+    pub filename: Option<String>,
+    /// Aggregate byte cap; clamped to `MAX_EXPORT_TOTAL_BYTES`.
+    #[serde(
+        default,
+        deserialize_with = "crate::tools::lenient_int::deserialize_opt_u64"
+    )]
+    #[schemars(schema_with = "crate::tools::lenient_int::schema_opt_u64")]
+    pub max_total_bytes: Option<u64>,
+    /// When true, write the successes to a `.partial.mbox` artifact instead
+    /// of failing the whole call. Default false (all-or-nothing).
+    pub allow_partial: Option<bool>,
+}
+
+/// One successfully exported message.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExportedUid {
+    pub uid: u32,
+    pub size_bytes: usize,
+}
+
+/// Reason a requested UID was not exported. Both are determined at the size
+/// preflight, before any body fetch — a UID that reaches the body fetch is
+/// known-present and in-bounds, and any error there is fatal (never per-UID),
+/// so there is no `FetchError` variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFailReason {
+    NotFound,
+    Oversize,
+}
+
+/// One requested UID that failed.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct FailedUid {
+    pub uid: u32,
+    pub reason: ExportFailReason,
+}
+
+/// Trusted metadata for an `export_messages` response.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExportMessagesMeta {
+    /// Folder the messages were exported from.
+    pub folder: String,
+    /// True iff every requested UID was exported.
+    pub complete: bool,
+    /// `git am`-ready mbox path. Present only on a complete export;
+    /// omitted from the response otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Path of a `.partial.mbox` artifact. Present only on a partial
+    /// export; omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_path: Option<String>,
+    /// SHA-256 of the written mbox, hex-encoded.
+    pub sha256: String,
+    /// Number of messages written to the artifact.
+    pub message_count: usize,
+    /// Total bytes written.
+    pub total_bytes: u64,
+    /// UIDVALIDITY the export was pinned to.
+    pub uid_validity: u32,
+    /// Exported UIDs, in mbox order, with sizes.
+    pub succeeded: Vec<ExportedUid>,
+    /// Requested UIDs that failed, with reasons.
+    pub failed: Vec<FailedUid>,
+}
+
+/// Execute the `export_messages` tool.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` — not yet implemented (filled in Task 7).
+#[expect(
+    clippy::unused_async,
+    reason = "inert handler; dispatch awaits this future and the real \
+              implementation (Task 7) performs IMAP I/O"
+)]
+pub async fn handle(
+    _account: &AccountState,
+    _input: ExportMessagesInput,
+) -> Result<ToolResponse<ExportMessagesMeta, ()>, rimap_core::RimapError> {
+    Err(rimap_core::RimapError::Internal(
+        "export_messages not yet implemented".into(),
+    ))
+}

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -1,6 +1,7 @@
 //! `export_messages` tool handler: bulk raw export of multiple UIDs to a
 //! single `git am`-able mbox file in the download sandbox.
 
+use rimap_imap::types::Uid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -92,6 +93,44 @@ pub struct ExportMessagesMeta {
     pub succeeded: Vec<ExportedUid>,
     /// Requested UIDs that failed, with reasons.
     pub failed: Vec<FailedUid>,
+}
+
+/// Max UIDs per export, shared with the mutation-tool batch cap.
+const MAX_EXPORT_UIDS: usize = 100;
+
+/// Validate and normalize the requested UID list: reject empty / over-cap,
+/// de-dup preserving first-seen order, and convert to `Uid`.
+///
+/// # Errors
+///
+/// `RimapError::Authz { code: InvalidInput }` for an empty list or one
+/// exceeding [`MAX_EXPORT_UIDS`].
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+fn validate_uids(uids: Vec<core::num::NonZeroU32>) -> Result<Vec<Uid>, rimap_core::RimapError> {
+    if uids.is_empty() {
+        return Err(rimap_core::RimapError::invalid_input(
+            "uids must not be empty",
+        ));
+    }
+    if uids.len() > MAX_EXPORT_UIDS {
+        return Err(rimap_core::RimapError::invalid_input(format!(
+            "uids exceeds the maximum of {MAX_EXPORT_UIDS} per export"
+        )));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::with_capacity(uids.len());
+    for u in uids {
+        if seen.insert(u.get()) {
+            out.push(Uid::from(u));
+        }
+    }
+    Ok(out)
+}
+
+/// Clamp the caller-supplied aggregate byte budget to the hard ceiling.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired into handle in Task 7"))]
+fn clamp_total_bytes(requested: Option<u64>) -> u64 {
+    requested.map_or(MAX_EXPORT_TOTAL_BYTES, |n| n.min(MAX_EXPORT_TOTAL_BYTES))
 }
 
 /// Pinned mboxrd separator. `git am`/`mailsplit` use it only as a delimiter
@@ -216,6 +255,53 @@ pub async fn handle(
     Err(rimap_core::RimapError::Internal(
         "export_messages not yet implemented".into(),
     ))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod input_tests {
+    use super::{MAX_EXPORT_TOTAL_BYTES, clamp_total_bytes, validate_uids};
+    use core::num::NonZeroU32;
+
+    fn nz(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).unwrap()
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_uids(Vec::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_over_100() {
+        let v: Vec<NonZeroU32> = (1..=101).map(nz).collect();
+        assert!(validate_uids(v).is_err());
+    }
+
+    #[test]
+    fn accepts_exactly_100() {
+        let v: Vec<NonZeroU32> = (1..=100).map(nz).collect();
+        assert_eq!(validate_uids(v).unwrap().len(), 100);
+    }
+
+    #[test]
+    fn dedups_preserving_first_order() {
+        let v = vec![nz(3), nz(1), nz(3), nz(2), nz(1)];
+        let out = validate_uids(v).unwrap();
+        let got: Vec<u32> = out.iter().map(|u| u.get()).collect();
+        assert_eq!(got, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn clamp_none_is_ceiling() {
+        assert_eq!(clamp_total_bytes(None), MAX_EXPORT_TOTAL_BYTES);
+    }
+
+    #[test]
+    fn clamp_caps_oversized_request() {
+        assert_eq!(clamp_total_bytes(Some(u64::MAX)), MAX_EXPORT_TOTAL_BYTES);
+        assert_eq!(clamp_total_bytes(Some(1024)), 1024);
+    }
 }
 
 #[cfg(test)]

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -384,6 +384,20 @@ struct FetchLimits {
 /// See [`handle`]. Notably: a missing UIDVALIDITY in the preflight, an
 /// over-budget eligible-size sum or framed output, an all-or-nothing abort, and
 /// any body-fetch error are all returned `Err` before anything is written.
+/// All-or-nothing abort error naming the UIDs that cannot be exported. Shared
+/// by the preflight short-circuit and the post-fetch [`Outcome::Abort`] path so
+/// both report the identical message shape.
+fn incomplete_export_error(failed_uids: &[u32]) -> rimap_core::RimapError {
+    let mut rendered: Vec<String> = Vec::with_capacity(failed_uids.len());
+    for uid in failed_uids {
+        rendered.push(uid.to_string());
+    }
+    rimap_core::RimapError::invalid_input(format!(
+        "export incomplete (set allow_partial=true to override); failed UIDs: {}",
+        rendered.join(", ")
+    ))
+}
+
 pub(crate) async fn run_export(
     source: &impl ExportSource,
     plan: RunPlan,
@@ -407,15 +421,32 @@ pub(crate) async fn run_export(
 
     let size_by_uid = preflight_sizes(source, &folder, &uids, limits).await?;
 
+    // All-or-nothing: if preflight already classifies any requested UID as a
+    // failure (NotFound / Oversize), abort before fetching ANY body. Without
+    // this, one missing/oversize UID would still pull every other body up to
+    // the byte budget only to discard all of them at `plan_outcome`.
+    if !allow_partial {
+        let mut preflight_failed: Vec<u32> = Vec::new();
+        for u in &uids {
+            match classify_uid(size_by_uid.get(&u.get()).copied(), per_msg_cap) {
+                UidPlan::Skip(_) => preflight_failed.push(u.get()),
+                UidPlan::Fetch => {}
+            }
+        }
+        if !preflight_failed.is_empty() {
+            return Err(incomplete_export_error(&preflight_failed));
+        }
+    }
+
     let outcomes = fetch_bodies(source, &folder, &uids, &size_by_uid, limits).await?;
 
     let (complete, bodies, succeeded, failed) = match plan_outcome(outcomes, allow_partial) {
         Outcome::Abort { failed } => {
-            let failed_uids: Vec<String> = failed.iter().map(|f| f.uid.to_string()).collect();
-            return Err(rimap_core::RimapError::invalid_input(format!(
-                "export incomplete (set allow_partial=true to override); failed UIDs: {}",
-                failed_uids.join(", ")
-            )));
+            let mut failed_uids: Vec<u32> = Vec::with_capacity(failed.len());
+            for f in &failed {
+                failed_uids.push(f.uid);
+            }
+            return Err(incomplete_export_error(&failed_uids));
         }
         Outcome::Proceed {
             complete,
@@ -1288,6 +1319,76 @@ mod source_seam_tests {
         assert!(
             dir_is_empty(tmp.path()),
             "dest dir must be empty — no 0-byte artifact written"
+        );
+    }
+
+    /// Reports a set of present UIDs at preflight but panics if any body fetch
+    /// is attempted — used to prove the all-or-nothing short-circuit aborts
+    /// BEFORE `fetch_one_body` when preflight already found a failed UID.
+    struct PreflightFailNoFetchSource {
+        present: Vec<(u32, u32)>,
+        uid_validity: u32,
+    }
+
+    impl ExportSource for PreflightFailNoFetchSource {
+        async fn fetch_sizes(
+            &self,
+            _folder: &str,
+            uids: &[Uid],
+            _expected: u32,
+        ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError> {
+            let requested: std::collections::BTreeSet<u32> = uids.iter().map(|u| u.get()).collect();
+            let sizes = self
+                .present
+                .iter()
+                .filter(|(u, _)| requested.contains(u))
+                .map(|(u, sz)| (*u, Some(*sz)))
+                .collect();
+            Ok((sizes, Some(self.uid_validity)))
+        }
+
+        async fn fetch_one_body(
+            &self,
+            _folder: &str,
+            _uid: Uid,
+            _expected: u32,
+        ) -> Result<Vec<u8>, rimap_core::RimapError> {
+            panic!(
+                "fetch_one_body must not run: allow_partial=false and preflight \
+                 already found a failed UID"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn all_or_nothing_aborts_before_any_body_fetch_on_preflight_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        // UID 7 is present; UID 8 is absent → NotFound at preflight. With
+        // allow_partial=false the export must abort before fetching UID 7's
+        // body (the fake panics if it does).
+        let fake = PreflightFailNoFetchSource {
+            present: vec![(7, 20)],
+            uid_validity: 4242,
+        };
+        let result = run_export(
+            &fake,
+            plan(tmp.path().to_path_buf(), vec![uid(7), uid(8)], 4242, false),
+        )
+        .await;
+
+        let err = result.expect_err("missing UID + allow_partial=false must abort");
+        assert_eq!(err.code(), rimap_core::ErrorCode::InvalidInput);
+        assert!(
+            err.to_string().contains("export incomplete"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains('8'),
+            "error must name the missing UID 8: {err}"
+        );
+        assert!(
+            dir_is_empty(tmp.path()),
+            "no artifact may be written on abort"
         );
     }
 }

--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -110,7 +110,7 @@ pub async fn handle(
 
     let uid = Uid::from(input.uid);
 
-    let raw = account.imap.fetch_body(&input.folder, uid).await?;
+    let raw = account.imap.fetch_body(&input.folder, uid, None).await?;
     let raw_size = raw.len();
 
     let content = crate::mcp::content::parse_message_async(raw).await?;

--- a/crates/rimap-server/src/tools/retrieval/mod.rs
+++ b/crates/rimap-server/src/tools/retrieval/mod.rs
@@ -1,6 +1,7 @@
 //! Retrieval tools: search, fetch, and attachment access.
 
 pub mod download_attachment;
+pub mod export_messages;
 pub mod fetch_message;
 pub mod list_attachments;
 pub(crate) mod part_walker;

--- a/crates/rimap-server/src/tools/retrieval/sandbox.rs
+++ b/crates/rimap-server/src/tools/retrieval/sandbox.rs
@@ -74,8 +74,6 @@ pub(crate) fn write_attachment(
     filename: &str,
     data: &[u8],
 ) -> Result<PathBuf, RimapError> {
-    use std::io::Write as _;
-
     // Strip path components to prevent directory traversal.
     let safe_name = Path::new(filename)
         .file_name()
@@ -101,14 +99,7 @@ pub(crate) fn write_attachment(
         };
         let path = dir.join(&name);
         match create_new_private(&path) {
-            Ok(mut file) => {
-                file.write_all(data)
-                    .map_err(|e| RimapError::InternalSourced {
-                        message: "failed to write attachment".into(),
-                        source: Box::new(e),
-                    })?;
-                return Ok(path);
-            }
+            Ok(file) => return finish_write(file, path, data),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 counter += 1;
                 if counter > 1000 {
@@ -139,6 +130,29 @@ fn create_new_private(path: &Path) -> std::io::Result<std::fs::File> {
         .custom_flags(libc::O_NOFOLLOW)
         .mode(0o600)
         .open(path)
+}
+
+/// Write `data` to the exclusively-created `file`, then return its `path`. If
+/// the write fails partway (short write, disk-full, I/O error), the file is
+/// removed so a failed download/export never leaves a partial artifact at the
+/// final path. The original write error is reported regardless of whether the
+/// cleanup unlink succeeds.
+#[cfg(unix)]
+fn finish_write(
+    mut file: std::fs::File,
+    path: PathBuf,
+    data: &[u8],
+) -> Result<PathBuf, RimapError> {
+    use std::io::Write as _;
+    if let Err(e) = file.write_all(data) {
+        drop(file);
+        let _ = std::fs::remove_file(&path);
+        return Err(RimapError::InternalSourced {
+            message: "failed to write attachment".into(),
+            source: Box::new(e),
+        });
+    }
+    Ok(path)
 }
 
 /// Fail-closed stub for non-Unix platforms.
@@ -334,6 +348,24 @@ mod tests {
         // The export oracle writes raw message bytes; the file must be
         // owner-only regardless of the process umask.
         assert_eq!(mode & 0o777, 0o600, "expected 0600, got {:o}", mode & 0o777);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn finish_write_removes_partial_file_on_write_error() {
+        // Reopen the just-created target read-only so write_all fails (EBADF),
+        // then assert the file is unlinked rather than left as a partial
+        // raw-email artifact at its final path.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("partial.mbox");
+        std::fs::write(&path, b"placeholder").unwrap();
+        let read_only = std::fs::OpenOptions::new().read(true).open(&path).unwrap();
+        let err = finish_write(read_only, path.clone(), b"raw email bytes").unwrap_err();
+        assert_eq!(err.code(), rimap_core::ErrorCode::Internal);
+        assert!(
+            !path.exists(),
+            "partial file must be removed on write error"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/rimap-server/src/tools/retrieval/sandbox.rs
+++ b/crates/rimap-server/src/tools/retrieval/sandbox.rs
@@ -46,15 +46,36 @@ pub(crate) fn resolve_dest_dir(
 /// Write `data` to `dir/filename`, de-duplicating on collision.
 /// Returns the final path.
 ///
+/// Each candidate is created with `O_CREAT | O_EXCL | O_NOFOLLOW` and mode
+/// `0600` (via [`create_new_private`]): the create is atomic and exclusive, so
+/// it never overwrites or follows a symlink at the final path component, and
+/// the resulting file is owner-only. A pre-existing name (regular file *or*
+/// symlink) yields `AlreadyExists`, and the de-dup counter advances — the
+/// reason `export_messages` (a raw-email export oracle) and
+/// `download_attachment` can share this primitive safely.
+///
+/// Containment of `dir` itself is enforced upstream by [`resolve_dest_dir`]
+/// (canonicalize + `starts_with(allowed_root)`) and by the config-time private
+/// download-root check. This writer does not hold a directory fd / create
+/// fd-relative (`openat`), because that requires `unsafe` FFI, which the
+/// workspace forbids (`unsafe_code = "forbid"`); the residual directory-swap
+/// window is bounded by that upstream canonicalization and the enforced
+/// non-group/world-writable root.
+///
 /// # Errors
 ///
 /// Returns `RimapError::Internal` if writing fails or if more than
-/// 1000 filename collisions occur.
+/// 1000 filename collisions occur. On non-Unix platforms the no-follow /
+/// private-mode semantics are unavailable, so the writer fails closed with
+/// `RimapError::Internal` rather than writing without those guarantees.
+#[cfg(unix)]
 pub(crate) fn write_attachment(
     dir: &Path,
     filename: &str,
     data: &[u8],
 ) -> Result<PathBuf, RimapError> {
+    use std::io::Write as _;
+
     // Strip path components to prevent directory traversal.
     let safe_name = Path::new(filename)
         .file_name()
@@ -68,31 +89,77 @@ pub(crate) fn write_attachment(
         .unwrap_or("attachment");
     let ext = base.extension().and_then(|s| s.to_str());
 
-    let mut path = dir.join(safe_name);
-    let mut counter = 1u32;
-    while path.exists() {
-        let new_name = match ext {
-            Some(e) => format!("{stem}_{counter}.{e}"),
-            None => format!("{stem}_{counter}"),
+    let mut counter = 0u32;
+    loop {
+        let name = if counter == 0 {
+            safe_name.to_string()
+        } else {
+            match ext {
+                Some(e) => format!("{stem}_{counter}.{e}"),
+                None => format!("{stem}_{counter}"),
+            }
         };
-        path = dir.join(new_name);
-        counter += 1;
-        if counter > 1000 {
-            return Err(RimapError::Internal("too many filename collisions".into()));
+        let path = dir.join(&name);
+        match create_new_private(&path) {
+            Ok(mut file) => {
+                file.write_all(data)
+                    .map_err(|e| RimapError::InternalSourced {
+                        message: "failed to write attachment".into(),
+                        source: Box::new(e),
+                    })?;
+                return Ok(path);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                counter += 1;
+                if counter > 1000 {
+                    return Err(RimapError::Internal("too many filename collisions".into()));
+                }
+            }
+            Err(e) => {
+                return Err(RimapError::InternalSourced {
+                    message: "failed to create attachment file".into(),
+                    source: Box::new(e),
+                });
+            }
         }
     }
+}
 
-    // The filename has already been stripped to its final component
-    // above, so `path` is always `dir/<safe_name>`. Directory-traversal
-    // containment is enforced by `resolve_dest_dir` for the initial
-    // `dir`, not here — a re-canonicalize at this point compares `dir`
-    // against itself and cannot fail meaningfully.
-    std::fs::write(&path, data).map_err(|e| RimapError::InternalSourced {
-        message: "failed to write attachment".into(),
-        source: Box::new(e),
-    })?;
+/// Atomically create `path` for writing with `O_CREAT | O_EXCL | O_NOFOLLOW`
+/// and mode `0600`. Fails with [`std::io::ErrorKind::AlreadyExists`] if the
+/// path already exists (including as a symlink), which the caller treats as a
+/// de-dup collision. Uses only the safe [`std::os::unix::fs::OpenOptionsExt`]
+/// surface — no `unsafe`.
+#[cfg(unix)]
+fn create_new_private(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .mode(0o600)
+        .open(path)
+}
 
-    Ok(path)
+/// Fail-closed stub for non-Unix platforms.
+///
+/// The hardened writer relies on `O_NOFOLLOW` and POSIX file modes, which are
+/// unavailable here. Rather than write raw message bytes without those
+/// guarantees, the sandbox refuses to write.
+///
+/// # Errors
+///
+/// Always returns `RimapError::Internal`.
+#[cfg(not(unix))]
+pub(crate) fn write_attachment(
+    _dir: &Path,
+    _filename: &str,
+    _data: &[u8],
+) -> Result<PathBuf, RimapError> {
+    Err(RimapError::Internal(
+        "sandboxed attachment writes require a Unix platform (O_NOFOLLOW / file-mode support)"
+            .into(),
+    ))
 }
 
 /// Async wrapper around [`resolve_dest_dir`] that runs on a
@@ -199,6 +266,7 @@ mod tests {
         assert_eq!(err.code(), rimap_core::ErrorCode::InvalidInput);
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_normal() {
         let tmp = tempfile::tempdir().unwrap();
@@ -207,6 +275,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_collision() {
         let tmp = tempfile::tempdir().unwrap();
@@ -216,6 +285,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"new");
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_no_extension() {
         let tmp = tempfile::tempdir().unwrap();
@@ -224,6 +294,7 @@ mod tests {
         assert_eq!(path, tmp.path().join("readme_1"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_rejects_relative_traversal() {
         let tmp = tempfile::tempdir().unwrap();
@@ -234,6 +305,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_rejects_absolute_path() {
         let tmp = tempfile::tempdir().unwrap();
@@ -243,12 +315,51 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_attachment_handles_deep_traversal() {
         let tmp = tempfile::tempdir().unwrap();
         let path = write_attachment(tmp.path(), "../../.ssh/authorized_keys", b"data").unwrap();
         assert!(path.starts_with(tmp.path()));
         assert_eq!(path.file_name().unwrap(), "authorized_keys");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_attachment_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_attachment(tmp.path(), "secret.mbox", b"raw email").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        // The export oracle writes raw message bytes; the file must be
+        // owner-only regardless of the process umask.
+        assert_eq!(mode & 0o777, 0o600, "expected 0600, got {:o}", mode & 0o777);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_attachment_does_not_follow_symlink_at_final_path() {
+        // A symlink pre-planted inside the sandbox must not be followed: the
+        // exclusive create yields AlreadyExists, so the writer de-dups to a
+        // fresh name and the symlink target outside the sandbox is never
+        // created or written. Guards the raw-export escape vector.
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        let outside = tmp.path().join("outside-target.txt");
+        std::os::unix::fs::symlink(&outside, sandbox.join("evil.mbox")).unwrap();
+
+        let path = write_attachment(&sandbox, "evil.mbox", b"payload").unwrap();
+
+        // Wrote a de-duped sibling, not through the symlink.
+        assert_eq!(path, sandbox.join("evil_1.mbox"));
+        assert!(path.starts_with(&sandbox));
+        // The symlink target outside the sandbox was never created.
+        assert!(
+            !outside.exists(),
+            "symlink was followed: target was written"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"payload");
     }
 
     #[test]

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -165,6 +165,11 @@ pub struct SearchMeta {
     pub returned: usize,
     /// Whether there are more results beyond this page.
     pub truncated: bool,
+    /// UIDVALIDITY observed for the searched folder, from the same
+    /// EXAMINE/UID SEARCH operation. Thread into `export_messages`'
+    /// `expected_uidvalidity`. `None` if the server omitted it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
 }
 
 /// Untrusted payload for a `search` response.
@@ -191,7 +196,7 @@ pub async fn handle(
 
     let query = build_query(&input)?;
 
-    let uids = Box::pin(account.imap.search(&input.folder, query)).await?;
+    let (uids, uid_validity) = Box::pin(account.imap.search(&input.folder, query)).await?;
     let total_matched = uids.len();
 
     let offset = input.offset.unwrap_or(0);
@@ -227,6 +232,7 @@ pub async fn handle(
         total_matched,
         returned: messages.len(),
         truncated,
+        uid_validity,
     })
     .with_untrusted(SearchUntrusted { messages }))
 }
@@ -853,5 +859,18 @@ mod tests {
         assert_eq!(s.answered, Some(true));
         assert_eq!(s.flagged, Some(false));
         assert_eq!(s.draft, Some(true));
+    }
+
+    #[test]
+    fn search_meta_serializes_uid_validity() {
+        let meta = SearchMeta {
+            folder: "INBOX".to_string(),
+            total_matched: 0,
+            returned: 0,
+            truncated: false,
+            uid_validity: Some(12345),
+        };
+        let v = serde_json::to_value(meta).unwrap();
+        assert_eq!(v["uid_validity"], serde_json::json!(12345));
     }
 }

--- a/crates/rimap-server/tests/dump_tool_catalog.rs
+++ b/crates/rimap-server/tests/dump_tool_catalog.rs
@@ -27,12 +27,12 @@ fn dump_tool_catalog_emits_object_schemas() {
     let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
     let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
 
-    // 24 ToolName variants minus 2 sub-capabilities (SearchAdvanced,
-    // FetchMessageHtml) that share schemas with their parents = 22 defs.
+    // 25 ToolName variants minus 2 sub-capabilities (SearchAdvanced,
+    // FetchMessageHtml) that share schemas with their parents = 23 defs.
     assert_eq!(
         lines.len(),
-        22,
-        "expected 22 tool defs (24 ToolName variants - 2 sub-capabilities); got {}",
+        23,
+        "expected 23 tool defs (25 ToolName variants - 2 sub-capabilities); got {}",
         lines.len(),
     );
 

--- a/crates/rimap-server/tests/e2e.rs
+++ b/crates/rimap-server/tests/e2e.rs
@@ -73,7 +73,7 @@ impl CredentialStore for StaticCreds {
 // ── Server builder ──────────────────────────────────────────────────
 
 struct TestEnv {
-    _harness: DovecotHarness,
+    harness: DovecotHarness,
     _audit_dir: TempDir,
     _download_dir: TempDir,
     server: ImapMcpServer,
@@ -118,7 +118,7 @@ fn build_test_env(harness: DovecotHarness) -> TestEnv {
     let server = ImapMcpServer::new(registry, audit, cancellation_sender);
 
     TestEnv {
-        _harness: harness,
+        harness,
         _audit_dir: audit_dir,
         _download_dir: download_dir,
         server,
@@ -143,7 +143,16 @@ fn test_account_config(harness: &DovecotHarness) -> ValidatedAccountConfig {
             ..SecurityConfig::default()
         },
         limits: LimitsConfig::default(),
-        tool_overrides: BTreeMap::new(),
+        // Enable the default-deny `export_messages` tool — the equivalent of
+        // `[security.tools] export_messages = true` in a real config.
+        tool_overrides: {
+            let mut o = BTreeMap::new();
+            o.insert(
+                rimap_core::tool::ToolName::ExportMessages,
+                rimap_config::model::Verdict::Allow,
+            );
+            o
+        },
         tls_fingerprint: Some(*harness.fingerprint()),
         fallback_mode: rimap_config::model::FallbackMode::default(),
     }
@@ -245,6 +254,9 @@ async fn e2e_full_session() {
     assert_mark_read(server, uid).await;
     assert_create_draft(server, uid).await;
     assert_create_draft_uses_special_use_when_available(server).await;
+    assert_export_happy_path(server, &env.harness).await;
+    assert_export_partial_success(server, uid).await;
+    assert_export_uidvalidity_change(server, &env.harness).await;
     assert_move_and_gone(server, uid).await;
 }
 
@@ -370,6 +382,247 @@ async fn assert_create_draft_uses_special_use_when_available(server: &ImapMcpSer
     .await
     .expect("create_draft failed");
     assert_eq!(result["meta"]["folder"].as_str().unwrap(), expected);
+}
+
+// ── export_messages ─────────────────────────────────────────────────
+
+/// A `git format-patch`-style email: exporting it to mbox must apply cleanly
+/// with `git am`. Adds a single file `hello.txt` on top of an empty base repo.
+fn patch_message() -> Vec<u8> {
+    concat!(
+        "From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001\r\n",
+        "From: Patch Author <author@example.com>\r\n",
+        "Date: Sat, 12 Apr 2026 11:00:00 +0000\r\n",
+        "Subject: [PATCH] add hello.txt\r\n",
+        "Message-ID: <e2e-patch-001@example.com>\r\n",
+        "MIME-Version: 1.0\r\n",
+        "Content-Type: text/plain; charset=utf-8\r\n",
+        "Content-Transfer-Encoding: 8bit\r\n",
+        "\r\n",
+        "Adds a greeting file.\r\n",
+        "---\r\n",
+        " hello.txt | 1 +\r\n",
+        " 1 file changed, 1 insertion(+)\r\n",
+        " create mode 100644 hello.txt\r\n",
+        "\r\n",
+        "diff --git a/hello.txt b/hello.txt\r\n",
+        "new file mode 100644\r\n",
+        "index 0000000..ce01362\r\n",
+        "--- /dev/null\r\n",
+        "+++ b/hello.txt\r\n",
+        "@@ -0,0 +1 @@\r\n",
+        "+hello\r\n",
+        "-- \r\n",
+        "2.40.0\r\n",
+    )
+    .as_bytes()
+    .to_vec()
+}
+
+/// Search a folder by subject and return `(first_uid, uid_validity)`.
+async fn search_uid_and_validity(
+    server: &ImapMcpServer,
+    folder: &str,
+    subject: &str,
+) -> (u32, u32) {
+    let result = call_tool(
+        server,
+        "search",
+        serde_json::json!({"folder": folder, "subject": subject}),
+    )
+    .await
+    .expect("search failed");
+    let messages = result["untrusted"]["messages"]
+        .as_array()
+        .expect("messages array");
+    let uid = json_u32(&messages[0]["uid"]);
+    let uid_validity = json_u32(&result["meta"]["uid_validity"]);
+    (uid, uid_validity)
+}
+
+/// Happy path: seed a `git format-patch`-style message in a dedicated folder,
+/// export it, and assert the artifact exists, its SHA-256 matches the file
+/// bytes, `message_count` is correct, and the file applies cleanly with
+/// `git am` in a throwaway repo.
+async fn assert_export_happy_path(server: &ImapMcpServer, harness: &DovecotHarness) {
+    let folder = "PatchExport";
+    harness.create_mailbox(folder);
+    let account = server.registry.resolve(None).expect("resolve account");
+    account
+        .imap
+        .append_message(folder, &patch_message(), &[], &[])
+        .await
+        .expect("APPEND patch message failed");
+
+    let (uid, uid_validity) = search_uid_and_validity(server, folder, "add hello.txt").await;
+    let result = call_tool(
+        server,
+        "export_messages",
+        serde_json::json!({
+            "folder": folder,
+            "uids": [uid],
+            "expected_uidvalidity": uid_validity,
+            "filename": "patch",
+        }),
+    )
+    .await
+    .expect("export_messages failed");
+
+    assert!(result["meta"]["complete"].as_bool().unwrap());
+    assert_eq!(result["meta"]["message_count"].as_u64().unwrap(), 1);
+    assert!(
+        result["meta"]["partial_path"].is_null(),
+        "complete export must not carry partial_path",
+    );
+    let path = result["meta"]["path"].as_str().expect("path");
+    let bytes = std::fs::read(path).expect("artifact exists on disk");
+    let expected_sha = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(&bytes))
+    };
+    assert_eq!(
+        result["meta"]["sha256"].as_str().unwrap(),
+        expected_sha,
+        "manifest sha256 must match file bytes",
+    );
+    assert_git_am_applies(path);
+}
+
+/// Partial success: request the present UID plus a non-existent one with
+/// `allow_partial=true`; assert a `.partial.mbox` is written, the present UID
+/// succeeds, and the missing UID is reported `not_found`. Then assert
+/// `allow_partial=false` errors and writes no `path`.
+async fn assert_export_partial_success(server: &ImapMcpServer, present_uid: u32) {
+    let (_uid, uid_validity) = search_uid_and_validity(server, "INBOX", "e2e-test-smoke").await;
+    let missing_uid = present_uid + 100_000;
+
+    let result = call_tool(
+        server,
+        "export_messages",
+        serde_json::json!({
+            "folder": "INBOX",
+            "uids": [present_uid, missing_uid],
+            "expected_uidvalidity": uid_validity,
+            "allow_partial": true,
+        }),
+    )
+    .await
+    .expect("partial export should succeed");
+
+    assert!(!result["meta"]["complete"].as_bool().unwrap());
+    assert!(result["meta"]["path"].is_null(), "partial must omit path");
+    let partial_path = result["meta"]["partial_path"]
+        .as_str()
+        .expect("partial_path present");
+    assert!(partial_path.ends_with(".partial.mbox"));
+    assert!(std::path::Path::new(partial_path).exists());
+    assert_eq!(result["meta"]["message_count"].as_u64().unwrap(), 1);
+    let failed = result["meta"]["failed"].as_array().expect("failed array");
+    assert_eq!(failed.len(), 1);
+    assert_eq!(json_u32(&failed[0]["uid"]), missing_uid);
+    assert_eq!(failed[0]["reason"].as_str().unwrap(), "not_found");
+
+    // allow_partial defaults to false: the same request must error and write
+    // no artifact.
+    let err = call_tool(
+        server,
+        "export_messages",
+        serde_json::json!({
+            "folder": "INBOX",
+            "uids": [present_uid, missing_uid],
+            "expected_uidvalidity": uid_validity,
+        }),
+    )
+    .await;
+    assert!(
+        err.is_err(),
+        "all-or-nothing export with a missing UID must error",
+    );
+}
+
+/// UIDVALIDITY change: seed a dedicated folder, capture its UIDVALIDITY,
+/// delete+recreate it (forcing a new UIDVALIDITY), then export with the STALE
+/// value. The preflight must abort with a UIDVALIDITY error under both
+/// `allow_partial` settings, writing no artifact.
+async fn assert_export_uidvalidity_change(server: &ImapMcpServer, harness: &DovecotHarness) {
+    let folder = "UidValidityExport";
+    harness.create_mailbox(folder);
+    let account = server.registry.resolve(None).expect("resolve account");
+    account
+        .imap
+        .append_message(folder, &test_message(), &[], &[])
+        .await
+        .expect("APPEND failed");
+
+    let (uid, stale_validity) = search_uid_and_validity(server, folder, "e2e-test-smoke").await;
+
+    // Force a new UIDVALIDITY by deleting and recreating the mailbox.
+    harness.delete_mailbox(folder);
+    harness.create_mailbox(folder);
+
+    // Snapshot the sandbox dir: a preflight UIDVALIDITY abort must not write a
+    // new artifact. Earlier export steps wrote files here, so compare counts
+    // rather than asserting empty.
+    let dest = account.download_dir.as_ref();
+    let before = dir_entry_count(dest);
+
+    for allow_partial in [false, true] {
+        let result = call_tool(
+            server,
+            "export_messages",
+            serde_json::json!({
+                "folder": folder,
+                "uids": [uid],
+                "expected_uidvalidity": stale_validity,
+                "allow_partial": allow_partial,
+            }),
+        )
+        .await;
+        let err = result.expect_err("stale UIDVALIDITY must abort the export");
+        // `execute_tool_for_test` flattens MCP errors to `Internal`, preserving
+        // the original message as a string. Match on the typed message text.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("UIDVALIDITY changed"),
+            "expected UIDVALIDITY error (allow_partial={allow_partial}), got {msg}",
+        );
+    }
+
+    assert_eq!(
+        dir_entry_count(dest),
+        before,
+        "preflight UIDVALIDITY abort must write no artifact to the sandbox",
+    );
+}
+
+/// Count entries directly under `dir`.
+fn dir_entry_count(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir).expect("read_dir").count()
+}
+
+/// Apply an exported mbox file with `git am` in a fresh throwaway repo. Panics
+/// if `git am` rejects the file.
+fn assert_git_am_applies(mbox_path: &str) {
+    use std::process::Command;
+    let repo = TempDir::new().expect("git repo tempdir");
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo.path())
+            .status()
+            .expect("git invocation failed");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run(&["init", "-q"]);
+    run(&["config", "user.email", "e2e@example.com"]);
+    run(&["config", "user.name", "e2e"]);
+    run(&["commit", "-q", "--allow-empty", "-m", "base"]);
+    let status = Command::new("git")
+        .args(["am", mbox_path])
+        .current_dir(repo.path())
+        .status()
+        .expect("git am invocation failed");
+    assert!(status.success(), "git am {mbox_path} did not apply cleanly");
 }
 
 async fn assert_move_and_gone(server: &ImapMcpServer, uid: u32) {

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
@@ -33,14 +33,14 @@
           "type": "integer"
         },
         "partial_path": {
-          "description": "Path of a `.partial.mbox` artifact; non-null only on a partial export.",
+          "description": "Path of a `.partial.mbox` artifact. Present only on a partial\nexport; omitted otherwise.",
           "type": [
             "string",
             "null"
           ]
         },
         "path": {
-          "description": "`git am`-ready mbox path; `null` when `complete` is false.",
+          "description": "`git am`-ready mbox path. Present only on a complete export;\nomitted from the response otherwise.",
           "type": [
             "string",
             "null"

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
@@ -1,0 +1,294 @@
+{
+  "$defs": {
+    "ExportFailReason": {
+      "description": "Reason a requested UID was not exported. Both are determined at the size\npreflight, before any body fetch \u2014 a UID that reaches the body fetch is\nknown-present and in-bounds, and any error there is fatal (never per-UID),\nso there is no `FetchError` variant.",
+      "enum": [
+        "not_found",
+        "oversize"
+      ],
+      "type": "string"
+    },
+    "ExportMessagesMeta": {
+      "description": "Trusted metadata for an `export_messages` response.",
+      "properties": {
+        "complete": {
+          "description": "True iff every requested UID was exported.",
+          "type": "boolean"
+        },
+        "failed": {
+          "description": "Requested UIDs that failed, with reasons.",
+          "items": {
+            "$ref": "#/$defs/FailedUid"
+          },
+          "type": "array"
+        },
+        "folder": {
+          "description": "Folder the messages were exported from.",
+          "type": "string"
+        },
+        "message_count": {
+          "description": "Number of messages written to the artifact.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "partial_path": {
+          "description": "Path of a `.partial.mbox` artifact; non-null only on a partial export.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "description": "`git am`-ready mbox path; `null` when `complete` is false.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha256": {
+          "description": "SHA-256 of the written mbox, hex-encoded.",
+          "type": "string"
+        },
+        "succeeded": {
+          "description": "Exported UIDs, in mbox order, with sizes.",
+          "items": {
+            "$ref": "#/$defs/ExportedUid"
+          },
+          "type": "array"
+        },
+        "total_bytes": {
+          "description": "Total bytes written.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY the export was pinned to.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "folder",
+        "complete",
+        "sha256",
+        "message_count",
+        "total_bytes",
+        "uid_validity",
+        "succeeded",
+        "failed"
+      ],
+      "type": "object"
+    },
+    "ExportedUid": {
+      "description": "One successfully exported message.",
+      "properties": {
+        "size_bytes": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "uid": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "uid",
+        "size_bytes"
+      ],
+      "type": "object"
+    },
+    "FailedUid": {
+      "description": "One requested UID that failed.",
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/ExportFailReason"
+        },
+        "uid": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "uid",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "SecurityWarning": {
+      "description": "A single warning emitted by the content pipeline.",
+      "properties": {
+        "code": {
+          "$ref": "#/$defs/WarningCode",
+          "description": "Classification of the warning."
+        },
+        "detail": {
+          "description": "Optional context string whose format is defined per-variant in\nthe [`WarningCode`] doc comments. Within a single crate version\nthe format is structured (key=value pairs), so tests may\npattern-match substrings against known variants. Consumers MUST\nNOT rely on this format across crate versions \u2014 it may change\nwithout notice; use `code` for stable dispatch.\n\n`None` when no additional detail is available.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "description": "Logical location in the message (e.g. `\"header:subject\"`,\n`\"body:part[2]\"`, `\"attachment[0]\"`). `None` for crate-wide events.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "code"
+      ],
+      "type": "object"
+    },
+    "WarningCode": {
+      "description": "Classification of pipeline warnings. New variants will be added as\nnew detectors land \u2014 the enum is `#[non_exhaustive]` so matches\noutside this crate must include a wildcard arm.",
+      "oneOf": [
+        {
+          "const": "unicode_zero_width_stripped",
+          "description": "Zero-width codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_bidi_override_stripped",
+          "description": "Bidi-override codepoints were present in input text and stripped.",
+          "type": "string"
+        },
+        {
+          "const": "unicode_c0_c1_stripped",
+          "description": "C0 or C1 control codepoints (other than tab and newline) were stripped.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_smuggling_blocked",
+          "description": "A header containing a raw CRLF inside an RFC 2047 encoded-word\nwas dropped before parsing continued.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_type_mismatch",
+          "description": "An attachment's declared content type did not match the magic\nbytes of its body. Detail format: `declared=<type>,sniffed=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_bodystructure_type_mismatch",
+          "description": "BODYSTRUCTURE-declared MIME type disagreed with the type reported\nby the MIME parser for the same part. Distinct from\n`ParseMimeTypeMismatch` (which compares declared type against\nmagic-byte sniffing). Detail format:\n`bodystructure=<type>,parser=<type>`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_polyglot",
+          "description": "An attachment matched multiple magic-byte signatures (polyglot\nfile). This frequently indicates a deliberate attempt to bypass\ncontent-type sniffing by encoding one file type as another.",
+          "type": "string"
+        },
+        {
+          "const": "parse_body_truncated",
+          "description": "The message body exceeded `MAX_BODY_BYTES` and was truncated.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_depth_exceeded",
+          "description": "MIME nesting depth exceeded `MAX_MIME_DEPTH`. Emitted alongside\na terminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_mime_part_count_exceeded",
+          "description": "MIME part count exceeded `MAX_MIME_PARTS`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_header_count_exceeded",
+          "description": "Header count exceeded `MAX_HEADER_COUNT`. Emitted alongside a\nterminal `ContentError::LimitExceeded`.",
+          "type": "string"
+        },
+        {
+          "const": "parse_attachment_filename_rewritten",
+          "description": "An attachment filename contained path separators, parent\nreferences, reserved Windows names, or other unsafe characters\nand was rewritten to a safe form.",
+          "type": "string"
+        },
+        {
+          "const": "html_hidden_content_detected",
+          "description": "HTML content contained hidden elements (e.g. `display:none`,\n`visibility:hidden`, `opacity:0`, off-screen positioning,\nzero font size, or background-color-matching text). Hidden\ncontent is stripped from `body_text` but may remain in\n`body_html` when the posture allows HTML exposure. Detail format:\n`method=<display_none|visibility_hidden|opacity_0|offscreen|zero_font|color_match>`\noptionally followed by `,count=N` when summarized.",
+          "type": "string"
+        },
+        {
+          "const": "html_link_text_href_mismatch",
+          "description": "An HTML anchor's visible text contained a URL-looking token\nwhose registrable domain differs from the anchor's `href`\nregistrable domain. Detail format:\n`text_domain=<ascii>,href_domain=<ascii>`.\n\nReflects the original message content (pre-ammonia), not the\nsanitized `body_html`. An anchor stripped by ammonia may still\nproduce this warning \u2014 the warning signals the message's\nintent, not the sanitized output.",
+          "type": "string"
+        },
+        {
+          "const": "html_script_stripped",
+          "description": "One or more `<script>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_style_stripped",
+          "description": "One or more `<style>` elements were removed during HTML\nsanitization. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_remote_image_stripped",
+          "description": "One or more `<img>` elements had their `src`/`srcset`\nattributes removed during HTML sanitization to prevent\nremote tracking-pixel loads. Detail format: `count=N`.",
+          "type": "string"
+        },
+        {
+          "const": "html_anchor_unparsable_href",
+          "description": "An HTML anchor's `href` could not be resolved to a registrable\ndomain via the Public Suffix List, but the anchor's visible text\ncontained a URL-looking token (detected by `linkify`). This\ndistinguishes \"we checked and it's fine\" from \"we couldn't\ncheck.\" Consumers should treat the anchor with suspicion.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_mixed_script",
+          "description": "A domain label contained characters from multiple Unicode\nscripts outside the TR39 Highly Restrictive profile. Detail\nformat: `domain=<punycode>,scripts=<S1+S2>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_homograph_domain",
+          "description": "A domain's TR39 skeleton matched a different domain's\nskeleton, indicating a homograph attack, OR bidi-override\ncharacters were stripped from the domain before processing.\nDetail format: `domain=<punycode>,skeleton_match=<other_punycode>`\nor `domain=<punycode>,reason=bidi_pre_strip`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_idn_punycode",
+          "description": "A domain was processed in punycode form (xn--) and the\nUnicode U-label form is reported for informational use.\nDetail format: `domain=<punycode>,ulabel=<unicode>`.",
+          "type": "string"
+        },
+        {
+          "const": "lookalike_filename_extension_spoof",
+          "description": "A filename's visible extension differs from its extension\nafter bidi-override stripping, indicating an RLO-bidi\nextension spoof. Detail format:\n`visible=<after_strip>,declared=<original>`.",
+          "type": "string"
+        },
+        {
+          "const": "server_non_atomic_move_fallback",
+          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Top-level tool response envelope.\n\n`M` is the trusted metadata shape (must `Serialize`). `U` is the\nuntrusted payload shape (must `Serialize`). Handlers that have no\nuntrusted body should return `ToolResponse<M, ()>` with\n`untrusted: None`.",
+  "properties": {
+    "meta": {
+      "$ref": "#/$defs/ExportMessagesMeta",
+      "description": "Server-controlled metadata. Trusted."
+    },
+    "security_warnings": {
+      "description": "Structured security observations. Trusted metadata.",
+      "items": {
+        "$ref": "#/$defs/SecurityWarning"
+      },
+      "type": "array"
+    },
+    "untrusted": {
+      "description": "Sanitized content derived from email data. Untrusted.",
+      "type": "null"
+    }
+  },
+  "required": [
+    "meta"
+  ],
+  "type": "object"
+}

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -22,6 +22,15 @@
         "truncated": {
           "description": "Whether there are more results beyond this page.",
           "type": "boolean"
+        },
+        "uid_validity": {
+          "description": "UIDVALIDITY observed for the searched folder, from the same\nEXAMINE/UID SEARCH operation. Thread into `export_messages`'\n`expected_uidvalidity`. `None` if the server omitted it.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [

--- a/crates/rimap-server/tests/support/dovecot/harness.rs
+++ b/crates/rimap-server/tests/support/dovecot/harness.rs
@@ -207,6 +207,21 @@ impl DovecotHarness {
         assert!(status.success(), "doveadm mailbox create {name} failed",);
     }
 
+    pub fn delete_mailbox(&self, name: &str) {
+        let status = Command::new(runtime())
+            .arg("exec")
+            .arg(container_name(&self.project))
+            .arg("doveadm")
+            .arg("mailbox")
+            .arg("delete")
+            .arg("-u")
+            .arg("rimap-test")
+            .arg(name)
+            .status()
+            .expect("doveadm exec failed");
+        assert!(status.success(), "doveadm mailbox delete {name} failed",);
+    }
+
     pub fn fingerprint(&self) -> &TlsFingerprint {
         &self.fingerprint
     }
@@ -323,4 +338,19 @@ fn is_port_collision(stderr: &str) -> bool {
     s.contains("port is already allocated")
         || s.contains("address already in use")
         || s.contains("bind for 127.0.0.1")
+}
+
+/// Per-binary dead-code suppression for items only some e2e binaries use.
+/// `delete_mailbox` is exercised by `e2e.rs` but not by `e2e_wire.rs` /
+/// `e2e_wire_cancellation.rs`; referencing it in a never-called function marks
+/// it used in every compilation unit (the same pattern as `fixtures.rs`'s
+/// `force_use_for_dead_code_link`). `clippy::allow_attributes = "deny"` forbids
+/// a bare `#[allow]`, and a `#![expect(dead_code)]` would be unfulfilled in the
+/// binaries that do call it.
+#[expect(
+    dead_code,
+    reason = "type-link to suppress per-binary dead-code for delete_mailbox"
+)]
+fn force_use_for_dead_code_link(h: &DovecotHarness) {
+    h.delete_mailbox("");
 }

--- a/crates/rimap-server/tests/support/wire/schema.rs
+++ b/crates/rimap-server/tests/support/wire/schema.rs
@@ -179,12 +179,12 @@ mod fixture_smoke_tests {
             .filter_map(Result::ok)
             .filter(|e| e.file_name().to_string_lossy().ends_with(".schema.json"))
             .collect();
-        // Pin to the current 22-tool set. Update when adding or removing
+        // Pin to the current 23-tool set. Update when adding or removing
         // tools from `build_schemas()` in cli/dump_tool_schemas.rs.
         assert_eq!(
             entries.len(),
-            22,
-            "expected exactly 22 tool schema fixtures (pinned), found {}",
+            23,
+            "expected exactly 23 tool schema fixtures (pinned), found {}",
             entries.len()
         );
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,7 @@ mark_read = "deny"                # deny even though draft-safe allows it
 
 #### Valid tool names
 
-All 24 valid tool names for `[security.tools]`:
+All 25 valid tool names for `[security.tools]`:
 
 | Tool name | Description | Default posture |
 |-----------|-------------|-----------------|
@@ -202,6 +202,7 @@ All 24 valid tool names for `[security.tools]`:
 | `fetch_message.include_html` | Fetch message with HTML parts | full+ |
 | `list_attachments` | List message attachments | readonly+ |
 | `download_attachment` | Download attachment to sandbox | readonly+ |
+| `export_messages` | Export raw messages to a `git am`-able mbox | disabled by default² |
 | `mark_read` | Mark message as read | draft-safe+ |
 | `mark_unread` | Mark message as unread | draft-safe+ |
 | `flag` | Add star/flag | draft-safe+ |
@@ -229,6 +230,11 @@ and `[security.tools]` cannot disable them. An `"allow"` or `"deny"`
 override targeting either name is accepted by config validation but has
 **no effect** at runtime — they remain available regardless.
 
+² `export_messages` is **denied in every posture** and is only available
+when explicitly enabled via `[security.tools]` with
+`export_messages = "allow"`. See
+[The `export_messages` tool](#the-export_messages-tool) below.
+
 Sub-capabilities (`.advanced_query`, `.include_html`) are separate
 authorization gates within their parent tool. The parent tool name
 (`search`, `fetch_message`) controls the base capability; the
@@ -246,6 +252,64 @@ sub-capability controls the escape hatch.
 
 If you see `unknown tool name 'mark_as_read'`, check the spelling
 against the table above. The correct name is `mark_read`.
+
+### The `export_messages` tool
+
+`export_messages` exports one or more raw messages from a folder into a
+single mbox file in the download sandbox. The mbox uses `mboxrd` framing
+and is consumable directly by `git am`, which makes it the bridge for
+turning emailed patches into local commits.
+
+#### Workflow
+
+```
+search → read uid_validity → export_messages → git am <path>
+```
+
+1. `search` for the messages to export and note the `uid_validity`
+   reported alongside the matching UIDs.
+2. Call `export_messages` with those UIDs and pass the observed
+   `uid_validity` as `expected_uidvalidity`. The server re-checks the
+   folder's UIDVALIDITY before fetching; if it changed (mailbox renumbered),
+   the call fails rather than exporting the wrong messages.
+3. Apply the resulting mbox with `git am <path>`.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `folder` | string | yes | IMAP folder containing the messages. |
+| `uids` | list of int | yes | UIDs to export, in mbox/patch order. Non-empty, max 100, de-duplicated. |
+| `expected_uidvalidity` | int | yes | UIDVALIDITY observed when the UIDs were discovered. Pins mailbox identity across `search`→`export_messages`; a mismatch fails the call. |
+| `dest_dir` | string | no | Destination directory. Must resolve inside the download root. Defaults to the download root. |
+| `filename` | string | no | Advisory basename prefix; sanitized before use. |
+| `max_total_bytes` | int | no | Aggregate byte cap for the export. Clamped to the hard ceiling of 100 MiB regardless of the value supplied. |
+| `allow_partial` | bool | no | Default `false` = all-or-nothing: if any requested UID is missing or oversize the whole call fails and no `.mbox` is written. `true` = best-effort: successes are written to a `.partial.mbox` artifact and the failures are reported in the response. |
+
+#### Default-disabled and how to enable
+
+`export_messages` is denied in **every** posture. It is enabled only by an
+explicit override:
+
+```toml
+[security.tools]
+export_messages = "allow"
+```
+
+#### Required: a server-private download root
+
+`export_messages` writes a **raw, unsanitized** copy of message bytes to
+the download sandbox. Because that export is an unredacted raw-message
+oracle, the download root must be writable only by the server — the write
+authority must be separated from the agent that consumes the file.
+
+On Unix, this is enforced as a **fail-closed config precondition**: when
+`export_messages` is enabled and `[attachments].download_dir` is set,
+config validation rejects startup if the download root is group- or
+world-writable (any of mode bits `0o022` set). Use a private directory
+(e.g. mode `0o700`). An empty `download_dir` (the default per-session
+temporary directory) is created privately by the server and is not
+subject to this check.
 
 ## `[limits]` section
 
@@ -287,7 +351,12 @@ Global (shared across all accounts).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `download_dir` | string | `""` | Directory for downloaded attachments. Empty string means a per-session temporary directory. |
+| `download_dir` | string | `""` | Directory for downloaded attachments and `export_messages` output. Empty string means a per-session temporary directory. |
+
+When `export_messages` is enabled, `download_dir` must be server-private
+on Unix: config validation rejects a group- or world-writable directory
+at startup. See
+[The `export_messages` tool](#the-export_messages-tool).
 
 ## `[defaults]` section (multi-account only)
 

--- a/docs/postures.md
+++ b/docs/postures.md
@@ -28,6 +28,7 @@ capability).
 | `fetch_message.include_html` | denied | denied | allowed | allowed |
 | `list_attachments` | allowed | allowed | allowed | allowed |
 | `download_attachment` | allowed | allowed | allowed | allowed |
+| `export_messages` | denied¹ | denied¹ | denied¹ | denied¹ |
 | `mark_read` | denied | allowed | allowed | allowed |
 | `mark_unread` | denied | allowed | allowed | allowed |
 | `flag` | denied | allowed | allowed | allowed |
@@ -46,6 +47,13 @@ capability).
 
 `use_account` and `list_accounts` are infrastructure tools that bypass
 posture checks entirely and are always available.
+
+¹ `export_messages` is denied in every posture and is enabled only by an
+explicit `export_messages = "allow"` override in `[security.tools]`. It
+writes a raw, unsanitized mbox to the download sandbox, so when enabled it
+also requires a server-private download root (config validation rejects a
+group/world-writable `download_dir` on Unix). See
+[configuration.md](configuration.md#the-export_messages-tool).
 
 ## Per-tool overrides
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -241,9 +241,18 @@ to the system trust store when pinning is configured.
 | `rename_folder` | - | - | yes | yes |
 | `expunge` | - | - | - | yes |
 | `delete_folder` | - | - | - | yes |
+| `export_messages` | - | - | - | - |
 
 Per-tool overrides (`"allow"` / `"deny"`) merge on top of the base
 posture. An override that matches the posture's default is a no-op.
+
+`export_messages` is denied in every posture; it is enabled only by an
+explicit `export_messages = "allow"` override. It writes a raw,
+unsanitized mbox to the download sandbox (an unredacted raw-message
+oracle), so when enabled it requires a server-private download root:
+config validation rejects a group/world-writable `attachments.download_dir`
+on Unix. See
+[configuration.md](configuration.md#the-export_messages-tool).
 
 ## Dispatch chain
 

--- a/docs/superpowers/plans/2026-05-26-export-messages-mbox.md
+++ b/docs/superpowers/plans/2026-05-26-export-messages-mbox.md
@@ -1,0 +1,1780 @@
+# export_messages (bulk mbox export) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `export_messages` MCP tool that fetches a caller-specified set of UIDs and writes them as one `git am`-able mbox file into the download sandbox, returning a path + trusted manifest.
+
+**Architecture:** A new retrieval tool mirroring `download_attachment`: reuses `resolve_dest_dir`/`write_attachment` for sandbox writes, `fetch`/`fetch_body` for IMAP, and the `Posture`/annotation/audit wiring. Output fidelity (raw RFC822 for `git am`) lives in a pure `build_mbox` function; all genuinely-testable logic is pure and unit-tested, while IMAP orchestration is thin and exercised by the dovecot e2e harness — matching how the existing retrieval handlers are tested. The tool is **default-deny** in the posture matrix (enabled only via `[security.tools].export_messages = "allow"`).
+
+**Tech Stack:** Rust (workspace crates `rimap-core`, `rimap-authz`, `rimap-imap`, `rimap-server`), `serde`/`schemars`, `tokio`, `cargo nextest`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md`
+
+**Conventions:**
+- Tests run with `cargo nextest run -p <crate> --locked` (workspace runner is `just test`).
+- Lints: `cargo clippy --all-targets --all-features -- -D warnings`. Wildcard match arms are banned; test modules carry `#[expect(clippy::unwrap_used, reason = "tests")]` etc.
+- Tool-schema fixtures live in `crates/rimap-server/tests/fixtures/rimap-tool-schemas/`; regenerate with `just regen-tool-schemas` (runs `./scripts/regen-tool-schemas.sh`).
+- Commit after each task. Imperative mood, ≤72-char subject.
+
+---
+
+## File Structure
+
+**Created:**
+- `crates/rimap-server/src/tools/retrieval/export_messages.rs` — input/meta types, pure helpers (`build_mbox`, `sanitize_filename_prefix`, `clamp_total_bytes`, `validate_uids`, `plan_outcome`), the `handle` orchestrator, and all unit tests (including the in-module real-`git` acceptance test).
+- `crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json` — generated schema fixture.
+
+**Modified:**
+- `crates/rimap-core/src/tool.rs` — `ToolName::ExportMessages` variant, `as_str`, three classification matches, `annotation_hints`, count test.
+- `crates/rimap-core/src/posture_matrix.rs` — default-deny matrix row, length bump.
+- `crates/rimap-authz/src/matrix.rs` — update four base-posture row tests to treat `ExportMessages` as the always-base-denied exception; add a gate test.
+- `crates/rimap-imap/src/ops/search.rs` + `crates/rimap-imap/src/connection/dispatch.rs` — `search` returns `(Vec<Uid>, Option<u32>)`.
+- `crates/rimap-imap/src/ops/fetch.rs` (`preflight_fetch_size`) + `crates/rimap-imap/src/connection/dispatch.rs` (`fetch_body`) — thread `expected_uidvalidity` so body fetches are UIDVALIDITY-guarded; `crates/rimap-server/src/tools/retrieval/download_attachment.rs` passes `None`.
+- `crates/rimap-server/src/tools/retrieval/search.rs` — surface `uid_validity` in `SearchMeta`.
+- `crates/rimap-server/src/tools/retrieval/mod.rs` — `pub mod export_messages;`.
+- `crates/rimap-server/src/mcp/dispatch.rs`, `tool_catalog.rs`, `tool_name.rs`, `cli/dump_tool_schemas.rs` — register/dispatch the tool.
+- `crates/rimap-server/src/mcp/audit_envelope.rs` — export-specific `tool_end` result summary (Task 8).
+- Docs (Task 10).
+
+---
+
+## Task 1: Register `ExportMessages` (inert) so the workspace compiles
+
+Adding the enum variant breaks every exhaustive `match` over `ToolName` (the codebase bans wildcard arms). This task adds the variant, the type definitions the schema registration needs, and an inert handler, then fixes every exhaustive site so the workspace compiles with the tool advertised (only when allowed) and returning a "not implemented" error when called.
+
+**Files:**
+- Modify: `crates/rimap-core/src/tool.rs`
+- Modify: `crates/rimap-core/src/posture_matrix.rs`
+- Modify: `crates/rimap-authz/src/matrix.rs`
+- Modify: `crates/rimap-audit/src/redact.rs` (redaction schema — compile-forced)
+- Create: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+- Modify: `crates/rimap-server/src/tools/retrieval/mod.rs`
+- Modify: `crates/rimap-server/src/mcp/dispatch.rs`
+- Modify: `crates/rimap-server/src/mcp/tool_catalog.rs`
+- Modify: `crates/rimap-server/src/mcp/tool_name.rs`
+- Modify: `crates/rimap-server/src/cli/dump_tool_schemas.rs`
+
+- [ ] **Step 1: Add the enum variant.** In `crates/rimap-core/src/tool.rs`, after the `DownloadAttachment` variant (line 30), add:
+
+```rust
+    /// `export_messages` — bulk raw export of multiple UIDs to a
+    /// `git am`-able mbox in the download sandbox. Default-denied in the
+    /// base posture matrix; enabled only via `[security.tools]`.
+    ExportMessages,
+```
+
+- [ ] **Step 2: Add the `as_str` mapping.** In `tool.rs` `as_str`, after the `DownloadAttachment` arm (line 82):
+
+```rust
+            Self::ExportMessages => "export_messages",
+```
+
+- [ ] **Step 3: Add to the three classification matches.** In `tool.rs`, add `| Self::ExportMessages` to the `false`-returning arm of each of `is_infrastructure` (after line 129), `is_draft_quota_gated` (after line 162), and `is_send_quota_gated` (after line 196). Example for `is_infrastructure`:
+
+```rust
+            | Self::DownloadAttachment
+            | Self::ExportMessages
+```
+
+- [ ] **Step 4: Add the annotation hints.** In `tool.rs` `annotation_hints`, add a dedicated arm (it is *not* idempotent, unlike the `DownloadAttachment` group — each call writes a new artifact):
+
+```rust
+            // Writes a new sandbox file per call (not idempotent), never
+            // overwrites (write_attachment de-dups), reads from IMAP.
+            Self::ExportMessages => (false, false, false, true),
+```
+
+- [ ] **Step 5: Update the variant-count test.** In `tool.rs` tests, change both `24` to `25`:
+
+```rust
+    #[test]
+    fn all_has_exactly_twenty_four_variants() {
+        assert_eq!(ToolName::all().len(), 25);
+        assert_eq!(ToolName::iter().count(), 25);
+    }
+```
+
+(Rename the fn to `all_has_exactly_twenty_five_variants` for accuracy.)
+
+- [ ] **Step 6: Add the default-deny posture row.** In `crates/rimap-core/src/posture_matrix.rs`, bump the array length `; 22]` → `; 23]` (line 14) and add after the `DownloadAttachment` row (line 21):
+
+```rust
+    // export_messages: default-DENY at every posture. Reachable only via
+    // an explicit [security.tools].export_messages = "allow" override.
+    (ToolName::ExportMessages, [false, false, false, false]),
+```
+
+- [ ] **Step 7: Update the four base-posture row tests.** In `crates/rimap-authz/src/matrix.rs`:
+  - `base_readonly_row_matches_spec`: add `ToolName::ExportMessages,` to the *denied* list (the second array, after line 139).
+  - `base_draft_safe_row_matches_spec`: add `ToolName::ExportMessages,` to the `denied` array (after line 155).
+  - `base_full_allows_except_destructive`: change `let denied = [ToolName::Expunge, ToolName::DeleteFolder];` (line 170) to `let denied = [ToolName::Expunge, ToolName::DeleteFolder, ToolName::ExportMessages];`.
+  - `base_destructive_allows_all_non_infrastructure`: this asserts every non-infra tool is allowed at Destructive; add an exception. Replace the `else` branch body (lines 199-204) so `ExportMessages` is asserted denied:
+
+```rust
+            } else if t == ToolName::ExportMessages {
+                assert!(
+                    !base_allows(Posture::Destructive, t),
+                    "export_messages is default-deny at every base posture"
+                );
+            } else {
+                assert!(
+                    base_allows(Posture::Destructive, t),
+                    "destructive should allow {t}"
+                );
+            }
+```
+
+- [ ] **Step 8: Add the default-deny gate test.** Append to `crates/rimap-authz/src/matrix.rs` tests:
+
+```rust
+    #[test]
+    fn export_messages_denied_by_default_enabled_only_by_override() {
+        // No override: denied at every posture.
+        for p in Posture::all() {
+            let m = EffectiveMatrix::build(p, &BTreeMap::new());
+            assert!(
+                m.is_allowed(ToolName::ExportMessages).is_err(),
+                "export_messages must be default-denied at {p:?}"
+            );
+        }
+        // Explicit allow override enables it.
+        let mut overrides = BTreeMap::new();
+        overrides.insert(ToolName::ExportMessages, Verdict::Allow);
+        let m = EffectiveMatrix::build(Posture::Readonly, &overrides);
+        assert!(m.is_allowed(ToolName::ExportMessages).is_ok());
+    }
+```
+
+(If the accessor is named differently than `is_allowed`, match the method used by neighbouring tests in this file — e.g. the one returning `Result<(), AuthzError::PostureDenied>`.)
+
+- [ ] **Step 8b: Add the redaction schema (compile-forced).** `ToolName::redaction_schema()` in `crates/rimap-audit/src/redact.rs` is an exhaustive match — the workspace will not compile without an arm for the new variant. After the `DownloadAttachment` arm (line 323) add:
+
+```rust
+            Self::ExportMessages => export_messages_schema(self),
+```
+
+and add the helper next to `download_attachment_schema` (after line 474):
+
+```rust
+fn export_messages_schema(tool: ToolName) -> RedactionSchema {
+    use FieldPolicy::{Forbidden, RedactString, Verbatim};
+    use VerbatimType::{Bool, String as VtString, U64, U64Array};
+    RedactionSchema::new(
+        tool,
+        &[
+            ("folder", Verbatim(VtString)),
+            ("uids", Verbatim(U64Array)),
+            ("expected_uidvalidity", Verbatim(U64)),
+            ("max_total_bytes", Verbatim(U64)),
+            ("allow_partial", Verbatim(Bool)),
+            ("dest_dir", RedactString),
+            ("filename", RedactString),
+            ("password", Forbidden),
+            ("token", Forbidden),
+        ],
+    )
+}
+```
+
+(`uids` uses `Verbatim(U64Array)` — the same policy `expunge`/`flag` use for UID arrays — so the **exact requested UID set is durably recorded** in the redacted audit args, not just the response. `dest_dir`/`filename` are path-ish and redacted.)
+
+> Known limitation (consistent with existing tools, not export-specific): `Verbatim`
+> preserves only JSON-number forms, so a client that sends a *string-form* lenient integer
+> (`"expected_uidvalidity": "12345"`) has that value redacted to `<redacted:N>` in the
+> audit args rather than recorded verbatim — the redactor runs on raw args before serde
+> canonicalizes them. This affects every lenient-int field across the codebase (`flag`'s
+> `uid`, `search`'s `limit`, …), so canonicalizing lenient numeric strings in the audit
+> layer is a **cross-cutting** improvement, deferred out of this tool. The
+> `arguments_hash_sha256` still covers the raw value, and the `uid_validity` is echoed in
+> the response.
+
+- [ ] **Step 9: Create the handler module with types + inert handler.** Create `crates/rimap-server/src/tools/retrieval/export_messages.rs`:
+
+```rust
+//! `export_messages` tool handler: bulk raw export of multiple UIDs to a
+//! single `git am`-able mbox file in the download sandbox.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::boot::registry::AccountState;
+use crate::mcp::response::ToolResponse;
+
+/// Hard ceiling on the aggregate export size, regardless of the
+/// caller-supplied `max_total_bytes`.
+pub const MAX_EXPORT_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Input for the `export_messages` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub struct ExportMessagesInput {
+    /// IMAP folder containing the messages.
+    pub folder: String,
+    /// UIDs to export, in mbox (patch) order. Non-empty, max 100, de-duped.
+    pub uids: Vec<core::num::NonZeroU32>,
+    /// UIDVALIDITY observed when the UID list was discovered (e.g. from
+    /// `search`). Required: pins mailbox identity across search→export.
+    #[serde(deserialize_with = "crate::tools::lenient_int::deserialize_nonzero_u32")]
+    #[schemars(schema_with = "crate::tools::lenient_int::schema_nonzero_u32")]
+    pub expected_uidvalidity: core::num::NonZeroU32,
+    /// Optional destination directory. Must be within the download root.
+    pub dest_dir: Option<String>,
+    /// Optional advisory basename prefix (sanitized).
+    pub filename: Option<String>,
+    /// Aggregate byte cap; clamped to `MAX_EXPORT_TOTAL_BYTES`.
+    #[serde(
+        default,
+        deserialize_with = "crate::tools::lenient_int::deserialize_opt_u64"
+    )]
+    #[schemars(schema_with = "crate::tools::lenient_int::schema_opt_u64")]
+    pub max_total_bytes: Option<u64>,
+    /// When true, write the successes to a `.partial.mbox` artifact instead
+    /// of failing the whole call. Default false (all-or-nothing).
+    pub allow_partial: Option<bool>,
+}
+
+/// One successfully exported message.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExportedUid {
+    pub uid: u32,
+    pub size_bytes: usize,
+}
+
+/// Reason a requested UID was not exported. Both are determined at the size
+/// preflight, before any body fetch — a UID that reaches the body fetch is
+/// known-present and in-bounds, and any error there is fatal (never per-UID),
+/// so there is no `FetchError` variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFailReason {
+    NotFound,
+    Oversize,
+}
+
+/// One requested UID that failed.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct FailedUid {
+    pub uid: u32,
+    pub reason: ExportFailReason,
+}
+
+/// Trusted metadata for an `export_messages` response.
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct ExportMessagesMeta {
+    /// Folder the messages were exported from.
+    pub folder: String,
+    /// True iff every requested UID was exported.
+    pub complete: bool,
+    /// `git am`-ready mbox path; `null` when `complete` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Path of a `.partial.mbox` artifact; non-null only on a partial export.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_path: Option<String>,
+    /// SHA-256 of the written mbox, hex-encoded.
+    pub sha256: String,
+    /// Number of messages written to the artifact.
+    pub message_count: usize,
+    /// Total bytes written.
+    pub total_bytes: u64,
+    /// UIDVALIDITY the export was pinned to.
+    pub uid_validity: u32,
+    /// Exported UIDs, in mbox order, with sizes.
+    pub succeeded: Vec<ExportedUid>,
+    /// Requested UIDs that failed, with reasons.
+    pub failed: Vec<FailedUid>,
+}
+
+/// Execute the `export_messages` tool.
+///
+/// # Errors
+///
+/// Returns `RimapError::Internal` — not yet implemented (filled in Task 7).
+pub async fn handle(
+    _account: &AccountState,
+    _input: ExportMessagesInput,
+) -> Result<ToolResponse<ExportMessagesMeta>, rimap_core::RimapError> {
+    Err(rimap_core::RimapError::Internal(
+        "export_messages not yet implemented".into(),
+    ))
+}
+```
+
+- [ ] **Step 10: Declare the module.** In `crates/rimap-server/src/tools/retrieval/mod.rs`, add `pub mod export_messages;` (alphabetical order near `download_attachment`).
+
+- [ ] **Step 11: Wire dispatch.** In `crates/rimap-server/src/mcp/dispatch.rs`, after the `DownloadAttachment` dispatch arm (lines 161-163), add:
+
+```rust
+            ToolName::ExportMessages => {
+                ser(Box::pin(export_messages::handle(account, parse_args(args)?)).await?)?
+            }
+```
+
+Add `export_messages` to the `use crate::tools::retrieval::{... }` import (alongside `download_attachment`), and add `| ToolName::ExportMessages` to the not-infrastructure catch-all (after `| ToolName::DownloadAttachment` in the lines 241-262 block).
+
+- [ ] **Step 12: Wire the catalog.** In `crates/rimap-server/src/mcp/tool_catalog.rs`:
+  - Import: add `export_messages::ExportMessagesMeta,` to the `use crate::tools::retrieval::{...}` block (near line 99-105).
+  - `output_schema`: after the `DownloadAttachment` arm (lines 123-125), add:
+
+```rust
+        ToolName::ExportMessages => {
+            envelope_schema::<ToolResponse<ExportMessagesMeta, ()>>()
+        }
+```
+
+  - `tool_spec`: after the `DownloadAttachment` arm (lines 190-194), add:
+
+```rust
+        ToolName::ExportMessages => (
+            "Export Messages",
+            "Export multiple messages by UID as a single git am-able mbox \
+             file in the download sandbox. Discover UIDs with `search` and \
+             pass its uid_validity. Disabled unless enabled in [security.tools].",
+            envelope_schema::<ExportMessagesInput>(),
+        ),
+```
+
+  Add `ExportMessagesInput` to the `use ... export_messages::ExportMessagesInput` import used by `tool_spec` (mirror how `DownloadAttachmentInput` is imported).
+
+- [ ] **Step 13: Wire tool-name refinement.** In `crates/rimap-server/src/mcp/tool_name.rs`, add `| ToolName::ExportMessages` to the catch-all base arm (lines 52-75, near `| ToolName::DownloadAttachment`).
+
+- [ ] **Step 14: Wire the schema dump.** In `crates/rimap-server/src/cli/dump_tool_schemas.rs`, add `export_messages::ExportMessagesMeta,` to the import (near line 45) and add an insert (near the `download_attachment` insert, lines 84-87):
+
+```rust
+    out.insert(
+        "export_messages",
+        tool_envelope::<ExportMessagesMeta, ()>(),
+    );
+```
+
+- [ ] **Step 15: Generate the schema fixture.** Run:
+
+```bash
+just regen-tool-schemas
+```
+
+Expected: creates `crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json`.
+
+- [ ] **Step 16: Build + test the workspace.** Run:
+
+```bash
+cargo build --workspace --locked
+cargo nextest run -p rimap-core -p rimap-authz -p rimap-audit --locked
+```
+
+Expected: PASS — `all_has_exactly_twenty_five_variants`, the updated base-posture row tests, `export_messages_denied_by_default_enabled_only_by_override`, and the `rimap-audit` redaction-schema coverage tests all pass.
+
+- [ ] **Step 17: Lint.** Run:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 18: Commit.**
+
+```bash
+git add -A
+git commit -m "feat(export_messages): register tool (inert) with default-deny gate"
+```
+
+---
+
+## Task 2: `build_mbox` byte-level mboxrd framing (pure)
+
+The heart of `git am` fidelity. Pure function over raw RFC822 bytes.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+- Test: same file (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests.** Add to `export_messages.rs`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod build_mbox_tests {
+    use super::build_mbox;
+
+    const SEP: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1970\n";
+
+    #[test]
+    fn single_message_gets_separator_and_trailing_newline() {
+        let out = build_mbox(&[b"Subject: hi\r\n\r\nbody".to_vec()]);
+        assert!(out.starts_with(SEP), "missing leading separator");
+        assert!(out.ends_with(b"\n"), "must end with newline");
+        assert!(out.windows(4).any(|w| w == b"body"));
+    }
+
+    #[test]
+    fn missing_terminal_newline_padded_before_next_separator() {
+        // First message has no trailing newline; the second separator must
+        // still start at column 0.
+        let out = build_mbox(&[b"a: 1\r\n\r\nno-newline".to_vec(), b"b: 2\r\n\r\nx\n".to_vec()]);
+        let text = String::from_utf8(out).unwrap();
+        // Exactly two separators, each at the start of a line.
+        let seps: Vec<_> = text.match_indices("From mboxrd@").collect();
+        assert_eq!(seps.len(), 2);
+        for (idx, _) in &seps {
+            assert!(*idx == 0 || text.as_bytes()[idx - 1] == b'\n', "separator not at col 0");
+        }
+    }
+
+    #[test]
+    fn escapes_every_from_line_including_nested_and_header_position() {
+        let msg = b"From the desk of X\r\n>From already escaped\r\nFrom \r\nnormal\n".to_vec();
+        let out = build_mbox(&[msg]);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains(">From the desk of X"));
+        assert!(text.contains(">>From already escaped"));
+        assert!(text.contains(">From \r\n"));
+        assert!(text.contains("\nnormal"));
+    }
+
+    #[test]
+    fn preserves_crlf_verbatim_in_body() {
+        let out = build_mbox(&[b"H: 1\r\n\r\nline1\r\nline2\r\n".to_vec()]);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("line1\r\nline2\r\n"));
+    }
+
+    #[test]
+    fn split_back_round_trips_messages() {
+        // Build, then split on separator lines and un-escape; must equal inputs.
+        let inputs = vec![
+            b"A: 1\r\n\r\nFrom space\r\nbody1\r\n".to_vec(),
+            b"B: 2\r\n\r\nbody2\n".to_vec(),
+        ];
+        let mbox = build_mbox(&inputs);
+        let recovered = split_and_unescape(&mbox);
+        assert_eq!(recovered.len(), inputs.len());
+        // Compare ignoring a single trailing newline build_mbox may add.
+        for (got, want) in recovered.iter().zip(inputs.iter()) {
+            assert_eq!(trim_one_trailing_nl(got), trim_one_trailing_nl(want));
+        }
+    }
+
+    fn trim_one_trailing_nl(b: &[u8]) -> &[u8] {
+        b.strip_suffix(b"\n").unwrap_or(b)
+    }
+
+    // Test-only inverse of build_mbox's framing: split on separator lines,
+    // strip one leading '>' from each `^>+From ` line.
+    fn split_and_unescape(mbox: &[u8]) -> Vec<Vec<u8>> {
+        let text = mbox;
+        let sep = SEP;
+        let mut parts: Vec<Vec<u8>> = Vec::new();
+        let mut cur: Option<Vec<u8>> = None;
+        for line in split_keep_newlines(text) {
+            if line == sep {
+                if let Some(c) = cur.take() {
+                    parts.push(c);
+                }
+                cur = Some(Vec::new());
+            } else if let Some(c) = cur.as_mut() {
+                c.extend_from_slice(&unescape_line(line));
+            }
+        }
+        if let Some(c) = cur.take() {
+            parts.push(c);
+        }
+        parts
+    }
+
+    fn unescape_line(line: &[u8]) -> Vec<u8> {
+        // If line is `>+From `, drop one leading '>'.
+        let mut j = 0;
+        while j < line.len() && line[j] == b'>' {
+            j += 1;
+        }
+        if j >= 1 && line[j..].starts_with(b"From ") {
+            line[1..].to_vec()
+        } else {
+            line.to_vec()
+        }
+    }
+
+    fn split_keep_newlines(b: &[u8]) -> Vec<&[u8]> {
+        let mut out = Vec::new();
+        let mut start = 0;
+        for i in 0..b.len() {
+            if b[i] == b'\n' {
+                out.push(&b[start..=i]);
+                start = i + 1;
+            }
+        }
+        if start < b.len() {
+            out.push(&b[start..]);
+        }
+        out
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+```bash
+cargo nextest run -p rimap-server build_mbox_tests --locked
+```
+
+Expected: FAIL — `build_mbox` not found.
+
+- [ ] **Step 3: Implement `build_mbox`.** Add to `export_messages.rs` (module scope):
+
+```rust
+/// Pinned mboxrd separator. `git am`/`mailsplit` use it only as a delimiter
+/// and take real authorship from each message's own `From:` header.
+const MBOX_SEPARATOR: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1970\n";
+
+/// Assemble raw RFC822 messages into a single mboxrd byte buffer suitable
+/// for `git am`. Each message is preceded by [`MBOX_SEPARATOR`] at column 0;
+/// every line matching `^>*From ` is escaped with one extra leading `>`;
+/// CRLF is preserved verbatim.
+fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for msg in messages {
+        // Ensure the previous message ended with a line feed so this
+        // separator starts at column 0.
+        if let Some(&last) = out.last()
+            && last != b'\n'
+        {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(MBOX_SEPARATOR);
+        escape_from_lines_into(&mut out, msg);
+    }
+    // Trailing newline for a well-formed final message.
+    if let Some(&last) = out.last()
+        && last != b'\n'
+    {
+        out.push(b'\n');
+    }
+    out
+}
+
+/// Append `msg` to `out`, escaping each `^>*From ` line with one extra `>`.
+fn escape_from_lines_into(out: &mut Vec<u8>, msg: &[u8]) {
+    let mut line_start = 0;
+    for i in 0..msg.len() {
+        if msg[i] == b'\n' {
+            write_mbox_line(out, &msg[line_start..=i]);
+            line_start = i + 1;
+        }
+    }
+    if line_start < msg.len() {
+        write_mbox_line(out, &msg[line_start..]);
+    }
+}
+
+fn write_mbox_line(out: &mut Vec<u8>, line: &[u8]) {
+    if line_is_from(line) {
+        out.push(b'>');
+    }
+    out.extend_from_slice(line);
+}
+
+/// Whether `line` (from column 0) matches `^>*From ` — any run of `>` then
+/// the literal `From `.
+fn line_is_from(line: &[u8]) -> bool {
+    let mut j = 0;
+    while j < line.len() && line[j] == b'>' {
+        j += 1;
+    }
+    line[j..].starts_with(b"From ")
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+```bash
+cargo nextest run -p rimap-server build_mbox_tests --locked
+```
+
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/export_messages.rs
+git commit -m "feat(export_messages): add build_mbox mboxrd framing"
+```
+
+---
+
+## Task 3: `sanitize_filename_prefix` (pure)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add a `mod sanitize_tests`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod sanitize_tests {
+    use super::sanitize_filename_prefix;
+
+    #[test]
+    fn default_when_absent() {
+        assert_eq!(sanitize_filename_prefix(None).unwrap(), "messages");
+    }
+
+    #[test]
+    fn accepts_plain_basename() {
+        assert_eq!(sanitize_filename_prefix(Some("dpdk-series")).unwrap(), "dpdk-series");
+    }
+
+    #[test]
+    fn rejects_everything_outside_the_allowlist() {
+        for bad in [
+            "../escape", "/abs/path", "a/b", "a\\b", "", "  ", "a\u{0}b", "a\nb", // separators/control
+            "a;b", "a b", "a'b", "a\"b", "a$b", "a|b", "a&b", "a`b",            // shell metachars/spaces/quotes
+            "-lead", ".hidden",                                                  // leading dash/dot
+            "a\u{202E}b", "a\u{200B}b", "a\u{E0001}b",                           // bidi / zero-width / tag
+        ] {
+            assert!(sanitize_filename_prefix(Some(bad)).is_err(), "should reject {bad:?}");
+        }
+        // Overlong (> 64 chars) is rejected.
+        let long = "a".repeat(65);
+        assert!(sanitize_filename_prefix(Some(&long)).is_err());
+    }
+
+    #[test]
+    fn accepts_conservative_ascii_basenames() {
+        for ok in ["messages", "dpdk-series", "patch_set.v2", "AB12"] {
+            assert!(sanitize_filename_prefix(Some(ok)).is_ok(), "should accept {ok:?}");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+```bash
+cargo nextest run -p rimap-server sanitize_tests --locked
+```
+
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Implement.** Add to `export_messages.rs`:
+
+```rust
+/// Sanitize the advisory `filename` prefix to a safe single basename, or
+/// return the default `"messages"` when absent.
+///
+/// Uses a conservative **allowlist** grammar — `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`
+/// — because the prefix ends up in the `path` returned to the agent and the
+/// documented flow is `git am <path>`. The allowlist rejects path separators,
+/// `..` traversal, shell metacharacters, whitespace, quotes, and all non-ASCII
+/// (so bidi / zero-width / tag display-spoofing codepoints cannot appear), and
+/// the alphanumeric-first rule rejects leading `.`/`-`.
+///
+/// # Errors
+///
+/// `RimapError::Authz { code: InvalidInput }` if the prefix is empty after
+/// trimming, longer than 64 bytes, or contains any character outside the
+/// grammar.
+fn sanitize_filename_prefix(prefix: Option<&str>) -> Result<String, rimap_core::RimapError> {
+    let Some(raw) = prefix else {
+        return Ok("messages".to_string());
+    };
+    let trimmed = raw.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed.len() <= 64
+        && trimmed.bytes().next().is_some_and(|b| b.is_ascii_alphanumeric())
+        && trimmed
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if !valid {
+        return Err(rimap_core::RimapError::invalid_input(
+            "filename prefix must match [A-Za-z0-9][A-Za-z0-9._-]{0,63} \
+             (conservative ASCII basename)",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+```bash
+cargo nextest run -p rimap-server sanitize_tests --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/export_messages.rs
+git commit -m "feat(export_messages): add filename prefix sanitization"
+```
+
+---
+
+## Task 4: `validate_uids` + `clamp_total_bytes` (pure)
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add `mod input_tests`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod input_tests {
+    use super::{clamp_total_bytes, validate_uids, MAX_EXPORT_TOTAL_BYTES};
+    use core::num::NonZeroU32;
+
+    fn nz(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).unwrap()
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_uids(Vec::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_over_100() {
+        let v: Vec<NonZeroU32> = (1..=101).map(nz).collect();
+        assert!(validate_uids(v).is_err());
+    }
+
+    #[test]
+    fn dedups_preserving_first_order() {
+        let v = vec![nz(3), nz(1), nz(3), nz(2), nz(1)];
+        let out = validate_uids(v).unwrap();
+        let got: Vec<u32> = out.iter().map(|u| u.get()).collect();
+        assert_eq!(got, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn clamp_none_is_ceiling() {
+        assert_eq!(clamp_total_bytes(None), MAX_EXPORT_TOTAL_BYTES);
+    }
+
+    #[test]
+    fn clamp_caps_oversized_request() {
+        assert_eq!(clamp_total_bytes(Some(u64::MAX)), MAX_EXPORT_TOTAL_BYTES);
+        assert_eq!(clamp_total_bytes(Some(1024)), 1024);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+```bash
+cargo nextest run -p rimap-server input_tests --locked
+```
+
+Expected: FAIL — functions not found.
+
+- [ ] **Step 3: Implement.** Add to `export_messages.rs` (with `use rimap_imap::types::Uid;` at the top of the file):
+
+```rust
+/// Max UIDs per export, shared with the mutation-tool batch cap.
+const MAX_EXPORT_UIDS: usize = 100;
+
+/// Validate and normalize the requested UID list: reject empty / over-cap,
+/// de-dup preserving first-seen order, and convert to `Uid`.
+///
+/// # Errors
+///
+/// `RimapError::Authz { code: InvalidInput }` for an empty list or one
+/// exceeding [`MAX_EXPORT_UIDS`].
+fn validate_uids(
+    uids: Vec<core::num::NonZeroU32>,
+) -> Result<Vec<Uid>, rimap_core::RimapError> {
+    if uids.is_empty() {
+        return Err(rimap_core::RimapError::invalid_input("uids must not be empty"));
+    }
+    if uids.len() > MAX_EXPORT_UIDS {
+        return Err(rimap_core::RimapError::invalid_input(
+            "uids exceeds the maximum of 100 per export",
+        ));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::with_capacity(uids.len());
+    for u in uids {
+        if seen.insert(u.get()) {
+            out.push(Uid::from(u));
+        }
+    }
+    Ok(out)
+}
+
+/// Clamp the caller-supplied aggregate byte budget to the hard ceiling.
+fn clamp_total_bytes(requested: Option<u64>) -> u64 {
+    requested.map_or(MAX_EXPORT_TOTAL_BYTES, |n| n.min(MAX_EXPORT_TOTAL_BYTES))
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+```bash
+cargo nextest run -p rimap-server input_tests --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/export_messages.rs
+git commit -m "feat(export_messages): add uid validation and byte-budget clamp"
+```
+
+---
+
+## Task 5: `plan_outcome` — partial/complete decision (pure)
+
+Decides, given per-UID fetch outcomes and `allow_partial`, whether to abort (default, with failures) or proceed (complete or partial).
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add `mod outcome_tests`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod outcome_tests {
+    use super::{plan_outcome, ExportFailReason, FetchOutcome, Outcome};
+
+    fn ok(uid: u32, body: &[u8]) -> FetchOutcome {
+        FetchOutcome { uid, result: Ok(body.to_vec()) }
+    }
+    fn err(uid: u32, reason: ExportFailReason) -> FetchOutcome {
+        FetchOutcome { uid, result: Err(reason) }
+    }
+
+    #[test]
+    fn all_success_is_complete() {
+        let out = plan_outcome(vec![ok(1, b"a"), ok(2, b"b")], false);
+        match out {
+            Outcome::Proceed { complete, bodies, succeeded, failed } => {
+                assert!(complete);
+                assert_eq!(bodies.len(), 2);
+                assert_eq!(succeeded.len(), 2);
+                assert!(failed.is_empty());
+            }
+            Outcome::Abort { .. } => panic!("expected Proceed"),
+        }
+    }
+
+    #[test]
+    fn failure_without_allow_partial_aborts() {
+        let out = plan_outcome(vec![ok(1, b"a"), err(2, ExportFailReason::NotFound)], false);
+        match out {
+            Outcome::Abort { failed } => {
+                assert_eq!(failed.len(), 1);
+                assert_eq!(failed[0].uid, 2);
+            }
+            Outcome::Proceed { .. } => panic!("expected Abort"),
+        }
+    }
+
+    #[test]
+    fn failure_with_allow_partial_proceeds_incomplete() {
+        let out = plan_outcome(vec![ok(1, b"a"), err(2, ExportFailReason::Oversize)], true);
+        match out {
+            Outcome::Proceed { complete, bodies, succeeded, failed } => {
+                assert!(!complete);
+                assert_eq!(bodies.len(), 1);
+                assert_eq!(succeeded.len(), 1);
+                assert_eq!(failed.len(), 1);
+            }
+            Outcome::Abort { .. } => panic!("expected Proceed"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+```bash
+cargo nextest run -p rimap-server outcome_tests --locked
+```
+
+Expected: FAIL — types/functions not found.
+
+- [ ] **Step 3: Implement.** Add to `export_messages.rs`:
+
+```rust
+/// Per-UID fetch result fed into [`plan_outcome`].
+pub(crate) struct FetchOutcome {
+    pub uid: u32,
+    pub result: Result<Vec<u8>, ExportFailReason>,
+}
+
+/// Decision produced by [`plan_outcome`].
+pub(crate) enum Outcome {
+    /// Default all-or-nothing path with failures: write nothing, error out.
+    Abort { failed: Vec<FailedUid> },
+    /// Write the bodies (in order) and report the manifest.
+    Proceed {
+        complete: bool,
+        bodies: Vec<Vec<u8>>,
+        succeeded: Vec<ExportedUid>,
+        failed: Vec<FailedUid>,
+    },
+}
+
+/// Partition per-UID outcomes into an export decision. With failures and
+/// `allow_partial == false`, returns [`Outcome::Abort`]; otherwise
+/// [`Outcome::Proceed`] with `complete == failed.is_empty()`.
+fn plan_outcome(outcomes: Vec<FetchOutcome>, allow_partial: bool) -> Outcome {
+    let mut bodies = Vec::new();
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+    for o in outcomes {
+        match o.result {
+            Ok(body) => {
+                succeeded.push(ExportedUid { uid: o.uid, size_bytes: body.len() });
+                bodies.push(body);
+            }
+            Err(reason) => failed.push(FailedUid { uid: o.uid, reason }),
+        }
+    }
+    if !failed.is_empty() && !allow_partial {
+        return Outcome::Abort { failed };
+    }
+    Outcome::Proceed {
+        complete: failed.is_empty(),
+        bodies,
+        succeeded,
+        failed,
+    }
+}
+
+/// What to do with one requested UID, decided from its preflight size entry.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum UidPlan {
+    /// Resolved at preflight without a body fetch (`NotFound` / `Oversize`).
+    Skip(ExportFailReason),
+    /// Present and in-bounds: fetch the body.
+    Fetch,
+}
+
+/// Classify a UID from its preflight size entry (`None` = absent from the
+/// folder; `Some(None)` = present, size unknown; `Some(Some(n))` = present,
+/// reported size `n`). Pure, so the security-critical NotFound/Oversize
+/// decision is unit-testable without a live IMAP server.
+fn classify_uid(reported: Option<Option<u32>>, per_msg_cap: u64) -> UidPlan {
+    match reported {
+        None => UidPlan::Skip(ExportFailReason::NotFound),
+        Some(Some(sz)) if u64::from(sz) > per_msg_cap => UidPlan::Skip(ExportFailReason::Oversize),
+        _ => UidPlan::Fetch,
+    }
+}
+```
+
+- [ ] **Step 4: Add `classify_uid` tests.** Append to `outcome_tests`:
+
+```rust
+    #[test]
+    fn classify_uid_cases() {
+        use super::{classify_uid, ExportFailReason, UidPlan};
+        assert_eq!(classify_uid(None, 100), UidPlan::Skip(ExportFailReason::NotFound));
+        assert_eq!(classify_uid(Some(Some(200)), 100), UidPlan::Skip(ExportFailReason::Oversize));
+        assert_eq!(classify_uid(Some(Some(50)), 100), UidPlan::Fetch);
+        assert_eq!(classify_uid(Some(None), 100), UidPlan::Fetch); // present, size unknown
+    }
+```
+
+- [ ] **Step 5: Run to verify pass.**
+
+```bash
+cargo nextest run -p rimap-server outcome_tests --locked
+```
+
+Expected: PASS (both `plan_outcome` and `classify_uid` cases).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/rimap-server/src/tools/retrieval/export_messages.rs
+git commit -m "feat(export_messages): add outcome planning and uid classification"
+```
+
+---
+
+## Task 6: IMAP layer — `search` returns `uid_validity`, and a UIDVALIDITY-guarded body fetch
+
+Two IMAP-layer changes: (a) `search` returns `(uids, uid_validity)` so the discovery
+flow can thread `uid_validity` into `export_messages`; (b) `fetch_body` gains an
+`expected_uidvalidity` guard so the export loop cannot write the wrong messages if the
+mailbox is recreated (and the same UIDs reused) *between* body fetches. This guard is
+correctness (which messages get exported), distinct from the streaming read-limit /
+durability machinery deliberately left out of scope.
+
+**Files:**
+- Modify: `crates/rimap-imap/src/ops/search.rs:9-31`
+- Modify: `crates/rimap-imap/src/connection/dispatch.rs:124-133` (search) and `:182-228` (fetch_body)
+- Modify: `crates/rimap-imap/src/ops/fetch.rs:255-278` (`preflight_fetch_size`)
+- Modify: `crates/rimap-server/src/tools/retrieval/download_attachment.rs:108` (pass `None`)
+- Modify: `crates/rimap-server/src/tools/retrieval/search.rs`
+
+- [ ] **Step 1: Change the IMAP search op.** In `crates/rimap-imap/src/ops/search.rs`, replace the function body (lines 9-31) so it selects read-only (capturing UIDVALIDITY from the same operation) and returns the pair:
+
+```rust
+pub(crate) async fn search(
+    session: &mut ImapSession,
+    folder: &str,
+    query: SearchQuery,
+) -> Result<(Vec<Uid>, Option<u32>), ImapError> {
+    // Read-only SELECT (EXAMINE) so the UID set and its UIDVALIDITY come
+    // from the same selected-mailbox operation.
+    let selected = super::folders::select(session, folder, true).await?;
+    let uid_validity = selected.uid_validity;
+
+    let key = match query {
+        SearchQuery::Structured(s) => structured_to_key(&s)?,
+        SearchQuery::Raw(r) => r,
+    };
+
+    let uids = session
+        .uid_search(&key)
+        .await
+        .map_err(super::folders::map_err)?;
+    Ok((uids.into_iter().filter_map(Uid::new).collect(), uid_validity))
+}
+```
+
+(If `Uid::new` here takes the raw `u32` from `uid_search`, keep it exactly as the original line used it — only the return type and the select change.)
+
+- [ ] **Step 2: Change the connection wrapper.** In `crates/rimap-imap/src/connection/dispatch.rs`, update the `search` method signature (lines 128-133) return type:
+
+```rust
+    pub async fn search(
+        &self,
+        folder: &str,
+        query: crate::types::SearchQuery,
+    ) -> Result<(Vec<crate::types::Uid>, Option<u32>), ImapError> {
+        self.with_session("search", async |session| {
+            crate::ops::search::search(session, folder, query).await
+        })
+        .await
+    }
+```
+
+- [ ] **Step 3: Add `uid_validity` to `SearchMeta` + write a serialization test.** In `crates/rimap-server/src/tools/retrieval/search.rs`, add the field to `SearchMeta` (after `truncated`, line 167):
+
+```rust
+    /// UIDVALIDITY observed for the searched folder, from the same
+    /// EXAMINE/UID SEARCH operation. Thread into `export_messages`'
+    /// `expected_uidvalidity`. `None` if the server omitted it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid_validity: Option<u32>,
+```
+
+Add a test at the bottom of `search.rs` tests:
+
+```rust
+    #[test]
+    fn search_meta_serializes_uid_validity() {
+        let meta = SearchMeta {
+            folder: "INBOX".to_string(),
+            total_matched: 0,
+            returned: 0,
+            truncated: false,
+            uid_validity: Some(12345),
+        };
+        let v = serde_json::to_value(meta).unwrap();
+        assert_eq!(v["uid_validity"], serde_json::json!(12345));
+    }
+```
+
+- [ ] **Step 4: Update the `search` handler to thread the value.** In `search.rs` `handle`, change the search call and the meta construction:
+
+```rust
+    let (uids, uid_validity) = Box::pin(account.imap.search(&input.folder, query)).await?;
+```
+
+and add `uid_validity,` to the `SearchMeta { ... }` literal (line 225-230 block).
+
+- [ ] **Step 5: Build + test.**
+
+```bash
+cargo build --workspace --locked
+cargo nextest run -p rimap-imap -p rimap-server search --locked
+```
+
+Expected: PASS, including `search_meta_serializes_uid_validity`. Fix any other in-crate callers of `account.imap.search(...)` flagged by the compiler (destructure the tuple).
+
+- [ ] **Step 6a: Add a fail-closed UIDVALIDITY error + strict check.** The shared `check_uidvalidity` (fetch.rs:79-104) *warns and proceeds* when `expected=Some` but the server omits UIDVALIDITY. For a raw export that is unsafe — a recreated mailbox whose EXAMINE omits UIDVALIDITY would export unguarded. Add a dedicated error and a strict helper. In `crates/rimap-imap/src/error.rs`, add a variant to `ImapError`:
+
+```rust
+    /// A guarded fetch required UIDVALIDITY but the server omitted it.
+    /// Distinct from `UidValidityChanged` (which carries a concrete
+    /// mismatch); here the guard simply could not be verified.
+    #[error("server omitted UIDVALIDITY for folder {folder} on a guarded fetch")]
+    UidValidityUnavailable { folder: String },
+```
+
+Wire the variant through every exhaustive `ImapError` match the compiler flags — at minimum: `ImapError::code()` (error.rs:~195) → `ErrorCode::UidValidityChanged`; the `From<ImapError> for RimapError` mapping in `crates/rimap-core/src/error.rs` (route through the generic `Imap` arm like other variants, so `code()` surfaces `ERR_UID_VALIDITY_CHANGED`); and the `should_invalidate` match in dispatch `fetch_body` (Step 6c) as **non-invalidating** (the session is healthy; only the mailbox identity is unverifiable). Then add the strict helper in `crates/rimap-imap/src/ops/fetch.rs`:
+
+```rust
+/// Like [`check_uidvalidity`] but **fail-closed**: when `expected` is set,
+/// an absent observed UIDVALIDITY is an error, not a warning.
+pub(crate) fn require_uidvalidity(
+    folder: &str,
+    expected: Option<u32>,
+    observed: Option<u32>,
+) -> Result<(), ImapError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    match observed {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(ImapError::UidValidityChanged {
+            folder: folder.to_owned(),
+            expected,
+            actual,
+        }),
+        None => Err(ImapError::UidValidityUnavailable { folder: folder.to_owned() }),
+    }
+}
+```
+
+- [ ] **Step 6b: Guard BOTH EXAMINEs in the body-fetch path.** The dispatch `fetch_body` runs two EXAMINEs: one in `preflight_fetch_size` (RFC822.SIZE) and one in `ops::fetch::fetch_body` (the EXAMINE immediately before `BODY.PEEK[]`, fetch.rs:194-197). The second determines *which bytes are returned*, so it must be guarded too. In `crates/rimap-imap/src/ops/fetch.rs`, change both to take `expected_uidvalidity` and verify via `folders::select(..., true)` (which returns `uid_validity`) + the strict `require_uidvalidity`:
+
+```rust
+pub(crate) async fn preflight_fetch_size(
+    session: &mut ImapSession,
+    folder: &str,
+    uid: Uid,
+    expected_uidvalidity: Option<u32>,
+) -> Result<Option<u32>, ImapError> {
+    let selected = super::folders::select(session, folder, true).await?;
+    require_uidvalidity(folder, expected_uidvalidity, selected.uid_validity)?;
+
+    let mut stream = session
+        .uid_fetch(uid.get().to_string(), "RFC822.SIZE")
+        .await
+        .map_err(super::folders::map_err)?;
+
+    let mut size: Option<u32> = None;
+    while let Some(msg) = stream.next().await {
+        let msg = msg.map_err(super::folders::map_err)?;
+        if msg.uid == Some(uid.get()) {
+            size = msg.size;
+        }
+    }
+    Ok(size)
+}
+
+pub(crate) async fn fetch_body(
+    session: &mut ImapSession,
+    folder: &str,
+    uid: Uid,
+    limit: u64,
+    expected_uidvalidity: Option<u32>,
+) -> Result<Vec<u8>, ImapError> {
+    let selected = super::folders::select(session, folder, true).await?;
+    require_uidvalidity(folder, expected_uidvalidity, selected.uid_validity)?;
+
+    let mut stream = session
+        .uid_fetch(uid.get().to_string(), "BODY.PEEK[]")
+        .await
+        .map_err(super::folders::map_err)?;
+    // ... rest of the existing body-accumulation loop unchanged ...
+```
+
+(Only the leading `session.examine(folder)` block of `ops::fetch::fetch_body` changes; the `uid_fetch`/accumulation/`found` logic below is untouched. `require_uidvalidity` with `expected=None` is a no-op, so `download_attachment`'s `None` caller is unaffected.)
+
+- [ ] **Step 6c: Invalidate the session on timeout in `fetch_body`.** A timed-out `BODY.PEEK[]` leaves the response stream half-consumed, so reusing the session corrupts later fetches. In `crates/rimap-imap/src/connection/dispatch.rs`, move `ImapError::Timeout { .. }` from the non-invalidating arm into the `true` arm of the `should_invalidate` match (dispatch.rs:207-223), alongside `ConnectionLost | SizeLimit`. Add `ImapError::UidValidityUnavailable { .. }` to the non-invalidating arm.
+
+- [ ] **Step 7: Thread `expected_uidvalidity` through dispatch `fetch_body`.** In `crates/rimap-imap/src/connection/dispatch.rs`, add the parameter to `fetch_body` (lines 182-228) and pass it into **both** internal calls:
+
+```rust
+    pub async fn fetch_body(
+        &self,
+        folder: &str,
+        uid: crate::types::Uid,
+        expected_uidvalidity: Option<u32>,
+    ) -> Result<Vec<u8>, ImapError> {
+```
+
+Update the preflight call to `preflight_fetch_size(session, folder, uid, expected_uidvalidity)` and the body call to `crate::ops::fetch::fetch_body(session, folder, uid, limit, expected_uidvalidity)`. A UIDVALIDITY mismatch returns `ImapError::UidValidityChanged`; add it to the `should_invalidate` match's non-invalidating (false) arm if the compiler's exhaustiveness check flags it (it is already listed there per dispatch.rs:217-219 — leave as-is).
+
+- [ ] **Step 8: Add a per-message cap accessor + update the single-message caller.** In `crates/rimap-imap/src/connection/mod.rs`, alongside the existing `host()`/`username()` accessors, add:
+
+```rust
+    /// Maximum bytes a single `fetch_body` will accept (config cap).
+    #[must_use]
+    pub fn max_fetch_body_bytes(&self) -> u64 {
+        self.inner.cfg.max_fetch_body_bytes
+    }
+```
+
+Then in `crates/rimap-server/src/tools/retrieval/download_attachment.rs:108`, change `account.imap.fetch_body(&input.folder, uid)` to `account.imap.fetch_body(&input.folder, uid, None)`.
+
+- [ ] **Step 9: Build + test.**
+
+```bash
+cargo build --workspace --locked
+cargo nextest run -p rimap-imap -p rimap-server --locked
+```
+
+Expected: PASS. Fix any other `fetch_body(...)` call sites flagged by the compiler to pass `None`.
+
+- [ ] **Step 10: Regenerate the search schema fixture** (SearchMeta changed):
+
+```bash
+just regen-tool-schemas
+```
+
+- [ ] **Step 11: Unit-test the fail-closed guard.** Add to `crates/rimap-imap/src/ops/fetch.rs` tests (this is the deterministic coverage for the omitted-UIDVALIDITY and mid-loop-recreation cases the Dovecot harness cannot reliably inject):
+
+```rust
+    #[test]
+    fn require_uidvalidity_strict() {
+        use super::require_uidvalidity;
+        // expected=None: no-op (download_attachment path).
+        assert!(require_uidvalidity("INBOX", None, None).is_ok());
+        assert!(require_uidvalidity("INBOX", None, Some(7)).is_ok());
+        // expected=Some: match ok, mismatch and ABSENT both error.
+        assert!(require_uidvalidity("INBOX", Some(7), Some(7)).is_ok());
+        assert!(matches!(
+            require_uidvalidity("INBOX", Some(7), Some(8)),
+            Err(crate::error::ImapError::UidValidityChanged { .. })
+        ));
+        assert!(matches!(
+            require_uidvalidity("INBOX", Some(7), None),
+            Err(crate::error::ImapError::UidValidityUnavailable { .. })
+        ));
+    }
+```
+
+Run: `cargo nextest run -p rimap-imap require_uidvalidity_strict --locked` → PASS.
+
+- [ ] **Step 12: Commit.**
+
+```bash
+git add -A
+git commit -m "feat(imap): search returns uid_validity; fetch_body gains UIDVALIDITY guard"
+```
+
+---
+
+## Task 7: Implement `export_messages::handle`
+
+Wire the pure helpers together with IMAP fetch + sandbox write.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs`
+
+- [ ] **Step 1: Add imports** at the top of `export_messages.rs`:
+
+```rust
+use std::sync::Arc;
+
+use rimap_imap::types::{FetchSpec, Uid};
+
+use crate::tools::retrieval::sandbox;
+```
+
+(Keep the existing `use rimap_imap::types::Uid;` consolidated into the line above. No
+`ImapError` import is needed — the handler converts any body-fetch error with `e.into()`
+without naming the type.)
+
+- [ ] **Step 2: Replace the inert `handle`** with the orchestration:
+
+```rust
+/// Execute the `export_messages` tool.
+///
+/// # Errors
+///
+/// - `RimapError::Authz { code: InvalidInput }` for an empty/over-cap UID
+///   list or an unsafe `filename`.
+/// - `RimapError::UidValidityChanged` if the folder's UIDVALIDITY no longer
+///   matches `expected_uidvalidity`.
+/// - `RimapError::Authz { code: InvalidInput }` (all-or-nothing default)
+///   listing failed UIDs when `allow_partial` is false and any UID fails.
+/// - `RimapError::Imap { ... }` for connection-dropping fetch failures.
+/// - `RimapError::Internal` for filesystem/hashing failures.
+pub async fn handle(
+    account: &AccountState,
+    input: ExportMessagesInput,
+) -> Result<ToolResponse<ExportMessagesMeta>, rimap_core::RimapError> {
+    crate::tools::validation::validate_folder_input("folder", &input.folder)?;
+
+    let prefix = sanitize_filename_prefix(input.filename.as_deref())?;
+    let uids = validate_uids(input.uids)?;
+    let budget = clamp_total_bytes(input.max_total_bytes);
+    let allow_partial = input.allow_partial.unwrap_or(false);
+    let expected = input.expected_uidvalidity.get();
+    let per_msg_cap = account.imap.max_fetch_body_bytes();
+
+    let dest =
+        sandbox::resolve_dest_dir_async(input.dest_dir, Arc::clone(&account.download_dir)).await?;
+
+    // Preflight: validate UIDVALIDITY (required), learn which UIDs exist, and
+    // collect reported sizes. A mismatch surfaces as UidValidityChanged here.
+    let (pre_msgs, uid_validity_opt) = account
+        .imap
+        .fetch(
+            &input.folder,
+            &uids,
+            FetchSpec { size: true, ..FetchSpec::default() },
+            Some(expected),
+        )
+        .await?;
+    // The shared guard only *warns* on an omitted UIDVALIDITY; export refuses
+    // to run unguarded, so reject an absent value.
+    let Some(uid_validity) = uid_validity_opt else {
+        return Err(rimap_core::RimapError::invalid_input(
+            "server omitted UIDVALIDITY; export_messages requires it to guard the mailbox",
+        ));
+    };
+
+    // uid -> reported RFC822.SIZE (None if the server omitted it). Absence from
+    // the map means the UID is not present in the folder.
+    let mut size_by_uid: std::collections::BTreeMap<u32, Option<u32>> =
+        std::collections::BTreeMap::new();
+    for m in &pre_msgs {
+        size_by_uid.insert(m.uid.get(), m.size);
+    }
+
+    // Advisory aggregate pre-check, summed over ONLY the UIDs that may be
+    // written — present and within the per-message cap. Excluding NotFound and
+    // known-Oversize UIDs means they cannot block an `allow_partial` export of
+    // the writable messages. (A present-but-size-unknown UID counts 0 here; the
+    // running actual-bytes check during fetch is its real guard.) The framed
+    // size check below is the final authority.
+    let eligible_sum: u64 = uids
+        .iter()
+        .filter_map(|u| match size_by_uid.get(&u.get()) {
+            Some(Some(sz)) if u64::from(*sz) <= per_msg_cap => Some(u64::from(*sz)),
+            _ => None,
+        })
+        .sum();
+    if eligible_sum > budget {
+        return Err(rimap_core::RimapError::invalid_input(
+            "export exceeds max_total_bytes",
+        ));
+    }
+
+    // Classify + fetch in caller order. Missing and known-oversize UIDs are
+    // per-UID failures resolved at preflight (no body fetch). `running` is the
+    // authoritative bound on *actual* transferred bytes — the reported-size
+    // pre-check above can be defeated by a server that omits/under-reports
+    // RFC822.SIZE, so we abort the moment real bytes exceed the budget.
+    let mut outcomes = Vec::with_capacity(uids.len());
+    let mut running: u64 = 0;
+    for uid in &uids {
+        let n = uid.get();
+        // Preflight-driven per-UID decision (pure, unit-tested). Skips never
+        // attempt a body fetch, so oversize never triggers SizeLimit.
+        if let UidPlan::Skip(reason) = classify_uid(size_by_uid.get(&n).copied(), per_msg_cap) {
+            outcomes.push(FetchOutcome { uid: n, result: Err(reason) });
+            continue;
+        }
+        match account.imap.fetch_body(&input.folder, *uid, Some(expected)).await {
+            Ok(body) => {
+                running = running.saturating_add(body.len() as u64);
+                if running > budget {
+                    return Err(rimap_core::RimapError::invalid_input(
+                        "export exceeds max_total_bytes",
+                    ));
+                }
+                outcomes.push(FetchOutcome { uid: n, result: Ok(body) });
+            }
+            // ANY body-fetch error is fatal — never downgraded to a per-UID
+            // failure. Per-UID absence/oversize is already resolved at preflight
+            // (above), so a UID that reaches the body fetch is known-present and
+            // in-bounds; an error here (UIDVALIDITY change/omission, SizeLimit,
+            // Timeout, connection loss, or a BODY-stream protocol error) means
+            // the session or the returned bytes are untrustworthy. Aborting
+            // prevents a corrupt/stale body landing in a `.partial.mbox`.
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let (complete, bodies, succeeded, failed) = match plan_outcome(outcomes, allow_partial) {
+        Outcome::Abort { failed } => {
+            let uids: Vec<String> = failed.iter().map(|f| f.uid.to_string()).collect();
+            return Err(rimap_core::RimapError::invalid_input(format!(
+                "export incomplete (set allow_partial=true to override); failed UIDs: {}",
+                uids.join(", ")
+            )));
+        }
+        Outcome::Proceed { complete, bodies, succeeded, failed } => {
+            (complete, bodies, succeeded, failed)
+        }
+    };
+
+    let mbox = build_mbox(&bodies);
+    let total_bytes = mbox.len() as u64;
+    // Authoritative budget check on the *framed* output: mboxrd separators,
+    // From-line escaping, and terminal padding add bytes beyond the raw
+    // bodies counted in the loop above. Reject before writing anything.
+    if total_bytes > budget {
+        return Err(rimap_core::RimapError::invalid_input(
+            "framed mbox exceeds max_total_bytes",
+        ));
+    }
+    let sha256 = sandbox::sha256_hex(&mbox);
+
+    let suffix = if complete { "mbox" } else { "partial.mbox" };
+    let token = export_token();
+    let filename = format!("{prefix}-{token}.{suffix}");
+    let written = sandbox::write_attachment_async(dest, filename, mbox).await?;
+    let written = written.to_string_lossy().to_string();
+
+    let (path, partial_path) = if complete {
+        (Some(written), None)
+    } else {
+        (None, Some(written))
+    };
+
+    Ok(ToolResponse::meta_only(ExportMessagesMeta {
+        folder: input.folder,
+        complete,
+        path,
+        partial_path,
+        sha256,
+        message_count: succeeded.len(),
+        total_bytes,
+        uid_validity,
+        succeeded,
+        failed,
+    }))
+}
+
+/// Short random token making concurrent exports' filenames distinct.
+fn export_token() -> String {
+    use rand::Rng as _;
+    let n: u64 = rand::thread_rng().r#gen();
+    format!("{n:016x}")
+}
+```
+
+- [ ] **Step 3: Confirm the `rand` dependency.** Check `crates/rimap-server/Cargo.toml` for `rand`. If absent, add it (look up the current workspace version — `grep -r "rand" Cargo.lock | head` to match the already-vendored version) and run `cargo deny check` after. If `rand` is undesirable, replace `export_token` with a counter+timestamp using `std::time::SystemTime` nanos; the `write_attachment` collision de-dup is the correctness backstop either way.
+
+- [ ] **Step 4: Build.**
+
+```bash
+cargo build --workspace --locked
+```
+
+Expected: compiles. Fix the `ImapError` import path / variant names if the compiler disagrees (confirm `SizeLimit`/`ConnectionLost` spelling against `crates/rimap-imap/src/error.rs`).
+
+- [ ] **Step 5: Run the unit tests (pure helpers still pass through `handle`).**
+
+```bash
+cargo nextest run -p rimap-server export_messages --locked
+```
+
+Expected: PASS (the pure-helper tests from Tasks 2-5).
+
+- [ ] **Step 6: Where each failure path is tested (read before writing tests).** The Dovecot e2e harness drives a *real* server and **cannot deterministically inject** protocol faults — lying/omitted `RFC822.SIZE`, omitted UIDVALIDITY on a specific EXAMINE, precise mid-loop interleaving, or `fetch_body` timeouts are not normal Dovecot behavior, so asserting them through Dovecot would be flaky sleeps or no real coverage. The security-critical *decisions* are therefore covered at the **deterministic pure-function seam**, and Dovecot covers only what it can do faithfully:
+  - **Unit (deterministic), already specified:** `require_uidvalidity` — mismatch → `UidValidityChanged`, absent → `UidValidityUnavailable`, match → `Ok` (Task 6); `classify_uid` — NotFound / Oversize / Fetch (Task 5); `build_mbox` framing + exact byte counts feeding the framed-budget threshold (Task 2); `clamp_total_bytes` (Task 4); `plan_outcome` partial/complete (Task 5). These prove the wrong-message, oversize-skip, fail-closed-UIDVALIDITY, and budget-threshold logic without a live server.
+  - **Handler is a thin driver over those pure pieces:** the only handler-level rules not pure are "any `fetch_body` error → fatal" (no branching) and the running/framed budget aborts (trivial comparisons). They are exercised by the happy-path e2e plus the pure tests above; deeper deterministic coverage would need a scriptable IMAP fake (a cross-cutting test seam — see the note in Step 7).
+
+- [ ] **Step 7: Add Dovecot e2e for what it can do faithfully.** In `crates/rimap-server/tests/e2e.rs`, mirroring the existing `download_attachment` e2e (seed messages, build `AccountState`, dispatch a tool call; gate as the neighbours are):
+  - **Happy path:** enable `export_messages` via `[security.tools]`, `search` a seeded folder for `(uids, uid_validity)`, call `export_messages`, assert the returned `path` exists, `sha256` matches the file bytes, `message_count` equals the requested count, and (separately) `git am` applies the file in a temp repo.
+  - **UIDVALIDITY change via delete+recreate:** delete and recreate the seeded folder so its UIDVALIDITY changes, then call `export_messages` with the *stale* `expected_uidvalidity`; assert the preflight aborts with `UidValidityChanged` and writes no artifact (a real, deterministic Dovecot operation — distinct from the unreproducible mid-loop interleaving, which is covered by the `require_uidvalidity` unit test). Run with both `allow_partial` values.
+  - **Partial success:** request a present UID plus a UID that does not exist in the folder with `allow_partial=true`; assert the present message is written to a `.partial.mbox`, the missing UID is in `failed[]` as `not_found`, and `allow_partial=false` instead returns an error with no artifact.
+  - If the dovecot harness is feature/CI-only, gate these the same way; a **scriptable IMAP fake** for protocol-level fault injection is noted as optional follow-up test infrastructure, not built here.
+
+Run (if the harness runs locally; else rely on CI):
+
+```bash
+just test-integration
+```
+
+Expected: the export e2e tests pass (or are collected to run in CI per the harness's gating).
+
+- [ ] **Step 8: Deterministic handler-level fault tests via a source seam.** Pure helpers prove the *decisions*, but not that the *handler wiring* passes `expected_uidvalidity` into every body fetch and treats every body-fetch error as fatal-with-no-artifact. Close that with a minimal injection seam: define a small trait the handler depends on instead of calling `account.imap` directly —
+
+```rust
+#[cfg_attr(test, mockall::automock)] // or a hand-written fake under #[cfg(test)]
+pub(crate) trait ExportSource {
+    async fn fetch_sizes(
+        &self, folder: &str, uids: &[Uid], expected_uidvalidity: u32,
+    ) -> Result<Vec<(u32, Option<u32>)>, rimap_core::RimapError>; // (uid, RFC822.SIZE)
+    async fn fetch_one_body(
+        &self, folder: &str, uid: Uid, expected_uidvalidity: u32,
+    ) -> Result<Vec<u8>, rimap_core::RimapError>;
+}
+```
+
+Implement it for `AccountState` (delegating to `account.imap.fetch(..)` / `fetch_body(.., Some(expected))`), split `handle` into the thin public `handle(account, input)` and an inner `run_export(source: &impl ExportSource, dest, prefix, uids, expected, budget, allow_partial)`. Then add unit tests with a fake `ExportSource` that injects, per body fetch: a `UidValidityChanged`, a `UidValidityUnavailable`, a `Timeout`, and a `SizeLimit` — each asserting `run_export` returns `Err` and **wrote no artifact** (the temp dir is empty), under both `allow_partial` values. Also assert the happy fake yields the expected manifest and that `fetch_one_body` is always called with the same `expected`. (If `mockall` is not already a dev-dependency, a 30-line hand-written fake struct is fine and avoids a new dep — check `Cargo.lock` first.)
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add -A
+git commit -m "feat(export_messages): handler orchestration + injectable source seam"
+```
+
+---
+
+## Task 8: Audit redaction test (result-summary parity)
+
+**Scope correction (read first).** The audit `tool_end` envelope in
+`crates/rimap-server/src/mcp/audit_envelope.rs` hardcodes `ResultSummary::default()`
+(empty) and an empty `Provenance` for **every** tool — `emit_tool_end` takes only
+`status`/`error_code`/`duration_ms`. No tool (including `download_attachment`) records
+a path/sha256/UID result summary today, and `ResultSummary`'s fields are
+`message_ids_returned` / `bytes_returned` / `truncated` / `security_warnings_emitted`
+(no path/sha256/uid-list fields). Recording rich per-export provenance durably would
+require extending the shared `ResultSummary` schema **and** plumbing handler results
+through `run_with_audit_envelope` → `emit_tool_end` for all tools — cross-cutting audit
+work, and exactly the kind of gold-plating the durability-tier trim rejected.
+
+Therefore `export_messages` gets the **same audit treatment as every other tool**:
+`tool_start`/`tool_end` with status/error/duration, redacted args (via the schema added
+in Task 1, Step 8b), and the `arguments_hash_sha256`. The rich per-export detail
+(ordered UID list, sizes, path, sha256) lives in the tool **response** returned to the
+caller. Extending the durable audit `ResultSummary` is tracked as separate, cross-cutting
+work (it must change the on-disk record format for all tools). This task only verifies
+the redaction schema behaves correctly.
+
+**Files:**
+- Modify: `crates/rimap-audit/src/redact.rs` (test only)
+
+- [ ] **Step 1: Write the failing redaction test.** In `crates/rimap-audit/src/redact.rs` tests (mirror the style of the existing per-tool schema tests), assert the `export_messages` schema redacts `dest_dir`/`filename` (path-ish, not verbatim), keeps `folder`/`expected_uidvalidity` recoverable, hashes `uids`, and forbids `password`/`token`:
+
+```rust
+    #[test]
+    fn export_messages_schema_redacts_paths_keeps_identifiers() {
+        let salt = RedactionSalt::for_test(); // use the same constructor neighbouring tests use
+        let schema = ToolName::ExportMessages.redaction_schema();
+        let args = serde_json::json!({
+            "folder": "INBOX",
+            "uids": [101, 102],
+            "expected_uidvalidity": 12345,
+            "dest_dir": "/home/user/secret-dir",
+            "filename": "private-series",
+            "password": "hunter2"
+        });
+        let out = Redactor::new(&schema, &salt).apply(&args);
+        assert_eq!(out["folder"], serde_json::json!("INBOX"));
+        assert_eq!(out["expected_uidvalidity"], serde_json::json!(12345));
+        // Requested UID set is recorded verbatim (recoverable for audit).
+        assert_eq!(out["uids"], serde_json::json!([101, 102]));
+        // dest_dir / filename / password must not appear verbatim.
+        let serialized = serde_json::to_string(&out).unwrap();
+        assert!(!serialized.contains("/home/user/secret-dir"));
+        assert!(!serialized.contains("private-series"));
+        assert!(!serialized.contains("hunter2"));
+    }
+```
+
+(Match `RedactionSalt`'s test constructor and the assertion idioms to the neighbouring schema tests already in this file — e.g. how `download_attachment`/`search` schema tests build a salt and call `Redactor`.)
+
+- [ ] **Step 2: Run.**
+
+```bash
+cargo nextest run -p rimap-audit export_messages --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add -A
+git commit -m "test(export_messages): verify argument redaction schema"
+```
+
+---
+
+## Task 9: Real-`git` mbox acceptance test (in-module unit test)
+
+Guards against a custom splitter passing while real `git` rejects/wrongly-splits the mbox. Operates on `build_mbox` output — no IMAP. Lives as a unit test **inside** `export_messages.rs` so it calls the private `build_mbox` directly (no `pub` exposure, no feature gate). `git` is available in dev/CI; `tempfile` is already a `rimap-server` dev-dependency.
+
+**Files:**
+- Modify: `crates/rimap-server/src/tools/retrieval/export_messages.rs` (add a `#[cfg(test)]` module)
+
+- [ ] **Step 1: Write the test.** Add to `export_messages.rs`:
+
+```rust
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod git_am_tests {
+    use super::build_mbox;
+    use std::process::Command;
+
+    fn git(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git runs")
+    }
+
+    fn patch(n: u32, body_extra: &str) -> Vec<u8> {
+        // A minimal git-format-patch-style message: From/Subject/Date headers,
+        // then a unified diff creating file_<n>.txt.
+        format!(
+            "From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001\r\n\
+             From: Dev <dev@example.com>\r\n\
+             Date: Mon, 1 Jan 2024 0{n}:00:00 +0000\r\n\
+             Subject: [PATCH {n}/2] add file {n}{body_extra}\r\n\
+             \r\n\
+             ---\r\n \
+             file_{n}.txt | 1 +\r\n \
+             1 file changed, 1 insertion(+)\r\n\
+             \r\n\
+             diff --git a/file_{n}.txt b/file_{n}.txt\r\n\
+             new file mode 100644\r\n\
+             index 0000000..0000001\r\n\
+             --- /dev/null\r\n\
+             +++ b/file_{n}.txt\r\n\
+             @@ -0,0 +1 @@\r\n\
+             +content {n}\r\n\
+             -- \r\n\
+             2.40.0\r\n"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn git_am_applies_generated_mbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        assert!(git(&["init", "-q"], repo).status.success());
+
+        // A From-line in the body content must survive escaping.
+        let mbox = build_mbox(&[patch(1, "\r\nFrom the author: note"), patch(2, "")]);
+        let mbox_path = repo.join("series.mbox");
+        std::fs::write(&mbox_path, &mbox).unwrap();
+
+        let out = git(&["am", mbox_path.to_str().unwrap()], repo);
+        assert!(
+            out.status.success(),
+            "git am failed: {}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+
+        let log = git(&["rev-list", "--count", "HEAD"], repo);
+        let count = String::from_utf8_lossy(&log.stdout).trim().to_string();
+        assert_eq!(count, "2", "expected 2 commits from a 2-patch series");
+        assert!(repo.join("file_1.txt").exists());
+        assert!(repo.join("file_2.txt").exists());
+    }
+}
+```
+
+(If `tempfile` is not yet a `rimap-server` dev-dependency, add it to `[dev-dependencies]` matching the workspace version.)
+
+- [ ] **Step 2: Run.**
+
+```bash
+cargo nextest run -p rimap-server git_am_applies_generated_mbox --locked
+```
+
+Expected: PASS — `git am` applies both patches, 2 commits, both files present. (No feature flag needed — it is a plain unit test.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add -A
+git commit -m "test(export_messages): verify mbox applies with real git am"
+```
+
+---
+
+## Task 10: Docs, final schema regen, full verification
+
+**Files:**
+- Modify: `docs/` tool reference + per-tool enable/disable section (find with `rg -l "download_attachment" docs/`).
+
+- [ ] **Step 1: Enforce a private download root when the tool is enabled (config validation).** Convert the private-root requirement from documentation into a hard, fail-closed precondition. In the config validation flow (`crates/rimap-config/src/validate/` — mirror how existing path validations in `paths.rs`/`compose.rs` are wired), add: when `security.tools` resolves `export_messages` to `Allow`, verify the resolved download root is **not group- or world-writable** on Unix, else fail validation. Sketch:
+
+```rust
+#[cfg(unix)]
+fn check_export_download_root_private(
+    download_root: &std::path::Path,
+) -> Result<(), ConfigError> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mode = std::fs::metadata(download_root)
+        .map_err(|e| ConfigError::invalid(format!(
+            "cannot stat download root {}: {e}", download_root.display()
+        )))?
+        .permissions()
+        .mode();
+    if mode & 0o022 != 0 {
+        return Err(ConfigError::invalid(format!(
+            "export_messages is enabled but the download root {} is group/world-writable \
+             (mode {:o}); export_messages requires a server-private download root",
+            download_root.display(), mode & 0o777,
+        )));
+    }
+    Ok(())
+}
+```
+
+Call it from the validation entry point only when `export_messages` is allowed. (Match the actual `ConfigError` constructor and download-root field names in `model.rs`/`validate`.) Add a validation test: enabling `export_messages` with a `0o777` temp dir fails; with `0o700` passes; disabled tool skips the check. Then document the requirement + this enforcement in the tool docs (`docs/configuration.md` + tool reference) alongside the `search → read uid_validity → export_messages → git am <path>` flow, the required `expected_uidvalidity`, `allow_partial` semantics, and that it is **default-disabled** (`[security.tools]\nexport_messages = "allow"`). Do **not** build the dir-fd writer here (cross-cutting, out of scope per the spec's *Durability scope*).
+
+- [ ] **Step 2: Regenerate all tool schemas** (catches any drift):
+
+```bash
+just regen-tool-schemas
+git diff --stat crates/rimap-server/tests/fixtures/rimap-tool-schemas/
+```
+
+Expected: only `export_messages.schema.json` (new) and `search.schema.json` (uid_validity added) differ.
+
+- [ ] **Step 3: Full workspace test + lint + deny.**
+
+```bash
+cargo nextest run --workspace --locked --no-tests=pass
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+cargo deny check
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add -A
+git commit -m "docs(export_messages): document tool, flow, and default-disable"
+```
+
+- [ ] **Step 5 (blocking gate):** Before merge, route the change past the `threat-model-reviewer`. The gate must explicitly rule on **four** recorded decisions, not rubber-stamp them (each is a deliberate scope call deferred here because it is cross-cutting / conflicts with the durability-tier trim, so the human gate is the right place to relitigate the risk tradeoff):
+  1. The `Readonly` seat + default-deny `[security.tools]` gating for an unsanitized raw-export oracle.
+  2. The **audit provenance gap** — durable audit records the *requested* UID set (verbatim) but the *actual* exported scope (succeeded/failed partition, artifact path, sha256, byte count) lives only in the tool response (spec *Audit contract* → "Accepted risk"). If not accepted, the prerequisite is the cross-cutting shared-`ResultSummary` extension across all tools, before this tool ships.
+  3. The **sandbox-write containment posture** — the writer is path-based (shares `download_attachment`'s TOCTOU window). The controls are (a) the deployment trust-model requirement that the download root's write authority is *separated from the consuming agent* (dedicated OS user / ownership / ACL — a mode-bit check alone does not prove same-UID separation), and (b) the fail-closed group/world-writable config check (Step 1) as a backstop. If the reviewer judges that insufficient, the prerequisite is cross-cutting `openat`/`O_NOFOLLOW`/exclusive-create hardening of the shared sandbox writer for `download_attachment` + `export_messages` together.
+  4. The **memory ceiling** — the effective bound is `max_total_bytes + max_fetch_body_bytes` (one buffered body before the running check trips), not exactly `max_total_bytes`, the same single-body bound the existing fetch paths have (spec *Resource bounds* → "Worst-case memory"). Pinning it exactly requires re-introducing the trimmed read-level `body_limit_bytes` literal limit. Accept the documented bound or require the streaming read path.
+  Record the reviewer's decision on each in the PR.
+
+---
+
+## Self-Review notes (spec coverage)
+
+- Required `expected_uidvalidity` + search same-op `uid_validity` → Tasks 1 (input), 6 (search + UIDVALIDITY-guarded `fetch_body`), 7 (preflight + per-body guard, race e2e).
+- `allow_partial` safe-by-default, `complete`/`path`/`partial_path` → Tasks 1, 5, 7.
+- byte-level mboxrd framing + real-`git` test → Tasks 2, 9.
+- aggregate `max_total_bytes` clamp + **framed-size** budget enforcement → Tasks 4, 7 (raw early-abort + authoritative framed check; overflow e2e).
+- default-deny gate + annotation hints → Task 1 (matrix + tests + hints).
+- argument redaction (compile-forced) → Task 1 Step 8b (`uids` verbatim `U64Array`, so
+  the requested scope is durably auditable); verified in Task 8.
+- audit *result* provenance (succeeded/failed partition, path, sha256) lives in the tool
+  **response**, not the durable audit summary: no tool records a non-empty
+  `ResultSummary` today, so durable rich provenance is out of scope (cross-cutting audit
+  work) — consistent with the durability-tier trim. The requested UID *set* IS durable
+  (redacted args). Recorded as an explicit accepted risk for the threat-model gate.
+- sandbox containment → Task 7 reuses `resolve_dest_dir`/`write_attachment` (parity with `download_attachment`), and Task 10 Step 1 adds a **fail-closed private-download-root config check** as the enforced control (group/world-writable root rejects enabling the tool). Per-tool dir-fd hardening is out of scope (cross-cutting).
+- security-critical fault paths are covered at three levels because the Dovecot harness
+  cannot reliably inject protocol faults: (a) **pure-function** unit tests of the decisions
+  (`require_uidvalidity`, `classify_uid`, `build_mbox` sizes, `plan_outcome`) — Tasks
+  2/4/5/6; (b) **handler-wiring** unit tests via an injectable `ExportSource` seam that
+  feeds per-body `UidValidityChanged`/`UidValidityUnavailable`/`Timeout`/`SizeLimit` and
+  asserts fatal-with-no-artifact (Task 7 Step 8); (c) **Dovecot** happy-path +
+  delete/recreate UIDVALIDITY change + missing-UID partial (Task 7 Step 7).
+- **Durability deliberately out of scope** (per spec's *Durability scope*): no WAL/lease/recovery/dir-fd tasks — matches the trimmed design.
+- **Three scope decisions deferred to the threat-model gate** (Task 10 Step 5): posture/gating, durable audit provenance gap, sandbox-write containment posture. These are deliberate, recorded holds (cross-cutting or conflicting with the user's durability-tier trim), not oversights.

--- a/docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md
+++ b/docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md
@@ -1,0 +1,417 @@
+# `export_messages`: bulk raw export to a `git am`-able mbox
+
+**Date:** 2026-05-26
+**Status:** Design — pending review
+**Branch:** `feature/export-messages-mbox`
+
+## Problem
+
+Reading a multi-message set (e.g. a 27-patch DPDK series) through `fetch_message`
+means 27 separate tool calls, each returning a sanitized, parsed JSON body. For an
+agent whose goal is to **apply the patches**, that path is wrong on every axis:
+
+- 27 round-trips and 27 bodies in context is expensive, so agents route around the
+  tool and try to script raw IMAP/`curl` access instead.
+- Sanitized `body_text` is the wrong artifact for `git am`: the content pipeline runs
+  NFKC normalization and disallowed-codepoint filtering that can corrupt a diff, and
+  the parsed JSON shape drops the raw `From`/`Subject`/`Date` headers `git am` turns
+  into commit metadata.
+
+The agent's actual need is a single artifact it can hand to `git am`.
+
+## Goal
+
+One tool call that fetches a caller-specified set of messages and writes them as a
+single `git am`-able **mbox** file into the existing download sandbox — written the same
+way `download_attachment` writes attachments — returning the path plus a trusted
+manifest. No per-message body content is surfaced inline.
+
+## Non-goals
+
+- **Server-side threading.** Selection is an explicit `uids[]` list; the caller
+  discovers the series with `search` (including its `List-Id` header filter) and
+  controls ordering. A `Message-ID`/`References` thread mode is a possible future
+  follow-up, not part of this work.
+- **Inline body content.** Bodies never enter the response. The artifact is the file.
+- **Modifying `fetch_message`.** Its deliberately-scalar `uid` contract
+  (`fetch_message.rs:11-21`) stays intact. This is a new, separate tool.
+- **Crash durability / atomic-artifact transactions.** The mbox is a **best-effort,
+  ephemeral sandbox file** written exactly like an attachment download — no `fsync`,
+  no write-ahead journal, no crash-recovery sweep, no lease. The agent consumes it in
+  the same session (`git am <path>`); a process crash may leave a stale file in the
+  sandbox, cleaned up like any other sandbox download. See *Durability scope* for why.
+
+## Approach (chosen over alternatives)
+
+A **new dedicated tool**, `export_messages`, rather than extending `fetch_message`
+with a batch/export mode (which would overload one schema with two output channels and
+contradict the documented scalar-shape rationale) or a prompt-only fix (which solves
+neither context bloat nor `git am` fidelity).
+
+The tool is a generic raw-export primitive that happens to be ideal for patch series.
+It **reuses `download_attachment`'s machinery** — `resolve_dest_dir` for path-validated,
+traversal-safe sandbox containment and `write_attachment` for collision-safe writes —
+and the same `Posture::Readonly` seat (same trust channel: raw bytes to a contained
+file, never into the agent's trusted context). It deliberately holds itself to the
+*same* durability and containment posture as `download_attachment`, no higher.
+
+## Durability scope
+
+An earlier draft of this spec specified a full write-ahead journal, liveness lease,
+crash/cancellation recovery, inode-ownership proofs, and directory-fd atomic finalize.
+That was trimmed: `export_messages` is a **default-disabled, opt-in convenience tool**,
+not a high-assurance durable store, and `download_attachment` — which writes comparable
+raw bytes to the same sandbox — ships with none of that machinery. Holding the new tool
+to a stricter durability bar than its sibling is inconsistent and over-engineered for
+the use case (fetch a series, `git am` it, done, in one session).
+
+The artifact therefore inherits `download_attachment`'s exact posture: a best-effort
+file in the sandbox, no durability guarantee across crashes. If the sandbox-durability
+or containment bar should rise, it should rise for `download_attachment` and
+`export_messages` **together**, as separate hardening work — not be gold-plated onto
+this tool alone.
+
+The existing sandbox writer (`resolve_dest_dir` canonicalize + `write_attachment`
+check-then-write) is **path-based, not directory-fd-based**, so it shares
+`download_attachment`'s theoretical TOCTOU/symlink-swap window: a *separate local process
+or agent with write access to the download root* could swap the directory or final path
+between resolution and write. The trimmed design does not add `openat`/no-follow/held-fd
+machinery for this one tool (that is the cross-cutting hardening above). Instead the
+mitigation is **operational and required**: the **download root must be a server-private,
+non-agent-writable directory** — a path only the MCP server process can write, not shared
+with the agent's general filesystem access. With no concurrent writer in the sandbox, the
+swap race has no actor. The **trust-model requirement** is that the download root's write
+authority is *separated from the consuming agent* — ideally a directory owned by a
+dedicated OS user / restricted by ownership or ACL, so neither the agent nor another
+same-UID-as-the-agent process can write it. As a fail-closed **backstop**, config
+validation refuses to start when `export_messages` is enabled and the resolved download
+root is group- or world-writable (`mode & 0o022 != 0` on Unix). The mode-bit check alone
+does **not** prove same-UID separation, so the deployment-model requirement above is the
+real control and is a blocking item for the threat-model gate.
+
+A fully race-proof `openat`/`O_NOFOLLOW`/exclusive-create writer for the shared sandbox
+remains the alternative the gate may require; it is cross-cutting (it must cover
+`download_attachment` too) and is deliberately out of this tool's scope per the trim.
+
+## Input schema
+
+```jsonc
+{
+  "folder": "string",            // required; validate_folder_input
+  "uids": [101, 102, 103],       // required; non-empty, max 100, de-duped, ORDER PRESERVED
+  "expected_uidvalidity": 12345, // REQUIRED; pins mailbox identity across search→export
+  "dest_dir": "string?",         // optional; canonicalized, must stay inside download root
+  "filename": "string?",         // optional; advisory basename PREFIX only (sanitized)
+  "max_total_bytes": 52428800,   // optional aggregate cap; clamped to MAX_EXPORT_TOTAL_BYTES
+  "allow_partial": false         // optional; default false. See partial-failure semantics
+}
+```
+
+`uids` is a plain ordered `Vec<NonZeroU32>`, **not** the `uid` XOR `uids`
+`UidSelector` — the caller's order is the mbox order, which is the patch order for
+`git am`. Integer fields use the existing `lenient_int` deserializers. The `max 100`
+batch cap is shared with the mutation tools.
+
+`expected_uidvalidity` is **required** (unlike the optional guard on the flag tools).
+UIDs are meaningful only relative to a UIDVALIDITY, and the documented discovery flow
+selects the UID list with `search` *before* the export runs. If the mailbox is recreated
+between those two steps, the same UIDs can be reused by different messages and the export
+would write the wrong ones. Requiring the caller to pass the UIDVALIDITY it saw at
+discovery closes that window: `search` surfaces `uid_validity` (from the same
+EXAMINE/UID SEARCH operation — see *Wiring*), the caller threads it in, and the export's
+preflight aborts if the mailbox no longer matches.
+
+`filename` is an **advisory basename prefix**, sanitized before use (see below);
+`max_total_bytes` is clamped to a compile-time `MAX_EXPORT_TOTAL_BYTES` ceiling so the
+aggregate budget cannot be inflated by an oversized request.
+
+## Data flow
+
+1. `validate_folder_input("folder", …)` and `resolve_dest_dir_async` — the same sandbox
+   containment `download_attachment` uses.
+2. **One** `fetch(folder, uids, FetchSpec { size: true, .. }, expected_uidvalidity)`
+   preflight: validates UIDVALIDITY against the required input (abort on mismatch **or**
+   an absent observed value — the tool cannot run unguarded), identifies which UIDs
+   exist, and sums `RFC822.SIZE` for an advisory aggregate-budget pre-check.
+3. For each UID in **caller order**, fetch the raw body with `fetch_body`, passing
+   `expected_uidvalidity` so the guard is re-checked **fail-closed** on **every** body
+   fetch (both EXAMINE commands in the fetch path) — the batch loop issues a fresh select per
+   call, so a mailbox recreation (with reused UIDs) between fetches would otherwise write
+   the wrong messages. The guard is fail-closed: a *mismatched* or *omitted* UIDVALIDITY
+   is fatal, never a per-UID failure. (Its per-message `max_fetch_body_bytes` cap,
+   preflight size check, and connection safety still apply.) **No MIME parse** — raw
+   bytes only, so this path never acquires the parse semaphore. A running raw-byte count
+   early-aborts against `max_total_bytes`.
+4. Frame each message into **mboxrd** (see below), then **re-check the budget against the
+   framed artifact size** (framing adds separators, escape bytes, and padding beyond the
+   raw bodies); on overflow, abort without writing. Otherwise write the assembled mbox
+   via `write_attachment` (collision-safe) and SHA-256 the file.
+
+Fetches are sequential (a single IMAP session serializes commands anyway). Peak memory is
+bounded by the successful bodies plus the framed mbox — i.e. by the clamped
+`max_total_bytes` (≤ `MAX_EXPORT_TOTAL_BYTES`), not literally one body at a time, since
+the bodies are buffered to decide complete-vs-partial before writing. The UIDVALIDITY
+guard covers both the preflight and every body fetch (this is correctness, distinct from
+the trimmed streaming-read-limit / durability machinery).
+
+## Filename sanitization
+
+`resolve_dest_dir` validates only the *directory*; the artifact name is built separately,
+so the advisory `filename` prefix is sanitized first:
+
+- Reject the request (`InvalidInput`) if `filename` is absolute, contains any path
+  separator (`/` or `\`), a parent component (`..`), control characters or NUL, is empty
+  after trimming, or is a platform-reserved name.
+- Reduce the accepted value to a single basename and use it only as the leading text of
+  `<prefix>-<token>.mbox` (or `.partial.mbox`), where `<token>` is a short random value
+  so two concurrent exports do not contend for the same name. `write_attachment`'s
+  collision handling is the backstop.
+
+## Resource bounds
+
+`max_total_bytes` is clamped to `MAX_EXPORT_TOTAL_BYTES` at input validation. Per-message
+size is bounded by the existing `fetch_body` cap (`max_fetch_body_bytes`, with its
+preflight `RFC822.SIZE` check and post-parse defense-in-depth) — the same protection
+`download_attachment` relies on. The aggregate budget is enforced in three places: an
+advisory pre-check summing the reported sizes of *eligible* UIDs only (present and within
+the per-message cap — so a skipped `NotFound`/`Oversize` UID cannot block an
+`allow_partial` export); a running sum of *actual* body bytes during the fetch loop that
+aborts the moment it exceeds the budget (this is the real guard against a server that
+omits or under-reports `RFC822.SIZE`); and an **authoritative re-check against the framed
+artifact size** before writing — mboxrd separators, `From`-line escaping, and terminal
+padding add bytes the raw sum does not see. Exceeding the budget aborts the whole run
+without writing (a byte budget is a batch-level limit, so it is fatal regardless of
+`allow_partial`).
+
+**Worst-case memory** (documented rather than engineered away with a streaming writer,
+per the trim): the running check fires within one body of the budget, and a single
+under-reported or size-unknown body is still bounded by the per-message
+`max_fetch_body_bytes` cap (async-imap buffers a body before the post-parse size check),
+so peak heap is roughly `clamped max_total_bytes` (buffered successful bodies) + the
+framed mbox copy + **at most one `max_fetch_body_bytes` of over-budget transfer** before
+the running check trips. Note `max_fetch_body_bytes` is **operator-configurable**, so the
+true memory ceiling is `max_total_bytes + max_fetch_body_bytes`, not exactly
+`max_total_bytes` — the same single-body bound the existing `fetch_message` /
+`download_attachment` paths already have. Pinning the ceiling exactly to `max_total_bytes`
+would require a read-level literal limit (the `body_limit_bytes` streaming variant that
+was trimmed). With both caps finite, peak is bounded and finite — acceptable for a
+default-disabled, opt-in tool; tightening it is a threat-model-gate decision (it
+re-introduces the trimmed streaming read path).
+
+Failure classification is **entirely preflight-driven**: the size preflight identifies
+UIDs **not present** in the folder (→ `NotFound`) and UIDs whose reported size exceeds the
+per-message cap (→ `Oversize`), both without attempting a body fetch. These are the only
+two per-UID reasons, and they feed `allow_partial`.
+
+A UID that reaches the body fetch is therefore known-present and in-bounds, so **any error
+from the body fetch is fatal** — never downgraded to a per-UID failure, even under
+`allow_partial`. That covers UIDVALIDITY mismatch or omission, a mid-stream `SizeLimit` (a
+server lying about size), a `Timeout` (leaves the BODY stream half-consumed; the body
+fetch invalidates the session on timeout), connection loss, and any BODY-stream protocol
+error (where the session or returned bytes are untrustworthy). The fatal cases abort with
+no artifact, so a corrupt or stale body can never land in a `.partial.mbox`.
+
+## mbox format: mboxrd
+
+`build_mbox` operates on raw RFC822 bytes, so framing is specified at the **byte level** —
+sloppy framing makes `git am`/`mailsplit` merge or drop messages and corrupt the series:
+
+- Each message is preceded by a synthesized separator line at column 0 with a **pinned
+  exact form**: `From mboxrd@rusty-imap-mcp <asctime>\n` (the classic mboxrd postmark;
+  `<asctime>` is a fixed-width UTC `ctime` string). `git am` uses it only as a delimiter
+  and takes real authorship from each message's own `From:` header.
+- The separator **must start at column 0**: before emitting any separator after the
+  first, if the previous message did not end with a line feed, insert one. That padding
+  byte is part of the persisted output and is counted in `total_bytes` / `sha256`.
+- **Every** raw line matching `^>*From ` is escaped with one extra leading `>` — body,
+  malformed, and header-position lines alike, since the splitter keys purely on column-0
+  `From `. `git am` un-escapes mboxrd on read.
+- CRLF endings are preserved verbatim; the column-0 and terminal-LF checks operate on
+  `\n` boundaries regardless of a preceding `\r`.
+
+The logic lives in a pure `build_mbox` function, unit- and property-testable without a
+live IMAP connection, with fixtures for no-terminal-newline, CRLF, and
+malformed/header-position `From ` lines.
+
+## Response (trusted metadata only)
+
+No body or subject is surfaced inline, so the response carries **only trusted metadata** —
+no untrusted payload, no sanitization step. The content stays in the sandbox file.
+
+Complete export:
+
+```jsonc
+{
+  "folder": "INBOX",
+  "complete": true,
+  "path": "<sandbox>/messages-a1b2c3.mbox",   // git am-ready
+  "partial_path": null,
+  "sha256": "…",
+  "message_count": 27,
+  "total_bytes": 1234567,
+  "uid_validity": 12345,
+  "succeeded": [{ "uid": 101, "size_bytes": 4096 }],
+  "failed":    []
+}
+```
+
+When some UIDs fail **and `allow_partial=true`**, `complete` is `false`, `path` is
+`null`, and the bytes are surfaced only as `partial_path` (`…-a1b2c3.partial.mbox`).
+When some UIDs fail and `allow_partial=false` (the default), **no artifact is written and
+the tool returns an error** listing the failed UIDs. `reason` ∈
+`not_found | oversize` (both preflight-determined). Exactly one of `path` / `partial_path` is non-null,
+keyed off `complete`.
+
+## Partial-failure semantics: safe by default, best-effort on request
+
+The default is **all-or-nothing**: if any requested UID is missing, oversize, or fails
+to fetch, the export returns an error naming the failed UIDs and writes no artifact. The
+documented `export_messages(uids) → git am <path>` flow therefore can never receive a
+partial series that would half-apply and leave a repository partially mutated.
+
+Best-effort export — the behavior chosen during brainstorming — is preserved as an
+explicit opt-in via **`allow_partial: true`**. Only then does the tool write the
+successes to a distinct `.partial.mbox` artifact, set `complete: false` / `path: null`,
+and surface the bytes as `partial_path`. The caller has consciously asked for a
+possibly-incomplete result and must resolve the gaps before applying anything.
+
+> Reconciliation: brainstorming chose best-effort; adversarial review flagged that any
+> returned incomplete artifact is reachable by `git am` regardless of which field carries
+> it. Making best-effort an explicit `allow_partial` opt-in keeps the capability while
+> making the safe behavior the default. This default is called out for the user's review.
+
+## Security posture
+
+`Posture::Readonly`, parity with `download_attachment`: identical trust channel (raw
+bytes to a contained, path-validated file — not the agent's trusted context). Two guards
+address that this is a broader oracle than a single attachment (`fetch_message` at
+`Readonly` returns *sanitized* content; this returns *unsanitized full RFC822*):
+
+- **Default-deny, not Readonly-by-default.** Because absent `[security.tools]` entries
+  fall back to `base_allows`, listing the tool at `Readonly` in the base matrix would
+  make it callable in a default deployment. Instead, `export_messages` is **denied in the
+  base matrix at every posture** and becomes callable *only* via an explicit
+  `[security.tools].export_messages = "allow"` operator override. An empty/default config
+  denies it and `list_tools` omits it.
+- **`threat-model-reviewer` sign-off is a blocking acceptance gate** — the tool does not
+  merge until that review approves the gating model versus requiring a higher posture.
+
+**The authz seat is distinct from the MCP annotation hints.** `Readonly` is the authz
+seat (no *mailbox* mutation), but the tool *writes a new file*, so — exactly like
+`download_attachment` (`read_only_hint=false`) — its `ToolName::annotation_hints` are
+`read_only=false`, `idempotent=false` (each call writes a new artifact),
+`destructive=false` (it never overwrites — `write_attachment` de-dups), `open_world=true`
+(it contacts an external IMAP server). These mirror `download_attachment`'s annotation
+tests so a client cannot auto-approve a raw export as read-only.
+
+## Audit contract
+
+`export_messages` uses the **same audit envelope as every other tool**, no more and no
+less: a `tool_start`/`tool_end` pair recording status, error code, and duration, plus the
+redacted arguments and an `arguments_hash_sha256`. This is parity, not a downgrade — the
+shared `tool_end` `ResultSummary` is currently recorded empty for *all* tools
+(`download_attachment` included), and its fields (`message_ids_returned`,
+`bytes_returned`, `truncated`, `security_warnings_emitted`) have no path/sha256/UID-list
+slots.
+
+- **Argument redaction** is the export-specific audit work: the tool adds a redaction
+  schema (compile-forced, since the dispatch is exhaustive) that keeps `folder`,
+  `expected_uidvalidity`, and the requested `uids` (verbatim `U64Array`) recoverable,
+  redacts the path-ish `dest_dir` / `filename`, and forbids `password` / `token`. **No
+  message content** ever enters the audit log.
+- **Rich result provenance** — the ordered succeeded-UID list with sizes, the failed
+  `{uid, reason}` list, `total_bytes`, artifact path, and `sha256` — is returned in the
+  tool **response** (trusted metadata), which is where an operating agent and any
+  response-logging consumer can see it.
+
+Recording that rich provenance *durably* in the audit log would require extending the
+shared `ResultSummary` record format and plumbing handler results through the envelope
+for every tool. That is deliberately **out of scope** here (cross-cutting audit work),
+for the same reason the durability tier was trimmed: this tool should not carry bespoke
+infrastructure that none of its siblings have.
+
+**Accepted risk (recorded for the threat-model gate).** Adversarial review flagged that
+a default-disabled but high-impact raw export should have durable provenance an operator
+can reconstruct after the fact. The durable trail that *is* recorded: the per-call
+`tool_start`/`tool_end` records (tool name, account, posture, timing, status), the
+`arguments_hash_sha256`, and the redacted arguments — which record `folder`,
+`expected_uidvalidity`, and the **exact requested `uids` verbatim** (`Verbatim(U64Array)`,
+the same policy `expunge` uses for UID arrays). So the *requested scope* of every export
+is durably auditable. What is **not** durable (only in the tool response) is the
+succeeded-vs-failed partition and the artifact path/`sha256`/byte count. We accept that
+narrower gap rather than build cross-cutting audit plumbing for one tool; if the
+`threat-model-reviewer` (the blocking gate) judges it insufficient for raw export, the
+prerequisite is the shared `ResultSummary` extension across all tools — done as separate
+work before this tool ships, not bolted onto it.
+
+## Wiring (files touched)
+
+- `rimap-core`: add `ToolName::ExportMessages` with canonical name + `FromStr`/`Display`;
+  add `MAX_EXPORT_TOTAL_BYTES`; add its `annotation_hints` (`read_only=false`,
+  `idempotent=false`, `destructive=false`, `open_world=true`).
+- `rimap-imap` search op + `rimap-server/src/tools/retrieval/search.rs`: return
+  `(uids, uid_validity)` from the **same** EXAMINE/UID SEARCH operation and surface that
+  exact `uid_validity` in the `search` response, so the discovery flow can thread it into
+  `expected_uidvalidity`. (The current path returns only UIDs; the UIDVALIDITY in the
+  handler comes from a later fetch — unsafe to pair with the searched UID set.)
+- `rimap-authz/src/matrix.rs`: **deny `ExportMessages` at every posture** in the base
+  matrix; reachable only via an explicit `[security.tools].export_messages = "allow"`.
+- `rimap-server/src/tools/retrieval/export_messages.rs`: handler + pure `build_mbox`;
+  reuses `fetch_body`, `resolve_dest_dir`, and `write_attachment` (no new IMAP fetch
+  variant, no atomic-writer machinery).
+- `rimap-server/src/tools/retrieval/mod.rs`: `pub mod export_messages;`.
+- `rimap-server/src/mcp/tool_name.rs`: exhaustive `refine_tool_name` arm (no refinement).
+- `rimap-server/src/mcp/tool_catalog.rs`: input + response envelope schema registration.
+- `rimap-server/src/mcp/dispatch.rs`: dispatch arm.
+- `rimap-audit/src/redact.rs`: add the export_messages argument redaction schema
+  (compile-forced — the dispatch is exhaustive). No `audit_envelope.rs` change: the tool
+  uses the standard envelope, same as every other tool.
+- `rimap-server/src/cli/dump_tool_schemas.rs`: schema-dump entry.
+- Docs: tool reference + the per-tool enable/disable section.
+
+The tool's MCP description states its intended use ("fetch many messages at once as a
+`git am`-able mbox"). The intended end-to-end flow is: `search` (e.g. `List-Id` +
+`[PATCH` subject) → read its `uid_validity` → `export_messages(uids,
+expected_uidvalidity)` → `git am <path>`.
+
+## Testing
+
+- **`build_mbox` unit tests:** escaping of every `^>*From ` line (body, malformed,
+  header-position), column-0 separator framing with terminal-LF padding counted in
+  `total_bytes`/`sha256`, CRLF preservation, caller-order preservation, empty/single-
+  message edges. Fixtures: no-terminal-newline, CRLF, malformed/header-position `From `.
+- **Property test:** N raw messages → `build_mbox` → split back → equals inputs.
+- **Real-`git` acceptance test:** run `git mailsplit` / `git am` in a throwaway fixture
+  repo against generated mboxes (CRLF, no-terminal-newline, `From `-line, multi-patch)
+  and assert the commits apply with the expected count and metadata.
+- **Partial semantics (default vs opt-in):** `allow_partial=false` + a failing UID →
+  error, no artifact, no `path`. `allow_partial=true` → `complete:false`, `path:null`,
+  populated `partial_path` (`.partial.mbox`), `failed[]` entry. Full success →
+  `complete:true`, non-null `path`, `partial_path:null`. An e2e assertion proves the
+  `git am <path>` flow never receives a path for an incomplete series.
+- **Filename sanitization:** `../escape`, `/abs/path`, `a/b`, `a\\b`, empty,
+  whitespace-only, control-char, platform-reserved names are rejected.
+- **Concurrency:** two concurrent exports with the same `filename` prefix get distinct
+  paths (random token + `write_attachment` de-dup), and each `sha256` matches the bytes
+  at its path.
+- **Aggregate budget:** caller `max_total_bytes` above `MAX_EXPORT_TOTAL_BYTES` is
+  clamped; a run whose written bytes exceed the clamped cap aborts.
+- **Sandbox containment:** reuse the `resolve_dest_dir` traversal/escape test pattern
+  (same containment model as `download_attachment`).
+- **UIDVALIDITY guard:** preflight aborts on mismatch and on an absent observed value
+  (distinct errors); the `search` API returns `(uids, uid_validity)` from one operation,
+  with a race test recreating the mailbox between UID SEARCH and the response so the
+  reported `uid_validity` matches the mailbox the UIDs came from.
+- **Fatal vs per-UID failures:** a mid-loop `UidValidityChanged`, an omitted UIDVALIDITY
+  (`UidValidityUnavailable`, fail-closed), a mid-stream `SizeLimit`, a `Timeout`, or
+  connection loss aborts the whole export with no artifact — **never** downgraded to a
+  per-UID failure (even under `allow_partial`); a missing UID is `NotFound` and a
+  preflight-oversize UID is `Oversize`, both per-UID.
+- **Argument redaction:** the export_messages redaction schema keeps `folder` /
+  `expected_uidvalidity` / the requested `uids` (verbatim) recoverable, redacts
+  `dest_dir` / `filename`, and forbids `password` / `token`; no message content reaches
+  the audit log. (The succeeded/failed partition + artifact path/sha256 are in the tool
+  response, not the durable audit summary — see *Audit contract*.)
+- **MCP annotation hints:** `read_only=false`, `idempotent=false`, `destructive=false`,
+  `open_world=true`, mirroring the `download_attachment` annotation test.
+- **Schema envelope:** validates under Draft-07 (all-scalar trusted meta, no date tuples).

--- a/docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md
+++ b/docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md
@@ -296,6 +296,12 @@ address that this is a broader oracle than a single attachment (`fetch_message` 
 - **`threat-model-reviewer` sign-off is a blocking acceptance gate** — the tool does not
   merge until that review approves the gating model versus requiring a higher posture.
 
+Note: `export_messages` guarantees faithful mboxrd framing (column-0 `From ` escaping is
+tested against real `git am`), but it does NOT sanitize message content. Running
+`git am <path>` applies attacker-influenceable `From:`/`Subject:`/diff content as commit
+metadata and working-tree files — that consumption step is a trust boundary the calling
+agent/operator owns, not one this tool mediates.
+
 **The authz seat is distinct from the MCP annotation hints.** `Readonly` is the authz
 seat (no *mailbox* mutation), but the tool *writes a new file*, so — exactly like
 `download_attachment` (`read_only_hint=false`) — its `ToolName::annotation_hints` are

--- a/tests/mcp-conformance/src/wire.test.ts
+++ b/tests/mcp-conformance/src/wire.test.ts
@@ -189,8 +189,8 @@ describe("wire conformance (CLI catalog dump)", () => {
     const entries = await dumpToolCatalog();
     expect(
       entries.length,
-      "dump must contain 22 tool defs (24 ToolName variants - 2 sub-capabilities)",
-    ).toBe(22);
+      "dump must contain 23 tool defs (25 ToolName variants - 2 sub-capabilities)",
+    ).toBe(23);
 
     for (const entry of entries) {
       const result = ToolSchema.safeParse(entry);


### PR DESCRIPTION
## Summary

Adds an `export_messages` MCP tool: bulk raw export of a caller-specified set of UIDs to a single `git am`-able mbox file in the download sandbox, returning a path + trusted manifest. Motivated by applying a multi-message patch series (e.g. a 27-email DPDK series) in one tool call instead of an agent scripting around per-message fetches.

Implements `docs/superpowers/specs/2026-05-26-export-messages-mbox-design.md` via the 10-task plan in `docs/superpowers/plans/2026-05-26-export-messages-mbox.md`.

## Posture & gating

- **Default-DENY at every posture.** Reachable only via an explicit `[security.tools].export_messages = "allow"` override. Absent from `list_tools` in a default config.
- Annotation hints `read_only=false, destructive=false, idempotent=false, open_world=true` (each call writes a new artifact) — a client can't auto-approve it as read-only.
- Mirrors `download_attachment`'s sandbox-write + ephemeral posture (a heavier durability/streaming tier was deliberately trimmed during design).

## Safety controls

- **Fail-closed UIDVALIDITY** end-to-end: `search` now returns `uid_validity`; `export_messages` requires `expected_uidvalidity` and rejects an omitted value at preflight, errors on mismatch at preflight, and re-checks (strict `require_uidvalidity`) on every body fetch — so a recreated mailbox reusing UID numbers can't cause the wrong messages to be exported.
- **Strict ASCII allowlist** for the filename prefix (`[A-Za-z0-9][A-Za-z0-9._-]{0,63}`).
- **3-layer byte budget**: eligible-sum pre-check, running actual-byte check (defeats a size-lying server), and an authoritative framed-output check before any write; hard ceiling 100 MiB, max 100 UIDs.
- **All body-fetch errors are fatal** and leave no artifact; a zero-success `allow_partial` export writes no empty artifact.
- **Fail-closed config check**: enabling the tool with a group/world-writable download root (Unix) is rejected at config validation.
- Audit records the requested UID set verbatim; `dest_dir`/`filename` redacted; `password`/`token` forbidden.

## Threat-model gate (plan Task 10, Step 5) — recorded rulings

Verdict: **CLEAR-TO-SHIP** with the four recorded scope decisions all **ACCEPT-AS-RECORDED**:

1. **Raw-export oracle posture** — ACCEPT. Readonly seat + default-deny + explicit opt-in + sandbox-only (raw bytes never re-enter the model context) is sufficient containment; same trust channel `download_attachment` already ships.
2. **Audit provenance gap** — ACCEPT. The requested UID set is durable; the actual exported scope lives in the response. Durable rich provenance is cross-cutting (no tool records a non-empty `ResultSummary` today). Tracked: #316.
3. **Sandbox-write TOCTOU** — ACCEPT. Path-based writer shares `download_attachment`'s window; controls are the deployment private-root trust-model requirement + the fail-closed config check. `openat`/`O_NOFOLLOW`/exclusive-create hardening is cross-cutting (both tools). Tracked: #317.
4. **Memory ceiling** — ACCEPT. Effective bound is `max_total_bytes + max_fetch_body_bytes` (one in-flight body), finite/configurable, at parity with existing fetch paths. Pinning exactly requires the trimmed streaming read path. Tracked: #318.

Requiring 2/3/4 as prerequisites would re-open the deliberate durability trim; each is filed as a tracked follow-up instead.

## Deferred follow-ups

- #316 — extend shared `ResultSummary` for durable per-tool result provenance
- #317 — harden shared sandbox writer (`openat`/`O_NOFOLLOW`/exclusive-create)
- #318 — pin `export_messages` peak memory with a read-level streaming limit

## Testing

- Pure helpers (mbox framing, filename allowlist, uid validation/clamp, outcome planning, uid classification), an `ExportSource` fake-injection suite (every body-fetch error → `Err` + no artifact, under both `allow_partial` values; same `expected` pinned on every fetch), a real `git am` acceptance test (host-config-isolated), the redaction-schema test, config-validation tests (single + multi-account, mutation-verified wiring), and Dovecot e2e (happy + real `git am`, partial/`not_found`, delete-recreate UIDVALIDITY abort).
- `cargo nextest run --workspace --locked`: 1526 passed (e2e ran locally with Docker). `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `cargo deny check`: clean.

## Review

Each of the 10 tasks was reviewed for spec compliance and code quality during implementation; a final whole-implementation review traced the cross-task seams (notably the fail-closed UIDVALIDITY across the warn-and-proceed preflight vs. the strict body-fetch guard) and returned ready-to-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
