### PR TITLE
chore(setup): check libdbus-1 dev headers on Linux

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,6 +56,8 @@ setup:
             H_ZIZMOR='cargo install --locked zizmor'
             H_TYPOS='cargo install --locked typos-cli'
             H_PNPM='npm install -g pnpm@11.1.1'
+            H_PKGCONFIG='sudo dnf install pkgconf-pkg-config'
+            H_DBUS='sudo dnf install dbus-devel'
             ;;
         debian)
             H_JUST='sudo apt install just'
@@ -66,6 +68,8 @@ setup:
             H_ZIZMOR='cargo install --locked zizmor'
             H_TYPOS='cargo install --locked typos-cli'
             H_PNPM='npm install -g pnpm@11.1.1'
+            H_PKGCONFIG='sudo apt install pkg-config'
+            H_DBUS='sudo apt install libdbus-1-dev'
             ;;
         arch)
             H_JUST='sudo pacman -S just'
@@ -76,6 +80,8 @@ setup:
             H_ZIZMOR='cargo install --locked zizmor'
             H_TYPOS='cargo install --locked typos-cli'
             H_PNPM='sudo pacman -S pnpm'
+            H_PKGCONFIG='sudo pacman -S pkgconf'
+            H_DBUS='sudo pacman -S dbus'
             ;;
         suse)
             H_JUST='sudo zypper install just'
@@ -86,6 +92,8 @@ setup:
             H_ZIZMOR='cargo install --locked zizmor'
             H_TYPOS='cargo install --locked typos-cli'
             H_PNPM='npm install -g pnpm@11.1.1'
+            H_PKGCONFIG='sudo zypper install pkg-config'
+            H_DBUS='sudo zypper install dbus-1-devel'
             ;;
         *)
             H_JUST='cargo install --locked just'
@@ -96,6 +104,8 @@ setup:
             H_ZIZMOR='cargo install --locked zizmor'
             H_TYPOS='cargo install --locked typos-cli'
             H_PNPM='npm install -g pnpm@11.1.1'
+            H_PKGCONFIG='install pkg-config via your package manager'
+            H_DBUS='install libdbus-1 development headers via your package manager'
             ;;
     esac
     missing=()
@@ -115,6 +125,16 @@ setup:
     need typos      "$H_TYPOS"
     need node       "install Node 22 LTS via your package manager or nvm"
     need pnpm       "$H_PNPM"
+    # Linux only: `keyring` pulls in `dbus-secret-service`, which links
+    # against `libdbus-1` at build time via pkg-config. macOS uses the
+    # Security framework instead, so no system headers are required there.
+    if [ "$os" = "Linux" ]; then
+        if ! command -v pkg-config >/dev/null 2>&1; then
+            missing+=("pkg-config ($H_PKGCONFIG)")
+        elif ! pkg-config --exists 'dbus-1 >= 1.6' 2>/dev/null; then
+            missing+=("libdbus-1 development headers ($H_DBUS)")
+        fi
+    fi
     if [ "${#missing[@]}" -ne 0 ]; then
         echo "Missing required tools:"
         printf '  - %s\n' "${missing[@]}"


### PR DESCRIPTION
## Summary

- `just setup` now detects when `pkg-config` or the `libdbus-1` development headers are missing on Linux and prints a per-distro install hint instead of letting the build later panic inside `libdbus-sys`' build script.
- Hints are wired for fedora, debian/ubuntu, arch, and opensuse/sles; the generic `*` fallback gets a plain-English hint.
- macOS is unaffected — `keyring` uses the Security framework there, so no system headers are required.

The check uses `pkg-config --exists 'dbus-1 >= 1.6'` to match what `libdbus-sys`' build script itself probes, so a passing `just setup` guarantees the subsequent build won't hit the documented `pkg_config failed` panic.

## Test plan

- [x] `just setup` still completes on macOS (no Linux branch executes).
- [x] Shellcheck clean on the extracted recipe body.
- [x] Simulated Linux branch on this Mac: missing `pkg-config` is reported with the chosen distro's install hint; replacing the `command -v` probe with a true and dropping the dbus probe surfaces the `libdbus-1` hint instead.
- [ ] On a fresh Fedora/Debian box without `libdbus-1-dev`, `just setup` exits 1 with the install hint before any cargo build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)