### PR TITLE
feat: structured ErrorData.data for RateLimited / CircuitOpen / AttachmentTooLarge (#303)

### DIFF
--- a/crates/rimap-authz/src/error.rs
+++ b/crates/rimap-authz/src/error.rs
@@ -14,15 +14,9 @@ pub enum AuthzError {
     PostureDenied(ToolName),
     /// Rate limiter rejected the call; `retry_after_ms` is a hint.
     ///
-    /// # Phase 2: structured `data` plumbing (deferred)
-    ///
-    /// Today `to_mcp_error` produces `ErrorData` with `data: None` for this
-    /// code; the typed `retry_after_ms` is absorbed into the message string
-    /// by `From<AuthzError> for RimapError` and lost. Plumbing it through
-    /// requires either extending `RimapError::Authz` with a data field or
-    /// introducing a dedicated variant. Tracked in GitHub issue #303; spec
-    /// reference: `docs/superpowers/specs/2026-05-20-mcp-tool-catalog-richness-design.md`
-    /// "Deferred work — Phase 2".
+    /// `From<AuthzError> for RimapError` routes this into the dedicated
+    /// `RimapError::RateLimited { retry_after_ms }` variant, which surfaces
+    /// the typed hint as structured MCP `data` (#303).
     #[error("rate limited; retry after {retry_after_ms} ms")]
     RateLimited {
         /// Hint for how long the caller should wait before retrying.
@@ -41,15 +35,9 @@ pub enum AuthzError {
     ///   off briefly and try again once the probe resolves." A short fixed
     ///   delay (e.g. tens of milliseconds) is the intended caller behavior.
     ///
-    /// # Phase 2: structured `data` plumbing (deferred)
-    ///
-    /// Today `to_mcp_error` produces `ErrorData` with `data: None` for this
-    /// code; the typed `retry_after_ms` is absorbed into the message string
-    /// by `From<AuthzError> for RimapError` and lost. Plumbing it through
-    /// requires either extending `RimapError::Authz` with a data field or
-    /// introducing a dedicated variant. Tracked in GitHub issue #303; spec
-    /// reference: `docs/superpowers/specs/2026-05-20-mcp-tool-catalog-richness-design.md`
-    /// "Deferred work — Phase 2".
+    /// `From<AuthzError> for RimapError` routes this into the dedicated
+    /// `RimapError::CircuitOpen { retry_after_ms }` variant, which surfaces
+    /// the typed hint as structured MCP `data` (#303).
     #[error("circuit breaker open; retry after {retry_after_ms} ms")]
     CircuitOpen {
         /// Hint for how long the caller should wait before retrying. See the
@@ -107,9 +95,21 @@ impl AuthzError {
 
 impl From<AuthzError> for RimapError {
     fn from(err: AuthzError) -> Self {
-        RimapError::Authz {
-            code: err.code(),
-            message: err.to_string(),
+        // RateLimited / CircuitOpen get dedicated RimapError variants so the
+        // typed retry hint survives into structured MCP `data` (#303),
+        // mirroring the UidValidityChanged routing in `From<ImapError>`.
+        // Everything else flattens through the generic `Authz` arm.
+        match err {
+            AuthzError::RateLimited { retry_after_ms } => {
+                RimapError::RateLimited { retry_after_ms }
+            }
+            AuthzError::CircuitOpen { retry_after_ms } => {
+                RimapError::CircuitOpen { retry_after_ms }
+            }
+            other => RimapError::Authz {
+                code: other.code(),
+                message: other.to_string(),
+            },
         }
     }
 }
@@ -122,13 +122,45 @@ mod tests {
     use rimap_core::tool::ToolName;
 
     #[test]
-    fn from_impl_preserves_code_and_message() {
+    fn rate_limited_routes_to_typed_variant() {
         let err = AuthzError::RateLimited { retry_after_ms: 42 };
+        let display = err.to_string();
+        let mapped: RimapError = err.into();
+        match mapped {
+            RimapError::RateLimited { retry_after_ms } => {
+                assert_eq!(retry_after_ms, 42);
+            }
+            other => panic!("expected RimapError::RateLimited, got {other:?}"),
+        }
+        // Display wording is preserved (only the ERR_ prefix differs upstream).
+        assert_eq!(
+            RimapError::RateLimited { retry_after_ms: 42 }.to_string(),
+            display
+        );
+    }
+
+    #[test]
+    fn circuit_open_routes_to_typed_variant() {
+        let err = AuthzError::CircuitOpen {
+            retry_after_ms: 15_000,
+        };
+        let mapped: RimapError = err.into();
+        match mapped {
+            RimapError::CircuitOpen { retry_after_ms } => {
+                assert_eq!(retry_after_ms, 15_000);
+            }
+            other => panic!("expected RimapError::CircuitOpen, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn posture_denied_still_flattens_to_authz() {
+        let err = AuthzError::PostureDenied(ToolName::CreateDraft);
         let msg = err.to_string();
         let mapped: RimapError = err.into();
         match mapped {
             RimapError::Authz { code, message } => {
-                assert_eq!(code, ErrorCode::RateLimited);
+                assert_eq!(code, ErrorCode::PostureDenied);
                 assert_eq!(message, msg);
             }
             other => panic!("expected Authz variant, got {other:?}"),

--- a/crates/rimap-core/src/error.rs
+++ b/crates/rimap-core/src/error.rs
@@ -270,6 +270,44 @@ pub enum RimapError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
+    /// Rate limiter rejected the call. Carries the typed `retry_after_ms`
+    /// hint so MCP clients can implement programmatic backoff without
+    /// parsing prose. Routed from `AuthzError::RateLimited` by
+    /// `From<AuthzError> for RimapError`. See
+    /// `docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md`.
+    #[error("rate limited; retry after {retry_after_ms} ms")]
+    RateLimited {
+        /// How long the caller should wait before retrying, in milliseconds.
+        retry_after_ms: u64,
+    },
+    /// Circuit breaker is open; fast-failing. Carries the typed
+    /// `retry_after_ms` hint. `retry_after_ms == 0` means the breaker is
+    /// half-open and a probe is already in flight — back off briefly, it is
+    /// *not* "retry immediately". Routed from `AuthzError::CircuitOpen`.
+    #[error("circuit breaker open; retry after {retry_after_ms} ms")]
+    CircuitOpen {
+        /// How long the caller should wait before retrying, in milliseconds.
+        /// `0` is the half-open probe case (see variant docs).
+        retry_after_ms: u64,
+    },
+    /// A hard size/structure cap was hit. Carries the typed `kind` (which
+    /// limit) and `limit` (the cap value) so clients can choose a smaller
+    /// request. Fed by `ContentError::LimitExceeded` (content pipeline) and
+    /// `ImapError::SizeLimit` (IMAP fetch body cap, `kind = "fetch_body_bytes"`).
+    ///
+    /// Unlike `UidValidityChanged`, this variant carries no `#[source]`:
+    /// both producers are leaves whose only payload is now surfaced as the
+    /// typed `limit` field, and the content producer is classified from a
+    /// borrow and cannot supply one. This is the documented exception to the
+    /// "every IMAP-origin variant carries a source" rule on `UidValidityChanged`.
+    #[error("content limit exceeded: {kind} (limit={limit})")]
+    AttachmentTooLarge {
+        /// Which limit tripped (e.g. `"mime_depth"`, `"message_bytes"`,
+        /// `"fetch_body_bytes"`).
+        kind: String,
+        /// The cap value that was exceeded.
+        limit: u64,
+    },
 }
 
 impl RimapError {
@@ -298,6 +336,9 @@ impl RimapError {
             Self::NoAccount { .. } => ErrorCode::NoAccount,
             Self::UnknownAccount { .. } => ErrorCode::UnknownAccount,
             Self::UidValidityChanged { .. } => ErrorCode::UidValidityChanged,
+            Self::RateLimited { .. } => ErrorCode::RateLimited,
+            Self::CircuitOpen { .. } => ErrorCode::CircuitOpen,
+            Self::AttachmentTooLarge { .. } => ErrorCode::AttachmentTooLarge,
         }
     }
 }
@@ -424,6 +465,46 @@ mod tests {
             source: Box::new(std::io::Error::other("test source")),
         };
         assert_eq!(err.code(), ErrorCode::UidValidityChanged);
+    }
+
+    #[test]
+    fn rate_limited_variant_code_and_display() {
+        let err = RimapError::RateLimited {
+            retry_after_ms: 250,
+        };
+        assert_eq!(err.code(), ErrorCode::RateLimited);
+        let s = err.to_string();
+        assert!(
+            s.contains("250"),
+            "Display must include retry_after_ms; got {s}"
+        );
+        assert!(
+            !s.starts_with("ERR_"),
+            "structured variants drop the ERR_ prefix; got {s}"
+        );
+    }
+
+    #[test]
+    fn circuit_open_variant_code_and_display() {
+        let err = RimapError::CircuitOpen { retry_after_ms: 0 };
+        assert_eq!(err.code(), ErrorCode::CircuitOpen);
+        // retry_after_ms == 0 is the half-open probe case, still a valid hint.
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn attachment_too_large_variant_code_and_display() {
+        let err = RimapError::AttachmentTooLarge {
+            kind: "mime_depth".to_string(),
+            limit: 8,
+        };
+        assert_eq!(err.code(), ErrorCode::AttachmentTooLarge);
+        let s = err.to_string();
+        assert!(
+            s.contains("mime_depth"),
+            "Display must include kind; got {s}"
+        );
+        assert!(s.contains('8'), "Display must include limit; got {s}");
     }
 
     #[test]

--- a/crates/rimap-imap/src/error.rs
+++ b/crates/rimap-imap/src/error.rs
@@ -218,10 +218,13 @@ impl From<ImapError> for RimapError {
     fn from(err: ImapError) -> Self {
         // UIDVALIDITY-change errors get a dedicated RimapError variant
         // so MCP clients receive the typed `folder`/`expected`/`actual`
-        // fields via structured `data`. Every other ImapError flattens
-        // through the generic `Imap` arm. Both arms preserve the
-        // original `ImapError` as a `#[source]` so reporters that walk
-        // `error.source().chain()` see consistent depth.
+        // fields via structured `data`. SizeLimit likewise gets the dedicated
+        // AttachmentTooLarge variant so its typed `limit` reaches structured
+        // `data` (#303). Every other ImapError flattens through the generic
+        // `Imap` arm, which preserves the original `ImapError` as a `#[source]`
+        // so reporters that walk `error.source().chain()` see consistent depth.
+        // SizeLimit is the documented exception: it is a leaf whose payload is
+        // now the typed `limit`, so it keeps no source.
         // UidValidityUnavailable has no concrete mismatch to surface, so it
         // intentionally flows through the generic Imap arm below — same
         // client-visible code() (UidValidityChanged) but no structured
@@ -237,6 +240,15 @@ impl From<ImapError> for RimapError {
                 expected: *expected,
                 actual: *actual,
                 source: Box::new(err),
+            }
+        } else if let ImapError::SizeLimit { limit } = &err {
+            // SizeLimit routes to the dedicated AttachmentTooLarge variant so
+            // its typed `limit` reaches structured MCP `data` (#303). It is a
+            // leaf, so no source is kept — the documented exception on
+            // RimapError::AttachmentTooLarge.
+            RimapError::AttachmentTooLarge {
+                kind: "fetch_body_bytes".to_string(),
+                limit: *limit,
             }
         } else {
             let code = err.code();
@@ -345,6 +357,21 @@ mod tests {
             }
             #[expect(clippy::panic, reason = "intentional test assertion failure path")]
             other => panic!("expected RimapError::UidValidityChanged, got {other:?}",),
+        }
+    }
+
+    #[test]
+    fn size_limit_routes_to_attachment_too_large() {
+        use rimap_core::RimapError;
+        let imap_err = ImapError::SizeLimit { limit: 26_214_400 };
+        let mapped: RimapError = imap_err.into();
+        match mapped {
+            RimapError::AttachmentTooLarge { kind, limit } => {
+                assert_eq!(kind, "fetch_body_bytes");
+                assert_eq!(limit, 26_214_400);
+            }
+            #[expect(clippy::panic, reason = "intentional test assertion failure path")]
+            other => panic!("expected RimapError::AttachmentTooLarge, got {other:?}"),
         }
     }
 }

--- a/crates/rimap-imap/tests/error_mapping.rs
+++ b/crates/rimap-imap/tests/error_mapping.rs
@@ -5,7 +5,6 @@
 //! instead of a source chain.
 
 #![expect(clippy::unwrap_used, reason = "tests")]
-#![expect(clippy::expect_used, reason = "tests")]
 #![expect(clippy::panic, reason = "tests")]
 
 use std::error::Error as _;

--- a/crates/rimap-imap/tests/error_mapping.rs
+++ b/crates/rimap-imap/tests/error_mapping.rs
@@ -1,8 +1,12 @@
 //! Round-trip tests for `From<rimap_imap::ImapError> for RimapError` — assert
-//! the source chain is preserved through `ImapError::source()`.
+//! the source chain is preserved through `ImapError::source()`. `SizeLimit` is
+//! the documented exception (#303): it routes to the source-less
+//! `RimapError::AttachmentTooLarge` variant, which surfaces the typed `limit`
+//! instead of a source chain.
 
 #![expect(clippy::unwrap_used, reason = "tests")]
 #![expect(clippy::expect_used, reason = "tests")]
+#![expect(clippy::panic, reason = "tests")]
 
 use std::error::Error as _;
 
@@ -54,8 +58,25 @@ fn size_limit_maps_to_err_attachment_too_large() {
     let err = ImapError::SizeLimit { limit: 1024 };
     let rimap: RimapError = err.into();
     assert_eq!(rimap.code(), ErrorCode::AttachmentTooLarge);
-    let chain = rimap.source().expect("source preserved");
-    assert!(chain.to_string().contains("1024"));
+    // SizeLimit routes to the dedicated, source-less AttachmentTooLarge variant
+    // (#303): the typed `limit` replaces the source chain so the cap value
+    // reaches MCP `data` as a structured field rather than as prose.
+    match rimap {
+        RimapError::AttachmentTooLarge { kind, limit } => {
+            assert_eq!(kind, "fetch_body_bytes");
+            assert_eq!(limit, 1024);
+        }
+        other => panic!("expected AttachmentTooLarge, got {other:?}"),
+    }
+    assert!(
+        RimapError::AttachmentTooLarge {
+            kind: "fetch_body_bytes".to_string(),
+            limit: 1024,
+        }
+        .source()
+        .is_none(),
+        "AttachmentTooLarge is intentionally source-less (#303)"
+    );
 }
 
 #[test]

--- a/crates/rimap-server/src/boot/registry.rs
+++ b/crates/rimap-server/src/boot/registry.rs
@@ -19,23 +19,22 @@ use rimap_authz::{DispatchGuard, FolderGuard};
 use rimap_config::validate::ValidatedAccountConfig;
 use rimap_core::RimapError;
 use rimap_core::account::AccountId;
-use rimap_core::error::ErrorCode;
 use rimap_imap::{Connection, ConnectionConfig, SpecialUseMap};
 use rimap_smtp::SmtpClient;
 
 /// In-memory, unkeyed governor limiter used for infrastructure tools.
 type InfrastructureLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;
 
-/// Translate a `governor` rejection into [`RimapError::Authz`] with a
-/// rate-limited error code and a human-readable retry hint. The
-/// underlying ms math is shared with the per-account governor via
-/// [`retry_after_ms`]; this wrapper adds the infrastructure-tool
-/// framing and skips the intermediate `AuthzError`.
+/// Translate a `governor` rejection into the dedicated
+/// [`RimapError::RateLimited`] variant so the typed `retry_after_ms` reaches
+/// MCP `data` (#303) — the same structured contract the per-account limiter
+/// gets via `From<AuthzError>`. The underlying ms math is shared with the
+/// per-account governor via [`retry_after_ms`]; this wrapper skips the
+/// intermediate `AuthzError` but lands on the same `RimapError` variant.
 fn infra_rate_limited(not_until: &NotUntil<DefaultInstant>, clock: &DefaultClock) -> RimapError {
     let wait_ms = retry_after_ms(not_until, clock);
-    RimapError::Authz {
-        code: ErrorCode::RateLimited,
-        message: format!("infrastructure tool rate limit exceeded; retry in {wait_ms}ms"),
+    RimapError::RateLimited {
+        retry_after_ms: wait_ms,
     }
 }
 
@@ -118,9 +117,9 @@ impl AccountRegistry {
     ///
     /// # Errors
     ///
-    /// Returns [`RimapError::Authz`] with
-    /// [`ErrorCode::RateLimited`] when the limit is exceeded. The
-    /// error message includes a retry hint in milliseconds.
+    /// Returns [`RimapError::RateLimited`] carrying the typed
+    /// `retry_after_ms` hint when the limit is exceeded, so the retry
+    /// timing reaches MCP `data` as a structured field (#303).
     pub fn check_infrastructure_rate(&self) -> Result<(), RimapError> {
         self.infrastructure_limiter
             .check()
@@ -315,10 +314,12 @@ mod tests {
             match reg.check_infrastructure_rate() {
                 Ok(()) => admitted += 1,
                 Err(err) => {
-                    // First rejection: confirm it's the expected variant.
+                    // First rejection: confirm it's the dedicated RateLimited
+                    // variant carrying the typed retry hint (#303), not a
+                    // stringified Authz error.
                     assert!(
-                        matches!(err, RimapError::Authz { code, .. } if code == ErrorCode::RateLimited),
-                        "expected rate-limited Authz error, got {err:?}",
+                        matches!(err, RimapError::RateLimited { .. }),
+                        "expected RimapError::RateLimited, got {err:?}",
                     );
                     rejected_with_rate_limited = true;
                     break;

--- a/crates/rimap-server/src/mcp/content.rs
+++ b/crates/rimap-server/src/mcp/content.rs
@@ -53,9 +53,10 @@ static PARSE_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8)
 /// - `ContentError::Malformed` surfaces as `RimapError::Authz { code:
 ///   InvalidInput, ... }` — the caller-supplied bytes are syntactically
 ///   broken.
-/// - `ContentError::LimitExceeded` surfaces as `RimapError::Authz { code:
-///   AttachmentTooLarge, ... }` — a hard content-pipeline cap (message
-///   bytes, MIME depth/parts, header count, HTML size) was exceeded.
+/// - `ContentError::LimitExceeded` surfaces as
+///   `RimapError::AttachmentTooLarge { kind, limit }` — a hard content-pipeline
+///   cap (message bytes, MIME depth/parts, header count, HTML size) was
+///   exceeded; `kind`/`limit` are surfaced as structured MCP `data` (#303).
 /// - Panics from the blocking task or a closed acquisition semaphore
 ///   surface as `RimapError::Internal` — those are infrastructure
 ///   failures, not content defects, and should trip the circuit breaker
@@ -77,7 +78,7 @@ pub async fn parse_message_async(raw: Vec<u8>) -> Result<Content, RimapError> {
 ///
 /// - `RimapError::Authz { code: InvalidInput, ... }` for
 ///   `ContentError::Malformed` (malformed RFC 5322).
-/// - `RimapError::Authz { code: AttachmentTooLarge, ... }` for
+/// - `RimapError::AttachmentTooLarge { kind, limit }` for
 ///   `ContentError::LimitExceeded` (hard content-pipeline cap hit).
 /// - `RimapError::Internal` for panics or a closed semaphore.
 pub async fn walk_attachment_parts_async(

--- a/crates/rimap-server/src/mcp/content.rs
+++ b/crates/rimap-server/src/mcp/content.rs
@@ -3,7 +3,7 @@
 use std::sync::LazyLock;
 
 use rimap_content::{Content, ContentError, parse_message};
-use rimap_core::{ErrorCode, RimapError};
+use rimap_core::RimapError;
 use tokio::sync::Semaphore;
 
 /// Classify a [`ContentError`] into the appropriate [`RimapError`].
@@ -27,17 +27,13 @@ fn classify_content_error(err: &ContentError) -> RimapError {
     // behavior change. The `LimitExceeded` arm-delete IS a real gap
     // and is killed by `limit_exceeded_classifies_as_attachment_too_large`.
     match err {
-        // Phase 2 — structured `data` plumbing (deferred): the typed
-        // `limit_bytes`/`actual_bytes` from `ContentError::LimitExceeded`
-        // are absorbed into the message string via `err.to_string()` and
-        // lost before reaching `to_mcp_error`. Plumbing requires
-        // refactoring `ContentError` to carry typed fields. Tracked in
-        // GitHub issue #303; spec reference:
-        // docs/superpowers/specs/2026-05-20-mcp-tool-catalog-richness-design.md
-        // "Deferred work — Phase 2".
-        ContentError::LimitExceeded { .. } => RimapError::Authz {
-            code: ErrorCode::AttachmentTooLarge,
-            message: err.to_string(),
+        // The typed `kind`/`limit` from `ContentError::LimitExceeded` are
+        // carried into the dedicated `RimapError::AttachmentTooLarge` variant
+        // so they surface as structured MCP `data` (#303), rather than being
+        // absorbed into a message string.
+        ContentError::LimitExceeded { kind, limit } => RimapError::AttachmentTooLarge {
+            kind: (*kind).to_string(),
+            limit: *limit as u64,
         },
         ContentError::Malformed { .. } => RimapError::invalid_input(err.to_string()),
         // `ContentError` is `#[non_exhaustive]`: future variants fall through
@@ -112,9 +108,10 @@ where
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::panic, reason = "tests")]
 mod tests {
     use super::*;
+    use rimap_core::ErrorCode;
 
     #[tokio::test]
     async fn parse_message_async_matches_sync() {
@@ -148,8 +145,13 @@ mod tests {
             kind: "mime_depth",
             limit: 8,
         };
-        let mapped = classify_content_error(&err);
-        assert_eq!(mapped.code(), ErrorCode::AttachmentTooLarge);
+        match classify_content_error(&err) {
+            RimapError::AttachmentTooLarge { kind, limit } => {
+                assert_eq!(kind, "mime_depth");
+                assert_eq!(limit, 8);
+            }
+            other => panic!("expected AttachmentTooLarge, got {other:?}"),
+        }
 
         // Sanity: Malformed → InvalidInput (same as `_` fallback).
         let malformed = ContentError::Malformed {

--- a/crates/rimap-server/src/mcp/error.rs
+++ b/crates/rimap-server/src/mcp/error.rs
@@ -72,6 +72,28 @@ pub fn to_mcp_error(err: &RimapError) -> ErrorData {
             });
             return ErrorData::invalid_params(message, Some(data));
         }
+        RimapError::RateLimited { retry_after_ms } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::RateLimited.as_str(),
+                "retry_after_ms": retry_after_ms,
+            });
+            return ErrorData::new(RATE_LIMITED, message, Some(data));
+        }
+        RimapError::CircuitOpen { retry_after_ms } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::CircuitOpen.as_str(),
+                "retry_after_ms": retry_after_ms,
+            });
+            return ErrorData::new(CIRCUIT_OPEN, message, Some(data));
+        }
+        RimapError::AttachmentTooLarge { kind, limit } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::AttachmentTooLarge.as_str(),
+                "kind": kind,
+                "limit": limit,
+            });
+            return ErrorData::new(ATTACHMENT_TOO_LARGE, message, Some(data));
+        }
         _ => {}
     }
 
@@ -245,6 +267,46 @@ mod tests {
         assert_eq!(data_value["error_code"], "ERR_UNKNOWN_ACCOUNT");
         assert_eq!(data_value["name"], "missing");
         assert_eq!(data_value["available"], serde_json::json!(["work"]));
+    }
+
+    #[test]
+    fn rate_limited_carries_structured_data() {
+        let err = RimapError::RateLimited {
+            retry_after_ms: 250,
+        };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::RATE_LIMITED);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_RATE_LIMITED");
+        assert_eq!(v["retry_after_ms"], 250);
+    }
+
+    #[test]
+    fn circuit_open_carries_structured_data() {
+        let err = RimapError::CircuitOpen { retry_after_ms: 0 };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::CIRCUIT_OPEN);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_CIRCUIT_OPEN");
+        // 0 is the half-open probe value and must round-trip, not be omitted.
+        assert_eq!(v["retry_after_ms"], 0);
+    }
+
+    #[test]
+    fn attachment_too_large_carries_structured_data() {
+        let err = RimapError::AttachmentTooLarge {
+            kind: "message_bytes".to_string(),
+            limit: 26_214_400,
+        };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::ATTACHMENT_TOO_LARGE);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_ATTACHMENT_TOO_LARGE");
+        assert_eq!(v["kind"], "message_bytes");
+        assert_eq!(v["limit"], 26_214_400);
     }
 
     #[test]

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -82,9 +82,9 @@ pub struct DownloadAttachmentUntrusted {
 ///   not present in the message.
 /// - Propagates `RimapError::Imap { ... }` from SELECT / UID FETCH.
 /// - `RimapError::Authz { code: InvalidInput, ... }` for malformed MIME
-///   bodies and `RimapError::Authz { code: AttachmentTooLarge, ... }`
+///   bodies and `RimapError::AttachmentTooLarge { kind, limit }`
 ///   when a content-pipeline cap (MIME depth/parts, header count, body
-///   size) is exceeded during parse.
+///   size) is exceeded during parse (`kind`/`limit` surface as MCP `data`).
 /// - `RimapError::Internal` for unrecoverable filesystem or hashing
 ///   failures while writing the attachment bytes.
 pub async fn handle(

--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -88,13 +88,15 @@ pub struct FetchMessageUntrusted {
 ///
 /// Returns `RimapError::Authz { code: InvalidInput, ... }` when
 /// `rimap-content` rejects the body as malformed RFC 5322.
-/// Returns `RimapError::Authz { code: AttachmentTooLarge, ... }` when a
+/// Returns `RimapError::AttachmentTooLarge { kind, limit }` when a
 /// content-pipeline cap (MIME depth/parts, header count, HTML size) is
-/// exceeded during parse. Returns `RimapError::Internal` if the
+/// exceeded during parse, or when the IMAP fetch-body cap is hit
+/// (`kind = "fetch_body_bytes"`); the typed fields surface as structured
+/// MCP `data` (#303). Returns `RimapError::Internal` if the
 /// `parse_message_async` blocking task panics or the parse semaphore
 /// is closed — those are infrastructure failures, not input failures.
-/// Returns `RimapError::Imap { ... }` for IMAP-layer failures (network,
-/// timeout, protocol, attachment-too-large). The upstream
+/// Returns `RimapError::Imap { ... }` for other IMAP-layer failures
+/// (network, timeout, protocol). The upstream
 /// `DispatchGuard::pre_dispatch` layer may also return `Authz { code: PostureDenied }`
 /// for `FetchMessageHtml` when `include_html=true` and posture forbids it.
 pub async fn handle(

--- a/docs/superpowers/plans/2026-05-27-structured-error-data-303.md
+++ b/docs/superpowers/plans/2026-05-27-structured-error-data-303.md
@@ -1,0 +1,531 @@
+# Structured ErrorData.data for RateLimited / CircuitOpen / AttachmentTooLarge (#303) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the typed recovery fields (`retry_after_ms`, attachment `kind`/`limit`) as structured MCP `ErrorData.data` on the rate-limit, circuit-open, and attachment-too-large error paths, instead of flattening them into prose.
+
+**Architecture:** Follow the Phase 1 `UidValidityChanged` precedent (issue option b): add dedicated `RimapError` variants carrying typed fields, route the upstream `AuthzError` / `ImapError` / `ContentError` producers into them via the existing `From` impls, and build the `data` JSON in short-circuit arms of `to_mcp_error`. Design: `docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md`.
+
+**Tech Stack:** Rust (workspace), `thiserror`, `serde_json`, `rmcp` (`ErrorData`), `cargo nextest`.
+
+---
+
+## File Structure
+
+- `crates/rimap-core/src/error.rs` — three new `RimapError` variants + `code()` arms + unit tests. (Single source of truth for the error enum.)
+- `crates/rimap-authz/src/error.rs` — route `RateLimited` / `CircuitOpen` in `From<AuthzError>`; rewrite the pinning test.
+- `crates/rimap-imap/src/error.rs` — route `SizeLimit` into `AttachmentTooLarge` in `From<ImapError>`.
+- `crates/rimap-server/src/mcp/content.rs` — `classify_content_error` builds `AttachmentTooLarge { kind, limit }`; extend its test.
+- `crates/rimap-server/src/mcp/error.rs` — three structured-`data` short-circuit arms in `to_mcp_error` + three shape tests.
+
+Adding variants to the `#[non_exhaustive]` `RimapError` only forces an update to the in-crate exhaustive match in `code()`; all out-of-crate matches already carry a `_` arm. A full `cargo build` after Task 1 confirms no other in-crate exhaustive match broke.
+
+---
+
+## Task 1: New `RimapError` variants (rimap-core)
+
+**Files:**
+- Modify: `crates/rimap-core/src/error.rs` (enum body after `UidValidityChanged`, ~line 272; `code()` match ~line 290-302)
+- Test: same file, `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `crates/rimap-core/src/error.rs`:
+
+```rust
+    #[test]
+    fn rate_limited_variant_code_and_display() {
+        let err = RimapError::RateLimited { retry_after_ms: 250 };
+        assert_eq!(err.code(), ErrorCode::RateLimited);
+        let s = err.to_string();
+        assert!(s.contains("250"), "Display must include retry_after_ms; got {s}");
+        assert!(!s.starts_with("ERR_"), "structured variants drop the ERR_ prefix; got {s}");
+    }
+
+    #[test]
+    fn circuit_open_variant_code_and_display() {
+        let err = RimapError::CircuitOpen { retry_after_ms: 0 };
+        assert_eq!(err.code(), ErrorCode::CircuitOpen);
+        // retry_after_ms == 0 is the half-open probe case, still a valid hint.
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn attachment_too_large_variant_code_and_display() {
+        let err = RimapError::AttachmentTooLarge {
+            kind: "mime_depth".to_string(),
+            limit: 8,
+        };
+        assert_eq!(err.code(), ErrorCode::AttachmentTooLarge);
+        let s = err.to_string();
+        assert!(s.contains("mime_depth"), "Display must include kind; got {s}");
+        assert!(s.contains('8'), "Display must include limit; got {s}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p rimap-core --locked rate_limited_variant_code_and_display circuit_open_variant_code_and_display attachment_too_large_variant_code_and_display`
+Expected: FAIL — `no variant named RateLimited` / `CircuitOpen` / `AttachmentTooLarge` (compile error).
+
+- [ ] **Step 3: Add the variants**
+
+In `crates/rimap-core/src/error.rs`, immediately after the `UidValidityChanged { ... }` variant closes (before the enum's closing `}`), add:
+
+```rust
+    /// Rate limiter rejected the call. Carries the typed `retry_after_ms`
+    /// hint so MCP clients can implement programmatic backoff without
+    /// parsing prose. Routed from `AuthzError::RateLimited` by
+    /// `From<AuthzError> for RimapError`. See
+    /// `docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md`.
+    #[error("rate limited; retry after {retry_after_ms} ms")]
+    RateLimited {
+        /// How long the caller should wait before retrying, in milliseconds.
+        retry_after_ms: u64,
+    },
+    /// Circuit breaker is open; fast-failing. Carries the typed
+    /// `retry_after_ms` hint. `retry_after_ms == 0` means the breaker is
+    /// half-open and a probe is already in flight — back off briefly, it is
+    /// *not* "retry immediately". Routed from `AuthzError::CircuitOpen`.
+    #[error("circuit breaker open; retry after {retry_after_ms} ms")]
+    CircuitOpen {
+        /// How long the caller should wait before retrying, in milliseconds.
+        /// `0` is the half-open probe case (see variant docs).
+        retry_after_ms: u64,
+    },
+    /// A hard size/structure cap was hit. Carries the typed `kind` (which
+    /// limit) and `limit` (the cap value) so clients can choose a smaller
+    /// request. Fed by `ContentError::LimitExceeded` (content pipeline) and
+    /// `ImapError::SizeLimit` (IMAP fetch body cap, `kind = "fetch_body_bytes"`).
+    ///
+    /// Unlike `UidValidityChanged`, this variant carries no `#[source]`:
+    /// both producers are leaves whose only payload is now surfaced as the
+    /// typed `limit` field, and the content producer is classified from a
+    /// borrow and cannot supply one. This is the documented exception to the
+    /// "every IMAP-origin variant carries a source" rule above.
+    #[error("content limit exceeded: {kind} (limit={limit})")]
+    AttachmentTooLarge {
+        /// Which limit tripped (e.g. `"mime_depth"`, `"message_bytes"`,
+        /// `"fetch_body_bytes"`).
+        kind: String,
+        /// The cap value that was exceeded.
+        limit: u64,
+    },
+```
+
+- [ ] **Step 4: Add the `code()` arms**
+
+In the `code()` match in `impl RimapError` (the exhaustive match ~line 290-302), add three arms before the closing brace:
+
+```rust
+            Self::RateLimited { .. } => ErrorCode::RateLimited,
+            Self::CircuitOpen { .. } => ErrorCode::CircuitOpen,
+            Self::AttachmentTooLarge { .. } => ErrorCode::AttachmentTooLarge,
+```
+
+- [ ] **Step 5: Run the new tests + full core build**
+
+Run: `cargo nextest run -p rimap-core --locked`
+Expected: PASS (all, including the three new tests).
+Run: `cargo build --workspace --locked`
+Expected: success — confirms no other in-crate exhaustive match over `RimapError` broke.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-core/src/error.rs
+git commit -m "feat(core): add RateLimited/CircuitOpen/AttachmentTooLarge RimapError variants (#303)"
+```
+
+---
+
+## Task 2: Route AuthzError into the typed variants (rimap-authz)
+
+**Files:**
+- Modify: `crates/rimap-authz/src/error.rs:108-115` (`From<AuthzError>`); test `from_impl_preserves_code_and_message` ~line 124-136
+
+- [ ] **Step 1: Rewrite the pinning test to assert the new routing**
+
+Replace `from_impl_preserves_code_and_message` in `crates/rimap-authz/src/error.rs` with:
+
+```rust
+    #[test]
+    fn rate_limited_routes_to_typed_variant() {
+        let err = AuthzError::RateLimited { retry_after_ms: 42 };
+        let display = err.to_string();
+        let mapped: RimapError = err.into();
+        match mapped {
+            RimapError::RateLimited { retry_after_ms } => {
+                assert_eq!(retry_after_ms, 42);
+            }
+            other => panic!("expected RimapError::RateLimited, got {other:?}"),
+        }
+        // Display wording is preserved (only the ERR_ prefix differs upstream).
+        assert_eq!(
+            RimapError::RateLimited { retry_after_ms: 42 }.to_string(),
+            display
+        );
+    }
+
+    #[test]
+    fn circuit_open_routes_to_typed_variant() {
+        let err = AuthzError::CircuitOpen { retry_after_ms: 15_000 };
+        let mapped: RimapError = err.into();
+        match mapped {
+            RimapError::CircuitOpen { retry_after_ms } => {
+                assert_eq!(retry_after_ms, 15_000);
+            }
+            other => panic!("expected RimapError::CircuitOpen, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn posture_denied_still_flattens_to_authz() {
+        let err = AuthzError::PostureDenied(ToolName::CreateDraft);
+        let msg = err.to_string();
+        let mapped: RimapError = err.into();
+        match mapped {
+            RimapError::Authz { code, message } => {
+                assert_eq!(code, ErrorCode::PostureDenied);
+                assert_eq!(message, msg);
+            }
+            other => panic!("expected Authz variant, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p rimap-authz --locked rate_limited_routes_to_typed_variant circuit_open_routes_to_typed_variant`
+Expected: FAIL — both map to `RimapError::Authz` today (panic "expected RimapError::RateLimited").
+
+- [ ] **Step 3: Route the two variants in `From<AuthzError>`**
+
+Replace the `from` body in `impl From<AuthzError> for RimapError` (`crates/rimap-authz/src/error.rs:108-115`) with:
+
+```rust
+    fn from(err: AuthzError) -> Self {
+        // RateLimited / CircuitOpen get dedicated RimapError variants so the
+        // typed retry hint survives into structured MCP `data` (#303),
+        // mirroring the UidValidityChanged routing in `From<ImapError>`.
+        // Everything else flattens through the generic `Authz` arm.
+        match err {
+            AuthzError::RateLimited { retry_after_ms } => {
+                RimapError::RateLimited { retry_after_ms }
+            }
+            AuthzError::CircuitOpen { retry_after_ms } => {
+                RimapError::CircuitOpen { retry_after_ms }
+            }
+            other => RimapError::Authz {
+                code: other.code(),
+                message: other.to_string(),
+            },
+        }
+    }
+```
+
+- [ ] **Step 4: Run the authz tests**
+
+Run: `cargo nextest run -p rimap-authz --locked`
+Expected: PASS (new routing tests + the unchanged `error_codes_match_spec`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-authz/src/error.rs
+git commit -m "feat(authz): route RateLimited/CircuitOpen into typed RimapError variants (#303)"
+```
+
+---
+
+## Task 3: Route ImapError::SizeLimit into AttachmentTooLarge (rimap-imap)
+
+**Files:**
+- Modify: `crates/rimap-imap/src/error.rs:217-251` (`From<ImapError>`)
+- Test: same file, `mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `crates/rimap-imap/src/error.rs`:
+
+```rust
+    #[test]
+    fn size_limit_routes_to_attachment_too_large() {
+        use rimap_core::RimapError;
+        let imap_err = ImapError::SizeLimit { limit: 26_214_400 };
+        let mapped: RimapError = imap_err.into();
+        match mapped {
+            RimapError::AttachmentTooLarge { kind, limit } => {
+                assert_eq!(kind, "fetch_body_bytes");
+                assert_eq!(limit, 26_214_400);
+            }
+            other => panic!("expected RimapError::AttachmentTooLarge, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p rimap-imap --locked size_limit_routes_to_attachment_too_large`
+Expected: FAIL — `SizeLimit` flows through the generic `Imap` arm today (panic "expected RimapError::AttachmentTooLarge").
+
+- [ ] **Step 3: Add the routing arm**
+
+Replace the entire `from` body in `impl From<ImapError> for RimapError` (`crates/rimap-imap/src/error.rs:218-250`) with the form below. It keeps the existing borrow-then-move `if let` for `UidValidityChanged` (a by-value `match` cannot both destructure and move `err` into `source`) and inserts the `SizeLimit` route as an `else if`:
+
+```rust
+    fn from(err: ImapError) -> Self {
+        // UIDVALIDITY-change errors keep a dedicated variant with a #[source]
+        // (consistent depth for IMAP-origin errors). SizeLimit routes to the
+        // dedicated AttachmentTooLarge variant so its typed `limit` reaches
+        // structured MCP `data` (#303); it is a leaf, so no source is kept —
+        // the documented exception on RimapError::AttachmentTooLarge.
+        // Everything else flattens through the generic `Imap` arm.
+        if let ImapError::UidValidityChanged {
+            folder,
+            expected,
+            actual,
+        } = &err
+        {
+            RimapError::UidValidityChanged {
+                folder: folder.clone(),
+                expected: *expected,
+                actual: *actual,
+                source: Box::new(err),
+            }
+        } else if let ImapError::SizeLimit { limit } = &err {
+            RimapError::AttachmentTooLarge {
+                kind: "fetch_body_bytes".to_string(),
+                limit: *limit,
+            }
+        } else {
+            let code = err.code();
+            let message = err.to_string();
+            RimapError::Imap {
+                code,
+                message,
+                source: Some(Box::new(err)),
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run the imap error tests**
+
+Run: `cargo nextest run -p rimap-imap --locked`
+Expected: PASS — new `size_limit_routes_to_attachment_too_large` plus existing `uid_validity_changed_*` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-imap/src/error.rs
+git commit -m "feat(imap): route SizeLimit into typed AttachmentTooLarge variant (#303)"
+```
+
+---
+
+## Task 4: classify_content_error builds AttachmentTooLarge (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/content.rs:29-46` (`classify_content_error`); test `limit_exceeded_classifies_as_attachment_too_large` ~line 137-160
+
+- [ ] **Step 1: Strengthen the existing test**
+
+In `crates/rimap-server/src/mcp/content.rs`, replace the body of `limit_exceeded_classifies_as_attachment_too_large` with an assertion on the typed fields, not just `code()`:
+
+```rust
+    #[test]
+    fn limit_exceeded_classifies_as_attachment_too_large() {
+        let err = ContentError::LimitExceeded {
+            kind: "mime_depth",
+            limit: 8,
+        };
+        match classify_content_error(&err) {
+            RimapError::AttachmentTooLarge { kind, limit } => {
+                assert_eq!(kind, "mime_depth");
+                assert_eq!(limit, 8);
+            }
+            other => panic!("expected AttachmentTooLarge, got {other:?}"),
+        }
+
+        // Malformed → InvalidInput (same as `_` fallback).
+        let malformed = ContentError::Malformed {
+            reason: "unterminated boundary".into(),
+        };
+        assert_eq!(
+            classify_content_error(&malformed).code(),
+            ErrorCode::InvalidInput
+        );
+    }
+```
+
+No module-attribute change is needed: `panic!` inside `#[cfg(test)]` is not flagged in this workspace (see the existing `panic!` at `crates/rimap-imap/src/error.rs:347` in a test module with no such attribute; `clippy.toml` sets only `future-size-threshold`). Adding `#[expect(clippy::panic)]` here would instead become an unfulfilled-expectation warning and fail the `cargo clippy -- -D warnings` gate in Task 6. Keep the module's existing `#[expect(clippy::unwrap_used, reason = "tests")]` — it stays fulfilled by `parse_message_async_matches_sync`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p rimap-server --locked limit_exceeded_classifies_as_attachment_too_large`
+Expected: FAIL — current code returns `RimapError::Authz { code: AttachmentTooLarge, .. }`, so the match hits `other` (panic).
+
+- [ ] **Step 3: Update the classifier**
+
+In `classify_content_error` (`crates/rimap-server/src/mcp/content.rs`), replace the `ContentError::LimitExceeded { .. }` arm with:
+
+```rust
+        ContentError::LimitExceeded { kind, limit } => RimapError::AttachmentTooLarge {
+            kind: (*kind).to_string(),
+            limit: *limit as u64,
+        },
+```
+
+Update the function's doc comment block (lines 30-37) to drop the "Phase 2 — deferred" note and state the fields are now plumbed through.
+
+- [ ] **Step 4: Run server content tests**
+
+Run: `cargo nextest run -p rimap-server --locked content`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/content.rs
+git commit -m "feat(server): classify LimitExceeded into typed AttachmentTooLarge (#303)"
+```
+
+---
+
+## Task 5: Structured `data` in to_mcp_error + shape tests (rimap-server)
+
+**Files:**
+- Modify: `crates/rimap-server/src/mcp/error.rs:44-76` (the short-circuit `match err`); tests in same file
+
+- [ ] **Step 1: Write the three shape tests**
+
+Add to `mod tests` in `crates/rimap-server/src/mcp/error.rs`:
+
+```rust
+    #[test]
+    fn rate_limited_carries_structured_data() {
+        let err = RimapError::RateLimited { retry_after_ms: 250 };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::RATE_LIMITED);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_RATE_LIMITED");
+        assert_eq!(v["retry_after_ms"], 250);
+    }
+
+    #[test]
+    fn circuit_open_carries_structured_data() {
+        let err = RimapError::CircuitOpen { retry_after_ms: 0 };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::CIRCUIT_OPEN);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_CIRCUIT_OPEN");
+        // 0 is the half-open probe value and must round-trip, not be omitted.
+        assert_eq!(v["retry_after_ms"], 0);
+    }
+
+    #[test]
+    fn attachment_too_large_carries_structured_data() {
+        let err = RimapError::AttachmentTooLarge {
+            kind: "message_bytes".to_string(),
+            limit: 26_214_400,
+        };
+        let mcp = to_mcp_error(&err);
+        assert_eq!(mcp.code, super::ATTACHMENT_TOO_LARGE);
+        let data = mcp.data.as_ref().expect("data populated");
+        let v = serde_json::to_value(data).expect("data serializes");
+        assert_eq!(v["error_code"], "ERR_ATTACHMENT_TOO_LARGE");
+        assert_eq!(v["kind"], "message_bytes");
+        assert_eq!(v["limit"], 26_214_400);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p rimap-server --locked rate_limited_carries_structured_data circuit_open_carries_structured_data attachment_too_large_carries_structured_data`
+Expected: FAIL — `data` is `None` today for these codes (`expect("data populated")` panics).
+
+- [ ] **Step 3: Add the short-circuit arms**
+
+In `to_mcp_error` (`crates/rimap-server/src/mcp/error.rs`), add three arms inside the first `match err { ... }` block, before `_ => {}`:
+
+```rust
+        RimapError::RateLimited { retry_after_ms } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::RateLimited.as_str(),
+                "retry_after_ms": retry_after_ms,
+            });
+            return ErrorData::new(RATE_LIMITED, message, Some(data));
+        }
+        RimapError::CircuitOpen { retry_after_ms } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::CircuitOpen.as_str(),
+                "retry_after_ms": retry_after_ms,
+            });
+            return ErrorData::new(CIRCUIT_OPEN, message, Some(data));
+        }
+        RimapError::AttachmentTooLarge { kind, limit } => {
+            let data = serde_json::json!({
+                "error_code": ErrorCode::AttachmentTooLarge.as_str(),
+                "kind": kind,
+                "limit": limit,
+            });
+            return ErrorData::new(ATTACHMENT_TOO_LARGE, message, Some(data));
+        }
+```
+
+(The Phase-1 arms use `ErrorData::invalid_params`; these use `ErrorData::new` with the custom code so the wire `code` matches the existing `code()`-based mapping at lines 98-100. The `code()`-based arms stay as defensive fallbacks.)
+
+- [ ] **Step 4: Run the shape tests + existing error tests**
+
+Run: `cargo nextest run -p rimap-server --locked --no-tests=pass error`
+Expected: PASS — new shape tests plus the unchanged `message_is_preserved`, `custom_codes_lie_in_jsonrpc_server_error_range`, etc.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/error.rs
+git commit -m "feat(server): emit structured data for RateLimited/CircuitOpen/AttachmentTooLarge (#303)"
+```
+
+---
+
+## Task 6: Clear the in-code Phase 2 deferral notes + final gates
+
+**Files:**
+- Modify: `crates/rimap-authz/src/error.rs:15-58` (the two `# Phase 2: structured data plumbing (deferred)` docblocks on `RateLimited` / `CircuitOpen`)
+- Modify: `crates/rimap-server/src/mcp/content.rs` (already touched in Task 4 — verify the deferral note is gone)
+
+- [ ] **Step 1: Replace the deferral docblocks**
+
+In `crates/rimap-authz/src/error.rs`, on `RateLimited` and `CircuitOpen`, delete the `# Phase 2: structured data plumbing (deferred)` sections and replace with one line each noting the field now reaches MCP `data` via `From<AuthzError> for RimapError` → `RimapError::RateLimited` / `CircuitOpen`. Keep the `CircuitOpen` `retry_after_ms` semantics block (it is still accurate and load-bearing).
+
+- [ ] **Step 2: Grep for stale references**
+
+Run: `rg -n "Phase 2|deferred" crates/`
+Expected: no remaining "deferred" plumbing notes in `rimap-authz`/`rimap-server` source. (The intentional `(#303)` issue-tracking refs added in Tasks 2-3 are expected and are matched by a separate `rg -n "#303" crates/` if you want to confirm them — do not treat those as stale.)
+
+- [ ] **Step 3: Full workspace gates**
+
+Run: `cargo fmt --all`
+Run: `cargo clippy --all-targets --all-features --locked -- -D warnings`
+Expected: clean.
+Run: `cargo nextest run --workspace --locked --no-tests=pass`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(authz): clear Phase 2 deferral notes now that #303 is implemented"
+```
+
+---
+
+## Self-Review checklist (run before handing off)
+
+- **Spec coverage:** Delta 1 → Task 1; Delta 2 → Task 2; Delta 3 (content) → Task 4; Delta 3 (imap SizeLimit) → Task 3; Delta 4 → Task 5; deferral-note cleanup → Task 6. Test plan's routing+shape pairs: routing tests in Tasks 2/3/4, shape tests in Task 5. ✔
+- **Type consistency:** variant field names `retry_after_ms: u64`, `kind: String`, `limit: u64` used identically across Tasks 1, 2, 3, 4, 5. `kind` from content is `&'static str` → `(*kind).to_string()`; `limit: usize` → `*limit as u64`. ✔
+- **Display wording:** unified `"content limit exceeded: {kind} (limit={limit})"` (Task 1) matches the spec's chosen lower-churn wording; shape tests assert `data`, not message text, so wording churn is isolated. ✔

--- a/docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md
@@ -96,6 +96,15 @@ The pinning test `from_impl_preserves_code_and_message` currently asserts
 (typed variant, preserved `retry_after_ms`, unchanged Display) — this is the
 intended contract change, not a regression.
 
+**Second `RateLimited` producer.** The infrastructure-tool limiter
+(`AccountRegistry::check_infrastructure_rate` →
+`infra_rate_limited`, `crates/rimap-server/src/boot/registry.rs`) does **not**
+go through `AuthzError`; it built `RimapError::Authz { code: RateLimited }`
+directly and stringified the retry hint. For the same wire-code-consistency
+reason as the dual `AttachmentTooLarge` producers (Delta 3), it is rerouted to
+return `RimapError::RateLimited { retry_after_ms }` so every `-32003` carries
+the typed hint regardless of which limiter tripped.
+
 ### Delta 3 — typed fields for `AttachmentTooLarge` (both producers)
 
 `ErrorCode::AttachmentTooLarge` has **two** producers and both must carry

--- a/docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md
@@ -1,0 +1,250 @@
+# Structured `ErrorData.data` for RateLimited / CircuitOpen / AttachmentTooLarge (#303)
+
+## Context
+
+Phase 1 of the MCP tool-catalog-richness work
+(`2026-05-20-mcp-tool-catalog-richness-design.md`) gave three error variants
+structured `ErrorData.data`: `NoAccount`, `UnknownAccount`,
+`UidValidityChanged`. Three more were deferred to Phase 2 (this issue) because
+their typed fields are flattened into a message string before reaching
+`to_mcp_error`:
+
+- `AuthzError::RateLimited { retry_after_ms }` — flattened by
+  `From<AuthzError> for RimapError` into `RimapError::Authz { code, message }`
+  (`crates/rimap-authz/src/error.rs:108`).
+- `AuthzError::CircuitOpen { retry_after_ms }` — same path.
+- `ContentError::LimitExceeded { kind, limit }` — classified into
+  `RimapError::Authz { code: AttachmentTooLarge, message }` at
+  `crates/rimap-server/src/mcp/content.rs:38`, stringified via `err.to_string()`.
+
+Today `to_mcp_error` (`crates/rimap-server/src/mcp/error.rs:98-100`) emits
+`data: None` for all three codes. Clients must parse prose to recover retry
+timing or size limits.
+
+### Correction to the issue text
+
+Issue #303 describes `ContentError::LimitExceeded { limit_bytes, actual_bytes }`.
+The actual variant (`crates/rimap-content/src/error.rs:24`) is
+`{ kind: &'static str, limit: usize }`. There are five construction sites and
+only two are byte-denominated:
+
+| kind | limit constant | byte-denominated? |
+|------|----------------|-------------------|
+| `message_bytes` | `MAX_MESSAGE_BYTES` | yes |
+| `html_body` | `MAX_HTML_BYTES` | yes |
+| `header_count` | `MAX_HEADER_COUNT` | no (count) |
+| `mime_parts` | `MAX_MIME_PARTS` | no (count) |
+| `mime_depth` | `MAX_MIME_DEPTH` | no (depth) |
+
+No construction site captures an "actual" value today. A `limit_bytes` /
+`actual_bytes` shape would be wrong for three of the five kinds. The design
+below exposes the fields that already exist (`kind`, `limit`) rather than
+inventing a byte-only shape or capturing a new `actual` value nothing currently
+measures (no client has asked for it — see "Rejected alternatives").
+
+## Goal
+
+Publish the typed recovery information as structured `ErrorData.data` so MCP
+clients can implement programmatic retry and size-aware fallbacks without
+parsing prose. Match the Phase 1 wire shape: a JSON object with an
+`error_code` string plus the typed fields.
+
+## Approach
+
+Follow the `UidValidityChanged` precedent exactly (issue option **b**):
+dedicated `RimapError` variants carrying typed fields, routed through a
+dedicated `From` arm, built into structured `data` by a short-circuit in
+`to_mcp_error`.
+
+Rationale for **b** over the alternatives:
+
+- **(a) extend `RimapError::Authz` with `data: Option<Value>`** — touches ~52
+  `RimapError::Authz` construct/match sites across the workspace and erases the
+  type information at the boundary (every site would hand-build JSON). The
+  precedent already rejected this for `UidValidityChanged`.
+- **(c) build `ErrorData` directly from `AuthzError` before `?`-flattening** —
+  splits error→wire mapping across two functions (`dispatch` and
+  `to_mcp_error`), so the wire contract is no longer in one place. Loses the
+  single-source-of-truth `to_mcp_error` gives us.
+- **(b)** keeps every error→wire decision in `to_mcp_error`, mirrors the
+  existing three short-circuit arms, and preserves the typed fields end to end.
+
+### Delta 1 — `rimap-core`: two new `RimapError` variants
+
+```rust
+RimapError::RateLimited { retry_after_ms: u64 }
+RimapError::CircuitOpen { retry_after_ms: u64 }
+```
+
+- `#[error(...)]` Display strings copy today's `AuthzError` wording so the
+  human-readable message is unchanged.
+- `code()` maps them to `ErrorCode::RateLimited` / `ErrorCode::CircuitOpen`.
+- No `#[source]` — unlike `UidValidityChanged`, the `AuthzError` source carries
+  no extra chain depth worth preserving (it is a leaf describing the same
+  condition). Sibling `Authz`-origin errors today carry no source either, so
+  this keeps reporter depth consistent for the authz family.
+
+### Delta 2 — `rimap-authz`: route the two variants in `From<AuthzError>`
+
+`From<AuthzError> for RimapError` gains a match (mirroring the
+`From<ImapError>` `if let`) that sends `RateLimited` / `CircuitOpen` to the new
+dedicated variants and everything else through the existing `Authz` arm. The
+`code()` accessor on `AuthzError` is unchanged.
+
+The pinning test `from_impl_preserves_code_and_message` currently asserts
+`RateLimited` flattens to `Authz`. It is rewritten to assert the new routing
+(typed variant, preserved `retry_after_ms`, unchanged Display) — this is the
+intended contract change, not a regression.
+
+### Delta 3 — typed fields for `AttachmentTooLarge` (both producers)
+
+`ErrorCode::AttachmentTooLarge` has **two** producers and both must carry
+structured `data`, or the wire code is inconsistent (a client keying on
+`-32005` would see `data` present sometimes, absent other times):
+
+1. `ContentError::LimitExceeded { kind, limit }` — content-pipeline caps
+   (message bytes, MIME depth/parts, header count, HTML body), classified at
+   `crates/rimap-server/src/mcp/content.rs:38`.
+2. `ImapError::SizeLimit { limit }` — the IMAP fetch-body cap
+   (`max_fetch_body_bytes`), at `crates/rimap-imap/src/error.rs:46` →
+   `code()` `AttachmentTooLarge` (`error.rs:206`), today flattened through the
+   generic `From<ImapError>` → `RimapError::Imap` arm.
+
+Add one dedicated variant that both producers feed:
+
+```rust
+RimapError::AttachmentTooLarge { kind: String, limit: u64 }
+```
+
+`kind` is `String` (not `&'static str`) because `RimapError` lives in
+`rimap-core`, below both `rimap-content` and `rimap-imap`, and must not borrow
+their constants. `code()` → `ErrorCode::AttachmentTooLarge`.
+
+- `classify_content_error` (`rimap-server`) constructs it from the
+  `LimitExceeded { kind, limit }` fields (`limit as u64`).
+- `From<ImapError>` (`rimap-imap`) gains an arm that routes
+  `SizeLimit { limit }` into it with a stable `kind: "fetch_body_bytes"`,
+  mirroring the existing `UidValidityChanged` `if let` arm. Everything else
+  still flows through the generic `Imap` arm.
+
+No change to `ContentError` or `ImapError` themselves and no change to their
+construction sites — the typed fields already exist.
+
+**Source chain — deliberate carve-out.** `AttachmentTooLarge` carries **no
+`#[source]`**, unlike `UidValidityChanged`. Rerouting `SizeLimit` out of the
+generic `Imap` arm drops the one-level source link that arm preserves today, so
+this is an explicit decision, not an oversight:
+
+- `ImapError::SizeLimit` is a *leaf* error
+  (`#[error("body size exceeded limit of {limit} bytes")]`, no `#[source]` of
+  its own). Its entire payload is `limit`, which `AttachmentTooLarge` now
+  surfaces as a typed field, and its message is reproduced in the variant's
+  Display (below). No diagnostic information is lost from the chain.
+- The other producer, `ContentError::LimitExceeded`, is **not** IMAP-origin and
+  is classified from a `&ContentError` borrow (`ContentError` is not `Clone`),
+  so it cannot supply a source at all. A source-less variant keeps both
+  producers symmetric.
+- This makes the three *new structured* variants
+  (`RateLimited` / `CircuitOpen` / `AttachmentTooLarge`) uniform: all are
+  source-less leaves whose recovery data lives in typed fields. The
+  "every IMAP-origin variant carries a source" rule on `UidValidityChanged`'s
+  docstring is amended to except `AttachmentTooLarge`, with this reason.
+
+**Display / message change.** The variant gets one unified `#[error(...)]`
+Display, reusing the existing content wording (lower churn):
+`"content limit exceeded: {kind} (limit={limit})"`. Following the Phase 1
+precedent (`NoAccount` / `UidValidityChanged` Display strings carry **no**
+`ERR_` prefix, since `to_mcp_error` sets `message = err.to_string()`), this
+**changes the human-readable `message`** for both producers:
+
+- Content path today: `"ERR_ATTACHMENT_TOO_LARGE: content limit exceeded: …"`
+  (via `RimapError::Authz`'s `"{code}: {message}"` Display) → becomes
+  `"content limit exceeded: {kind} (limit={limit})"` (prefix dropped).
+- IMAP fetch path today: `"ERR_ATTACHMENT_TOO_LARGE: body size exceeded limit
+  of N bytes"` (via `RimapError::Imap`) → becomes the unified
+  `"content limit exceeded: fetch_body_bytes (limit=N)"`.
+
+This is acceptable: the MCP `message` is explanatory prose, not a stable
+contract — only `code` and the new `data` are contractual (see Wire-contract /
+semver impact). The shape tests assert the unified wording, not the old
+per-producer strings.
+
+### Delta 4 — `rimap-server`: structured `data` in `to_mcp_error`
+
+Three new short-circuit arms, mirroring the existing three:
+
+```jsonc
+// RateLimited  → code -32003
+{ "error_code": "ERR_RATE_LIMITED",  "retry_after_ms": <u64> }
+// CircuitOpen  → code -32004
+{ "error_code": "ERR_CIRCUIT_OPEN",  "retry_after_ms": <u64> }
+// AttachmentTooLarge → code -32005
+{ "error_code": "ERR_ATTACHMENT_TOO_LARGE", "kind": "<str>", "limit": <u64> }
+```
+
+The custom MCP codes (`RATE_LIMITED` -32003, `CIRCUIT_OPEN` -32004,
+`ATTACHMENT_TOO_LARGE` -32005) already exist; only the `data` payload is new.
+The existing `code()`-based arms stay as defensive fallbacks (same pattern the
+Phase 1 arms use) so an accidental `Authz { code: RateLimited, .. }` still
+maps to the right code with `data: None`.
+
+## Wire-contract / semver impact
+
+- `data` moves from `null` to a populated object on three error paths.
+  Additive for clients that ignore `data`; the wire `code` is unchanged.
+  Not a breaking change.
+- **`message` text changes** on the `RateLimited` / `CircuitOpen` /
+  `AttachmentTooLarge` paths: the dedicated variants' Display carries no
+  `ERR_…:` prefix (matching the Phase 1 structured variants), and
+  `AttachmentTooLarge` unifies the two producers' wording (see Delta 3). MCP
+  `message` is explanatory prose, not a stable contract — only `code` and the
+  typed `data` fields are contractual — so this is acceptable. The
+  `RateLimited` / `CircuitOpen` Display strings are copied verbatim from the
+  current `AuthzError` wording, so those two paths lose only the `ERR_…:`
+  prefix that the old `Authz`-routed form added.
+- The `CircuitOpen` `retry_after_ms == 0` half-open semantics
+  (`crates/rimap-authz/src/error.rs:33-42`) carry through verbatim — `0` is a
+  valid value, not "retry now". The variant docstring is copied so the meaning
+  travels with the typed field.
+
+## Test plan
+
+The `data` contract for each path is guarded by a **named pair** of tests — a
+routing test (does the typed `From` impl preserve the fields into the dedicated
+variant?) and a shape test (does `to_mcp_error` serialize the right payload?).
+Neither alone is sufficient: the `to_mcp_error` tests construct `RimapError`
+directly and so never exercise the `From` routing where the historical
+field-loss occurs.
+
+- `rimap-core`: `code()` accessor + Display for the three new variants;
+  round-trip of `retry_after_ms` / `kind` / `limit`.
+- **Routing — `rimap-authz`:** rewrite `from_impl_preserves_code_and_message`
+  to assert `RateLimited` / `CircuitOpen` route into the dedicated `RimapError`
+  variants with preserved `retry_after_ms` and unchanged Display.
+- **Routing — `rimap-imap`:** assert `From<ImapError>` sends
+  `SizeLimit { limit }` into `RimapError::AttachmentTooLarge { kind:
+  "fetch_body_bytes", limit }` (new test alongside the existing
+  `UidValidityChanged` routing test).
+- **Routing — `rimap-server`:** extend
+  `limit_exceeded_classifies_as_attachment_too_large` so
+  `classify_content_error` produces `RimapError::AttachmentTooLarge { kind,
+  limit }` with the `kind`/`limit` preserved (not just the right `code()`).
+- **Shape — `rimap-server` `error.rs`:** three `*_carries_structured_data`
+  unit tests asserting the exact `data` payload shape and values for the
+  rate-limit, circuit-open, and attachment-too-large paths (mirror the Phase 1
+  trio). These are the on-wire contract.
+- The rate-limit / circuit-open / attachment `data` contract is therefore
+  pinned by the routing-test + shape-test pair above; no single deleted test
+  leaves a path silently emitting `data: null`. A full `e2e_wire.rs` round trip
+  is added only if a deterministic trigger is cheap — it is not the contract of
+  record.
+
+## Rejected alternatives
+
+- **Adding `actual` to `ContentError::LimitExceeded`** — would require capturing
+  a measured value at all five sites (three of which are counts/depths, not
+  bytes) and a `ContentError` signature change rippling through fuzz/test
+  fixtures. No client has requested actual-vs-limit deltas; the limit alone lets
+  a client choose a smaller request. Deferred unless a concrete need appears
+  (YAGNI; matches the issue's own "revisit if a real client surfaces a need").
+- **Single `RimapError::Authz { data }` field** — see Approach (a) above.


### PR DESCRIPTION
Closes #303.

## What this does

Surfaces the typed recovery fields as structured MCP `ErrorData.data` on the three error paths Phase 1 deferred, so clients can implement programmatic retry and size-aware fallbacks without parsing prose. Follows the Phase 1 `UidValidityChanged` precedent: dedicated `RimapError` variants carrying typed fields, routed through the existing `From` impls, with the `data` JSON built in `to_mcp_error`.

New `RimapError` variants (`rimap-core`):

- `RateLimited { retry_after_ms }` → wire code `-32003`, `data: { error_code, retry_after_ms }`
- `CircuitOpen { retry_after_ms }` → `-32004`, `data: { error_code, retry_after_ms }`
- `AttachmentTooLarge { kind, limit }` → `-32005`, `data: { error_code, kind, limit }`

Every producer of each wire code routes to the dedicated variant, so `data` is consistent per code:

- `RateLimited`: account limiter (`From<AuthzError>`) **and** the infrastructure-tool limiter (`infra_rate_limited`).
- `AttachmentTooLarge`: content-pipeline caps (`ContentError::LimitExceeded`) **and** the IMAP fetch-body cap (`ImapError::SizeLimit`, `kind = "fetch_body_bytes"`).

## Notes

- The issue described `ContentError::LimitExceeded { limit_bytes, actual_bytes }`; the actual variant is `{ kind, limit }` (only 2 of 5 caps are byte-denominated). This PR exposes the real `kind`/`limit` fields rather than inventing a byte-only shape. See the design doc for the correction.
- `message` text changes on these three paths (drops the `ERR_…:` prefix, matching the Phase 1 structured variants; `AttachmentTooLarge` unifies wording across producers). MCP `message` is explanatory prose — only `code` and the typed `data` are contractual.
- `AttachmentTooLarge` is intentionally source-less (documented carve-out from the "every IMAP-origin variant carries a source" rule): both producers are leaves whose payload is now the typed `limit`.

## Verification

- `cargo nextest run --workspace`: 1555 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- Design + plan: `docs/superpowers/specs/2026-05-27-issue-303-structured-error-data-design.md`, `docs/superpowers/plans/2026-05-27-structured-error-data-303.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)