### PR TITLE
feat(audit): durable per-tool result provenance in tool_end (#316)

### DIFF
--- a/crates/rimap-audit/src/record/mod.rs
+++ b/crates/rimap-audit/src/record/mod.rs
@@ -209,6 +209,12 @@ pub enum ToolStatus {
 
 /// A coarse summary of what a tool returned. Structured so reviewers can
 /// reconstruct activity without reading message bodies.
+///
+/// This is the **un-redacted result-provenance sink** of the `tool_end`
+/// record: unlike `arguments_redacted`, its fields are serialized verbatim
+/// (e.g. raw `message_ids_returned`). Any field added here therefore bypasses
+/// the argument redaction schema and MUST be consciously reviewed for
+/// sensitivity before being recorded durably.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ResultSummary {
     /// RFC 822 `Message-ID` values returned to the caller.
@@ -226,6 +232,27 @@ pub struct ResultSummary {
     /// the field carried when it was typed `Vec<String>`.
     #[serde(default)]
     pub security_warnings_emitted: Vec<WarningCode>,
+    /// Absolute path of a durable artifact this tool wrote (e.g.
+    /// `download_attachment`, `export_messages`), if any. Recorded so the
+    /// actual on-disk scope is reconstructable post-incident (#316). Omitted
+    /// from the on-disk record when absent, so tools that write nothing keep
+    /// their prior `tool_end` shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_path: Option<String>,
+    /// SHA-256 (hex) of the written artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_sha256: Option<String>,
+    /// Byte length of the written artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_bytes: Option<u64>,
+    /// UIDs actually exported (the `export_messages` succeeded partition), in
+    /// caller order. Empty (and omitted) for tools that do not export.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uids_exported: Vec<u32>,
+    /// Requested UIDs that were not exported (the `export_messages` failed
+    /// partition). Empty (and omitted) for tools that do not export.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uids_failed: Vec<u32>,
 }
 
 /// Snapshot of the provenance ring buffer at `tool_end` time.
@@ -452,6 +479,7 @@ mod tests {
                     bytes_returned: 4821,
                     truncated: false,
                     security_warnings_emitted: vec![],
+                    ..Default::default()
                 },
                 provenance: crate::record::Provenance {
                     window_seconds: 60,
@@ -466,6 +494,53 @@ mod tests {
         assert_eq!(v["status"], "ok");
         assert_eq!(v["result_summary"]["bytes_returned"], 4821);
         assert_eq!(v["provenance"]["window_seconds"], 60);
+        // Unpopulated provenance fields are omitted, so a non-artifact tool's
+        // tool_end keeps its prior on-disk shape (#316).
+        assert!(v["result_summary"].get("artifact_path").is_none());
+        assert!(v["result_summary"].get("uids_exported").is_none());
+        let back: AuditRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
+    }
+
+    #[test]
+    fn tool_end_records_artifact_provenance_and_round_trips() {
+        // A write-producing tool's tool_end carries the artifact path/sha/bytes
+        // and the exported/failed UID partition durably (#316).
+        let rec = AuditRecord {
+            seq: Seq(13),
+            ts: Timestamp::now(),
+            process_id: ProcessId::new_now(),
+            payload: Payload::ToolEnd(crate::record::ToolEnd {
+                account: None,
+                start_seq: Seq(12),
+                tool: ToolName::ExportMessages,
+                status: crate::record::ToolStatus::Ok,
+                error_code: None,
+                duration_ms: 91,
+                result_summary: crate::record::ResultSummary {
+                    artifact_path: Some("/srv/dl/messages-abc.partial.mbox".to_string()),
+                    artifact_sha256: Some("ab".repeat(32)),
+                    artifact_bytes: Some(2048),
+                    uids_exported: vec![7, 9],
+                    uids_failed: vec![8],
+                    ..Default::default()
+                },
+                provenance: crate::record::Provenance {
+                    window_seconds: 60,
+                    message_ids_recently_read: vec![],
+                },
+            }),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["result_summary"]["artifact_path"],
+            "/srv/dl/messages-abc.partial.mbox"
+        );
+        assert_eq!(v["result_summary"]["artifact_bytes"], 2048);
+        assert_eq!(v["result_summary"]["uids_exported"][0], 7);
+        assert_eq!(v["result_summary"]["uids_exported"][1], 9);
+        assert_eq!(v["result_summary"]["uids_failed"][0], 8);
         let back: AuditRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(back, rec);
     }

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -21,6 +21,15 @@ use rmcp::model::{CallToolResult, ErrorData};
 use crate::mcp::dispatch::{DispatchTicket, PostureContext};
 use crate::mcp::server::ImapMcpServer;
 
+/// The terminal outcome of a tool call, bundled so `emit_tool_end` stays
+/// within the positional-parameter limit: the status, the error code (on
+/// failure), and the derived durable [`ResultSummary`] (#316).
+struct ToolOutcome {
+    status: ToolStatus,
+    error_code: Option<rimap_core::ErrorCode>,
+    result_summary: ResultSummary,
+}
+
 impl ImapMcpServer {
     /// Wrap an inner dispatch `body` in the full audit envelope:
     /// redact+hash args, emit `tool_start`, time the body, emit
@@ -71,19 +80,24 @@ impl ImapMcpServer {
             .as_millis()
             .try_into()
             .unwrap_or(u64::MAX);
-        let (status, error_code) = match &result {
-            Ok(_) => (ToolStatus::Ok, None),
-            Err(e) => (ToolStatus::Error, Some(e.code())),
+        // Derive the durable result provenance from the successful result so
+        // the actual on-disk scope (artifact path/sha/bytes, exported/failed
+        // UIDs) is reconstructable post-incident; a failed call wrote no
+        // artifact, so it records the default summary (#316).
+        let outcome = match &result {
+            Ok(value) => ToolOutcome {
+                status: ToolStatus::Ok,
+                error_code: None,
+                result_summary: crate::mcp::result_provenance::result_provenance(tool, value),
+            },
+            Err(e) => ToolOutcome {
+                status: ToolStatus::Error,
+                error_code: Some(e.code()),
+                result_summary: ResultSummary::default(),
+            },
         };
-        self.emit_tool_end(
-            start_seq,
-            tool,
-            audit_account,
-            status,
-            error_code,
-            duration_ms,
-        )
-        .await;
+        self.emit_tool_end(start_seq, tool, audit_account, duration_ms, outcome)
+            .await;
 
         match result {
             Ok(value) => Ok(CallToolResult::structured(value)),
@@ -152,9 +166,8 @@ impl ImapMcpServer {
         start_seq: rimap_audit::Seq,
         tool: ToolName,
         account: Option<String>,
-        status: ToolStatus,
-        error_code: Option<rimap_core::ErrorCode>,
         duration_ms: u64,
+        outcome: ToolOutcome,
     ) {
         let audit = self.audit.clone();
         // The provenance ring buffer is not yet wired for multi-account.
@@ -164,15 +177,14 @@ impl ImapMcpServer {
             window_seconds: 60,
             message_ids_recently_read: Vec::new(),
         };
-        let summary = ResultSummary::default();
         let inputs = rimap_audit::ToolEndInputs {
             start_seq,
             tool,
             account,
-            status,
-            error_code,
+            status: outcome.status,
+            error_code: outcome.error_code,
             duration_ms,
-            result_summary: summary,
+            result_summary: outcome.result_summary,
             provenance,
         };
         let join = tokio::task::spawn_blocking(move || audit.log_tool_end(inputs)).await;
@@ -476,5 +488,65 @@ mod tests {
             !contents.contains(r#""status":"cancelled""#),
             "disarmed guard must not write a cancellation record: {contents}",
         );
+    }
+
+    /// End-to-end wiring (#316): a successful export-shaped result drives
+    /// `run_with_audit_envelope` → `result_provenance` → `emit_tool_end`, and
+    /// the durable `tool_end` record carries the artifact path/sha/bytes and
+    /// the exported/failed UID partition.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_end_records_export_provenance_from_result() {
+        use std::sync::Arc;
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer(path.clone());
+        let (tx, _rx) = cancellation_channel();
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx));
+
+        let args = serde_json::Map::new();
+        let result = server
+            .run_with_audit_envelope(
+                ToolName::ExportMessages,
+                None,
+                PostureContext::Infrastructure,
+                &args,
+                |_ticket| async {
+                    Ok(serde_json::json!({
+                        "meta": {
+                            "path": "/srv/dl/messages-xyz.mbox",
+                            "sha256": "ab",
+                            "total_bytes": 4096,
+                            "succeeded": [{ "uid": 7 }, { "uid": 9 }],
+                            "failed": [{ "uid": 8 }]
+                        }
+                    }))
+                },
+            )
+            .await;
+        assert!(result.is_ok(), "envelope should surface the Ok result");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let tool_end = contents
+            .lines()
+            .find(|l| l.contains(r#""kind":"tool_end""#))
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(tool_end).unwrap();
+        assert_eq!(v["status"], "ok");
+        assert_eq!(
+            v["result_summary"]["artifact_path"],
+            "/srv/dl/messages-xyz.mbox"
+        );
+        assert_eq!(v["result_summary"]["artifact_bytes"], 4096);
+        assert_eq!(
+            v["result_summary"]["uids_exported"],
+            serde_json::json!([7, 9])
+        );
+        assert_eq!(v["result_summary"]["uids_failed"], serde_json::json!([8]));
     }
 }

--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod dispatch;
 pub mod error;
 pub mod preinit;
 pub mod response;
+pub(crate) mod result_provenance;
 pub mod server;
 // `tool_catalog` is `pub` (doc-hidden via the parent `#[doc(hidden)] pub mod
 // mcp` in `lib.rs`) so the binary's test-support `dump-tool-catalog`

--- a/crates/rimap-server/src/mcp/result_provenance.rs
+++ b/crates/rimap-server/src/mcp/result_provenance.rs
@@ -1,0 +1,245 @@
+//! Derive the durable [`ResultSummary`] from a tool's successful result for
+//! the `tool_end` audit record (#316).
+//!
+//! Only the write-producing tools (`export_messages`, `download_attachment`)
+//! contribute artifact provenance — the path, sha256, byte count, and (for
+//! export) the succeeded/failed UID partition — so the *actual* on-disk scope
+//! is reconstructable post-incident, not just the requested scope in the
+//! redacted args. Every other tool records the default summary, preserving its
+//! prior `tool_end` shape.
+
+use rimap_audit::record::ResultSummary;
+use rimap_core::tool::ToolName;
+
+/// Build the [`ResultSummary`] recorded in `tool_end` from a successful tool
+/// result `value` (the serialized `ToolResponse`, with a top-level `meta`).
+///
+/// The match is exhaustive on purpose: a new tool that writes a durable
+/// artifact is a compile error here until its provenance is wired (or it is
+/// explicitly added to the no-provenance arm), so provenance can never be
+/// silently dropped for a future tool.
+pub(super) fn result_provenance(tool: ToolName, value: &serde_json::Value) -> ResultSummary {
+    match tool {
+        ToolName::ExportMessages => export_provenance(value),
+        ToolName::DownloadAttachment => download_provenance(value),
+        ToolName::ListFolders
+        | ToolName::Search
+        | ToolName::SearchAdvanced
+        | ToolName::FetchMessage
+        | ToolName::FetchMessageHtml
+        | ToolName::ListAttachments
+        | ToolName::MarkRead
+        | ToolName::MarkUnread
+        | ToolName::Flag
+        | ToolName::Unflag
+        | ToolName::AddLabel
+        | ToolName::RemoveLabel
+        | ToolName::ListLabels
+        | ToolName::MoveMessage
+        | ToolName::CreateDraft
+        | ToolName::SendEmail
+        | ToolName::DeleteMessage
+        | ToolName::Expunge
+        | ToolName::CreateFolder
+        | ToolName::RenameFolder
+        | ToolName::DeleteFolder
+        | ToolName::UseAccount
+        | ToolName::ListAccounts => ResultSummary::default(),
+    }
+}
+
+/// `export_messages`: a complete export reports `path`, a partial reports
+/// `partial_path`, and a zero-success partial reports neither but still
+/// records the failed UID partition.
+///
+/// The field names below are the contract with `ExportMessagesMeta`; the
+/// `tests` module serializes a real `ExportMessagesMeta` so a rename here (or
+/// there) fails an assertion. Keep them in sync.
+fn export_provenance(value: &serde_json::Value) -> ResultSummary {
+    let Some(meta) = value.get("meta") else {
+        return ResultSummary::default();
+    };
+    ResultSummary {
+        artifact_path: string_field(meta, "path").or_else(|| string_field(meta, "partial_path")),
+        artifact_sha256: string_field(meta, "sha256"),
+        artifact_bytes: meta.get("total_bytes").and_then(serde_json::Value::as_u64),
+        uids_exported: uid_list(meta, "succeeded"),
+        uids_failed: uid_list(meta, "failed"),
+        ..ResultSummary::default()
+    }
+}
+
+/// `download_attachment`: always writes exactly one artifact on success.
+///
+/// Field names are the contract with `DownloadAttachmentMeta`, pinned by the
+/// `tests` module (which serializes a real `DownloadAttachmentMeta`).
+fn download_provenance(value: &serde_json::Value) -> ResultSummary {
+    let Some(meta) = value.get("meta") else {
+        return ResultSummary::default();
+    };
+    ResultSummary {
+        artifact_path: string_field(meta, "path"),
+        artifact_sha256: string_field(meta, "sha256"),
+        artifact_bytes: meta.get("size_bytes").and_then(serde_json::Value::as_u64),
+        ..ResultSummary::default()
+    }
+}
+
+fn string_field(meta: &serde_json::Value, key: &str) -> Option<String> {
+    meta.get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// Extract each object's `uid` (as `u32`) from the `key` array of `meta`.
+fn uid_list(meta: &serde_json::Value, key: &str) -> Vec<u32> {
+    let Some(arr) = meta.get(key).and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for entry in arr {
+        if let Some(uid) = entry.get("uid").and_then(serde_json::Value::as_u64)
+            && let Ok(uid) = u32::try_from(uid)
+        {
+            out.push(uid);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::result_provenance;
+    use crate::mcp::response::ToolResponse;
+    use crate::tools::retrieval::download_attachment::DownloadAttachmentMeta;
+    use crate::tools::retrieval::export_messages::{
+        ExportFailReason, ExportMessagesMeta, ExportedUid, FailedUid,
+    };
+    use rimap_core::tool::ToolName;
+
+    /// Serialize a real meta through the response envelope, exactly as dispatch
+    /// does, so a meta field rename breaks this test at compile time.
+    fn value_of<M: serde::Serialize>(meta: M) -> serde_json::Value {
+        serde_json::to_value(ToolResponse::<M, ()>::meta_only(meta)).expect("serialize meta")
+    }
+
+    #[test]
+    fn export_complete_records_path_sha_bytes_and_partition() {
+        let meta = ExportMessagesMeta {
+            folder: "INBOX".to_string(),
+            complete: true,
+            path: Some("/srv/dl/messages-abc.mbox".to_string()),
+            partial_path: None,
+            sha256: "ab".repeat(32),
+            message_count: 2,
+            total_bytes: 4096,
+            uid_validity: 42,
+            succeeded: vec![
+                ExportedUid {
+                    uid: 7,
+                    size_bytes: 100,
+                },
+                ExportedUid {
+                    uid: 9,
+                    size_bytes: 200,
+                },
+            ],
+            failed: vec![],
+        };
+        let summary = result_provenance(ToolName::ExportMessages, &value_of(meta));
+        assert_eq!(
+            summary.artifact_path.as_deref(),
+            Some("/srv/dl/messages-abc.mbox")
+        );
+        assert_eq!(summary.artifact_sha256, Some("ab".repeat(32)));
+        assert_eq!(summary.artifact_bytes, Some(4096));
+        assert_eq!(summary.uids_exported, vec![7, 9]);
+        assert!(summary.uids_failed.is_empty());
+    }
+
+    #[test]
+    fn export_partial_uses_partial_path_and_records_failed_partition() {
+        let meta = ExportMessagesMeta {
+            folder: "INBOX".to_string(),
+            complete: false,
+            path: None,
+            partial_path: Some("/srv/dl/messages-abc.partial.mbox".to_string()),
+            sha256: "cd".repeat(32),
+            message_count: 1,
+            total_bytes: 50,
+            uid_validity: 42,
+            succeeded: vec![ExportedUid {
+                uid: 7,
+                size_bytes: 50,
+            }],
+            failed: vec![FailedUid {
+                uid: 8,
+                reason: ExportFailReason::NotFound,
+            }],
+        };
+        let summary = result_provenance(ToolName::ExportMessages, &value_of(meta));
+        assert_eq!(
+            summary.artifact_path.as_deref(),
+            Some("/srv/dl/messages-abc.partial.mbox")
+        );
+        assert_eq!(summary.uids_exported, vec![7]);
+        assert_eq!(summary.uids_failed, vec![8]);
+    }
+
+    #[test]
+    fn export_zero_success_records_failed_partition_without_path() {
+        let meta = ExportMessagesMeta {
+            folder: "INBOX".to_string(),
+            complete: false,
+            path: None,
+            partial_path: None,
+            sha256: "ef".repeat(32),
+            message_count: 0,
+            total_bytes: 0,
+            uid_validity: 42,
+            succeeded: vec![],
+            failed: vec![
+                FailedUid {
+                    uid: 10,
+                    reason: ExportFailReason::NotFound,
+                },
+                FailedUid {
+                    uid: 20,
+                    reason: ExportFailReason::Oversize,
+                },
+            ],
+        };
+        let summary = result_provenance(ToolName::ExportMessages, &value_of(meta));
+        assert!(summary.artifact_path.is_none());
+        assert!(summary.uids_exported.is_empty());
+        assert_eq!(summary.uids_failed, vec![10, 20]);
+    }
+
+    #[test]
+    fn download_records_path_sha_and_size() {
+        let meta = DownloadAttachmentMeta {
+            folder: "INBOX".to_string(),
+            uid: 5,
+            part_id: "2".to_string(),
+            path: "/srv/dl/doc.pdf".to_string(),
+            size_bytes: 1234,
+            sha256: "11".repeat(32),
+            mime_declared: "application/pdf".to_string(),
+            mime_sniffed: Some("application/pdf".to_string()),
+        };
+        let summary = result_provenance(ToolName::DownloadAttachment, &value_of(meta));
+        assert_eq!(summary.artifact_path.as_deref(), Some("/srv/dl/doc.pdf"));
+        assert_eq!(summary.artifact_sha256, Some("11".repeat(32)));
+        assert_eq!(summary.artifact_bytes, Some(1234));
+        assert!(summary.uids_exported.is_empty());
+    }
+
+    #[test]
+    fn non_artifact_tool_records_default_summary() {
+        // A search result carries no artifact provenance.
+        let value = serde_json::json!({ "meta": { "results": [] } });
+        let summary = result_provenance(ToolName::Search, &value);
+        assert_eq!(summary, rimap_audit::record::ResultSummary::default());
+    }
+}

--- a/docs/superpowers/plans/2026-05-27-result-summary-provenance-316.md
+++ b/docs/superpowers/plans/2026-05-27-result-summary-provenance-316.md
@@ -1,0 +1,142 @@
+# Extend shared ResultSummary for durable per-tool result provenance (#316)
+
+## Context
+
+`emit_tool_end` hardcodes `ResultSummary::default()` for every tool
+(`crates/rimap-server/src/mcp/audit_envelope.rs`). The shared `ResultSummary`
+(`crates/rimap-audit/src/record/mod.rs`) carries `message_ids_returned`,
+`bytes_returned`, `truncated`, `security_warnings_emitted` — none of which
+cover the *artifact* a write-producing tool emits. So for `export_messages`
+the **requested** UID set is durably recorded (redacted args), but the
+**actual exported scope** (succeeded/failed UID partition, artifact path,
+sha256, byte count) lives only in the tool *response*, not the durable audit
+record. `download_attachment` has the same gap.
+
+## Threat
+
+Repudiation / post-incident forensics (STRIDE-R). Under `allow_partial=true`
+the actual exported scope is not durably reconstructable from the audit log.
+
+## Acceptance (from #316)
+
+- Durable audit records the succeeded/failed UID partition, artifact path,
+  sha256, and byte count for `export_messages`.
+- The shared `ResultSummary` extension + plumbing is applied consistently
+  across tools (at minimum `download_attachment` and `export_messages`).
+
+## Design
+
+### 1. Extend `ResultSummary` (rimap-audit), backward-compatibly
+
+Add five fields, each `#[serde(default, skip_serializing_if = ...)]` so a tool
+that does not populate them serializes **byte-identically to today** — the
+on-disk format changes *only* for records that actually carry provenance
+(export / download), and existing tool_end assertions/round-trips are
+unaffected:
+
+```rust
+/// Path of a durable artifact this tool wrote (download/export), if any.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub artifact_path: Option<String>,
+/// SHA-256 (hex) of the written artifact.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub artifact_sha256: Option<String>,
+/// Byte length of the written artifact.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub artifact_bytes: Option<u64>,
+/// UIDs actually exported (export_messages succeeded partition).
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub uids_exported: Vec<u32>,
+/// Requested UIDs that were not exported (export_messages failed partition).
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub uids_failed: Vec<u32>,
+```
+
+Consistent with the existing pattern where not every tool populates every
+field (`message_ids_returned` is search/fetch-specific).
+
+### 2. Derive the summary from the result and plumb it to `emit_tool_end`
+
+The body future already returns the tool's serialized `ToolResponse`
+(`serde_json::Value` with a top-level `meta`). `run_with_audit_envelope`
+computes the summary from that result and passes it to `emit_tool_end`
+(replacing the hardcoded default):
+
+- New `fn result_provenance(tool: ToolName, value: &serde_json::Value) ->
+  ResultSummary` (a small dedicated module). It matches on `tool`:
+  - `ExportMessages`: `artifact_path = meta.path ∨ meta.partial_path`,
+    `artifact_sha256 = meta.sha256`, `artifact_bytes = meta.total_bytes`,
+    `uids_exported = meta.succeeded[].uid`, `uids_failed = meta.failed[].uid`.
+  - `DownloadAttachment`: `artifact_path = meta.path`,
+    `artifact_sha256 = meta.sha256`, `artifact_bytes = meta.size_bytes`.
+  - all other tools: `ResultSummary::default()` (unchanged behavior).
+  Extraction is defensive (`get().and_then()`), so a missing field yields
+  `None`/empty rather than a panic.
+- `emit_tool_end` gains a `result_summary: ResultSummary` parameter.
+  `run_with_audit_envelope` passes the derived summary on `Ok`, and
+  `ResultSummary::default()` on `Err` (a failed call wrote no artifact).
+- The cancellation drop-guard (`AuditEnvelopeGuard`) keeps `default()`: a call
+  cancelled before completion produced no result.
+
+### Why derive from the result `Value` (not thread a typed summary)
+
+`dispatch_tool` returns a uniform `serde_json::Value`; threading a typed
+`ResultSummary` out would touch all 24 dispatch arms and the envelope
+signature. The result already flows through the envelope as a `Value`, so
+deriving there is localized and is exactly "plumb handler results through
+`run_with_audit_envelope` → `emit_tool_end`." The coupling to meta field
+names is bounded: the per-tool output **schema fixtures** pin those names, and
+the extraction unit tests build their input by serializing a real
+`ExportMessagesMeta` / `DownloadAttachmentMeta`, so a field rename breaks the
+test at compile time.
+
+### Privacy / redaction
+
+`ResultSummary` is, by design, the **un-redacted result-provenance sink** of
+the audit record: arguments flow through `Redactor`, but `ResultSummary` is
+serialized verbatim (it already stores raw RFC822 `message_ids_returned`). The
+new fields record no data not already durable: the requested UIDs are already
+in the redacted args (`Verbatim(U64Array)`), the artifact path lives under the
+operator-controlled download root and embeds only the already-recorded
+sanitized filename prefix, and the sha256 is non-sensitive. No redaction-schema
+change is needed.
+
+Because this struct bypasses redaction, **any future field added here must be
+consciously reviewed for sensitivity** — a doc note on the struct will say so.
+
+`artifact_path` is recorded **absolute** on purpose: it matches what the tool
+returns to the caller and maximizes forensic value (which file, where). This
+is a deliberate, minor directory-structure disclosure in the audit log, not an
+accident; it is not switched to a download-root-relative path (which would
+lose where-it-landed forensics).
+
+`ResultSummary` derives `Serialize`/`Deserialize` but **not** `JsonSchema`, so
+it is not part of any published tool schema and the schemars→fixture rule does
+not apply to it. The round-trip and extraction unit tests (below) are the
+guard for these fields, not schema fixtures.
+
+## Execution tasks (TDD)
+
+1. Extend `ResultSummary` with the five `skip_serializing_if` fields; update
+   the one full-literal test in `record/mod.rs` (`..Default::default()`); add
+   a test asserting empty new fields are omitted from JSON and populated ones
+   round-trip.
+2. Add `result_provenance(tool, &Value) -> ResultSummary` with unit tests that
+   serialize real `ExportMessagesMeta` (complete, partial, zero-success) and
+   `DownloadAttachmentMeta`, asserting the extracted fields; and that an
+   unrelated tool yields `default()`.
+3. Thread it through: `emit_tool_end` takes the summary;
+   `run_with_audit_envelope` derives it on `Ok`, `default()` on `Err`;
+   guard/cancellation path unchanged.
+4. Verify: `clippy -D warnings`, `fmt`, `cargo deny`, targeted `rimap-audit` +
+   `rimap-server` tests, and tool-schema regen (no tool *input/meta* doc
+   changed, so no fixture drift expected — confirm).
+
+## Out of scope
+
+- Populating `message_ids_returned` / `bytes_returned` / `truncated` /
+  `security_warnings_emitted` for tools that currently leave them default —
+  this issue is specifically the artifact-provenance gap for the
+  write-producing tools.
+- Threading a typed summary through `dispatch_tool` (deferred; the JSON
+  derivation is sufficient and far less invasive).


### PR DESCRIPTION
Closes #316.

## What

`emit_tool_end` previously hardcoded `ResultSummary::default()` for every
tool, so for `export_messages`/`download_attachment` the **actual** on-disk
scope (artifact path, sha256, byte count, and — for export — the
succeeded/failed UID partition) lived only in the tool *response*, never the
durable audit record. Under `allow_partial=true` the exported scope was not
reconstructable post-incident (STRIDE-R repudiation).

### Extend the shared `ResultSummary` (rimap-audit)
Adds `artifact_path` / `artifact_sha256` / `artifact_bytes` and the
`uids_exported` / `uids_failed` partition. Each is
`#[serde(default, skip_serializing_if = ...)]`, so a tool that writes nothing
serializes **byte-identically** to before — the on-disk `tool_end` format
changes only for records that actually carry provenance. (No audit type uses
`deny_unknown_fields`, so old readers tolerate the new fields and old records
`default`-fill on read.) `ResultSummary` is documented as the un-redacted
result-provenance sink, so future fields are reviewed for sensitivity.

### Derive + plumb the summary (rimap-server)
A new `result_provenance` module extracts the fields from the result `Value`
(the serialized `ToolResponse`) for `export_messages` and
`download_attachment`; `run_with_audit_envelope` derives it on `Ok` and passes
it to `emit_tool_end` (default on `Err`/cancellation). The match is
**exhaustive** on `ToolName`, so a future write-producing tool is a compile
error until its provenance is wired — provenance can never be silently dropped.

## Why derive from the result `Value`
`dispatch_tool` returns a uniform `serde_json::Value`; threading a typed
summary would touch all 24 dispatch arms. The result already flows through the
envelope, so deriving there is localized. The coupling to meta field names is
guarded: the extraction unit tests build input by serializing the **real**
`ExportMessagesMeta` / `DownloadAttachmentMeta`, so a rename fails an assertion.

## Tests
- `rimap-audit`: populated provenance round-trips; unpopulated fields are
  omitted (prior shape preserved).
- `result_provenance`: complete / partial / zero-success export and download,
  plus a non-artifact tool → default.
- `audit_envelope`: end-to-end — a successful export-shaped result lands its
  path/bytes and the `[7,9]`/`[8]` UID partition in the on-disk `tool_end`
  record; cancellation/disarm paths unchanged.
- `clippy -D warnings`, `fmt`, `cargo deny`, and tool-schema regen (no drift —
  `ResultSummary` is not a `JsonSchema` type) all clean.

## Out of scope
Populating `message_ids_returned` / `bytes_returned` / `truncated` /
`security_warnings_emitted` for tools that leave them default; threading a
typed summary through `dispatch_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
