### PR TITLE
perf(export_messages): pin peak heap to ~max_total_bytes (#318)

### DIFF
--- a/crates/rimap-imap/src/connection/dispatch.rs
+++ b/crates/rimap-imap/src/connection/dispatch.rs
@@ -198,8 +198,37 @@ impl Connection {
         uid: crate::types::Uid,
         expected_uidvalidity: Option<u32>,
     ) -> Result<Vec<u8>, ImapError> {
+        self.fetch_body_with_limit(
+            folder,
+            uid,
+            expected_uidvalidity,
+            self.inner.cfg.max_fetch_body_bytes,
+        )
+        .await
+    }
+
+    /// Like [`Self::fetch_body`], but with a caller-supplied byte `limit`
+    /// instead of the configured `max_fetch_body_bytes`.
+    ///
+    /// `export_messages` passes `min(max_fetch_body_bytes, remaining_budget)`
+    /// so a single in-flight body cannot exceed the export's remaining
+    /// aggregate budget, pinning peak heap to ≈ the budget (#318). The `limit`
+    /// drives both the `RFC822.SIZE` preflight and the post-parse
+    /// `project_size` read check, so an oversize body is rejected with
+    /// `ImapError::SizeLimit` — before reading when the server reports an
+    /// honest size, or mid-stream when it under-reports.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::fetch_body`], with `SizeLimit` keyed to `limit`.
+    pub async fn fetch_body_with_limit(
+        &self,
+        folder: &str,
+        uid: crate::types::Uid,
+        expected_uidvalidity: Option<u32>,
+        limit: u64,
+    ) -> Result<Vec<u8>, ImapError> {
         let dur = self.inner.cfg.command_timeout;
-        let limit = self.inner.cfg.max_fetch_body_bytes;
         let result = crate::time::with_timeout("fetch_body", dur, async {
             let mut guard = self.session().await?;
             let session =

--- a/crates/rimap-server/src/tools/retrieval/export_messages.rs
+++ b/crates/rimap-server/src/tools/retrieval/export_messages.rs
@@ -144,10 +144,25 @@ const MBOX_SEPARATOR: &[u8] = b"From mboxrd@rusty-imap-mcp Thu Jan  1 00:00:00 1
 /// CRLF is preserved verbatim.
 ///
 /// Callers pass already-fetched, non-empty message bodies. The handler never calls this
-/// with an empty slice (it short-circuits a zero-success export before building), and
+/// with an empty vec (it short-circuits a zero-success export before building), and
 /// per-body emptiness isn't expected from a real BODY.PEEK[] fetch.
-fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
-    let mut out = Vec::new();
+///
+/// Takes the bodies by value and drops each as it is framed, so the raw bodies
+/// are freed while the framed buffer grows — the framed mbox is the only
+/// `max_total_bytes`-scale allocation held at once, rather than the raw bodies
+/// *plus* a separate framing copy (#318).
+fn build_mbox(messages: Vec<Vec<u8>>) -> Vec<u8> {
+    // Pre-size to one allocation: raw body bytes + a separator and a possible
+    // padding newline per message. This keeps the framed buffer a single
+    // ~`max_total_bytes` allocation, avoiding the transient ~2x spike a growing
+    // `Vec` would incur while copying the large body bytes (#318). `From`-line
+    // escaping may add a few bytes beyond this; that is negligible and at most
+    // one small growth.
+    let raw_total: usize = messages.iter().map(Vec::len).sum();
+    let framing = messages
+        .len()
+        .saturating_mul(MBOX_SEPARATOR.len().saturating_add(1));
+    let mut out = Vec::with_capacity(raw_total.saturating_add(framing).saturating_add(1));
     for msg in messages {
         // Ensure the previous message ended with a line feed so this
         // separator starts at column 0.
@@ -157,7 +172,8 @@ fn build_mbox(messages: &[Vec<u8>]) -> Vec<u8> {
             out.push(b'\n');
         }
         out.extend_from_slice(MBOX_SEPARATOR);
-        escape_from_lines_into(&mut out, msg);
+        escape_from_lines_into(&mut out, &msg);
+        // `msg` is dropped here, freeing this body before the next is framed.
     }
     // Trailing newline for a well-formed final message.
     if let Some(&last) = out.last()
@@ -258,7 +274,9 @@ pub(crate) trait ExportSource {
         expected_uidvalidity: u32,
     ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError>;
 
-    /// Fetch one message body, guarded by `expected_uidvalidity`.
+    /// Fetch one message body, guarded by `expected_uidvalidity`, with a
+    /// per-call read limit of `body_limit` bytes (the export passes the
+    /// remaining aggregate budget so the in-flight body cannot exceed it).
     ///
     /// # Errors
     ///
@@ -268,6 +286,7 @@ pub(crate) trait ExportSource {
         folder: &str,
         uid: Uid,
         expected_uidvalidity: u32,
+        body_limit: u64,
     ) -> Result<Vec<u8>, rimap_core::RimapError>;
 }
 
@@ -299,10 +318,11 @@ impl ExportSource for AccountState {
         folder: &str,
         uid: Uid,
         expected_uidvalidity: u32,
+        body_limit: u64,
     ) -> Result<Vec<u8>, rimap_core::RimapError> {
         Ok(self
             .imap
-            .fetch_body(folder, uid, Some(expected_uidvalidity))
+            .fetch_body_with_limit(folder, uid, Some(expected_uidvalidity), body_limit)
             .await?)
     }
 }
@@ -456,7 +476,9 @@ pub(crate) async fn run_export(
         } => (complete, bodies, succeeded, failed),
     };
 
-    let mbox = build_mbox(&bodies);
+    // Move `bodies` in: `build_mbox` drains it, so the raw bodies are freed as
+    // the framed mbox is built rather than lingering through the write (#318).
+    let mbox = build_mbox(bodies);
     let total_bytes = mbox.len() as u64;
     // Authoritative budget check on the *framed* output: mboxrd separators,
     // From-line escaping, and terminal padding add bytes beyond the raw bodies
@@ -591,8 +613,22 @@ async fn fetch_bodies(
             });
             continue;
         }
-        let body = source.fetch_one_body(folder, *uid, limits.expected).await?;
+        // Cap this body's read at the smaller of the per-message cap and the
+        // budget still unspent, so the single in-flight body cannot exceed the
+        // remaining budget: `running (raw bytes so far) + in-flight <= budget`
+        // pins peak heap to ~`max_total_bytes` (#318). A body that would push
+        // past it aborts mid-read with `SizeLimit` (fatal) — the same bound
+        // `fetch_message`/`download_attachment` accept per body.
+        let body_limit = limits
+            .per_msg_cap
+            .min(limits.budget.saturating_sub(running));
+        let body = source
+            .fetch_one_body(folder, *uid, limits.expected, body_limit)
+            .await?;
         running = running.saturating_add(body.len() as u64);
+        // Defense-in-depth backstop. Unreachable while `body_limit` caps each
+        // body to the remaining budget (so `running <= budget` always); kept
+        // fail-closed against future changes to the limit computation (#318).
         if running > limits.budget {
             return Err(rimap_core::RimapError::invalid_input(
                 "export exceeds max_total_bytes",
@@ -919,7 +955,7 @@ mod build_mbox_tests {
 
     #[test]
     fn single_message_gets_separator_and_trailing_newline() {
-        let out = build_mbox(&[b"Subject: hi\r\n\r\nbody".to_vec()]);
+        let out = build_mbox(vec![b"Subject: hi\r\n\r\nbody".to_vec()]);
         assert!(out.starts_with(SEP), "missing leading separator");
         assert!(out.ends_with(b"\n"), "must end with newline");
         assert!(out.ends_with(b"body\n"));
@@ -929,7 +965,7 @@ mod build_mbox_tests {
     fn missing_terminal_newline_padded_before_next_separator() {
         // First message has no trailing newline; the second separator must
         // still start at column 0.
-        let out = build_mbox(&[
+        let out = build_mbox(vec![
             b"a: 1\r\n\r\nno-newline".to_vec(),
             b"b: 2\r\n\r\nx\n".to_vec(),
         ]);
@@ -948,7 +984,7 @@ mod build_mbox_tests {
     #[test]
     fn escapes_every_from_line_including_nested_and_header_position() {
         let msg = b"From the desk of X\r\n>From already escaped\r\nFrom \r\nnormal\n".to_vec();
-        let out = build_mbox(&[msg]);
+        let out = build_mbox(vec![msg]);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains(">From the desk of X"));
         assert!(text.contains(">>From already escaped"));
@@ -958,7 +994,7 @@ mod build_mbox_tests {
 
     #[test]
     fn preserves_crlf_verbatim_in_body() {
-        let out = build_mbox(&[b"H: 1\r\n\r\nline1\r\nline2\r\n".to_vec()]);
+        let out = build_mbox(vec![b"H: 1\r\n\r\nline1\r\nline2\r\n".to_vec()]);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("line1\r\nline2\r\n"));
     }
@@ -970,7 +1006,7 @@ mod build_mbox_tests {
             b"A: 1\r\n\r\nFrom space\r\nbody1\r\n".to_vec(),
             b"B: 2\r\n\r\nbody2\n".to_vec(),
         ];
-        let mbox = build_mbox(&inputs);
+        let mbox = build_mbox(inputs.clone());
         let recovered = split_and_unescape(&mbox);
         assert_eq!(recovered.len(), inputs.len());
         // Compare ignoring a single trailing newline build_mbox may add.
@@ -1064,6 +1100,7 @@ mod source_seam_tests {
         uid_validity: Option<u32>,
         body_error: Option<fn() -> rimap_core::RimapError>,
         seen_expected: RefCell<Vec<u32>>,
+        seen_body_limits: RefCell<Vec<u64>>,
     }
 
     impl FakeSource {
@@ -1073,6 +1110,7 @@ mod source_seam_tests {
                 uid_validity: Some(uid_validity),
                 body_error: None,
                 seen_expected: RefCell::new(Vec::new()),
+                seen_body_limits: RefCell::new(Vec::new()),
             }
         }
 
@@ -1085,6 +1123,7 @@ mod source_seam_tests {
                 uid_validity: Some(uid_validity),
                 body_error: Some(body_error),
                 seen_expected: RefCell::new(Vec::new()),
+                seen_body_limits: RefCell::new(Vec::new()),
             }
         }
     }
@@ -1111,8 +1150,10 @@ mod source_seam_tests {
             _folder: &str,
             uid: Uid,
             expected: u32,
+            body_limit: u64,
         ) -> Result<Vec<u8>, rimap_core::RimapError> {
             self.seen_expected.borrow_mut().push(expected);
+            self.seen_body_limits.borrow_mut().push(body_limit);
             if let Some(make_err) = self.body_error {
                 return Err(make_err());
             }
@@ -1257,6 +1298,7 @@ mod source_seam_tests {
             _folder: &str,
             _uid: Uid,
             _expected: u32,
+            _body_limit: u64,
         ) -> Result<Vec<u8>, rimap_core::RimapError> {
             // Should never be called: all UIDs are classified NotFound at preflight.
             panic!("fetch_one_body must not be called when all UIDs are absent");
@@ -1348,6 +1390,7 @@ mod source_seam_tests {
             _folder: &str,
             _uid: Uid,
             _expected: u32,
+            _body_limit: u64,
         ) -> Result<Vec<u8>, rimap_core::RimapError> {
             panic!(
                 "fetch_one_body must not run: allow_partial=false and preflight \
@@ -1378,6 +1421,119 @@ mod source_seam_tests {
             err.to_string().contains('8'),
             "error must name the missing UID 8: {err}"
         );
+        assert!(
+            dir_is_empty(tmp.path()),
+            "no artifact may be written on abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn body_limit_clamps_to_remaining_budget() {
+        // Budget tighter than per_msg_cap: each body's read limit is the
+        // budget still unspent, shrinking as bytes are fetched. (The framed
+        // mbox then overflows the tiny budget so the call errors — here we
+        // assert the limits threaded into each fetch, the #318 plumbing.)
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = FakeSource::happy(
+            vec![
+                Seeded {
+                    uid: 1,
+                    body: vec![b'a'; 10],
+                },
+                Seeded {
+                    uid: 2,
+                    body: vec![b'b'; 4],
+                },
+            ],
+            7,
+        );
+        let dest =
+            super::sandbox::resolve_dest_dir(None, tmp.path(), tmp.path()).expect("resolve dest");
+        let plan = RunPlan {
+            folder: "INBOX".to_string(),
+            dest,
+            prefix: "messages".to_string(),
+            uids: vec![uid(1), uid(2)],
+            expected: 7,
+            // eligible_sum = 10 + 4 = 14 <= 15 passes preflight; per_msg_cap is
+            // larger than the budget, so the remaining budget gates the limit.
+            budget: 15,
+            per_msg_cap: 80,
+            allow_partial: false,
+        };
+        let _ = run_export(&fake, plan).await;
+        // First fetch: min(80, 15 - 0) = 15. Second: min(80, 15 - 10) = 5.
+        assert_eq!(*fake.seen_body_limits.borrow(), vec![15, 5]);
+    }
+
+    /// Reports a tiny `RFC822.SIZE` but returns a far larger body, and honors
+    /// the per-call `body_limit` exactly as the real IMAP read does (aborting
+    /// with `SizeLimit` when the body would exceed it). Models the STRIDE-D
+    /// hostile-server under-reporting #318 targets.
+    struct UnderReportSource {
+        uid_validity: u32,
+        reported: u32,
+        body: Vec<u8>,
+    }
+
+    impl ExportSource for UnderReportSource {
+        async fn fetch_sizes(
+            &self,
+            _folder: &str,
+            uids: &[Uid],
+            _expected: u32,
+        ) -> Result<(Vec<(u32, Option<u32>)>, Option<u32>), rimap_core::RimapError> {
+            let sizes = uids
+                .iter()
+                .map(|u| (u.get(), Some(self.reported)))
+                .collect();
+            Ok((sizes, Some(self.uid_validity)))
+        }
+
+        async fn fetch_one_body(
+            &self,
+            _folder: &str,
+            _uid: Uid,
+            _expected: u32,
+            body_limit: u64,
+        ) -> Result<Vec<u8>, rimap_core::RimapError> {
+            if self.body.len() as u64 > body_limit {
+                return Err(rimap_core::RimapError::from(
+                    rimap_imap::ImapError::SizeLimit { limit: body_limit },
+                ));
+            }
+            Ok(self.body.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn under_reported_body_exceeding_remaining_budget_aborts_no_artifact() {
+        // The server claims 1 byte (passes the eligible-sum preflight) but the
+        // body is 100 bytes. The read limit = min(80, 50 - 0) = 50 < 100, so
+        // the in-flight read aborts with SizeLimit before buffering it — peak
+        // stays bounded and no artifact is written.
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = UnderReportSource {
+            uid_validity: 9,
+            reported: 1,
+            body: vec![b'x'; 100],
+        };
+        let dest =
+            super::sandbox::resolve_dest_dir(None, tmp.path(), tmp.path()).expect("resolve dest");
+        let plan = RunPlan {
+            folder: "INBOX".to_string(),
+            dest,
+            prefix: "messages".to_string(),
+            uids: vec![uid(1)],
+            expected: 9,
+            budget: 50,
+            per_msg_cap: 80,
+            allow_partial: false,
+        };
+        let err = run_export(&fake, plan)
+            .await
+            .expect_err("under-reported oversize body must abort");
+        assert_eq!(err.code(), rimap_core::ErrorCode::AttachmentTooLarge);
         assert!(
             dir_is_empty(tmp.path()),
             "no artifact may be written on abort"
@@ -1447,7 +1603,7 @@ mod git_am_tests {
         // A spurious `From `-leading line in the message (here in the header
         // region) must be escaped by build_mbox, or git's mbox splitter would
         // wrongly split the series there.
-        let mbox = build_mbox(&[patch(1, "\r\nFrom the author: note"), patch(2, "")]);
+        let mbox = build_mbox(vec![patch(1, "\r\nFrom the author: note"), patch(2, "")]);
         let mbox_path = repo.join("series.mbox");
         std::fs::write(&mbox_path, &mbox).unwrap();
 

--- a/docs/superpowers/plans/2026-05-27-export-streaming-limit-318.md
+++ b/docs/superpowers/plans/2026-05-27-export-streaming-limit-318.md
@@ -1,0 +1,115 @@
+# Pin export_messages peak memory with a read-level streaming limit (#318)
+
+## Context
+
+`export_messages` worst-case heap today is ~`2·max_total_bytes +
+max_fetch_body_bytes`:
+
+- `fetch_bodies` collects every successful body into `outcomes`
+  (`Vec<FetchOutcome>`), then `plan_outcome` moves them into `bodies`
+  (`Vec<Vec<u8>>`) — one `max_total_bytes` (S) worth of raw bodies;
+- `build_mbox(&bodies)` allocates a **separate** framed copy `mbox` (≈ S)
+  while `bodies` is still alive (it stays in scope through the
+  `write_attachment_async` call) — the second S;
+- during the fetch loop, one in-flight body up to `max_fetch_body_bytes` (B)
+  accumulates before the running-byte check trips.
+
+The gate accepted this as bounded (`max_total_bytes` is hard-clamped to the
+100 MiB ceiling; the running-sum check counts *actual* transferred bytes; the
+framed-size re-check is authoritative before any write) but filed this to pin
+the peak to ≈ `max_total_bytes`.
+
+## Goal / acceptance (from #318)
+
+- Pin peak heap to approximately `max_total_bytes`.
+- Preserve the existing fail-closed running-byte and framed-size checks.
+
+## Design
+
+Two reinforcing changes, each small and behavior-preserving on the happy path:
+
+### A. `build_mbox` consumes its input (removes the second S)
+
+Change `build_mbox(messages: &[Vec<u8>]) -> Vec<u8>` to
+`build_mbox(messages: Vec<Vec<u8>>) -> Vec<u8>`, draining each body as it is
+framed (`for msg in messages { ...frame...; drop(msg) }`). At the call site
+`let mbox = build_mbox(bodies);` moves `bodies` in, so the raw bodies are
+freed as the framed buffer grows — peak during framing ≈ S (bytes transfer
+from `bodies` to `mbox`), and `bodies` no longer lingers (holding a second S)
+through the write. Output bytes are identical, so all `build_mbox` assertions
+stand; only the call form changes.
+
+### B. Per-body read limit = `min(per_msg_cap, budget − running)`
+
+`fetch_bodies` currently fetches each body up to `per_msg_cap`
+(`max_fetch_body_bytes`) and only afterwards checks `running > budget`. Pass a
+per-call read limit of `min(per_msg_cap, budget.saturating_sub(running))` so
+the in-flight body cannot exceed the remaining budget. Then
+`outcomes (≈ running raw) + in-flight (≤ budget − running) ≤ budget`, pinning
+the fetch-phase peak to ≈ S.
+
+Plumbing (additive, no existing caller touched):
+
+- `Imap::fetch_body_with_limit(folder, uid, expected, limit)` — the current
+  `fetch_body` body, parameterized on `limit`; `fetch_body` becomes a
+  one-line delegate passing `self.inner.cfg.max_fetch_body_bytes` (so
+  `fetch_message` / `download_attachment` / `message_builder` are unchanged).
+- `ExportSource::fetch_one_body` gains a `body_limit: u64` parameter; the
+  `AccountState` impl forwards it to `fetch_body_with_limit`.
+- `fetch_bodies` computes `body_limit` per UID from the live `running` total.
+
+### Interaction with the existing checks (preserved)
+
+- **Preflight `eligible_sum`** (sum of *reported* sizes) still rejects a
+  legitimately over-budget request with `InvalidInput "export exceeds
+  max_total_bytes"` **before any body fetch** — so a user who simply set a
+  small `max_total_bytes` is rejected cleanly at preflight, not via the read
+  limit.
+- **Running-byte check** (`running > budget`) is kept verbatim. Be honest:
+  with the read limit in place it is **unreachable by construction** — every
+  accepted body satisfies `body.len() ≤ budget − running`, so `running` can
+  never exceed `budget` (and when `running == budget` the limit is `0`, so a
+  non-empty body trips `SizeLimit` first). It is retained only as a cheap
+  fail-closed backstop guarding future changes to the limit computation, not
+  as a live guard. (It is *already* untested today — every test uses the
+  100 MiB max budget — so change B removes no existing coverage.) A surviving
+  mutation that deletes it is expected and acceptable.
+- **Framed-size re-check** (`total_bytes > budget`) on the assembled mbox is
+  unchanged and remains authoritative before the write. Note the peak buffer
+  is this *framed* mbox: ≈ raw `budget` plus bounded framing overhead
+  (separators + `From `-escaping, ≤ ~5 KB for 100 messages), not exactly
+  `max_total_bytes`.
+
+### Behavior change (adversarial path only)
+
+When a hostile server under-reports/omits `RFC822.SIZE` (the STRIDE-D threat
+this issue targets), a body that would push past the remaining budget now
+aborts mid-read with `ImapError::SizeLimit` (fatal; the dispatch layer drops
+the half-consumed session) instead of being fully buffered and then rejected
+by the running-byte check. This bounds memory for the exact attack and only
+affects the adversarial case — the legitimate over-budget request is already
+caught at preflight. Documented, not hidden.
+
+## Execution tasks (TDD)
+
+1. `build_mbox` → by-value `Vec<Vec<u8>>`, drain while framing; update its
+   unit tests' call form (assertions unchanged). Update the `run_export` call
+   site so `bodies` is moved (freed before the write).
+2. `fetch_body_with_limit` in `rimap-imap` dispatch; `fetch_body` delegates.
+   No new behavior for existing callers (same limit value).
+3. `ExportSource::fetch_one_body` + `body_limit`; thread `min(per_msg_cap,
+   budget − running)` from `fetch_bodies`; update the 3 fake sources.
+4. Test: a fake source whose body exceeds the remaining budget makes the
+   in-flight read abort (peak bounded) — assert the call fails closed and no
+   artifact is written; keep the happy-path tests green (large budget ⇒ limit
+   == per_msg_cap, unchanged).
+5. Verify: `clippy -D warnings`, `fmt`, targeted `rimap-server` +
+   `rimap-imap` tests, `cargo deny`.
+
+## Out of scope
+
+- Framing each body directly into the mbox *during* the fetch loop (removing
+  the `outcomes`/`bodies` intermediate entirely) would also work but discards
+  the pure, unit-tested `fetch_bodies` / `plan_outcome` / `build_mbox`
+  separation for a marginal gain; the read limit already caps the
+  intermediate to ≤ budget.


### PR DESCRIPTION
Closes #318.

## What

Pins `export_messages` peak heap to ≈ the aggregate `max_total_bytes`
budget, instead of today's ~`2·budget + max_fetch_body_bytes`.

### 1. `build_mbox` streams instead of double-buffering
Takes the bodies by value and drains each as it is framed, so the raw bodies
are freed while the framed `mbox` grows — the framed buffer is the only
`max_total_bytes`-scale allocation, rather than the raw `bodies` *plus* a
separate framing copy that lingered through the write. It also pre-sizes the
buffer to one allocation to avoid `Vec` growth-doubling spikes.

### 2. Per-body read limit = `min(per_msg_cap, budget − running)`
`fetch_bodies` caps each body's read at the remaining budget via a new
`Imap::fetch_body_with_limit`, so the single in-flight body cannot exceed what
the budget has left: `running (raw so far) + in-flight ≤ budget`. `fetch_body`
delegates to it with the configured `max_fetch_body_bytes`, leaving
`fetch_message` / `download_attachment` / `message_builder` unchanged.

## Preserved checks
- Preflight `eligible_sum` still rejects a legitimately over-budget request
  with `InvalidInput` **before any body fetch** (so a small `max_total_bytes`
  is a clean preflight error, not a mid-read abort).
- Framed-size re-check on the assembled mbox remains authoritative.
- Running-byte check is kept as a fail-closed backstop — now
  **unreachable-by-construction** with the read limit in place (documented;
  a surviving mutation that deletes it is expected).

## Behavior change (adversarial path only)
A hostile server under-reporting/omitting `RFC822.SIZE` (the STRIDE-D threat
this targets) now aborts mid-read with `ImapError::SizeLimit` once a body
would exceed the remaining budget, instead of buffering a full body. Only the
adversarial case is affected — the legitimate over-budget request is caught at
preflight.

## Tests
- `body_limit_clamps_to_remaining_budget`: asserts the per-fetch limit
  sequence (`[15, 5]`) shrinks with the remaining budget.
- `under_reported_body_exceeding_remaining_budget_aborts_no_artifact`: an
  under-reporting fake that honors the limit aborts with `SizeLimit`
  (`AttachmentTooLarge`) and writes no artifact.
- All existing `build_mbox` / outcome / source-seam / `git am` tests pass
  unchanged (framed output is byte-identical).

The peak-memory bound is established structurally (consume-on-frame +
per-body read limit), documented in code comments; Rust makes peak-heap
impractical to assert in a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
