### PR TITLE
harden(sandbox): dir-fd-anchored writer + export-root checks (#317)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "ammonia"
 version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +312,36 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cc"
@@ -900,6 +936,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1407,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1677,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -2454,12 +2535,12 @@ dependencies = [
  "arc-swap",
  "assert_cmd",
  "base64 0.22.1",
+ "cap-std",
  "clap",
  "governor",
  "hex",
  "infer",
  "jsonschema",
- "libc",
  "mail-builder",
  "mail-parser",
  "predicates",
@@ -2592,6 +2673,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3841,6 +3932,16 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ clap = { version = "4.5", features = ["derive", "env"] }
 # Audit log
 fs4 = { version = "1", default-features = false, features = ["sync"] }
 libc = "0.2"
+# Capability-based filesystem: dir-fd-anchored writes for the attachment
+# sandbox (#317). Bytecode Alliance; encapsulates its `unsafe` so the
+# `unsafe_code = "forbid"` workspace lint still holds. Builds on `rustix`,
+# already in the tree.
+cap-std = "4"
 serde_json = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde", "serde-well-known"] }
 ulid = { version = "1.2", features = ["serde"] }

--- a/crates/rimap-config/src/validate/paths.rs
+++ b/crates/rimap-config/src/validate/paths.rs
@@ -69,14 +69,28 @@ pub(super) fn validate_export_download_root(
 fn check_export_download_root_private(download_root: &Path) -> Result<(), ConfigError> {
     use std::os::unix::fs::PermissionsExt as _;
 
-    let mode = std::fs::metadata(download_root)
-        .map_err(|e| ConfigError::PathNotWritable {
+    // A symlinked root means the operator-named path and the path the writer
+    // resolves differ; whoever controls the link target controls the export
+    // destination. Reject before any metadata call (which follows the link).
+    let link_meta =
+        std::fs::symlink_metadata(download_root).map_err(|e| ConfigError::PathNotWritable {
             path: download_root.to_path_buf(),
             reason: format!("cannot stat download root: {e}"),
-        })?
-        .permissions()
-        .mode();
-    // 0o022 = group-write (0o020) | other-write (0o002)
+        })?;
+    if link_meta.file_type().is_symlink() {
+        return Err(ConfigError::PathNotWritable {
+            path: download_root.to_path_buf(),
+            reason: "export_messages download root is a symlink; it must be a real \
+                     directory so its resolved path cannot be redirected to an \
+                     attacker-writable target"
+                .to_string(),
+        });
+    }
+
+    // Not a symlink, so `link_meta` already describes the directory itself —
+    // no second (link-following) stat needed. The root must not be
+    // group/world-writable. 0o022 = group-write (0o020) | other-write (0o002).
+    let mode = link_meta.permissions().mode();
     if mode & 0o022 != 0 {
         return Err(ConfigError::PathNotWritable {
             path: download_root.to_path_buf(),
@@ -85,6 +99,52 @@ fn check_export_download_root_private(download_root: &Path) -> Result<(), Config
                  group/world-writable (mode {:o}); export_messages requires \
                  a server-private download root",
                 mode & 0o777,
+            ),
+        });
+    }
+
+    check_export_download_root_parent(download_root)
+}
+
+/// Reject a download root whose immediate parent lets another user swap the
+/// root inode out from under the resolver.
+///
+/// Renaming/replacing a directory entry requires write+execute on its parent,
+/// so a group/world-writable parent permits the swap — *unless* the sticky bit
+/// is set, which restricts rename/delete to each entry's owner (the `/tmp`
+/// model). Only the immediate parent is checked; deeper ancestors are out of
+/// scope (the runtime held-fd writer is the backstop).
+#[cfg(unix)]
+fn check_export_download_root_parent(download_root: &Path) -> Result<(), ConfigError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let canonical =
+        std::fs::canonicalize(download_root).map_err(|e| ConfigError::PathNotWritable {
+            path: download_root.to_path_buf(),
+            reason: format!("canonicalize download root: {e}"),
+        })?;
+    let Some(parent) = canonical.parent() else {
+        // The root is the filesystem root `/`: no parent can swap it.
+        return Ok(());
+    };
+    let mode = std::fs::metadata(parent)
+        .map_err(|e| ConfigError::PathNotWritable {
+            path: parent.to_path_buf(),
+            reason: format!("cannot stat download-root parent: {e}"),
+        })?
+        .permissions()
+        .mode();
+    let group_or_world_writable = mode & 0o022 != 0;
+    let sticky = mode & 0o1000 != 0;
+    if group_or_world_writable && !sticky {
+        return Err(ConfigError::PathNotWritable {
+            path: parent.to_path_buf(),
+            reason: format!(
+                "export_messages download root's parent {} is group/world-writable \
+                 without the sticky bit (mode {:o}); another user could swap the \
+                 download root. Use a server-private parent or set the sticky bit",
+                parent.display(),
+                mode & 0o7777,
             ),
         });
     }
@@ -341,6 +401,66 @@ mod tests {
         let attachments = AttachmentsConfig {
             download_dir: String::new(),
         };
+        assert!(validate_export_download_root(&attachments, true).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_symlink_rejected_when_enabled() {
+        // A symlinked root must be rejected even when its target is private:
+        // the resolved path can be redirected by whoever controls the link.
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        set_mode(&real, 0o700);
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let attachments = attachments_with(&link);
+        let err = validate_export_download_root(&attachments, true).unwrap_err();
+        let ConfigError::PathNotWritable { reason, .. } = &err else {
+            panic!("expected PathNotWritable, got {err:?}");
+        };
+        assert!(reason.contains("symlink"), "reason: {reason}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_parent_world_writable_rejected_when_enabled() {
+        // A private root under a world-writable, non-sticky parent is
+        // rejected: another user could rename the root and substitute their
+        // own directory.
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join("parent");
+        std::fs::create_dir(&parent).unwrap();
+        let root = parent.join("root");
+        std::fs::create_dir(&root).unwrap();
+        set_mode(&root, 0o700);
+        set_mode(&parent, 0o777); // world-writable, no sticky bit
+
+        let attachments = attachments_with(&root);
+        let err = validate_export_download_root(&attachments, true).unwrap_err();
+        let ConfigError::PathNotWritable { reason, .. } = &err else {
+            panic!("expected PathNotWritable, got {err:?}");
+        };
+        assert!(reason.contains("swap the"), "reason: {reason}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_root_sticky_parent_accepted_when_enabled() {
+        // A world-writable parent WITH the sticky bit (the `/tmp` model) does
+        // not permit swapping another user's entry, so a private root under it
+        // is accepted.
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join("parent");
+        std::fs::create_dir(&parent).unwrap();
+        let root = parent.join("root");
+        std::fs::create_dir(&root).unwrap();
+        set_mode(&root, 0o700);
+        set_mode(&parent, 0o1777); // sticky + world-writable
+
+        let attachments = attachments_with(&root);
         assert!(validate_export_download_root(&attachments, true).is_ok());
     }
 }

--- a/crates/rimap-server/Cargo.toml
+++ b/crates/rimap-server/Cargo.toml
@@ -76,6 +76,10 @@ infer = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
+# Dir-fd-anchored sandbox writes (#317): the destination directory is held as
+# a capability `Dir` and files are created/linked fd-relative, closing the
+# resolve→write directory-swap race without `unsafe`.
+cap-std = { workspace = true }
 anyhow = { workspace = true }
 secrecy = { workspace = true }
 sha2 = { workspace = true }
@@ -93,12 +97,6 @@ tempfile = { workspace = true }
 # features) do not pull this in. The `dev-dependencies` entry below
 # remains for integration-test consumers; cargo dedupes the version.
 jsonschema = { workspace = true, optional = true }
-
-# Used only for the `O_NOFOLLOW` open flag in the attachment sandbox writer
-# (`tools::retrieval::sandbox`). Referenced as a plain constant — no `unsafe`
-# (the workspace forbids it). Unix-only; non-Unix builds use a fail-closed stub.
-[target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -356,7 +356,7 @@ pub async fn handle(
 /// positional-parameter limit.
 pub(crate) struct RunPlan {
     pub folder: String,
-    pub dest: std::path::PathBuf,
+    pub dest: sandbox::DestDir,
     pub prefix: String,
     pub uids: Vec<Uid>,
     pub expected: u32,
@@ -1042,7 +1042,7 @@ mod source_seam_tests {
     use core::num::NonZeroU32;
     use rimap_imap::types::Uid;
     use std::cell::RefCell;
-    use std::path::PathBuf;
+    use std::path::Path;
 
     fn uid(n: u32) -> Uid {
         Uid::from(NonZeroU32::new(n).unwrap())
@@ -1125,7 +1125,9 @@ mod source_seam_tests {
         }
     }
 
-    fn plan(dest: PathBuf, uids: Vec<Uid>, expected: u32, allow_partial: bool) -> RunPlan {
+    fn plan(dest_dir: &Path, uids: Vec<Uid>, expected: u32, allow_partial: bool) -> RunPlan {
+        let dest = super::sandbox::resolve_dest_dir(None, dest_dir, dest_dir)
+            .expect("resolve test dest dir");
         RunPlan {
             folder: "INBOX".to_string(),
             dest,
@@ -1158,12 +1160,9 @@ mod source_seam_tests {
             ],
             4242,
         );
-        let resp = run_export(
-            &fake,
-            plan(tmp.path().to_path_buf(), vec![uid(7), uid(9)], 4242, false),
-        )
-        .await
-        .expect("export should succeed");
+        let resp = run_export(&fake, plan(tmp.path(), vec![uid(7), uid(9)], 4242, false))
+            .await
+            .expect("export should succeed");
 
         let meta = &resp.meta;
         assert!(meta.complete);
@@ -1184,11 +1183,8 @@ mod source_seam_tests {
         for allow_partial in [false, true] {
             let tmp = tempfile::tempdir().unwrap();
             let fake = FakeSource::failing(4242, make_err);
-            let result = run_export(
-                &fake,
-                plan(tmp.path().to_path_buf(), vec![uid(1)], 4242, allow_partial),
-            )
-            .await;
+            let result =
+                run_export(&fake, plan(tmp.path(), vec![uid(1)], 4242, allow_partial)).await;
             assert!(
                 result.is_err(),
                 "body error must abort (allow_partial={allow_partial})"
@@ -1275,7 +1271,7 @@ mod source_seam_tests {
         let result = run_export(
             &fake,
             plan(
-                tmp.path().to_path_buf(),
+                tmp.path(),
                 vec![uid(10), uid(20), uid(30)],
                 1234,
                 true, // allow_partial=true: every-UID-failed is "allowed"
@@ -1370,11 +1366,7 @@ mod source_seam_tests {
             present: vec![(7, 20)],
             uid_validity: 4242,
         };
-        let result = run_export(
-            &fake,
-            plan(tmp.path().to_path_buf(), vec![uid(7), uid(8)], 4242, false),
-        )
-        .await;
+        let result = run_export(&fake, plan(tmp.path(), vec![uid(7), uid(8)], 4242, false)).await;
 
         let err = result.expect_err("missing UID + allow_partial=false must abort");
         assert_eq!(err.code(), rimap_core::ErrorCode::InvalidInput);

--- a/crates/rimap-server/src/tools/retrieval/sandbox.rs
+++ b/crates/rimap-server/src/tools/retrieval/sandbox.rs
@@ -1,31 +1,60 @@
 //! Attachment download sandboxing.
 //!
 //! Validates download destinations against an allowed root directory,
-//! writes attachment data with collision-safe filenames, and provides
-//! MIME sniffing and SHA-256 hashing utilities.
+//! holds the destination open as a capability directory, writes attachment
+//! data fd-relative with collision-safe filenames, and provides MIME sniffing
+//! and SHA-256 hashing utilities.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
+
 use rimap_core::RimapError;
 
-/// Resolve and validate the download destination.
+/// A resolved, validated download destination held open as a capability.
 ///
-/// If `dest_dir` is provided, canonicalize it and verify it starts
-/// with `allowed_root`. If absent, use `fallback_dir`.
+/// `canonical` is retained only to render the human-readable result path; all
+/// writes go through `dir`, an open directory descriptor. Anchoring writes to
+/// a held fd closes the resolve→write directory-swap window: once the `Dir` is
+/// open, no rename/replace of a path component can redirect the write, because
+/// `cap-std` creates files fd-relative (`openat`-family) and refuses `..`,
+/// absolute paths, and symlinks that escape the directory.
+#[derive(Debug)]
+pub struct DestDir {
+    canonical: PathBuf,
+    dir: Dir,
+}
+
+impl DestDir {
+    /// The canonical directory path, for building the reported result path.
+    #[must_use]
+    pub(crate) fn canonical(&self) -> &Path {
+        &self.canonical
+    }
+}
+
+/// Resolve and validate the download destination, returning it held open as a
+/// capability [`DestDir`].
+///
+/// If `dest_dir` is provided, canonicalize it and verify it starts with
+/// `allowed_root`. If absent, use `fallback_dir`. The resolved directory is
+/// then opened once via the host's ambient authority; every subsequent write
+/// is fd-relative to that held descriptor.
 ///
 /// # Errors
 ///
 /// Returns `RimapError::Authz { code: InvalidInput, ... }` when the
-/// user-supplied `dest_dir` cannot be canonicalized (missing path,
-/// permission denied) or when the canonical form falls outside
-/// `allowed_root`.
+/// user-supplied `dest_dir` cannot be canonicalized (missing path, permission
+/// denied) or when the canonical form falls outside `allowed_root`. Returns
+/// `RimapError::InternalSourced` if the resolved directory cannot be opened.
 pub(crate) fn resolve_dest_dir(
     dest_dir: Option<&str>,
     allowed_root: &Path,
     fallback_dir: &Path,
-) -> Result<PathBuf, RimapError> {
-    let dir = match dest_dir {
+) -> Result<DestDir, RimapError> {
+    let dir_path = match dest_dir {
         Some(d) => {
             let p = PathBuf::from(d);
             let canonical = p
@@ -40,46 +69,60 @@ pub(crate) fn resolve_dest_dir(
         }
         None => fallback_dir.to_path_buf(),
     };
-    Ok(dir)
+    // The single ambient (path-following) step. Everything after is
+    // fd-relative to this held directory descriptor.
+    let dir = Dir::open_ambient_dir(&dir_path, ambient_authority()).map_err(|e| {
+        RimapError::InternalSourced {
+            message: "failed to open download directory".into(),
+            source: Box::new(e),
+        }
+    })?;
+    Ok(DestDir {
+        canonical: dir_path,
+        dir,
+    })
 }
 
-/// Write `data` to `dir/filename`, de-duplicating on collision.
-/// Returns the final path.
+/// Write `data` into `dest`, de-duplicating on collision. Returns the final
+/// path.
 ///
-/// Each candidate is created with `O_CREAT | O_EXCL | O_NOFOLLOW` and mode
-/// `0600` (via [`create_new_private`]): the create is atomic and exclusive, so
-/// it never overwrites or follows a symlink at the final path component, and
-/// the resulting file is owner-only. A pre-existing name (regular file *or*
-/// symlink) yields `AlreadyExists`, and the de-dup counter advances — the
-/// reason `export_messages` (a raw-email export oracle) and
-/// `download_attachment` can share this primitive safely.
+/// The bytes are first written to a process-unique temp file created
+/// fd-relative with `create_new` (`O_EXCL`, which refuses to follow a symlink
+/// at the final component) and mode `0600` (owner-only). The temp is then
+/// atomically placed at the first free candidate name via [`Dir::hard_link`]
+/// — `EEXIST` (a pre-existing regular file *or* symlink) advances the de-dup
+/// counter, so the writer never overwrites or follows an existing name. The
+/// final name therefore only ever appears fully-written: a crash between the
+/// write and the link leaves a recognizable `.rimap-tmp-*` orphan, never a
+/// truncated raw-email artifact at the final path. Every handled error path
+/// unlinks the temp.
 ///
-/// Containment of `dir` itself is enforced upstream by [`resolve_dest_dir`]
+/// Containment of the directory is enforced upstream by [`resolve_dest_dir`]
 /// (canonicalize + `starts_with(allowed_root)`) and by the config-time private
-/// download-root check. This writer does not hold a directory fd / create
-/// fd-relative (`openat`), because that requires `unsafe` FFI, which the
-/// workspace forbids (`unsafe_code = "forbid"`); the residual directory-swap
-/// window is bounded by that upstream canonicalization and the enforced
-/// non-group/world-writable root.
+/// download-root check; the held `Dir` fd closes the resolve→write swap window
+/// for both `download_attachment` and `export_messages`, which share this
+/// primitive.
 ///
 /// # Errors
 ///
-/// Returns `RimapError::Internal` if writing fails or if more than
-/// 1000 filename collisions occur. On non-Unix platforms the no-follow /
-/// private-mode semantics are unavailable, so the writer fails closed with
+/// Returns `RimapError::Internal` if writing fails or if more than 1000
+/// filename collisions occur. On non-Unix platforms the no-follow / private-
+/// mode semantics are unavailable, so the writer fails closed with
 /// `RimapError::Internal` rather than writing without those guarantees.
 #[cfg(unix)]
 pub(crate) fn write_attachment(
-    dir: &Path,
+    dest: &DestDir,
     filename: &str,
     data: &[u8],
 ) -> Result<PathBuf, RimapError> {
+    use cap_std::fs::{OpenOptions, OpenOptionsExt as _};
+    use std::io::Write as _;
+
     // Strip path components to prevent directory traversal.
     let safe_name = Path::new(filename)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("attachment");
-
     let base = Path::new(safe_name);
     let stem = base
         .file_stem()
@@ -87,28 +130,49 @@ pub(crate) fn write_attachment(
         .unwrap_or("attachment");
     let ext = base.extension().and_then(|s| s.to_str());
 
+    // 1. Create the temp fd-relative: exclusive, owner-only, no-follow.
+    let tmp_name = unique_temp_name();
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true).mode(0o600);
+    let mut file =
+        dest.dir
+            .open_with(&tmp_name, &options)
+            .map_err(|e| RimapError::InternalSourced {
+                message: "failed to create temporary download file".into(),
+                source: Box::new(e),
+            })?;
+
+    // 2. Write the bytes; unlink the temp on any error.
+    if let Err(e) = file.write_all(data) {
+        drop(file);
+        let _ = dest.dir.remove_file(&tmp_name);
+        return Err(RimapError::InternalSourced {
+            message: "failed to write download file".into(),
+            source: Box::new(e),
+        });
+    }
+    drop(file);
+
+    // 3. Atomically place the temp at the first free candidate name.
     let mut counter = 0u32;
     loop {
-        let name = if counter == 0 {
-            safe_name.to_string()
-        } else {
-            match ext {
-                Some(e) => format!("{stem}_{counter}.{e}"),
-                None => format!("{stem}_{counter}"),
+        let name = candidate_name(safe_name, stem, ext, counter);
+        match dest.dir.hard_link(&tmp_name, &dest.dir, &name) {
+            Ok(()) => {
+                let _ = dest.dir.remove_file(&tmp_name);
+                return Ok(dest.canonical().join(&name));
             }
-        };
-        let path = dir.join(&name);
-        match create_new_private(&path) {
-            Ok(file) => return finish_write(file, path, data),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 counter += 1;
                 if counter > 1000 {
+                    let _ = dest.dir.remove_file(&tmp_name);
                     return Err(RimapError::Internal("too many filename collisions".into()));
                 }
             }
             Err(e) => {
+                let _ = dest.dir.remove_file(&tmp_name);
                 return Err(RimapError::InternalSourced {
-                    message: "failed to create attachment file".into(),
+                    message: "failed to place download file".into(),
                     source: Box::new(e),
                 });
             }
@@ -116,99 +180,90 @@ pub(crate) fn write_attachment(
     }
 }
 
-/// Atomically create `path` for writing with `O_CREAT | O_EXCL | O_NOFOLLOW`
-/// and mode `0600`. Fails with [`std::io::ErrorKind::AlreadyExists`] if the
-/// path already exists (including as a symlink), which the caller treats as a
-/// de-dup collision. Uses only the safe [`std::os::unix::fs::OpenOptionsExt`]
-/// surface — no `unsafe`.
+/// The candidate final name for de-dup `counter`: the original name for the
+/// first attempt, then `stem_N` / `stem_N.ext` siblings.
 #[cfg(unix)]
-fn create_new_private(path: &Path) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt as _;
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .mode(0o600)
-        .open(path)
+fn candidate_name(safe_name: &str, stem: &str, ext: Option<&str>, counter: u32) -> String {
+    if counter == 0 {
+        safe_name.to_string()
+    } else {
+        match ext {
+            Some(e) => format!("{stem}_{counter}.{e}"),
+            None => format!("{stem}_{counter}"),
+        }
+    }
 }
 
-/// Write `data` to the exclusively-created `file`, then return its `path`. If
-/// the write fails partway (short write, disk-full, I/O error), the file is
-/// removed so a failed download/export never leaves a partial artifact at the
-/// final path. The original write error is reported regardless of whether the
-/// cleanup unlink succeeds.
+/// A process-unique temp filename. The PID, a process-local atomic counter,
+/// and wall-clock nanos make it distinct across concurrent writers (download +
+/// export, or two exports) so the exclusive temp create never collides between
+/// them. The `.rimap-tmp-` prefix is recognizable for operator cleanup of any
+/// crash-orphaned temp.
 #[cfg(unix)]
-fn finish_write(
-    mut file: std::fs::File,
-    path: PathBuf,
-    data: &[u8],
-) -> Result<PathBuf, RimapError> {
-    use std::io::Write as _;
-    if let Err(e) = file.write_all(data) {
-        drop(file);
-        let _ = std::fs::remove_file(&path);
-        return Err(RimapError::InternalSourced {
-            message: "failed to write attachment".into(),
-            source: Box::new(e),
-        });
-    }
-    Ok(path)
+fn unique_temp_name() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(".rimap-tmp-{pid}-{seq}-{nanos:x}")
 }
 
 /// Fail-closed stub for non-Unix platforms.
 ///
-/// The hardened writer relies on `O_NOFOLLOW` and POSIX file modes, which are
-/// unavailable here. Rather than write raw message bytes without those
-/// guarantees, the sandbox refuses to write.
+/// The hardened writer relies on `O_EXCL` semantics and POSIX file modes for
+/// its no-follow / owner-only guarantees. Rather than write raw message bytes
+/// without those guarantees, the sandbox refuses to write.
 ///
 /// # Errors
 ///
 /// Always returns `RimapError::Internal`.
 #[cfg(not(unix))]
 pub(crate) fn write_attachment(
-    _dir: &Path,
+    _dest: &DestDir,
     _filename: &str,
     _data: &[u8],
 ) -> Result<PathBuf, RimapError> {
     Err(RimapError::Internal(
-        "sandboxed attachment writes require a Unix platform (O_NOFOLLOW / file-mode support)"
-            .into(),
+        "sandboxed attachment writes require a Unix platform (O_EXCL / file-mode support)".into(),
     ))
 }
 
-/// Async wrapper around [`resolve_dest_dir`] that runs on a
-/// blocking thread.
+/// Async wrapper around [`resolve_dest_dir`] that runs on a blocking thread.
 ///
 /// # Errors
 ///
 /// Propagates whatever [`resolve_dest_dir`] returns (typically
 /// `RimapError::Authz` with `InvalidInput` when the path cannot be
-/// canonicalized or escapes `allowed_root`). Returns
-/// `RimapError::Internal` if the blocking task panics.
+/// canonicalized or escapes `allowed_root`, or `RimapError::InternalSourced`
+/// if the directory cannot be opened). Returns `RimapError::Internal` if the
+/// blocking task panics.
 pub async fn resolve_dest_dir_async(
     dest_dir: Option<String>,
     root: Arc<Path>,
-) -> Result<PathBuf, RimapError> {
+) -> Result<DestDir, RimapError> {
     tokio::task::spawn_blocking(move || resolve_dest_dir(dest_dir.as_deref(), &root, &root))
         .await
         .unwrap_or_else(|e| Err(crate::mcp::spawn_blocking_panic_error(e)))
 }
 
-/// Async wrapper around [`write_attachment`] that runs on a
-/// blocking thread.
+/// Async wrapper around [`write_attachment`] that runs on a blocking thread.
 ///
 /// # Errors
 ///
-/// Propagates whatever [`write_attachment`] returns
-/// (`RimapError::Internal` on I/O failure or after >1000 filename
-/// collisions). Also returns `RimapError::Internal` if the blocking
-/// task panics.
+/// Propagates whatever [`write_attachment`] returns (`RimapError::Internal` on
+/// I/O failure or after >1000 filename collisions). Also returns
+/// `RimapError::Internal` if the blocking task panics.
 pub async fn write_attachment_async(
-    dir: PathBuf,
+    dest: DestDir,
     filename: String,
     data: Vec<u8>,
 ) -> Result<PathBuf, RimapError> {
-    tokio::task::spawn_blocking(move || write_attachment(&dir, &filename, &data))
+    tokio::task::spawn_blocking(move || write_attachment(&dest, &filename, &data))
         .await
         .unwrap_or_else(|e| Err(crate::mcp::spawn_blocking_panic_error(e)))
 }
@@ -232,12 +287,19 @@ pub fn sha256_hex(data: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    /// Open `dir` as a held [`DestDir`] for the write tests (allowed-root ==
+    /// the dir itself, no user-supplied `dest_dir`).
+    #[cfg(unix)]
+    fn dest_for(dir: &Path) -> DestDir {
+        resolve_dest_dir(None, dir, dir).unwrap()
+    }
+
     #[test]
     fn resolve_dest_dir_uses_fallback_when_none() {
-        let fallback = PathBuf::from("/tmp/fallback");
-        let allowed = Path::new("/tmp");
-        let result = resolve_dest_dir(None, allowed, &fallback).unwrap();
-        assert_eq!(result, fallback);
+        let tmp = tempfile::tempdir().unwrap();
+        let fallback = tmp.path();
+        let result = resolve_dest_dir(None, fallback, fallback).unwrap();
+        assert_eq!(result.canonical(), fallback);
     }
 
     #[test]
@@ -252,9 +314,8 @@ mod tests {
         let allowed = tmp.path().canonicalize().unwrap();
         let sub = allowed.join("sub");
         std::fs::create_dir_all(&sub).unwrap();
-        let fallback = allowed.clone();
-        let result = resolve_dest_dir(Some(sub.to_str().unwrap()), &allowed, &fallback).unwrap();
-        assert!(result.starts_with(&allowed));
+        let result = resolve_dest_dir(Some(sub.to_str().unwrap()), &allowed, &allowed).unwrap();
+        assert!(result.canonical().starts_with(&allowed));
     }
 
     #[test]
@@ -284,9 +345,25 @@ mod tests {
     #[test]
     fn write_attachment_normal() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_attachment(tmp.path(), "doc.pdf", b"data").unwrap();
-        assert_eq!(path, tmp.path().join("doc.pdf"));
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "doc.pdf", b"data").unwrap();
+        assert_eq!(path, dest.canonical().join("doc.pdf"));
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_attachment_leaves_no_temp_orphan() {
+        // A successful write removes its temp; only the final file remains.
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = dest_for(tmp.path());
+        write_attachment(&dest, "doc.pdf", b"data").unwrap();
+        let leftover: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".rimap-tmp-"))
+            .collect();
+        assert!(leftover.is_empty(), "temp orphan left behind: {leftover:?}");
     }
 
     #[cfg(unix)]
@@ -294,8 +371,9 @@ mod tests {
     fn write_attachment_collision() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("doc.pdf"), b"old").unwrap();
-        let path = write_attachment(tmp.path(), "doc.pdf", b"new").unwrap();
-        assert_eq!(path, tmp.path().join("doc_1.pdf"));
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "doc.pdf", b"new").unwrap();
+        assert_eq!(path, dest.canonical().join("doc_1.pdf"));
         assert_eq!(std::fs::read(&path).unwrap(), b"new");
     }
 
@@ -304,18 +382,19 @@ mod tests {
     fn write_attachment_no_extension() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("readme"), b"old").unwrap();
-        let path = write_attachment(tmp.path(), "readme", b"new").unwrap();
-        assert_eq!(path, tmp.path().join("readme_1"));
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "readme", b"new").unwrap();
+        assert_eq!(path, dest.canonical().join("readme_1"));
     }
 
     #[cfg(unix)]
     #[test]
     fn write_attachment_rejects_relative_traversal() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_attachment(tmp.path(), "../escape.txt", b"data").unwrap();
-        // Must land inside tmp, not escape.
-        assert!(path.starts_with(tmp.path()));
-        assert_eq!(path.file_name().unwrap(), "escape.txt");
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "../escape.txt", b"data").unwrap();
+        // Must land inside the dir, not escape.
+        assert_eq!(path, dest.canonical().join("escape.txt"));
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
     }
 
@@ -323,9 +402,9 @@ mod tests {
     #[test]
     fn write_attachment_rejects_absolute_path() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_attachment(tmp.path(), "/etc/passwd", b"data").unwrap();
-        assert!(path.starts_with(tmp.path()));
-        assert_eq!(path.file_name().unwrap(), "passwd");
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "/etc/passwd", b"data").unwrap();
+        assert_eq!(path, dest.canonical().join("passwd"));
         assert_eq!(std::fs::read(&path).unwrap(), b"data");
     }
 
@@ -333,9 +412,9 @@ mod tests {
     #[test]
     fn write_attachment_handles_deep_traversal() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_attachment(tmp.path(), "../../.ssh/authorized_keys", b"data").unwrap();
-        assert!(path.starts_with(tmp.path()));
-        assert_eq!(path.file_name().unwrap(), "authorized_keys");
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "../../.ssh/authorized_keys", b"data").unwrap();
+        assert_eq!(path, dest.canonical().join("authorized_keys"));
     }
 
     #[cfg(unix)]
@@ -343,7 +422,8 @@ mod tests {
     fn write_attachment_sets_owner_only_permissions() {
         use std::os::unix::fs::PermissionsExt as _;
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_attachment(tmp.path(), "secret.mbox", b"raw email").unwrap();
+        let dest = dest_for(tmp.path());
+        let path = write_attachment(&dest, "secret.mbox", b"raw email").unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         // The export oracle writes raw message bytes; the file must be
         // owner-only regardless of the process umask.
@@ -352,46 +432,86 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn finish_write_removes_partial_file_on_write_error() {
-        // Reopen the just-created target read-only so write_all fails (EBADF),
-        // then assert the file is unlinked rather than left as a partial
-        // raw-email artifact at its final path.
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("partial.mbox");
-        std::fs::write(&path, b"placeholder").unwrap();
-        let read_only = std::fs::OpenOptions::new().read(true).open(&path).unwrap();
-        let err = finish_write(read_only, path.clone(), b"raw email bytes").unwrap_err();
-        assert_eq!(err.code(), rimap_core::ErrorCode::Internal);
-        assert!(
-            !path.exists(),
-            "partial file must be removed on write error"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn write_attachment_does_not_follow_symlink_at_final_path() {
-        // A symlink pre-planted inside the sandbox must not be followed: the
-        // exclusive create yields AlreadyExists, so the writer de-dups to a
-        // fresh name and the symlink target outside the sandbox is never
-        // created or written. Guards the raw-export escape vector.
+        // A symlink pre-planted at the final name must not be followed: the
+        // atomic hard_link placement yields AlreadyExists, so the writer
+        // de-dups to a fresh name and the symlink target outside the sandbox
+        // is never created or written. Guards the raw-export escape vector.
         let tmp = tempfile::tempdir().unwrap();
         let sandbox = tmp.path().join("sandbox");
         std::fs::create_dir_all(&sandbox).unwrap();
         let outside = tmp.path().join("outside-target.txt");
         std::os::unix::fs::symlink(&outside, sandbox.join("evil.mbox")).unwrap();
 
-        let path = write_attachment(&sandbox, "evil.mbox", b"payload").unwrap();
+        let dest = dest_for(&sandbox);
+        let path = write_attachment(&dest, "evil.mbox", b"payload").unwrap();
 
         // Wrote a de-duped sibling, not through the symlink.
-        assert_eq!(path, sandbox.join("evil_1.mbox"));
-        assert!(path.starts_with(&sandbox));
+        assert_eq!(path, dest.canonical().join("evil_1.mbox"));
         // The symlink target outside the sandbox was never created.
         assert!(
             !outside.exists(),
             "symlink was followed: target was written"
         );
         assert_eq!(std::fs::read(&path).unwrap(), b"payload");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_lands_via_held_fd_after_dir_swap() {
+        // Open the destination as a held capability, then swap the directory
+        // out from under its path: the original inode is moved aside (kept
+        // linked at `real_moved`) and an attacker dir is planted at the
+        // original path. The write must follow the held fd to the ORIGINAL
+        // inode, not the attacker's dir now sitting at the path. This is the
+        // directory-component race #317 targets; it would land in the
+        // attacker's dir under the old path-based writer.
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().canonicalize().unwrap();
+        let real = allowed.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let dest = resolve_dest_dir(Some(real.to_str().unwrap()), &allowed, &real).unwrap();
+
+        // Move the original inode aside (still linked) and plant an attacker
+        // directory at the original path.
+        let real_moved = allowed.join("real_moved");
+        std::fs::rename(&real, &real_moved).unwrap();
+        std::fs::create_dir_all(&real).unwrap();
+
+        write_attachment(&dest, "x.mbox", b"data").unwrap();
+
+        // The held fd wrote to the original inode (now at `real_moved`)...
+        assert_eq!(std::fs::read(real_moved.join("x.mbox")).unwrap(), b"data");
+        // ...and never to the attacker's directory at the swapped-in path.
+        assert!(
+            !real.join("x.mbox").exists(),
+            "write followed the swapped-in path instead of the held fd"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_attachment_cleans_temp_on_collision_exhaustion() {
+        // Force the de-dup loop to exhaust by pre-filling the original name and
+        // all 1000 siblings, then assert the error path unlinks the temp (no
+        // `.rimap-tmp-*` residue) rather than leaking a raw-email temp.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("f"), b"x").unwrap();
+        for i in 1..=1000 {
+            std::fs::write(tmp.path().join(format!("f_{i}")), b"x").unwrap();
+        }
+        let dest = dest_for(tmp.path());
+        let err = write_attachment(&dest, "f", b"payload").unwrap_err();
+        assert_eq!(err.code(), rimap_core::ErrorCode::Internal);
+        let temps: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".rimap-tmp-"))
+            .collect();
+        assert!(
+            temps.is_empty(),
+            "temp not cleaned on exhaustion: {temps:?}"
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -122,6 +122,15 @@ skip = [
     # Both are upstream-pinned to their latest releases; we cannot unify
     # without forking. Revisit when governor bumps to hashbrown 0.17.
     { name = "hashbrown", version = "0.16" },
+
+    # `io-lifetimes` 2.0.4 is pulled by `fs-set-times 0.20.3` (latest), a
+    # transitive dep of `cap-primitives`/`cap-std 4` (the #317 sandbox
+    # dir-fd writer). cap-std and its other Bytecode Alliance deps
+    # (`cap-primitives`, `io-extras`) already use the 3.x line; only
+    # `fs-set-times` lags on its io-lifetimes pin. All are at their latest
+    # crates.io releases — `cargo update` cannot unify across the 2.x/3.x
+    # major split. Revisit when `fs-set-times` bumps to io-lifetimes 3.
+    { name = "io-lifetimes", version = "2" },
 ]
 # Multiple `windows-sys` major lines coexist because each transitive
 # consumer (`directories`, `keyring`/`dbus-secret-service`, `rpassword`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,13 +303,38 @@ the download sandbox. Because that export is an unredacted raw-message
 oracle, the download root must be writable only by the server — the write
 authority must be separated from the agent that consumes the file.
 
-On Unix, this is enforced as a **fail-closed config precondition**: when
-`export_messages` is enabled and `[attachments].download_dir` is set,
-config validation rejects startup if the download root is group- or
-world-writable (any of mode bits `0o022` set). Use a private directory
-(e.g. mode `0o700`). An empty `download_dir` (the default per-session
-temporary directory) is created privately by the server and is not
-subject to this check.
+On Unix, this is enforced as a set of **fail-closed config preconditions**:
+when `export_messages` is enabled and `[attachments].download_dir` is set,
+config validation rejects startup if the download root
+
+- is group- or world-writable (any of mode bits `0o022` set) — use a
+  private directory (e.g. mode `0o700`);
+- is a **symlink** — the resolved path must not be redirectable by whoever
+  controls the link target; use a real directory;
+- has an **immediate parent that is group/world-writable without the sticky
+  bit** — otherwise another user could rename the root and substitute their
+  own directory. A sticky parent (the `/tmp` model, mode `0o1777`) is
+  accepted because it restricts rename/delete to each entry's owner.
+
+An empty `download_dir` (the default per-session temporary directory) is
+created privately by the server and is not subject to these checks. Only
+the **immediate** parent is validated; a writable, non-sticky *grand*parent
+is not walked — the runtime held-fd writer (below) is the backstop for
+deeper path components.
+
+These startup checks are gated on `export_messages` being enabled, because
+the raw-export oracle is the high-value asset they protect. `download_attachment`
+writes *decoded* attachments to the same root but does not, on its own,
+trigger them; it relies on the same runtime writer protections and on the
+operator keeping the download root server-private.
+
+At runtime, writes (for both `download_attachment` and `export_messages`)
+are anchored to a held directory descriptor and placed atomically (write to
+a `.rimap-tmp-*` temp, then hard-link to the final name), so a partially
+written file never appears at the final path and a rename of a path
+component cannot redirect the write. A process killed mid-write may leave a
+`0600` `.rimap-tmp-*` orphan in the download root; operators can safely
+delete stale `.rimap-tmp-*` files.
 
 ## `[limits]` section
 

--- a/docs/superpowers/plans/2026-05-27-sandbox-writer-dirfd-317.md
+++ b/docs/superpowers/plans/2026-05-27-sandbox-writer-dirfd-317.md
@@ -1,0 +1,191 @@
+# Harden shared sandbox writer with dir-fd anchoring (#317)
+
+## Context
+
+`d16986a5` landed the dependency-free half of #317: the shared
+`write_attachment` (`crates/rimap-server/src/tools/retrieval/sandbox.rs`) now
+creates each candidate with `O_CREAT | O_EXCL | O_NOFOLLOW` and mode `0600`,
+and cleans up a partial file on write error. This closes the
+`path.exists()`-then-write race and the final-component symlink swap.
+
+The **directory-component** race remains: between `resolve_dest_dir`
+(canonicalize + `starts_with(allowed_root)`) and the `open` of the final file,
+a same-UID local writer can rename/replace the resolved destination directory
+and redirect the write. Closing it requires creating the file *fd-relative* to
+a held directory descriptor (`openat`-family), which needs either `unsafe` FFI
+(forbidden: `unsafe_code = "forbid"`) or a capability-style wrapper. Per the
+owner's decision on the issue, adopt [`cap-std`] (Bytecode Alliance; its
+`unsafe` is encapsulated).
+
+Two adjacent gaps the runtime writer cannot close on its own, called out in the
+issue, are addressed at config-validation time:
+
+- a download **root that is itself a symlink** to an attacker-writable target;
+- a `0o700` root whose **immediate parent** is group/world-writable (lets an
+  attacker swap the root inode out from under the resolver).
+
+[`cap-std`]: https://crates.io/crates/cap-std
+
+## Scope
+
+Shared by `download_attachment` and `export_messages` — one code path, no
+fork. Two crates change:
+
+- `rimap-server` — the writer + its resolve/write seam (`sandbox.rs` and the
+  two callers).
+- `rimap-config` — the export-gated private-root check (`validate/paths.rs`).
+
+Non-Unix stays fail-closed (the `0600` / no-follow guarantees are Unix-only);
+unchanged from today.
+
+## Dependency
+
+`cap-std = "4"` (4.0.2 latest; license `Apache-2.0 WITH LLVM-exception OR
+Apache-2.0 OR MIT`, all on the deny.toml allow-list). Builds on `rustix`,
+already in the tree. Added to `rimap-server` only.
+
+API confirmed against cap-std 4.0.2 docs (the load-bearing surface):
+`Dir::open_ambient_dir(path, ambient_authority())`, `Dir::open_with(path,
+&OpenOptions)`, `OpenOptions{create_new, mode}` (`mode` via
+`cap_std::fs::OpenOptionsExt`), `Dir::hard_link(src, &dst_dir, dst)` (mirrors
+`std::fs::hard_link` → `EEXIST` on an existing destination, which is the de-dup
+signal), `Dir::remove_file`, `Dir::symlink_metadata`. `Dir` is `Send + Sync`
+(owns an fd), so it crosses `spawn_blocking` and `.await` points.
+
+## Design
+
+### Layer A — runtime dir-fd anchoring (`rimap-server`)
+
+Replace the `(resolve → PathBuf) … (write PathBuf)` split, which re-resolves
+the directory by path at write time, with a **held capability** carried from
+resolve through write:
+
+```rust
+/// A resolved, validated download destination held open as a capability.
+/// `canonical` is kept only to render the human-readable result path; `dir`
+/// is the held cap-std directory fd that anchors every write fd-relative,
+/// closing the resolve→write directory-swap window.
+pub struct DestDir {
+    canonical: PathBuf,
+    dir: cap_std::fs::Dir,
+}
+```
+
+- `resolve_dest_dir(dest_dir, allowed_root, fallback) -> Result<DestDir>`:
+  1. target = canonicalize(`dest_dir`) checked `starts_with(allowed_root)`, or
+     `fallback` when `dest_dir` is `None` (unchanged containment logic).
+  2. `cap_std::fs::Dir::open_ambient_dir(&target, ambient_authority())` — the
+     one ambient (path-following) step; everything after is fd-relative.
+  3. return `DestDir { canonical: target, dir }`.
+
+- `write_attachment(dest: &DestDir, filename, data) -> Result<PathBuf>`
+  (temp-file + atomic placement, so the final name only ever appears
+  fully-written — a crash mid-write leaves a `.tmp` orphan, never a truncated
+  raw-email artifact at the final path):
+  1. create a temp fd-relative with a **process-unique** name
+     `.rimap-tmp-<token>` where `<token>` = `pid` + a process-local atomic
+     counter + wall-clock nanos (same recipe as the existing `export_token()`,
+     lifted into a shared `unique_temp_name()` helper so two concurrent
+     writers — download + export, or two exports — never derive the same temp):
+     `dest.dir.open_with(tmp, create_new(true).write(true).mode(0o600))`
+     (cap-std `create_new` ⇒ `O_EXCL`, which refuses to follow a symlink at the
+     final component; `OpenOptionsExt::mode` sets `0600`).
+  2. `write_all`; on error `dest.dir.remove_file(tmp)` and return. (No
+     `sync_all`: atomic *appearance* comes from link-after-full-write, not from
+     fsync; power-loss durability is not a requirement and the prior writer
+     never fsynced — adding it would be a silent latency cost on up-to-100 MiB
+     exports.)
+  3. de-dup loop over candidate final names (`name`, `name_1`, …): atomically
+     place via `dest.dir.hard_link(tmp, &dest.dir, final_name)` — `EEXIST`
+     ⇒ collision, advance the counter (cap at 1000); other error ⇒ remove temp,
+     return.
+  4. on success remove the temp; return `dest.canonical.join(final_name)`.
+
+  The de-dup, traversal-stripping (`file_name()` only), and 1000-collision cap
+  carry over unchanged. The `.rimap-tmp-` prefix is recognizable and `0600`;
+  the only way one survives is a `SIGKILL`/power loss between create and link
+  (every handled error path unlinks it). Sweeping stale `.rimap-tmp-*` orphans
+  is left to the operator and noted in the tool docs — bounded because the
+  window is a single un-acked syscall gap, not the whole write.
+
+- async wrappers: `resolve_dest_dir_async` now returns `DestDir`;
+  `write_attachment_async(dest: DestDir, filename, data)` takes it by value
+  (`cap_std::fs::Dir` is `Send`). Both callers thread `DestDir` from resolve to
+  write — the held fd lives across the intervening body fetch.
+
+### Layer B — config-time root hardening (`rimap-config`)
+
+Extend `check_export_download_root_private` (fires only when `export_enabled`
+and `download_dir` is non-empty; Unix-only) beyond the existing
+group/world-writable mode check:
+
+1. **Symlinked root** — `symlink_metadata(root)`; if the root itself is a
+   symlink, reject (the canonicalized path the resolver trusts would differ
+   from the operator-named root).
+2. **Parent writability** — canonicalize the root, stat its immediate parent;
+   if the parent is group/world-writable (`mode & 0o022 != 0`), reject (an
+   attacker who can write the parent can swap the root inode).
+
+Both reuse the existing `ConfigError::PathNotWritable` shape with actionable
+reasons.
+
+## Why this is the right cut
+
+- The held `Dir` fd closes the resolve→write directory-swap window (#1): once
+  opened, fd-relative create/link cannot be redirected by renaming a path
+  component. This is the only *runtime* guarantee and the heart of the fix.
+- The config checks (Layer B) are **necessary-but-not-sufficient capability
+  reduction**, not a runtime guarantee: they read mode bits / symlink status
+  once at startup and remove the attacker's *ability* to swap the root under
+  the documented trust model (write authority to the root separated from the
+  consuming agent). They do not re-check per request, and they walk only the
+  immediate parent.
+- One shared writer keeps `download_attachment` and `export_messages` on the
+  identical primitive (no export-only fork).
+
+### Residual windows (named, not hidden)
+
+- Inside Layer A, a window remains between `canonicalize(dest_dir)` and
+  `open_ambient_dir(canonical)` — far smaller than today's resolve→fetch→write
+  span, and only exploitable by an actor who can write a path component, which
+  the trust model and Layer B's parent check deny.
+- Layer B is a startup snapshot; a writable *grand*parent could let the parent
+  be swapped later. Closing that fully means holding the root `Dir` for the
+  process lifetime (see Out of scope).
+
+## Out of scope (residual, documented)
+
+- Holding the download **root** Dir for the whole process lifetime and deriving
+  per-request dirs fd-relative from it would also close the per-request
+  re-resolution window, but reshapes `AccountState.download_dir`
+  (`Arc<Path>` → a held `Dir`) across `registry`/`main`/`test_support`. The
+  per-operation open + parent-writable check is the bounded cut here.
+- Deep-ancestor writability (beyond the immediate parent) is not walked; the
+  immediate parent is the case named in the issue.
+
+## Execution tasks (TDD; test first, watch it fail, then implement)
+
+1. **Add `cap-std`** to `rimap-server`; `cargo build -p rimap-server`; run
+   `cargo deny check` to confirm licenses/advisories pass.
+2. **`DestDir` + dir-fd writer** in `sandbox.rs`. Port existing writer tests to
+   the new signature; add tests:
+   - directory-swap: open `DestDir`, rename the underlying dir, confirm the
+     write lands via the held fd (not the swapped path) or fails closed — never
+     escapes.
+   - crash-safety: a write error leaves no file at the final name (temp only).
+   - keep: collision de-dup, traversal/absolute stripping, `0600`, symlink at
+     final name not followed.
+3. **Thread `DestDir`** through `download_attachment` and `export_messages`
+   call sites; `cargo build` + existing integration tests green.
+4. **Config checks** in `validate/paths.rs` with tests: symlinked root
+   rejected; parent group/world-writable rejected; private root + private
+   parent accepted; non-export / empty-root no-op.
+5. **Verify**: `cargo clippy --all-targets --all-features -- -D warnings`,
+   `cargo fmt --check`, targeted `cargo test` for `rimap-server` sandbox +
+   retrieval and `rimap-config` paths, `cargo deny check`.
+
+## Acceptance criteria (from #317)
+
+- Race-proof create (dir-fd-anchored, no-follow, exclusive) for **both**
+  `download_attachment` and `export_messages`. ✔ Layer A.
+- Handle symlinked-root and parent-dir-writable. ✔ Layer B.


### PR DESCRIPTION
Closes #317.

## What

Hardens the shared attachment/export sandbox writer against the
directory-component TOCTOU that `d16986a5` left open (it landed the
dependency-free half: `O_EXCL`/`O_NOFOLLOW`/`0600` + partial cleanup).

### Runtime: dir-fd-anchored writer (`rimap-server`)
- `resolve_dest_dir` opens the validated destination once as a held
  `cap-std` `Dir` capability (`DestDir`). Writes go fd-relative to that
  descriptor, so renaming/replacing a path component between resolve and
  write can no longer redirect the write — closing the swap window that
  spanned the intervening body fetch.
- Files are placed atomically: write a process-unique `.rimap-tmp-*` temp
  (`create_new` ⇒ `O_EXCL`, mode `0600`), then `hard_link` it to the first
  free final name (`EEXIST` drives the existing de-dup counter). The final
  name only ever appears fully-written; a crash leaves a recognizable temp,
  never a truncated raw-email artifact.
- `download_attachment` and `export_messages` share this one primitive.
- The redundant `libc` `O_NOFOLLOW` is dropped (`create_new` + `hard_link`
  already refuse to follow/overwrite a symlink).

### Config-time: root provenance (`rimap-config`)
The export-gated private-root check now also rejects:
- a root that is **itself a symlink** (resolved path could be redirected);
- a root whose **immediate parent** is group/world-writable **without the
  sticky bit** (another user could swap the root inode). A sticky parent
  (the `/tmp` model, `0o1777`) is accepted.

## Dependency
`cap-std = "4"` (Bytecode Alliance; builds on in-tree `rustix`; encapsulated
`unsafe` keeps `unsafe_code = "forbid"` intact). `deny.toml` skips the
`io-lifetimes` 2/3 duplicate that `fs-set-times` pins (upstream lag).

## Tests
- `sandbox`: directory-swap proves the write follows the held fd to the
  original inode and never the attacker's swapped-in dir; temp-orphan
  cleanup on success and on collision-exhaustion; symlink-at-final not
  followed; `0600`; traversal/absolute stripping; de-dup.
- `rimap-config`: symlinked-root rejected, parent-writable rejected,
  sticky-parent accepted, private-root still accepted.
- `cargo deny`, `clippy -D warnings`, `fmt`, tool-schema regen (no diff) all
  clean.

## Residual (documented)
Only the immediate parent is validated; a writable, non-sticky *grand*parent
is out of scope (the runtime held-fd writer is the backstop). The config
root checks are export-gated by design; `download_attachment` relies on the
same runtime writer and operator root hygiene. See `docs/configuration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
