### PR TITLE
Surface folder-wide EXPUNGE data loss; harden breaker + mUTF-7 tests

### DIFF
--- a/crates/rimap-authz/src/folder_guard.rs
+++ b/crates/rimap-authz/src/folder_guard.rs
@@ -271,16 +271,47 @@ mod tests {
     }
 
     #[test]
-    fn malformed_mutf7_does_not_panic_and_does_not_bypass() {
+    fn malformed_mutf7_input_does_not_panic() {
         // A dangling shift sequence ("&" with no terminating "-") is
-        // malformed mUTF-7. normalize() must not panic, and such a name
-        // must not be treated as an unlisted (allowed) folder when it is
-        // in fact the protected one in encoded form.
+        // malformed mUTF-7. normalize() must not panic on it, and an
+        // unrelated plain protected name must remain protected afterward.
         let g = FolderGuard::new(&["Drafts".into()], &[]);
         let _ = g.check_protected("&malformed", "delete");
         assert!(
             g.check_protected("Drafts", "delete").is_err(),
             "plain protected name must remain protected after a malformed probe",
+        );
+    }
+
+    #[test]
+    fn protected_folder_not_bypassed_by_alternate_mutf7_encoding() {
+        // Protect the folder by its decoded, non-ASCII name. An attacker
+        // must not be able to slip the same folder past the guard by
+        // presenting it in an alternate wire encoding or different casing.
+        let decoded = "Caf\u{00e9}";
+        let g = FolderGuard::new(std::slice::from_ref(&decoded.to_string()), &[]);
+
+        // (a) The mUTF-7 wire form decodes back to the protected name.
+        let encoded = utf7_imap::encode_utf7_imap(decoded.to_string());
+        assert_ne!(
+            encoded, decoded,
+            "test input must actually be mUTF-7 encoded"
+        );
+        assert!(
+            matches!(
+                g.check_protected(&encoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "the mUTF-7 wire form must not bypass the protected entry",
+        );
+
+        // (b) An uppercased decoded variant normalizes to the same name.
+        assert!(
+            matches!(
+                g.check_protected("CAF\u{00c9}", "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "an uppercased variant must not bypass the protected entry",
         );
     }
 }

--- a/crates/rimap-authz/src/folder_guard.rs
+++ b/crates/rimap-authz/src/folder_guard.rs
@@ -209,4 +209,78 @@ mod tests {
         let g = guard();
         assert!(g.check_rename("Old", "New").is_ok());
     }
+
+    #[test]
+    fn protected_non_ascii_folder_rejected_in_both_mutf7_and_decoded_forms() {
+        // "Café" — the é forces a Modified-UTF-7 base64 run.
+        let decoded = "Caf\u{00e9}";
+        let encoded = utf7_imap::encode_utf7_imap(decoded.to_string());
+        assert_ne!(
+            encoded, decoded,
+            "test input must actually be mUTF-7 encoded"
+        );
+
+        // Configured in WIRE (encoded) form; request arrives DECODED.
+        let g = FolderGuard::new(std::slice::from_ref(&encoded), &[]);
+        assert!(
+            matches!(
+                g.check_protected(decoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "decoded form must match an encoded protected entry",
+        );
+        assert!(
+            matches!(
+                g.check_protected(&encoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "encoded form must match an encoded protected entry",
+        );
+
+        // Configured in DECODED form; request arrives ENCODED (and vice versa).
+        let g2 = FolderGuard::new(&[decoded.to_string()], &[]);
+        assert!(
+            matches!(
+                g2.check_protected(&encoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "encoded form must match a decoded protected entry",
+        );
+        assert!(
+            matches!(
+                g2.check_protected(decoded, "rename"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "decoded form must match a decoded protected entry",
+        );
+    }
+
+    #[test]
+    fn expunge_allowlist_matches_across_mutf7_forms() {
+        let decoded = "Caf\u{00e9}";
+        let encoded = utf7_imap::encode_utf7_imap(decoded.to_string());
+        let g = FolderGuard::new(&[], std::slice::from_ref(&encoded));
+        // Allowlisted in encoded form; both request forms must be allowed.
+        assert!(g.check_expunge(decoded).is_ok());
+        assert!(g.check_expunge(&encoded).is_ok());
+        // A different non-ASCII folder must still be denied.
+        assert!(matches!(
+            g.check_expunge("Sp\u{00e4}m"),
+            Err(AuthzError::ExpungeDenied { .. })
+        ));
+    }
+
+    #[test]
+    fn malformed_mutf7_does_not_panic_and_does_not_bypass() {
+        // A dangling shift sequence ("&" with no terminating "-") is
+        // malformed mUTF-7. normalize() must not panic, and such a name
+        // must not be treated as an unlisted (allowed) folder when it is
+        // in fact the protected one in encoded form.
+        let g = FolderGuard::new(&["Drafts".into()], &[]);
+        let _ = g.check_protected("&malformed", "delete");
+        assert!(
+            g.check_protected("Drafts", "delete").is_err(),
+            "plain protected name must remain protected after a malformed probe",
+        );
+    }
 }

--- a/crates/rimap-authz/src/guard.rs
+++ b/crates/rimap-authz/src/guard.rs
@@ -127,33 +127,50 @@ mod tests {
     }
 
     #[test]
-    fn breaker_failure_feedback_eventually_blocks_allowed_tool() {
-        let g = guard(Posture::DraftSafe);
-        g.pre_dispatch(ToolName::ListFolders).unwrap();
-        g.on_failure(FailureReason::Timeout);
-        g.on_failure(FailureReason::Timeout);
-        let err = g.pre_dispatch(ToolName::ListFolders).unwrap_err();
-        assert!(matches!(err, AuthzError::CircuitOpen { .. }));
-    }
-
-    #[test]
-    fn on_success_after_probe_closes_breaker() {
-        let g = guard(Posture::DraftSafe);
-        g.on_failure(FailureReason::Timeout);
-        g.on_failure(FailureReason::Timeout);
-        assert!(matches!(
-            g.pre_dispatch(ToolName::ListFolders),
-            Err(AuthzError::CircuitOpen { .. })
-        ));
-        g.breaker().clock.advance(Duration::from_secs(5));
-        g.pre_dispatch(ToolName::ListFolders).unwrap(); // HalfOpen probe
-        g.on_success();
-        g.pre_dispatch(ToolName::ListFolders).unwrap();
-    }
-
-    #[test]
     fn matrix_accessor_returns_effective_matrix() {
         let g = guard(Posture::Full);
         assert_eq!(g.matrix().posture(), Posture::Full);
+    }
+
+    #[test]
+    fn timeout_threshold_trips_breaker_then_probe_success_closes_it() {
+        let g = guard(Posture::DraftSafe);
+
+        // A tool that DraftSafe permits, so admission is gated only by the breaker.
+        g.pre_dispatch(ToolName::ListFolders).unwrap();
+
+        // One non-auth service failure is below threshold (2): still Closed.
+        g.on_failure(FailureReason::Timeout);
+        g.pre_dispatch(ToolName::ListFolders).unwrap(); // one failure is below the threshold; breaker stays Closed
+
+        // Second non-auth failure reaches threshold → Open.
+        g.on_failure(FailureReason::Timeout);
+        assert!(
+            matches!(
+                g.pre_dispatch(ToolName::ListFolders),
+                Err(AuthzError::CircuitOpen { .. })
+            ),
+            "two service failures must trip the breaker Open",
+        );
+
+        // After cooldown, a probe + success closes it again.
+        g.breaker().clock.advance(Duration::from_secs(5));
+        g.pre_dispatch(ToolName::ListFolders).unwrap(); // HalfOpen probe
+        g.on_success();
+        g.pre_dispatch(ToolName::ListFolders).unwrap(); // on_success after a half-open probe must close the breaker
+    }
+
+    #[test]
+    fn single_auth_failure_trips_breaker_immediately() {
+        let g = guard(Posture::DraftSafe);
+        g.pre_dispatch(ToolName::ListFolders).unwrap();
+        g.on_failure(FailureReason::Auth);
+        assert!(
+            matches!(
+                g.pre_dispatch(ToolName::ListFolders),
+                Err(AuthzError::CircuitOpen { .. })
+            ),
+            "a single Auth failure must trip the breaker Open immediately",
+        );
     }
 }

--- a/crates/rimap-core/src/warning.rs
+++ b/crates/rimap-core/src/warning.rs
@@ -106,10 +106,19 @@ pub enum WarningCode {
     /// extension spoof. Detail format:
     /// `visible=<after_strip>,declared=<original>`.
     LookalikeFilenameExtensionSpoof,
-    /// The IMAP server lacked the MOVE capability; a non-atomic
-    /// COPY+DELETE+EXPUNGE fallback was used. Other messages with
-    /// `\Deleted` flag in the source folder may have been expunged.
+    /// The IMAP server lacked the MOVE capability, so a non-atomic
+    /// COPY+DELETE+EXPUNGE fallback was used instead of an atomic
+    /// `UID MOVE`. The operation is not atomic: a crash or connection
+    /// drop between the COPY and the EXPUNGE can leave the message
+    /// duplicated in both folders. This signals non-atomicity only;
+    /// the folder-wide data-loss risk is reported separately by
+    /// `ServerFolderWideExpungeDataLoss`.
     ServerNonAtomicMoveFallback,
+    /// The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a
+    /// folder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\Deleted` message
+    /// in the source folder, not only the targeted UIDs. Messages another
+    /// client flagged `\Deleted` may have been permanently destroyed.
+    ServerFolderWideExpungeDataLoss,
 }
 
 /// Severity classification for [`WarningCode`] variants. Posture rules
@@ -155,6 +164,7 @@ impl WarningCode {
             | WarningCode::HtmlScriptStripped
             | WarningCode::LookalikeMixedScript
             | WarningCode::LookalikeHomographDomain
+            | WarningCode::ServerFolderWideExpungeDataLoss
             | WarningCode::LookalikeFilenameExtensionSpoof => WarningSeverity::Adversarial,
             WarningCode::ParseBodyTruncated
             | WarningCode::HtmlStyleStripped
@@ -195,6 +205,27 @@ mod tests {
         assert_eq!(
             WarningCode::ParseHeaderSmugglingBlocked.severity(),
             WarningSeverity::Adversarial
+        );
+    }
+
+    #[test]
+    fn folder_wide_expunge_data_loss_is_adversarial() {
+        // The folder-wide EXPUNGE fallback can permanently destroy messages
+        // another client flagged `\Deleted`; that is a realized data-loss
+        // event, not a benign informational signal.
+        assert_eq!(
+            WarningCode::ServerFolderWideExpungeDataLoss.severity(),
+            WarningSeverity::Adversarial
+        );
+    }
+
+    #[test]
+    fn non_atomic_move_fallback_stays_informational() {
+        // Non-atomicity (possible duplicates on a crash) is an operational
+        // caveat, distinct from the data-loss variant above.
+        assert_eq!(
+            WarningCode::ServerNonAtomicMoveFallback.severity(),
+            WarningSeverity::Informational
         );
     }
 }

--- a/crates/rimap-imap/src/ops/delete.rs
+++ b/crates/rimap-imap/src/ops/delete.rs
@@ -38,6 +38,7 @@ pub(crate) async fn delete_message(
             uid,
             moved_to_trash: false,
             used_fallback: false,
+            folder_wide_expunge: false,
         });
     }
 
@@ -63,6 +64,10 @@ pub(crate) async fn delete_message(
         uid,
         moved_to_trash: true,
         used_fallback: !has_move,
+        folder_wide_expunge: super::expunge::fallback_uses_folder_wide_expunge(
+            has_move,
+            has_uidplus,
+        ),
     })
 }
 
@@ -81,4 +86,10 @@ pub struct DeleteResult {
     /// fallback issues a folder-wide EXPUNGE (data-loss risk); callers
     /// should surface a security warning. Mirrors `MoveOutcome::used_fallback`.
     pub used_fallback: bool,
+    /// `true` only when the fallback ran AND the server lacked UIDPLUS, so
+    /// the EXPUNGE was folder-wide (RFC 3501) — removing every `\Deleted`
+    /// message in the source folder, not just the targeted UID. This is the
+    /// distinct data-loss condition (`!has_move && !has_uidplus`); callers
+    /// should surface `ServerFolderWideExpungeDataLoss`.
+    pub folder_wide_expunge: bool,
 }

--- a/crates/rimap-imap/src/ops/delete.rs
+++ b/crates/rimap-imap/src/ops/delete.rs
@@ -1,7 +1,5 @@
 //! `delete_message`: STORE +FLAGS (\Deleted) + UID MOVE to Trash.
 
-use futures_util::StreamExt;
-
 use crate::connection::ImapSession;
 use crate::error::ImapError;
 use crate::ops::store;
@@ -39,6 +37,7 @@ pub(crate) async fn delete_message(
         return Ok(DeleteResult {
             uid,
             moved_to_trash: false,
+            used_fallback: false,
         });
     }
 
@@ -50,47 +49,36 @@ pub(crate) async fn delete_message(
             .await
             .map_err(super::folders::map_err)?;
     } else {
-        // Fallback: COPY + scoped EXPUNGE.
+        // Fallback: COPY + scoped-or-folder-wide EXPUNGE.
         session
             .uid_copy(&uid_set, trash_folder)
             .await
             .map_err(super::folders::map_err)?;
         // The \Deleted flag was already set in step 1.
-        if has_uidplus {
-            // UID EXPUNGE (RFC 4315): only expunge this specific UID.
-            let stream = session
-                .uid_expunge(&uid_set)
-                .await
-                .map_err(super::folders::map_err)?;
-            futures_util::pin_mut!(stream);
-            while let Some(item) = StreamExt::next(&mut stream).await {
-                let _uid = item.map_err(super::folders::map_err)?;
-            }
-        } else {
-            // Plain EXPUNGE: removes ALL \Deleted messages in the folder.
-            // This is a known data-loss risk when other messages are
-            // concurrently flagged \Deleted. Servers without both MOVE
-            // and UIDPLUS are rare in practice.
-            let stream = session.expunge().await.map_err(super::folders::map_err)?;
-            futures_util::pin_mut!(stream);
-            while let Some(item) = StreamExt::next(&mut stream).await {
-                let _seq = item.map_err(super::folders::map_err)?;
-            }
-        }
+        let strategy = super::expunge::expunge_strategy(has_uidplus);
+        super::expunge::run_expunge(session, &uid_set, strategy, source_folder).await?;
     }
 
     Ok(DeleteResult {
         uid,
         moved_to_trash: true,
+        used_fallback: !has_move,
     })
 }
 
 /// Result of a `delete_message` operation.
 #[derive(Debug)]
+#[must_use = "check used_fallback for security warnings"]
+#[non_exhaustive]
 pub struct DeleteResult {
     /// The UID of the deleted message (in its original folder).
     pub uid: Uid,
     /// `true` if the message was moved to Trash; `false` if it was
     /// already in Trash and only flagged.
     pub moved_to_trash: bool,
+    /// `true` when the non-atomic COPY+EXPUNGE fallback was used instead
+    /// of server-side `UID MOVE`. When the server also lacks UIDPLUS this
+    /// fallback issues a folder-wide EXPUNGE (data-loss risk); callers
+    /// should surface a security warning. Mirrors `MoveOutcome::used_fallback`.
+    pub used_fallback: bool,
 }

--- a/crates/rimap-imap/src/ops/expunge.rs
+++ b/crates/rimap-imap/src/ops/expunge.rs
@@ -1,10 +1,73 @@
 //! EXPUNGE: permanently remove messages flagged as `\Deleted`.
+//!
+//! Also provides the EXPUNGE strategy selection shared by delete and move
+//! fallbacks. After flagging messages `\Deleted`, the server's UIDPLUS
+//! capability decides whether we can scope the expunge to specific UIDs
+//! (RFC 4315 `UID EXPUNGE`, safe) or must issue a folder-wide RFC 3501
+//! `EXPUNGE` that removes ALL `\Deleted` messages in the selected mailbox.
 
 use futures_util::StreamExt;
 
 use crate::connection::ImapSession;
 use crate::error::ImapError;
 use crate::types::Uid;
+
+/// Which EXPUNGE form to issue after flagging messages `\Deleted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpungeStrategy {
+    /// `UID EXPUNGE` (RFC 4315): removes only the named UIDs. Safe.
+    Scoped,
+    /// Plain `EXPUNGE` (RFC 3501): removes ALL `\Deleted` messages in the
+    /// selected folder. Data-loss risk when other messages are flagged
+    /// `\Deleted` by concurrent clients.
+    FolderWide,
+}
+
+/// Choose the EXPUNGE strategy from the server's UIDPLUS capability.
+pub(crate) fn expunge_strategy(has_uidplus: bool) -> ExpungeStrategy {
+    if has_uidplus {
+        ExpungeStrategy::Scoped
+    } else {
+        ExpungeStrategy::FolderWide
+    }
+}
+
+/// Execute the chosen EXPUNGE against the currently selected mailbox,
+/// draining the response stream. Emits a `warn!` on the folder-wide
+/// (data-loss) path so operators can see when the unsafe fallback ran.
+pub(crate) async fn run_expunge(
+    session: &mut ImapSession,
+    uid_set: &str,
+    strategy: ExpungeStrategy,
+    selected_folder: &str,
+) -> Result<(), ImapError> {
+    match strategy {
+        ExpungeStrategy::Scoped => {
+            let stream = session
+                .uid_expunge(uid_set)
+                .await
+                .map_err(super::folders::map_err)?;
+            futures_util::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                let _uid = item.map_err(super::folders::map_err)?;
+            }
+        }
+        ExpungeStrategy::FolderWide => {
+            tracing::warn!(
+                folder = %selected_folder,
+                "issuing folder-wide EXPUNGE because the server lacks UIDPLUS; \
+                 every message flagged \\Deleted in this folder is removed, not \
+                 only the targeted UIDs",
+            );
+            let stream = session.expunge().await.map_err(super::folders::map_err)?;
+            futures_util::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                let _seq = item.map_err(super::folders::map_err)?;
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Count of `\Deleted`-flagged messages before expunge, for audit logging.
 ///
@@ -46,4 +109,19 @@ pub(crate) async fn expunge(session: &mut ImapSession) -> Result<u32, ImapError>
         count = count.saturating_add(1);
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ExpungeStrategy, expunge_strategy};
+
+    #[test]
+    fn uidplus_present_selects_scoped() {
+        assert_eq!(expunge_strategy(true), ExpungeStrategy::Scoped);
+    }
+
+    #[test]
+    fn uidplus_absent_selects_folder_wide() {
+        assert_eq!(expunge_strategy(false), ExpungeStrategy::FolderWide);
+    }
 }

--- a/crates/rimap-imap/src/ops/expunge.rs
+++ b/crates/rimap-imap/src/ops/expunge.rs
@@ -32,6 +32,14 @@ pub(crate) fn expunge_strategy(has_uidplus: bool) -> ExpungeStrategy {
     }
 }
 
+/// `true` when the COPY+EXPUNGE fallback path ran AND it had to issue a
+/// folder-wide EXPUNGE (server lacks both MOVE and UIDPLUS) — the data-loss
+/// condition. Distinct from `used_fallback` (`!has_move`), which is also
+/// true on the safe scoped-UID-EXPUNGE path.
+pub(crate) fn fallback_uses_folder_wide_expunge(has_move: bool, has_uidplus: bool) -> bool {
+    !has_move && !has_uidplus
+}
+
 /// Execute the chosen EXPUNGE against the currently selected mailbox,
 /// draining the response stream. Emits a `warn!` on the folder-wide
 /// (data-loss) path so operators can see when the unsafe fallback ran.
@@ -113,7 +121,7 @@ pub(crate) async fn expunge(session: &mut ImapSession) -> Result<u32, ImapError>
 
 #[cfg(test)]
 mod tests {
-    use super::{ExpungeStrategy, expunge_strategy};
+    use super::{ExpungeStrategy, expunge_strategy, fallback_uses_folder_wide_expunge};
 
     #[test]
     fn uidplus_present_selects_scoped() {
@@ -123,5 +131,25 @@ mod tests {
     #[test]
     fn uidplus_absent_selects_folder_wide() {
         assert_eq!(expunge_strategy(false), ExpungeStrategy::FolderWide);
+    }
+
+    #[test]
+    fn folder_wide_expunge_only_when_no_move_and_no_uidplus() {
+        // The data-loss condition is exactly (!has_move && !has_uidplus).
+        assert!(fallback_uses_folder_wide_expunge(false, false));
+    }
+
+    #[test]
+    fn move_capable_never_uses_folder_wide_expunge() {
+        // With MOVE the fallback path never runs, regardless of UIDPLUS.
+        assert!(!fallback_uses_folder_wide_expunge(true, false));
+        assert!(!fallback_uses_folder_wide_expunge(true, true));
+    }
+
+    #[test]
+    fn uidplus_fallback_is_scoped_not_folder_wide() {
+        // No MOVE but UIDPLUS present: the fallback runs but scopes the
+        // EXPUNGE to the targeted UIDs — safe, not the data-loss path.
+        assert!(!fallback_uses_folder_wide_expunge(false, true));
     }
 }

--- a/crates/rimap-imap/src/ops/expunge.rs
+++ b/crates/rimap-imap/src/ops/expunge.rs
@@ -20,6 +20,13 @@ pub(crate) enum ExpungeStrategy {
     /// Plain `EXPUNGE` (RFC 3501): removes ALL `\Deleted` messages in the
     /// selected folder. Data-loss risk when other messages are flagged
     /// `\Deleted` by concurrent clients.
+    ///
+    /// This branch runs only against a server advertising neither MOVE nor
+    /// UIDPLUS. The integration suite is **not exercised** against such a
+    /// server — Dovecot (the only integration target) always advertises
+    /// UIDPLUS, so CI reaches [`ExpungeStrategy::Scoped`] exclusively.
+    /// Closing this gap requires an in-process TLS mock that advertises
+    /// neither capability; see `tests/expunge_folder_wide_gap.rs`.
     FolderWide,
 }
 
@@ -43,6 +50,11 @@ pub(crate) fn fallback_uses_folder_wide_expunge(has_move: bool, has_uidplus: boo
 /// Execute the chosen EXPUNGE against the currently selected mailbox,
 /// draining the response stream. Emits a `warn!` on the folder-wide
 /// (data-loss) path so operators can see when the unsafe fallback ran.
+///
+/// The folder-wide branch (and its `warn!` / `used_fallback=true` /
+/// `folder_wide_expunge=true` surface) is not exercised by the Dovecot
+/// integration suite, which always advertises UIDPLUS. See
+/// [`ExpungeStrategy::FolderWide`] and `tests/expunge_folder_wide_gap.rs`.
 pub(crate) async fn run_expunge(
     session: &mut ImapSession,
     uid_set: &str,

--- a/crates/rimap-imap/src/ops/move_message.rs
+++ b/crates/rimap-imap/src/ops/move_message.rs
@@ -1,8 +1,6 @@
 //! UID MOVE with COPY+DELETE fallback for servers without the MOVE
 //! extension (RFC 6851).
 
-use futures_util::StreamExt;
-
 use crate::connection::ImapSession;
 use crate::error::ImapError;
 use crate::ops::store;
@@ -109,7 +107,7 @@ pub(crate) async fn move_messages(
 
     if !has_move {
         let (results, destination_uid_validity) =
-            copy_delete_fallback(session, dest_folder, uids, has_uidplus).await?;
+            copy_delete_fallback(session, src_folder, dest_folder, uids, has_uidplus).await?;
         return Ok(MoveOutcome {
             results,
             used_fallback: true,
@@ -134,15 +132,15 @@ pub(crate) async fn move_messages(
 
 /// Fallback: COPY + STORE \Deleted + EXPUNGE. Not atomic.
 ///
-/// When `has_uidplus` is true, UID EXPUNGE (RFC 4315) is used to remove only
-/// the flagged UIDs. Otherwise plain EXPUNGE removes all `\Deleted` messages,
-/// which is a known data-loss risk for concurrent operations.
-/// Servers that support MOVE never reach this path.
+/// EXPUNGE selection (scoped UID EXPUNGE vs folder-wide) is delegated to
+/// [`crate::ops::expunge::run_expunge`]. Servers that support MOVE never
+/// reach this path.
 ///
 /// Returns `(results, destination_uid_validity)`. The destination UIDVALIDITY
 /// is probed via STATUS after the COPY succeeds so the caller can surface it.
 async fn copy_delete_fallback(
     session: &mut ImapSession,
+    src_folder: &str,
     dest_folder: &str,
     uids: &[Uid],
     has_uidplus: bool,
@@ -176,26 +174,8 @@ async fn copy_delete_fallback(
     store::store(session, uids, &[Flag::Deleted], FlagAction::Add).await?;
 
     // Step 4: Remove the flagged messages from the source folder.
-    if has_uidplus {
-        // UID EXPUNGE (RFC 4315): only expunge the UIDs we flagged.
-        let stream = session
-            .uid_expunge(&uid_set)
-            .await
-            .map_err(super::folders::map_err)?;
-        futures_util::pin_mut!(stream);
-        while let Some(item) = stream.next().await {
-            let _uid = item.map_err(super::folders::map_err)?;
-        }
-    } else {
-        // Plain EXPUNGE: removes ALL \Deleted messages. Known data-loss
-        // risk with concurrent \Deleted flags. Servers without both MOVE
-        // and UIDPLUS are rare in practice.
-        let stream = session.expunge().await.map_err(super::folders::map_err)?;
-        futures_util::pin_mut!(stream);
-        while let Some(item) = stream.next().await {
-            let _seq = item.map_err(super::folders::map_err)?;
-        }
-    }
+    let strategy = crate::ops::expunge::expunge_strategy(has_uidplus);
+    crate::ops::expunge::run_expunge(session, &uid_set, strategy, src_folder).await?;
 
     Ok((build_results(uids), destination_uid_validity))
 }

--- a/crates/rimap-imap/src/ops/move_message.rs
+++ b/crates/rimap-imap/src/ops/move_message.rs
@@ -20,6 +20,12 @@ pub struct MoveOutcome {
     /// instead of the atomic UID MOVE command. Callers should surface a
     /// security warning when this is `true`.
     pub used_fallback: bool,
+    /// `true` only when the fallback ran AND the server lacked UIDPLUS, so
+    /// the EXPUNGE was folder-wide (RFC 3501) — removing every `\Deleted`
+    /// message in the source folder, not just the moved UIDs. This is the
+    /// distinct data-loss condition (`!has_move && !has_uidplus`); callers
+    /// should surface `ServerFolderWideExpungeDataLoss`.
+    pub folder_wide_expunge: bool,
     /// Source-folder UIDVALIDITY observed at the guard STATUS probe, or
     /// `None` if no guard was requested or the server omitted it.
     pub source_uid_validity: Option<u32>,
@@ -68,6 +74,7 @@ pub(crate) async fn move_messages(
         return Ok(MoveOutcome {
             results: Vec::new(),
             used_fallback: false,
+            folder_wide_expunge: false,
             source_uid_validity: None,
             destination_uid_validity: None,
         });
@@ -111,6 +118,10 @@ pub(crate) async fn move_messages(
         return Ok(MoveOutcome {
             results,
             used_fallback: true,
+            folder_wide_expunge: crate::ops::expunge::fallback_uses_folder_wide_expunge(
+                false,
+                has_uidplus,
+            ),
             source_uid_validity,
             destination_uid_validity,
         });
@@ -123,6 +134,7 @@ pub(crate) async fn move_messages(
         Ok(()) => Ok(MoveOutcome {
             results: build_results(uids),
             used_fallback: false,
+            folder_wide_expunge: false,
             source_uid_validity,
             destination_uid_validity: None,
         }),

--- a/crates/rimap-imap/tests/expunge_folder_wide_gap.rs
+++ b/crates/rimap-imap/tests/expunge_folder_wide_gap.rs
@@ -1,0 +1,29 @@
+//! Placeholder marking the one untested-by-design runtime path: the
+//! folder-wide `EXPUNGE` fallback taken when an IMAP server advertises
+//! neither MOVE nor UIDPLUS.
+//!
+//! Dovecot — the only integration target on this host — always advertises
+//! UIDPLUS, so the integration suite reaches the scoped `UID EXPUNGE` path
+//! exclusively and never the folder-wide branch. The data-loss behavior
+//! there (plain `EXPUNGE` removing every `\Deleted` message in the source
+//! folder), the `warn!`, and the `used_fallback=true` /
+//! `folder_wide_expunge=true` result surface are therefore unverified at
+//! runtime.
+//!
+//! The pure pieces of that path are unit-tested elsewhere:
+//! `rimap_imap::ops::expunge::fallback_uses_folder_wide_expunge` (the
+//! data-loss predicate) and `rimap_server`'s `fallback_security_warnings`
+//! (the warning mapping). Only the live wire behavior remains open.
+//!
+//! This test stays `#[ignore]`d so the gap is visible in `cargo nextest`
+//! output rather than silently implied as covered.
+
+/// Documented coverage gap. See the `#[ignore]` reason for the intended
+/// harness; the body is a no-op so the placeholder compiles and the gap
+/// surfaces as a skipped test.
+#[test]
+#[ignore = "folder-wide EXPUNGE runtime path is untested: needs an in-process \
+            TLS-terminating mock (tokio-rustls + rcgen, pinned-fingerprint mode) \
+            advertising neither MOVE nor UIDPLUS, scripting login -> SELECT -> \
+            STORE -> COPY and asserting a plain EXPUNGE is issued"]
+fn folder_wide_expunge_runtime_path_is_unverified() {}

--- a/crates/rimap-server/src/mcp/audit_envelope.rs
+++ b/crates/rimap-server/src/mcp/audit_envelope.rs
@@ -280,7 +280,7 @@ impl Drop for AuditEnvelopeGuard {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
     use rimap_audit::writer::AuditOptions;
     use rimap_audit::{AuditWriter, Seq, ToolStartInputs, cancellation_channel, spawn_drainer};
@@ -296,6 +296,18 @@ mod tests {
             rotate_keep: 5,
             retention_seconds: None,
             fail_open: false,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap()
+    }
+
+    fn test_writer_fail_open(path: std::path::PathBuf, fail_open: bool) -> AuditWriter {
+        AuditWriter::open(&AuditOptions {
+            path,
+            rotate_bytes: 10 * 1024 * 1024,
+            rotate_keep: 5,
+            retention_seconds: None,
+            fail_open,
             initial_seq: Seq::FIRST,
         })
         .unwrap()
@@ -548,5 +560,116 @@ mod tests {
             serde_json::json!([7, 9])
         );
         assert_eq!(v["result_summary"]["uids_failed"], serde_json::json!([8]));
+    }
+
+    /// `fail_open` = false: an injected `tool_start` write failure must abort
+    /// the call with an "audit write failed" error, never run the body, and
+    /// leave ZERO records on disk (no orphan `tool_start`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_start_failure_fail_closed_aborts_with_no_orphan() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer_fail_open(path.clone(), false);
+        writer.force_next_write_failure();
+
+        let (tx, _rx) = cancellation_channel();
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx));
+
+        let body_ran = Arc::new(AtomicBool::new(false));
+        let body_ran_clone = Arc::clone(&body_ran);
+        let args = serde_json::Map::new();
+        let result = server
+            .run_with_audit_envelope(
+                ToolName::ListAccounts,
+                None,
+                PostureContext::Infrastructure,
+                &args,
+                |_ticket| async move {
+                    body_ran_clone.store(true, Ordering::SeqCst);
+                    Ok(serde_json::Value::Null)
+                },
+            )
+            .await;
+
+        let err = result.expect_err("fail-closed audit failure must abort the call");
+        assert_eq!(
+            err.code,
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            "fail-closed audit failure must surface as an MCP internal error",
+        );
+        assert!(
+            err.message.contains("audit write failed"),
+            "expected audit-write-failed error, got: {}",
+            err.message,
+        );
+        assert!(
+            !body_ran.load(Ordering::SeqCst),
+            "body must not run when tool_start fails fail-closed",
+        );
+
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            contents.lines().count(),
+            0,
+            "a failed tool_start must leave zero records on disk (no orphan):\n{contents}",
+        );
+    }
+
+    /// `fail_open` = true: the injected `tool_start` write failure is
+    /// suppressed (counted), the body runs, and the call succeeds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_start_failure_fail_open_proceeds_and_counts() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer_fail_open(path.clone(), true);
+        writer.force_next_write_failure();
+        // Hold a clone so we can read the suppressed-failure counter after.
+        let writer_probe = writer.clone();
+
+        let (tx, _rx) = cancellation_channel();
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx));
+
+        let body_ran = Arc::new(AtomicBool::new(false));
+        let body_ran_clone = Arc::clone(&body_ran);
+        let args = serde_json::Map::new();
+        let result = server
+            .run_with_audit_envelope(
+                ToolName::ListAccounts,
+                None,
+                PostureContext::Infrastructure,
+                &args,
+                |_ticket| async move {
+                    body_ran_clone.store(true, Ordering::SeqCst);
+                    Ok(serde_json::Value::Null)
+                },
+            )
+            .await;
+
+        assert!(result.is_ok(), "fail-open must let the call succeed");
+        assert!(
+            body_ran.load(Ordering::SeqCst),
+            "body must run when the tool_start failure is suppressed",
+        );
+        assert_eq!(
+            writer_probe.suppressed_failures(),
+            1,
+            "fail-open must increment the suppressed-failure counter exactly once",
+        );
     }
 }

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -282,35 +282,57 @@ mod tests {
     use super::rimap_error_to_breaker_reason;
 
     #[test]
-    fn breaker_reason_maps_service_failures() {
+    fn breaker_reason_maps_every_error_code() {
         use rimap_authz::breaker::FailureReason;
         use rimap_core::{ErrorCode, RimapError};
-        let err = RimapError::Imap {
-            code: ErrorCode::Timeout,
-            message: "x".into(),
-            source: None,
-        };
+
+        // Pins the SEMANTICS for all 20 current ErrorCode variants (service
+        // failures trip, user/policy/internal errors do not). Exhaustiveness
+        // is enforced upstream: the mapping fn's own `match` is
+        // compile-exhaustive, so a new ErrorCode breaks THAT build and forces
+        // a classification decision before this table matters.
+        let cases: &[(ErrorCode, Option<FailureReason>)] = &[
+            (
+                ErrorCode::ConnectionLost,
+                Some(FailureReason::ConnectionLost),
+            ),
+            (ErrorCode::Auth, Some(FailureReason::Auth)),
+            (ErrorCode::Timeout, Some(FailureReason::Timeout)),
+            (ErrorCode::ImapProtocol, Some(FailureReason::Protocol)),
+            (ErrorCode::SmtpProtocol, Some(FailureReason::Protocol)),
+            (ErrorCode::Tls, Some(FailureReason::Tls)),
+            (ErrorCode::InvalidInput, None),
+            (ErrorCode::PostureDenied, None),
+            (ErrorCode::RateLimited, None),
+            (ErrorCode::CircuitOpen, None),
+            (ErrorCode::NotFound, None),
+            (ErrorCode::AttachmentTooLarge, None),
+            (ErrorCode::ProtectedFolder, None),
+            (ErrorCode::ExpungeDenied, None),
+            (ErrorCode::Config, None),
+            (ErrorCode::Internal, None),
+            (ErrorCode::NoAccount, None),
+            (ErrorCode::UnknownAccount, None),
+            (ErrorCode::Cancelled, None),
+            (ErrorCode::UidValidityChanged, None),
+        ];
+
+        for (code, expected) in cases {
+            let err = RimapError::Imap {
+                code: *code,
+                message: "x".into(),
+                source: None,
+            };
+            assert_eq!(
+                rimap_error_to_breaker_reason(&err),
+                *expected,
+                "mapping mismatch for {code:?}",
+            );
+        }
         assert_eq!(
-            rimap_error_to_breaker_reason(&err),
-            Some(FailureReason::Timeout),
-        );
-        let auth = RimapError::Imap {
-            code: ErrorCode::Auth,
-            message: "x".into(),
-            source: None,
-        };
-        assert_eq!(
-            rimap_error_to_breaker_reason(&auth),
-            Some(FailureReason::Auth),
-        );
-        let tls = RimapError::Imap {
-            code: ErrorCode::Tls,
-            message: "x".into(),
-            source: None,
-        };
-        assert_eq!(
-            rimap_error_to_breaker_reason(&tls),
-            Some(FailureReason::Tls)
+            cases.len(),
+            20,
+            "table must list all variants (6 service + 14 user)"
         );
     }
 
@@ -338,19 +360,6 @@ mod tests {
             Some(Posture::Readonly),
         );
         assert_eq!(PostureContext::Infrastructure.posture(), None);
-    }
-
-    #[test]
-    fn breaker_reason_ignores_user_errors() {
-        use rimap_core::RimapError;
-        assert_eq!(
-            rimap_error_to_breaker_reason(&RimapError::invalid_input("bad")),
-            None,
-        );
-        assert_eq!(
-            rimap_error_to_breaker_reason(&RimapError::Internal("bug".into())),
-            None,
-        );
     }
 
     #[tokio::test]

--- a/crates/rimap-server/src/mcp/dispatch.rs
+++ b/crates/rimap-server/src/mcp/dispatch.rs
@@ -286,53 +286,77 @@ mod tests {
         use rimap_authz::breaker::FailureReason;
         use rimap_core::{ErrorCode, RimapError};
 
-        // Pins the SEMANTICS for all 20 current ErrorCode variants (service
-        // failures trip, user/policy/internal errors do not). Exhaustiveness
-        // is enforced upstream: the mapping fn's own `match` is
-        // compile-exhaustive, so a new ErrorCode breaks THAT build and forces
-        // a classification decision before this table matters.
-        let cases: &[(ErrorCode, Option<FailureReason>)] = &[
-            (
-                ErrorCode::ConnectionLost,
-                Some(FailureReason::ConnectionLost),
-            ),
-            (ErrorCode::Auth, Some(FailureReason::Auth)),
-            (ErrorCode::Timeout, Some(FailureReason::Timeout)),
-            (ErrorCode::ImapProtocol, Some(FailureReason::Protocol)),
-            (ErrorCode::SmtpProtocol, Some(FailureReason::Protocol)),
-            (ErrorCode::Tls, Some(FailureReason::Tls)),
-            (ErrorCode::InvalidInput, None),
-            (ErrorCode::PostureDenied, None),
-            (ErrorCode::RateLimited, None),
-            (ErrorCode::CircuitOpen, None),
-            (ErrorCode::NotFound, None),
-            (ErrorCode::AttachmentTooLarge, None),
-            (ErrorCode::ProtectedFolder, None),
-            (ErrorCode::ExpungeDenied, None),
-            (ErrorCode::Config, None),
-            (ErrorCode::Internal, None),
-            (ErrorCode::NoAccount, None),
-            (ErrorCode::UnknownAccount, None),
-            (ErrorCode::Cancelled, None),
-            (ErrorCode::UidValidityChanged, None),
+        // The expected classification is a `match` with NO wildcard arm, so a
+        // newly added `ErrorCode` fails THIS test build until its breaker
+        // classification is declared here — mirroring the no-wildcard intent
+        // of the production mapping fn. Service failures trip the breaker;
+        // user / policy / internal errors do not.
+        fn expected_reason(code: ErrorCode) -> Option<FailureReason> {
+            match code {
+                ErrorCode::ConnectionLost => Some(FailureReason::ConnectionLost),
+                ErrorCode::Auth => Some(FailureReason::Auth),
+                ErrorCode::Timeout => Some(FailureReason::Timeout),
+                ErrorCode::ImapProtocol | ErrorCode::SmtpProtocol => Some(FailureReason::Protocol),
+                ErrorCode::Tls => Some(FailureReason::Tls),
+                ErrorCode::InvalidInput
+                | ErrorCode::PostureDenied
+                | ErrorCode::RateLimited
+                | ErrorCode::CircuitOpen
+                | ErrorCode::NotFound
+                | ErrorCode::AttachmentTooLarge
+                | ErrorCode::ProtectedFolder
+                | ErrorCode::ExpungeDenied
+                | ErrorCode::Config
+                | ErrorCode::Internal
+                | ErrorCode::NoAccount
+                | ErrorCode::UnknownAccount
+                | ErrorCode::Cancelled
+                | ErrorCode::UidValidityChanged => None,
+            }
+        }
+
+        // The explicit variant list is also enforced by the no-wildcard match
+        // above (a forgotten entry leaves `expected_reason` non-exhaustive),
+        // and the length assert below catches a list entry dropped here.
+        const ALL: &[ErrorCode] = &[
+            ErrorCode::ConnectionLost,
+            ErrorCode::Auth,
+            ErrorCode::Timeout,
+            ErrorCode::ImapProtocol,
+            ErrorCode::SmtpProtocol,
+            ErrorCode::Tls,
+            ErrorCode::InvalidInput,
+            ErrorCode::PostureDenied,
+            ErrorCode::RateLimited,
+            ErrorCode::CircuitOpen,
+            ErrorCode::NotFound,
+            ErrorCode::AttachmentTooLarge,
+            ErrorCode::ProtectedFolder,
+            ErrorCode::ExpungeDenied,
+            ErrorCode::Config,
+            ErrorCode::Internal,
+            ErrorCode::NoAccount,
+            ErrorCode::UnknownAccount,
+            ErrorCode::Cancelled,
+            ErrorCode::UidValidityChanged,
         ];
 
-        for (code, expected) in cases {
+        for &code in ALL {
             let err = RimapError::Imap {
-                code: *code,
+                code,
                 message: "x".into(),
                 source: None,
             };
             assert_eq!(
                 rimap_error_to_breaker_reason(&err),
-                *expected,
+                expected_reason(code),
                 "mapping mismatch for {code:?}",
             );
         }
         assert_eq!(
-            cases.len(),
+            ALL.len(),
             20,
-            "table must list all variants (6 service + 14 user)"
+            "list must enumerate all variants (6 service + 14 user)"
         );
     }
 

--- a/crates/rimap-server/src/tools/mailbox/delete_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/delete_message.rs
@@ -75,13 +75,17 @@ pub async fn handle(
         .delete_message(&input.folder, uid, TRASH_FOLDER)
         .await?;
 
+    let warnings =
+        super::fallback_security_warnings(result.used_fallback, result.folder_wide_expunge);
+
     Ok(ToolResponse::meta_only(DeleteMessageMeta {
         deleted: true,
         folder: input.folder,
         uid: input.uid.get(),
         moved_to_trash: result.moved_to_trash,
         destination: TRASH_FOLDER,
-    }))
+    })
+    .with_warnings(warnings))
 }
 
 #[cfg(test)]

--- a/crates/rimap-server/src/tools/mailbox/mod.rs
+++ b/crates/rimap-server/src/tools/mailbox/mod.rs
@@ -6,3 +6,65 @@ pub mod flags;
 pub mod folder_management;
 pub mod labels;
 pub mod move_message;
+
+/// Build the security warnings for a delete/move that may have fallen back
+/// from atomic `UID MOVE` to COPY+EXPUNGE.
+///
+/// `used_fallback` (`!has_move`) flags the non-atomic fallback; it always
+/// yields `ServerNonAtomicMoveFallback`. `folder_wide_expunge`
+/// (`!has_move && !has_uidplus`) is the distinct data-loss condition and
+/// additionally yields `ServerFolderWideExpungeDataLoss`. Shared by the
+/// `delete_message` and `move_message` handlers so both surface the same
+/// signals.
+pub(crate) fn fallback_security_warnings(
+    used_fallback: bool,
+    folder_wide_expunge: bool,
+) -> Vec<rimap_content::SecurityWarning> {
+    let mut warnings = Vec::new();
+    if used_fallback {
+        warnings.push(rimap_content::SecurityWarning::new(
+            rimap_content::WarningCode::ServerNonAtomicMoveFallback,
+            None,
+            None,
+        ));
+    }
+    if folder_wide_expunge {
+        warnings.push(rimap_content::SecurityWarning::new(
+            rimap_content::WarningCode::ServerFolderWideExpungeDataLoss,
+            None,
+            None,
+        ));
+    }
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fallback_security_warnings;
+    use rimap_content::WarningCode;
+
+    #[test]
+    fn no_fallback_yields_no_warnings() {
+        assert!(fallback_security_warnings(false, false).is_empty());
+    }
+
+    #[test]
+    fn scoped_fallback_yields_only_non_atomic_warning() {
+        let warnings = fallback_security_warnings(true, false);
+        let codes: Vec<WarningCode> = warnings.iter().map(|w| w.code).collect();
+        assert_eq!(codes, vec![WarningCode::ServerNonAtomicMoveFallback]);
+    }
+
+    #[test]
+    fn folder_wide_fallback_yields_both_warnings_in_order() {
+        let warnings = fallback_security_warnings(true, true);
+        let codes: Vec<WarningCode> = warnings.iter().map(|w| w.code).collect();
+        assert_eq!(
+            codes,
+            vec![
+                WarningCode::ServerNonAtomicMoveFallback,
+                WarningCode::ServerFolderWideExpungeDataLoss,
+            ],
+        );
+    }
+}

--- a/crates/rimap-server/src/tools/mailbox/move_message.rs
+++ b/crates/rimap-server/src/tools/mailbox/move_message.rs
@@ -119,14 +119,8 @@ pub async fn handle(
         })
         .collect();
 
-    let mut warnings: Vec<rimap_content::SecurityWarning> = Vec::new();
-    if outcome.used_fallback {
-        warnings.push(rimap_content::SecurityWarning::new(
-            rimap_content::WarningCode::ServerNonAtomicMoveFallback,
-            None,
-            None,
-        ));
-    }
+    let warnings =
+        super::fallback_security_warnings(outcome.used_fallback, outcome.folder_wide_expunge);
 
     Ok(ToolResponse::meta_only(MoveMessageMeta {
         folder: input.folder,

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/add_label.schema.json
@@ -179,7 +179,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_draft.schema.json
@@ -179,7 +179,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_folder.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/create_folder.schema.json
@@ -160,7 +160,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/delete_folder.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/delete_folder.schema.json
@@ -167,7 +167,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/delete_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/delete_message.schema.json
@@ -177,7 +177,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/download_attachment.schema.json
@@ -209,7 +209,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/export_messages.schema.json
@@ -262,7 +262,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/expunge.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/expunge.schema.json
@@ -172,7 +172,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/fetch_message.schema.json
@@ -294,7 +294,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/flag.schema.json
@@ -174,7 +174,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_accounts.schema.json
@@ -183,7 +183,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_attachments.schema.json
@@ -217,7 +217,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_folders.schema.json
@@ -229,7 +229,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/list_labels.schema.json
@@ -179,7 +179,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_read.schema.json
@@ -174,7 +174,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/mark_unread.schema.json
@@ -174,7 +174,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/move_message.schema.json
@@ -210,7 +210,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/remove_label.schema.json
@@ -179,7 +179,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/rename_folder.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/rename_folder.schema.json
@@ -165,7 +165,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/search.schema.json
@@ -275,7 +275,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/send_email.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/send_email.schema.json
@@ -214,7 +214,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/unflag.schema.json
@@ -174,7 +174,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
+++ b/crates/rimap-server/tests/fixtures/rimap-tool-schemas/use_account.schema.json
@@ -162,7 +162,12 @@
         },
         {
           "const": "server_non_atomic_move_fallback",
-          "description": "The IMAP server lacked the MOVE capability; a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used. Other messages with\n`\\Deleted` flag in the source folder may have been expunged.",
+          "description": "The IMAP server lacked the MOVE capability, so a non-atomic\nCOPY+DELETE+EXPUNGE fallback was used instead of an atomic\n`UID MOVE`. The operation is not atomic: a crash or connection\ndrop between the COPY and the EXPUNGE can leave the message\nduplicated in both folders. This signals non-atomicity only;\nthe folder-wide data-loss risk is reported separately by\n`ServerFolderWideExpungeDataLoss`.",
+          "type": "string"
+        },
+        {
+          "const": "server_folder_wide_expunge_data_loss",
+          "description": "The IMAP server lacked UIDPLUS, so the COPY+DELETE fallback issued a\nfolder-wide `EXPUNGE` (RFC 3501) that removes EVERY `\\Deleted` message\nin the source folder, not only the targeted UIDs. Messages another\nclient flagged `\\Deleted` may have been permanently destroyed.",
           "type": "string"
         }
       ]

--- a/docs/reviews/test-coverage-gap-review.md
+++ b/docs/reviews/test-coverage-gap-review.md
@@ -1,0 +1,403 @@
+# Test Coverage Gap Review
+
+## 1. Executive summary
+
+> **Correction (2026-05-28).** An earlier draft of this summary claimed the Docker-gated
+> integration suites are unreachable on this host because "macOS cannot run Docker." That
+> is wrong for local development. With Docker Desktop and the ARM64 image
+> `docker.io/dovecot/dovecot:2.4.4-root`, all of them **run and pass on this host**:
+> `rimap-imap` `dovecot` (43 passed), `rimap-server` `e2e` (1), `e2e_wire` (7),
+> `e2e_wire_cancellation` (7), all with `RIMAP_REQUIRE_DOCKER=1`. The macOS-Docker
+> limitation applies only to GitHub's *hosted* Apple-Silicon runners, not to this machine
+> or to Linux CI runners. The analysis below has been revised accordingly.
+
+This sweep covered 11 areas of the rusty-imap-mcp workspace. The integration suites are
+runnable, so connection lifecycle, MCP dispatch, and the server boot path do have working
+coverage — but it is **happy-path coverage**. `e2e_full_session` walks list → search →
+fetch → mark_read → create_draft → export → move; the Dovecot connection cases cover
+TLS-pin mismatch (`case_02`, `case_22`, `starttls_with_wrong_pin`), login rejection
+(`case_04`), connection drop/recovery (`case_10`, `case_11`), and folder/store/move/expunge
+operations. Pure helpers below the orchestration layers are also well tested.
+
+The real gaps that survive are of two kinds, **neither of which is closed by the suites
+being runnable**:
+
+1. **Fault-injection branches the e2e suites never trigger even though they execute.** The
+   e2e server wires a `CircuitBreaker` but never trips it, so the service-vs-user tripping
+   decision in `dispatch_account_scoped` is unasserted. It opens the audit writer with
+   `fail_open: false` but never induces a write failure, so the fail-closed abort and the
+   no-orphan-`tool_start` property are unasserted. The non-UIDPLUS plain-`EXPUNGE`
+   data-loss fallback is unreachable against Dovecot (which always advertises UIDPLUS), so
+   it needs a mock IMAP server, not a container.
+2. **Pure-unit gaps independent of any server.** FolderGuard Modified-UTF-7 normalization
+   (all current tests are ASCII-only — a fail-open protected-folder bypass), rimap-content
+   body accounting / secondary-HTML drop, the SMTP error taxonomy, and AccountId/FolderName
+   validation owe nothing to Docker.
+
+The most common defect class is a fail-open that is "safe today only by accident": a
+dead defensive branch, a mirror function that can drift from production, or a side effect
+committed before a later stage can reject it. Several confirmed bugs (SMTP error
+taxonomy, AccountId deserialize, breaker probe waste) are of this kind.
+
+The single biggest change from the earlier draft: the recommended **in-process rustls/rcgen
+TLS mock is redundant** — TLS-pin mismatch with a typed error and a single AuthEvent is
+already tested against real Dovecot here (`case_02`/`case_22`/`starttls_with_wrong_pin`).
+Any missing auth-provenance variant (e.g. `LOGINDISABLED`) should be added by extending
+`dovecot.rs`, not by building a mock.
+
+## 2. Confirmed, untested bugs
+
+Counts: 14 confirmed bugs across the sweep. Severity below reflects the verified
+verdicts, not the original reporter estimates.
+
+| Severity | Area | Location | Defect | Suggested test |
+|----------|------|----------|--------|----------------|
+| high | rimap-authz | folder_guard.rs:17-45 | Modified-UTF-7 normalization is exercised only with ASCII; the decode + decode-failure-fallback paths for protected-folder matching are unverified (potential fail-open bypass) | Build FolderGuard from a raw mUTF-7 protected name, assert `check_protected` rejects both the encoded and decoded request forms, plus a malformed-encoding fallback case |
+| high | server-mcp | server.rs:125-139 | breaker `on_success`/`on_failure` and posture/rate gating in `dispatch_account_scoped` are only covered behind Docker e2e | Drive a `DispatchGuard<ManualClock>` fed by `rimap_error_to_breaker_reason`: assert Timeout/Auth trip, InvalidInput does not, Ok resets |
+| high | server-mcp | audit_envelope.rs:124-159 | fail-closed tool_start audit failure and the no-orphan-tool_start property are untested at the envelope level | `run_with_audit_envelope` + `force_next_write_failure`: assert Err on fail_open=false with zero records on disk; Ok + suppressed counter on fail_open=true |
+| medium | rimap-core | account.rs:15 | `AccountId` derives `Deserialize`, bypassing `AccountId::new` validation and lowercasing (verdict: real, low blast radius today) | Assert `from_str::<AccountId>("\"WORK\"") == AccountId::new("work")` and that empty/space/oversized strings are rejected |
+| medium | server-mcp | server.rs:546-549 | A non-string `account` arg (`123`/`null`) silently falls through to auto-select/session-default instead of erroring | Multi-account harness with a session default: send `{"account":123}`/`{"account":null}`, assert invalid_input rather than success against the default |
+| medium | server-tools | part_walker.rs:43-47 | `BodyStructure::Message` arm reuses the wrapper part_id and re-descends with it, producing a part-ID collision / RFC-incorrect numbering for embedded messages | Walk `Message{ body: single }`, assert ids are `["1","1.1"]` not `["1","1"]` |
+| low | rimap-core | folder_name.rs:107 | Doc promises C0/C1 rejection but C1 controls (U+0080–U+009F) are never rejected; proptest reference shares the omission | Assert `FolderName::new("bad\u{0080}name")` and `\u{009f}` are rejected; update the proptest reference predicate |
+| low | rimap-config | credential.rs:83-86 | `split_account_for_error` splits on the first `@`, wrongly attributing username/host for namespaced (`id/user@host`) and multi-`@` keys, breaking log-tag correlation | Drive a Keychain error and assert `account_tag == hash_account_tag("alice", host)` (not `hash_account_tag("work/alice", host)`) |
+| low | rimap-imap | fetch.rs:158-163 | FETCH silently `continue`s on UID-absent or UID-0 messages with no warning (only reachable on a non-conformant server) | Extract a pure UID helper; assert None/Some(0) produce a warn/skip signal, not a silent drop |
+| medium | rimap-content | bodies.rs:64-70 | Secondary text/html parts are silently dropped (no warning, not counted, anchors escape lookalike audit) | Two-HTML-part multipart/mixed with a homograph anchor in part 2; assert the second part surfaces OR a warning fires, and the homograph is audited |
+| low | rimap-content | bodies.rs:76-85 | Aggregate body cap is checked only after a part is appended, so one part can straddle MAX_TOTAL_BODY_BYTES by up to ~1MiB | Parts that cross the 4MiB boundary mid-part; assert retained total exceeds the cap (pins the overshoot) |
+| low | rimap-content | bodies.rs:159 vs 132 | `body_html` bytes are never counted toward `total_bytes`, so serialized Content can exceed the transport cap | Small text + large-body_html primary part; assert serialized total (incl. body_html) > MAX_TOTAL_BODY_BYTES while body_truncated is false |
+| medium | rimap-authz | guard.rs:40-45 | `breaker.pre_call` transitions Open→HalfOpen before `governor.check`; a rate-limit rejection wastes the probe slot and can wedge the breaker | Trip Open, advance past cooldown, drain the global bucket, assert pre_dispatch returns RateLimited AND breaker is wedged HalfOpen with retry_after_ms=0 |
+| low | rimap-authz | rate_limit.rs:100-108 | A rejected create_draft/send_email still debits a global token (consumed before the specific bucket rejects) | Control vs experiment run with small global burst; assert rejected drafts reduce admitted Search calls |
+| medium | rimap-smtp | client.rs:160-168 | Timeouts misclassify as Transport→ErrorCode::Internal; `SmtpError::Timeout`/`ErrorCode::Timeout` are never produced by send paths | Refactor classifier to take (is_response, is_client, is_timeout); assert is_timeout=true → Timeout/ErrorCode::Timeout |
+| medium | rimap-smtp | client.rs:148-157 | Auth and TLS failures collapse into Connection/Transport; `SmtpError::Auth`/`Tls` are never produced | Extend `SmtpErrorShape` to consult `is_tls()`/auth predicate; assert TLS/auth lettre errors map to Tls/Auth and ErrorCode::Tls/Auth |
+| low | rimap-smtp | client.rs:170-181 | `shape_to_variant_name` is a `#[cfg(test)]` duplicate of `classify_smtp_error` that can silently drift | Extract a single shared `shape→variant` function used by both production and tests |
+| low | server-mcp | audit_envelope.rs:272-278 | Cancellation tool_end is silently dropped when the cancellation channel is full (documented tradeoff; breaks tool_start/tool_end pairing at >1024 backlog) | Saturate the channel without a drainer, drive 1025 guard drops, assert orphaned tool_start |
+| low | server-boot | migrate_keyring.rs:36-42 | migrate-keyring is non-atomic: a failure after writing the new key leaves the secret in BOTH keys with no rollback | Add a fail-on-second-set MockStore knob; assert Err leaves both keys populated |
+
+### HIGH-severity bugs
+
+**FolderGuard mUTF-7 normalization (folder_guard.rs:17-45).** Every folder_guard test
+uses plain ASCII, so the Modified-UTF-7 decode branch and the documented "fall back to
+ASCII-lowercased input on decode failure" behavior are unexercised. If a protected folder
+is stored in its raw wire form and the runtime passes the decoded form (or vice versa),
+the equality at line 45 must still match after normalization on both sides. A
+non-idempotent decode, a one-sided encoding, or a dropped fallback would let a protected
+folder be deleted/renamed/expunged — a fail-open on the core authz boundary. This is the
+top fix because it is a security gate with zero coverage of its non-trivial path.
+
+**Breaker `dispatch_account_scoped` wiring (server.rs:125-139).** The decision of whether
+a service failure trips the circuit and whether an agent is denied is exercised only
+behind Docker e2e. No host-runnable test asserts that a Timeout/Auth error calls
+`on_failure` while an InvalidInput does not, nor that a successful call calls
+`on_success`. A regression that swapped the Ok/Err arms or dropped `on_failure` would pass
+all non-Docker CI. `rimap_error_to_breaker_reason` is host-runnable, so a mapping table
+plus a `DispatchGuard<ManualClock>` driver fully closes this without a live server.
+
+**Envelope-level fail-closed audit (audit_envelope.rs:124-159).** `audit_fail_open.rs`
+only drives `AuditWriter::log_tool_start` directly; it never drives
+`run_with_audit_envelope`. The fail-closed contract (the tool call MUST fail when audit is
+broken) and the no-orphan property (the guard is constructed AFTER `emit_tool_start`, so a
+failed start must not leave a dangling tool_start) are untested. `force_next_write_failure`
+makes this host-runnable today.
+
+## 3. Coverage gaps by area
+
+### rimap-core
+- Serde wire-format paths untested for the on-disk audit types: `AuthEvent` (skip/default/None handling), `AuthResult` snake_case, `Posture` kebab-case round-trip and its agreement with `as_str()`/`from_str()`, `ErrorCode` full deserialize/unknown-code rejection.
+- `AccountId` deserialize bypasses validation/normalization (confirmed bug).
+- `ImapEncryption` serde (lowercase) and `Default=Tls` completely untested — a casing or default flip would silently alter encryption negotiation.
+- `CredentialResolverError` source-chain / `reason`/`into_reason` sanitization contract untested.
+- `TlsFingerprint::from_hex` defensive fallbacks (hex/length map_err) and empty-string input are dead-untested; `BoundedUids::TryFrom` 100/101 boundary tested only via serde, not the direct API.
+- `FolderName` C1 control range never rejected despite the doc (confirmed bug).
+
+### rimap-config
+- `classify_format` for a non-array `accounts` key routes to the legacy parse path (but the refuted claim shows it surfaces a clear "unknown field accounts" error, not a misleading missing-`[imap]` error).
+- Credential migration-hint and keyring-failure `tracing::warn!` branches are never asserted; the skip-legacy-on-new-key-transport-error policy is untested.
+- `split_account_for_error` namespaced/multi-`@` key handling (confirmed bug); `KeyringStore::get/set_password` NoEntry-vs-error discrimination untested.
+- `KeyringCredentialResolver::resolve` adapter error mapping (username redaction preservation) untested.
+- `validate_paths_multi` non-export writable-dir branch, audit-containment fail-closed branches (base missing / `default_audit_base()` None), and UTF-7-encoded protected-folder collision untested.
+- `run_login` store-write failure path uncovered.
+
+### rimap-imap
+- The plain-EXPUNGE data-loss fallback in move/delete (has_uidplus=false) is unreachable against Dovecot and has no unit/mock test; `delete.rs` has no `#[cfg(test)]` at all.
+- FETCH silent UID drop and the preflight UID-omission fail-open (confirmed/related bugs), plus the untested preflight→project_size defense-in-depth chain.
+- `with_session` does NOT invalidate on `Protocol` mid-stream — a half-consumed session is reused with no test proving safety.
+- Post-login CAPABILITY probe failure silently downgrades to the non-atomic fallback (the broader data-loss framing was refuted, but the transient-probe-error fail-open remains untested at the unit level).
+- `probe_preflight` greeting/capability path and `is_dead_tcp_kind` wildcard arm are reachable only against a live server (the wildcard claim itself was refuted — `#[non_exhaustive]` forces the arm).
+
+### rimap-content
+- `alternate_parts` is never populated by any test or snapshot (all 26 snaps empty); the secondary-HTML drop, post-hoc aggregate cap, and body_html exclusion are confirmed bugs.
+- `convert_datetime` invalid/out-of-range Date, `audit_domain_bidi_prestrip` idna-failure fallback, `sniff` Rar/opendocument branches, and `raw_parts` depth-cap/index-out-of-bounds arms are dead-untested defensive paths.
+- `extract_message_id` raw passthrough vs `sanitize_msg_id` divergence (claim refuted as already-covered indirectly, but the divergence is worth a direct pin).
+
+### rimap-audit
+- fail_open rotation-then-write-fails seq gap (the "permanent gap" framing was refuted against the monotonic-only contract, but the suppression-at-rotation path and post-write fsync failure are still untested).
+- Mutex-poisoned degradation, drainer Ok(Err)/join-panic survival, `try_send` Full/Closed boundaries.
+- `unique_rotated_path` exhaustion-overwrite, mixed-mtime `retention_seconds` pruning, reader mid-stream I/O error / non-UTF-8 line, self_check interior-corruption tolerance vs reader fail-fast, Some(0)-inode sentinel.
+
+### rimap-authz
+- Breaker probe waste under same-pre_dispatch rate-limit (confirmed bug); global-token leak on rejected draft/send (confirmed bug).
+- Mixed auth/non-auth cooldown ceiling, post-recovery doubling sequence, `on_success`-in-Open, Closed-state mixed-reason accumulation (several refuted as design-consistent or dead state, but cooldown-class interactions remain thinly tested).
+- FolderGuard mUTF-7 (confirmed bug); `matrix.check` on an infrastructure tool and `rate_limit` burst saturation boundary untested.
+
+### rimap-smtp
+- Real `classify_smtp_error`, the Tls/Starttls construction branches, `format_response` shape, zero-timeout behavior, and four of six `From<SmtpError>` arms are untested (confirmed bugs around taxonomy collapse).
+
+### server-mcp
+- `dispatch_account_scoped` breaker wiring and envelope fail-closed (confirmed high bugs); `read_resource` no-reflection invariant, namespaced-infrastructure-tool rejection, TOOL_DEFS-before-refine ordering, `run_on_blocking_pool` closed-semaphore/panic arms, and `extract_json_from_call_tool_result` fallbacks untested outside Docker.
+
+### server-tools
+- `search` pagination arithmetic (the truncated-on-out-of-range claim was refuted as mathematically wrong), `list_folders` status-projection (Noselect→None), `send_email` copy-to-Sent fail-open wiring, `fetch_message` truncation, `download_attachment` MIME cross-validation skip, and `part_walker` Message arm (confirmed bug) are handler-orchestration paths covered only by skipped e2e.
+
+### server-boot
+- The entire `run()` two-phase `tokio::select!` lifecycle, `handle_init_failure` dispatch, `emit_process_end` reason mapping, `build_registry` protected-folder merge/special-use expansion, download-dir lockdown of pre-existing loose-perm dirs, `compute_config_hash` fail-open, multi-account `process_start` summary, and `logging::init` env-precedence chain are untested (several lifecycle sub-claims refuted as unreachable, but the happy/error reason mapping and registry merge remain uncovered).
+
+## 4. Complex functional test sequences to add
+
+### Theme: ingest pipeline (rimap-content)
+
+**Two-HTML-part multipart/mixed: secondary HTML dropped, anchors escape audit**
+- Steps: build multipart/mixed with text/plain primary, a second text/plain, a clean text/html, and a second text/html carrying `<a href="https://p\u{0430}ypal.com/login">`; call `parse_message`; assert `alternate_parts` is non-empty (first time exercised); assert body_html is the first HTML only; assert NO LookalikeMixedScript warning for the homograph host; add a single-HTML-part positive control that DOES fire the warning.
+- Components: parse/bodies.rs, parse/pipeline.rs, html/sanitize.rs, lookalike.rs.
+- Oracle: alternate_parts populated; the homograph host appears in neither body_html nor a warning (pins the silent drop and the audit blind spot in both directions).
+- Harness: inline `#[cfg(test)]` in bodies.rs or tests/ using public `parse_message`.
+
+**Adversarial smuggling + zero-width subject + bidi From domain: warning aggregation**
+- Steps: one raw message that triggers CRLF-smuggled Bcc, a U+200B subject, and an RLO bidi-override From domain; assert Bcc was scrubbed before parse (no bcc recipient + ParseHeaderSmugglingBlocked), the zero-width was stripped (UnicodeZeroWidthStripped), a LookalikeHomographDomain at header:from with `reason=bidi_pre_strip`, and that all three coexist with the smuggling warning preceding the lookalike warning.
+- Components: mime_scrub.rs, safe_parser.rs, headers.rs, meta.rs, unicode.rs, lookalike.rs.
+- Oracle: all three codes present, ordering preserved, Bcc absent, subject free of U+200B.
+- Harness: inline test in pipeline.rs.
+
+**mailto: anchor feeds homograph host into lookalike (scheme-rejection divergence)**
+- Steps: HTML-only body with one `mailto:user@p\u{0430}ypal.com` anchor; assert lookalike audits it (extract_domain_from_url has no mailto rejection); contrast against `extract_registrable_domain("mailto:...")==None` in the mismatch pass; pin the divergence.
+- Components: lookalike.rs, html/mismatch.rs, html/sanitize.rs, parse/pipeline.rs.
+- Oracle: LookalikeMixedScript at html:anchor_href present for the mailto case; mismatch still returns None.
+- Harness: inline test in lookalike.rs + one parse-level assertion.
+
+**Aggregate cap straddle + body_html exclusion**
+- Steps: three near-1MiB text parts (total ~3MiB) then a large-body_html/small-text HTML primary; compute serialized = body_text + alternates + body_html; assert text+alternates ≤ cap but serialized > cap with body_truncated false.
+- Components: parse/bodies.rs, html/sanitize.rs, parse/pipeline.rs.
+- Oracle: serialized total exceeds MAX_TOTAL_BODY_BYTES while no truncation fired.
+- Harness: inline test in bodies.rs/pipeline.rs.
+
+**FETCH UID-less/zero-UID drop + preflight bypass + defense-in-depth + dispatch classification**
+- Steps: (A) feed UID=None and UID=Some(0) through the fetch loop guards, assert both excluded with no error; (B) drive preflight_fetch_size with a UID-omitting response so size stays None, feed None to preflight_size_check (Ok), then project_size over-limit returns SizeLimit; cross-reference dispatch classifying SizeLimit as should_invalidate=true.
+- Components: ops/fetch.rs, connection/dispatch.rs, types Uid.
+- Oracle: dropped messages excluded; preflight passes but project_size errors; dispatch invalidates only on SizeLimit.
+- Harness: inline tests in fetch.rs (helpers exist; a thin UID-guard helper may be needed since no mock session exists).
+
+**Outbound Message-ID round-trip divergence**
+- Steps: hostile Message-ID (angle brackets + control char); compare `extract_message_id` vs `extract_threading_headers().message_id`; assert they differ and the former retains `<`/`>`/control char; show the would-be outbound header is malformed; verify the threading path round-trips cleanly.
+- Components: lib.rs, threading.rs, unicode.rs.
+- Oracle: extract_message_id output != sanitized form and contains the hostile chars.
+- Harness: inline test in lib.rs.
+
+### Theme: authz posture gating (rimap-authz)
+
+**Wasted half-open probe under same-pre_dispatch rate-limit**
+- Steps: build `DispatchGuard<ManualClock>` at DraftSafe with error_threshold=2 and a tiny `Governor::new(1,5,3)`; trip Open; advance past cooldown; drain the global bucket; call pre_dispatch once so breaker flips Open→HalfOpen then governor rejects; assert RateLimited; assert breaker is HalfOpen with no callback; assert the next call returns CircuitOpen{retry_after_ms:0}; assert recovery only after an explicit on_success/on_failure.
+- Components: guard.rs, breaker.rs, rate_limit.rs, rimap-core tool/posture.
+- Oracle: RateLimited returned, breaker wedged HalfOpen, retry_after_ms=0; reorder/rollback fix flips it.
+- Harness: inline test in guard.rs.
+
+**Mixed auth/non-auth cooldown ceiling**
+- Steps: breaker with distinct auth vs non-auth bounds; auth-first trip then a non-auth half-open failure (and the reverse); read cooldown via the CircuitOpen retry hint; assert the cap selected matches the current reason's ceiling and pin the carried-over current_cooldown behavior.
+- Components: breaker.rs.
+- Oracle: retry_after_ms equals (carried current_cooldown × 2) capped by the current reason's cap.
+- Harness: inline test in breaker.rs (ManualClock).
+
+**Stray on_success while Open**
+- Steps: trip Open; without advancing the clock or calling pre_call, call on_success directly; assert state→Closed and pre_call→Ok (early cooldown clear); repeat for a non-auth trip.
+- Components: breaker.rs.
+- Oracle: pins current fail-open behavior so a future guard is a deliberate change.
+- Harness: inline test in breaker.rs.
+
+**Rejected create_draft erodes the global bucket**
+- Steps: `Governor::new(2,1,3)`; control run counts Search admits; experiment run drains the draft bucket (including rejected attempts that still debit global) then counts remaining Search admits.
+- Components: rate_limit.rs, rimap-core is_draft_quota_gated.
+- Oracle: experiment Search admits < control by the count of rejected drafts.
+- Harness: inline test in rate_limit.rs.
+
+**FolderGuard mUTF-7 bypass attempts + malformed fallback**
+- Steps: encode a non-ASCII protected name; build guards from the raw and decoded forms; assert all four (config-form × request-form) combinations reject; test a malformed (dangling `&`) name's fallback; cross-check byte-identity with rimap-config's normalization.
+- Components: folder_guard.rs, folder_name.rs, utf7_imap, rimap-config validate/rules.rs.
+- Oracle: all combinations return ProtectedFolder; malformed name still blocked.
+- Harness: inline test in folder_guard.rs.
+
+**Service vs user error breaker feeding + exhaustive reason mapping**
+- Steps: assert `rimap_error_to_breaker_reason` over every ErrorCode (Some for ConnectionLost/Auth/Timeout/ImapProtocol/SmtpProtocol/Tls, None for the rest); then via a `DispatchGuard<ManualClock>` driver feed 3× Timeout (Open), N× InvalidInput (still Closed), 2× Timeout + Ok (reset), 1× Auth (immediate Open).
+- Components: mcp/dispatch.rs, mcp/server.rs reason-feeding, rimap-authz breaker, rimap-core error.
+- Oracle: per-code Some/None plus the four breaker-state outcomes; swapped Ok/Err arm or misclassified service error flips one.
+- Harness: mapping table inline in dispatch.rs; breaker sequence in guard.rs via `DispatchGuard<ManualClock>`.
+
+### Theme: audit lifecycle (rimap-audit)
+
+**Seq gap survives crash-resume across rotation under fail_open**
+- Steps: open with rotate_bytes just above one line, fail_open=true; write seq=1; force the threshold-crossing write to fail (read-only parent); assert suppressed_failures==1 and Ok; next write reports seq=3; drop and run read_trailing_state across siblings asserting no seq==2 anywhere.
+- Components: rimap-audit.
+- Oracle: gap at seq 2, suppression counted, resume reflects highest durable seq.
+- Harness: tests/ (Unix-gated; extends fail_open.rs + rotation.rs).
+
+**Reader vs self-check tolerance divergence on interior corruption after rotation**
+- Steps: write+rotate to produce a sibling; corrupt the active file into good/garbage/good lines; assert read_trailing_state skips the garbage (last_seq=N+2) while stream_records returns Err(Read) at "line 2".
+- Components: rimap-audit.
+- Oracle: self-check tolerant, reader fail-fast on the same file.
+- Harness: tests/ (combines self_check + reader paths).
+
+**Rotation-changed inode not wrongly flagged as tamper**
+- Steps: process_start with inode_A; rotate (active gets inode_B); resume and log_process_start with current_inode=inode_B; assert audit_file_inode_changed=true; contrast a no-rotation control asserting false.
+- Components: rimap-audit.
+- Oracle: legitimate rotation inode change vs missed real tamper, both pinned.
+- Harness: tests/ (Unix-gated; extends inode_change.rs with a real rotation).
+
+**Cancellation drainer survives a failing record**
+- Steps: fail_open=false writer; spawn drainer; enqueue valid #1, force the next write to fail then enqueue #2, enqueue valid #3; drop tx, await drainer Ok; assert #1 and #3 on disk, #2 absent.
+- Components: rimap-audit.
+- Oracle: drainer does not die on the Ok(Err) arm; subsequent records still written.
+- Harness: inline `#[tokio::test]` (multi_thread) in cancellation.rs.
+
+**Fail-closed tool_start audit abort with no orphan; fail-open proceeds**
+- Steps: ImapMcpServer::new_for_tests with fail_open=false; force the tool_start write to fail; call run_with_audit_envelope; assert Err with "audit write failed" and ZERO records on disk; repeat fail_open=true asserting Ok + suppressed_failures>=1.
+- Components: rimap-server, rimap-audit.
+- Oracle: no orphan tool_start on fail-closed; body proceeds on fail-open.
+- Harness: inline `#[tokio::test]` in audit_envelope.rs.
+
+**Interleaved tool_start/tool_end across rotation preserve contiguous seq**
+- Steps: small rotate_bytes, fail_open=false; interleave log_tool_start/log_tool_end/log_auth from two writer clones across several rotations; drop; collect seq across all siblings; assert the set equals 1..=N with no gaps/dupes and tool_start count == tool_end count.
+- Components: rimap-audit.
+- Oracle: contiguous seq + paired envelopes survive rotation with interleaved writers.
+- Harness: tests/ (extends rotation.rs with clones).
+
+### Theme: MCP wire protocol (server-mcp)
+
+**Split frame reassembly + unterminated final frame at EOF**
+- Steps: spawn the binary (zero-account); handshake; write one tools/list line in three mid-token chunks; assert reassembled result; send a second request with no trailing newline then close stdin; assert clean close or a valid trailing response, never hang/crash.
+- Components: wire_validator::inbound, mcp::server, main::run, rmcp.
+- Oracle: reassembled frame returns a valid result; EOF outcome is clean.
+- Harness: tests/ mcp_wire_negative.rs.
+
+**Mixed batch: parse-error + invalid-request-with-id + valid request under stdout-mutex contention**
+- Steps: handshake; send `not json`, `{method:42,id:7}`, valid tools/list id 8 in a burst; drain until id 8; assert three standalone schema-valid envelopes; parse-error has no id, invalid-request echoes id 7, valid returns a result.
+- Components: wire_validator inbound/envelope/outbound, rmcp.
+- Oracle: exactly 3 well-framed envelopes; no torn/concatenated lines.
+- Harness: tests/ mcp_wire_negative.rs.
+
+**Oversized/fractional request ids round-tripped through the synthesized error envelope**
+- Steps: send a rejected request with id `9223372036854775808`, then `2.5`, then a string id; assert numeric out-of-range/fractional ids are suppressed to absent while the string id is echoed; every envelope passes the MCP schema; a trailing tools/list confirms responsiveness.
+- Components: envelope is_forwardable_id/extract_id/synthesize_error_line, rmcp, MCP schema validator.
+- Oracle: synthesized lines schema-valid; no oversized/fractional id echoed.
+- Harness: tests/ mcp_wire_negative.rs.
+
+**Cancellation tool_end dropped when channel saturated**
+- Steps: saturate the cancellation channel (no drainer); new_for_tests server with fail_open=false; spawn a pending-body tool via run_envelope_with_body_for_test, sleep, abort; assert exactly one record (tool_start) and no cancelled tool_end; control run with a drained channel + drainer asserts the tool_end lands.
+- Components: audit_envelope guard drop, rimap-audit try_send Full path.
+- Oracle: saturated run orphans the tool_start; control run pairs it.
+- Harness: inline / tests (extends dispatch_ticket.rs).
+
+**notifications/cancelled for in-flight, unknown, and completed ids (host-runnable)**
+- Steps: handshake; tools/call nonexistent_tool (fast RESOURCE_NOT_FOUND) then cancel its id; assert exactly one envelope; cancel a never-issued id and assert no response within 200ms; a final tools/list confirms responsiveness.
+- Components: mcp::server call_tool + notifications/cancelled, wire_validator passthrough, rmcp.
+- Oracle: one envelope per issued id; unknown-id cancel is a no-op; server stays responsive.
+- Harness: tests/ mcp_wire_negative.rs (host-runnable variant of the Docker-gated suite).
+
+**Duplicate top-level id key caught before parse**
+- Steps: send the #266 duplicate-top-level-key line; assert -32600 with no id; send a params-only dup (forwards, valid result); send an error-body dup (rejected -32600); confirm responsiveness.
+- Components: envelope has_duplicate_keys_in_rmcp_strict_positions, dup-check visitors, inbound, rmcp, serde_json.
+- Oracle: strict-position dups rejected, lenient params dup forwards.
+- Harness: tests/ mcp_wire_negative.rs.
+
+### Theme: connection lifecycle (rimap-imap)
+
+> **Revised.** Most of this theme is already covered against real Dovecot on this host and
+> does **not** need the proposed TLS mock: pin mismatch + typed `Tls` error + AuthEvent
+> (`case_02`, `case_22`, `starttls_with_wrong_pin`), login rejection (`case_04`), and
+> connection drop/recovery (`case_10`, `case_11`). What remains genuinely open: the
+> **non-UIDPLUS plain-`EXPUNGE` fallback** (unreachable against Dovecot — needs a mock) and
+> any **auth-provenance variant not yet in `dovecot.rs`** (`LOGINDISABLED`,
+> resolver-error → `CredentialUnavailable`), which should be added to the existing harness.
+
+**TLS pin mismatch → typed Tls error + exactly one AuthEvent; matching pin → Success once**
+*(already covered by `case_02`/`case_22`/`starttls_with_wrong_pin` — listed for completeness, not as new work)*
+- Steps: stand up an in-process rustls/rcgen TLS server; compute the leaf fingerprint; mismatch run asserts ImapError::Tls{observed,expected} and exactly one AuthEvent (Failure, error_code=Tls, fingerprint_match=false, credential_source=None); matching run asserts success and exactly one AuthEvent (Success, fingerprint_match=true, source=EnvVar).
+- Components: connection/mod.rs connect_inner + enrich_tls_handshake_error, handshake.rs, login.rs, auth.rs, rimap-core types.
+- Oracle: typed Tls error with correct fingerprints; single AuthEvent per termination.
+- Harness: tests/ TLS mock (host-runnable, not Docker).
+
+**Auth-failure provenance: missing credential vs LOGIN rejection vs LOGINDISABLED**
+- Steps: over the TLS mock, drive (A) resolver Err → CredentialUnavailable, source=None; (B) LOGIN NO → LoginRejected, source=Some(Keyring); (C) LOGINDISABLED → CapabilityMissing, source=None and resolver never called.
+- Components: login.rs imap_login/drain_for_logindisabled, connect_inner, rimap-core credential types.
+- Oracle: each AuthFailure variant + error_code=Auth; source threading and resolver-not-called ordering.
+- Harness: tests/ same TLS mock.
+
+**Protocol mid-stream reuses session; ConnectionLost reconnects; fetch_body SizeLimit invalidates**
+- Steps: cache a session; (A) Protocol error then a second op on the same Connection asserting reuse (one TCP accept); (B) ConnectionLost then a reconnect (second accept + second AuthEvent); (C) fetch_body_with_limit SizeLimit then reconnect.
+- Components: connection/dispatch.rs with_session/fetch_body_with_limit, connection/mod.rs, ops/fetch.rs.
+- Oracle: accept-count / session-state assertions per error class.
+- Harness: tests/ TLS mock with multi-connection accept loop.
+
+**Per-account FallbackMode + env-var: no cross-account credential bleed**
+- Steps: multi-account TOML (A keyring-only, B keyring-then-env) over a shared MockStore + temp_env; assert A never consults env (NoCredential), B resolves to its own Keyring key; remove B's key and assert B→EnvVar while A still fails.
+- Components: validate/compose.rs, credential.rs resolve/adapter, test_support MockStore, rimap-core.
+- Oracle: A never returns the env secret; B's source flips correctly.
+- Harness: tests/ in rimap-config (host-runnable).
+
+**Adapter preserves ConfigError on source chain while keeping reason username-free**
+- Steps: KeyringCredentialResolver over MockStore::failing in KeyringOnly; assert reason omits the username, source() downcasts to ConfigError::Keychain, into_reason()==reason(); thread into a Connection and assert ImapError::Auth{CredentialUnavailable} still omits the username; KeyringThenEnv leg succeeds with EnvVar.
+- Components: credential.rs resolver/split/KeyringStore, rimap-core CredentialResolverError, login.rs map_err.
+- Oracle: username never in reason() through the full chain; source preserved.
+- Harness: tests/ spanning rimap-config + rimap-core + the TLS mock.
+
+**probe_preflight greeting-budget starvation**
+- Steps: TLS mock delays the greeting after handshake; size connect_timeout so TLS + delay approach it; assert the deterministic outcome (Timeout{op:"imap_greeting"} vs Ok) and pin it; contrast a generous-timeout run asserting Ok with capabilities and fingerprint populated.
+- Components: preflight.rs greeting_budget, handshake.rs tls_handshake, tls.rs capture-only config.
+- Oracle: starvation outcome pinned; contrast run returns PreflightInfo with the mock fingerprint.
+- Harness: tests/ TLS mock with a pre-greeting delay knob.
+
+## 5. Refuted / already-covered claims
+
+Reviewers do not need to re-investigate these:
+
+- **posture_matrix base_allows fallthrough** — already covered cross-crate in rimap-authz matrix.rs.
+- **AuthEvent error_code Some-on-Failure/None-on-Success invariant** — already asserted in rimap-imap auth.rs producers.
+- **rimap-config port-vs-encryption consistency validation** — refuted; no such validation is advertised (model docstrings are descriptive hints).
+- **Non-array `accounts` misclassified with a misleading error** — refuted; `deny_unknown_fields` yields a clear "unknown field `accounts`" error.
+- **KeyringThenEnv cross-account env bleed** — already covered/documented; KeyringOnly is the documented multi-account mitigation with tests.
+- **SMTP plaintext localhost allowlist missing spellings** — refuted; the deny outcome for non-listed spellings is the safe intended path.
+- **Post-login CAPABILITY failure enabling plain-EXPUNGE fallback** — refuted as framed (a dead stream fails the COPY step first).
+- **move_messages empty-input skipping the UIDVALIDITY guard** — refuted; the path is unreachable (BoundedUids rejects empty) and an empty move is a no-op.
+- **probe_preflight zero greeting budget** — refuted; design intent, only reachable with a near-exhausted connect budget.
+- **is_dead_tcp_kind wildcard arm** — refuted; `#[non_exhaustive]` requires the arm and the cited future kinds are not stable; current kinds are tested.
+- **extract_message_id leaks brackets** — already covered indirectly (parse strips them; value only echoed to response meta) — but a direct pin is still recommended.
+- **collect_anchor_hrefs mailto survives into lookalike** — already covered (pure-ASCII anchors emit no warning).
+- **fail_open suppression leaves a permanent seq gap** — refuted against the monotonic-only (not contiguous) contract.
+- **previous_file_inode stores current inode** — already covered; field is documented and round-trip tested.
+- **Reader positional trailing tolerance** — refuted; the actual crash-recovery path (read_trailing_state) is newline-aware.
+- **Rotation threshold >= against pre-open bytes** — refuted; intentional and tested (content preserved, seq resumes).
+- **Mixed auth/non-auth wrong cooldown ceiling** — refuted; last_trip_was_auth is dead state and the single-accumulator doubling is the documented design.
+- **on_success-in-Open clears cooldown** — refuted as a defect (production caller only calls on_success after a genuine Ok dispatch); still worth a behavior-pin test.
+- **FolderGuard mUTF-7 fail-open** — the decode non-idempotency variant was refuted; the untested-ASCII-only variant remains a confirmed high bug.
+- **SMTP send() clones the whole Message** — refuted; forced by lettre's API and not on the production path (send_raw is used).
+- **tools/list_changed notify gate** — refuted; advertised tool list does not vary with the session default.
+- **Forward path retains trailing \r** — already covered; rmcp's codec strips \r identically.
+- **search out-of-range offset reports truncated=true** — refuted; the predicate is mathematically false for offset >= total_matched.
+- **send_email sent:true without rollback** — already covered; documented fail-open with mapping tests.
+- **fetch_message tiny-max grapheme truncation** — already covered in unicode.rs truncation tests.
+- **main.rs lifecycle sub-claims (both-bridges-exit, Bridge clean-exit distinction, configured download_dir loose perms)** — refuted as unreachable or guarded elsewhere (export download-root privacy checks, EOF→Rmcp routing).
+- **registry resolve stale-active fallthrough** — refuted; set_active validates membership and no removal API exists.
+
+## 6. Recommended priority order
+
+Revised after confirming the Dovecot/e2e suites run on this host. The TLS-mock harness
+(previously #2) is **dropped** — it duplicates `case_02`/`case_22`/`starttls_with_wrong_pin`.
+The surviving high items are fault-injection and pure-unit gaps the runnable suites do not
+exercise.
+
+1. **FolderGuard mUTF-7 normalization** (authz fail-open, high) — pure unit, Docker-independent. Close the protected-folder bypass with encoded/decoded/malformed cases.
+2. **Envelope fail-closed audit + no-orphan tool_start** (server-mcp, high) — `e2e` runs with `fail_open: false` but never induces a write failure; assert via `force_next_write_failure` at the `run_with_audit_envelope` level.
+3. **Breaker service-vs-user tripping via DispatchGuard<ManualClock>** (server-mcp, high) — `e2e` wires a `SystemClock` breaker but never trips it; a `ManualClock` unit test + reason-mapping table is the right tool, not e2e.
+4. **Non-UIDPLUS plain-`EXPUNGE` data-loss fallback** (rimap-imap, high) — unreachable against Dovecot (always UIDPLUS); needs a mock IMAP server. Data-loss severity.
+5. **SMTP error taxonomy** (timeout/auth/tls misclassification + shared shape→variant function) (rimap-smtp, medium) — fixes three confirmed bugs and removes the drift-prone test mirror.
+6. **Breaker wasted-probe wedge + global-token leak** (rimap-authz, medium) — deterministic with ManualClock and a small Governor.
+7. **rimap-content secondary-HTML drop + cap/body_html accounting** (medium/low) — first tests to populate alternate_parts.
+8. **AccountId validating Deserialize + FolderName C1 rejection** (rimap-core, low) — small, high-clarity invariant pins.
+9. **Audit lifecycle sequences** (drainer survival, interleaved-rotation seq, channel-full cancellation drop) (medium/low).
+10. **part_walker Message arm, split_account_for_error, fetch UID-drop, migrate-keyring atomicity** (low) — targeted regression nets.
+11. **Extend `dovecot.rs` with missing auth-provenance variants** (e.g. `LOGINDISABLED` → `CapabilityMissing`, resolver-error → `CredentialUnavailable`) — the harness already exists; no mock needed.

--- a/docs/reviews/test-coverage-gap-review.md
+++ b/docs/reviews/test-coverage-gap-review.md
@@ -314,6 +314,19 @@ makes this host-runnable today.
 > any **auth-provenance variant not yet in `dovecot.rs`** (`LOGINDISABLED`,
 > resolver-error → `CredentialUnavailable`), which should be added to the existing harness.
 
+> **Known residual gap (folder-wide `EXPUNGE`).** The folder-wide `EXPUNGE`
+> runtime path — taken only when the server advertises neither MOVE nor
+> UIDPLUS — remains untested **by design**: the supporting TLS mock is
+> deferred. Dovecot always advertises UIDPLUS, so CI exercises the scoped
+> `UID EXPUNGE` path exclusively. What is now in place: the data-loss
+> predicate (`fallback_uses_folder_wide_expunge`) and the warning mapping
+> (`fallback_security_warnings`) are pure and unit-tested, and both the
+> `delete_message` and `move_message` tools surface `used_fallback`
+> (`ServerNonAtomicMoveFallback`) and `folder_wide_expunge`
+> (`ServerFolderWideExpungeDataLoss`) to callers. The live wire behavior is
+> tracked by the `#[ignore]`d placeholder `tests/expunge_folder_wide_gap.rs`,
+> whose ignore reason names the intended harness.
+
 **TLS pin mismatch → typed Tls error + exactly one AuthEvent; matching pin → Success once**
 *(already covered by `case_02`/`case_22`/`starttls_with_wrong_pin` — listed for completeness, not as new work)*
 - Steps: stand up an in-process rustls/rcgen TLS server; compute the leaf fingerprint; mismatch run asserts ImapError::Tls{observed,expected} and exactly one AuthEvent (Failure, error_code=Tls, fingerprint_match=false, credential_source=None); matching run asserts success and exactly one AuthEvent (Success, fingerprint_match=true, source=EnvVar).

--- a/docs/superpowers/plans/2026-05-28-test-coverage-gap-fixes.md
+++ b/docs/superpowers/plans/2026-05-28-test-coverage-gap-fixes.md
@@ -1,0 +1,684 @@
+# Test Coverage Gap Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four high-severity coverage gaps from the test-coverage-gap review: FolderGuard Modified-UTF-7 normalization, the fail-closed audit envelope (no-orphan `tool_start`), breaker service-vs-user error tripping, and the non-UIDPLUS folder-wide `EXPUNGE` data-loss fallback.
+
+**Architecture:** Issues 1–3 are pure test additions against code believed correct (TDD characterization tests; if any test goes red it has found a real defect to fix). Issue 4 makes a known, documented data-loss path observable: extract the UIDPLUS branch into a pure `expunge_strategy` function (unit-tested), emit a `tracing::warn!` on the folder-wide branch, and add a `used_fallback` signal to `DeleteResult` to match `MoveOutcome`. Current delete/expunge behavior is preserved — only observability changes.
+
+**Tech Stack:** Rust 2024, tokio, `cargo nextest`, `utf7-imap` 0.3.2, `rimap-audit` test-injection feature, `rimap-authz` `ManualClock`.
+
+**Branch:** `fix/repo-bug-sweep` (already created; not main).
+
+**Ground rules:**
+- One issue per commit. Run that crate's tests + `cargo clippy --all-targets --all-features -- -D warnings` for the touched crate before each commit.
+- Commit only (do not push); the user pushes separately.
+- Do NOT run `cargo-mutants` or full-workspace content runs (host RAM constraint).
+
+---
+
+### Task 1: FolderGuard Modified-UTF-7 normalization tests
+
+**Issue:** `FolderGuard::normalize` (`crates/rimap-authz/src/folder_guard.rs:17-20`) decodes Modified UTF-7 then lowercases, but every existing test uses ASCII only. A protected folder configured in one form (raw mUTF-7 wire form or decoded Unicode) must still be rejected when the request arrives in the other form, and a malformed encoding must not bypass the guard or panic.
+
+**Files:**
+- Modify (tests only): `crates/rimap-authz/src/folder_guard.rs` (append to the existing `#[cfg(test)] mod tests` block, which ends at the file's last `}`)
+
+- [ ] **Step 1: Write the failing/characterization tests**
+
+Append these tests inside `mod tests` in `crates/rimap-authz/src/folder_guard.rs`, after `rename_allows_unprotected_both`:
+
+```rust
+    #[test]
+    fn protected_non_ascii_folder_rejected_in_both_mutf7_and_decoded_forms() {
+        // "Café" — the é forces a Modified-UTF-7 base64 run.
+        let decoded = "Caf\u{00e9}";
+        let encoded = utf7_imap::encode_utf7_imap(decoded.to_string());
+        assert_ne!(encoded, decoded, "test input must actually be mUTF-7 encoded");
+
+        // Configured in WIRE (encoded) form; request arrives DECODED.
+        let g = FolderGuard::new(&[encoded.clone()], &[]);
+        assert!(
+            matches!(
+                g.check_protected(decoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "decoded form must match an encoded protected entry",
+        );
+        assert!(
+            matches!(
+                g.check_protected(&encoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "encoded form must match an encoded protected entry",
+        );
+
+        // Configured in DECODED form; request arrives ENCODED (and vice versa).
+        let g2 = FolderGuard::new(&[decoded.to_string()], &[]);
+        assert!(
+            matches!(
+                g2.check_protected(&encoded, "delete"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "encoded form must match a decoded protected entry",
+        );
+        assert!(
+            matches!(
+                g2.check_protected(decoded, "rename"),
+                Err(AuthzError::ProtectedFolder { .. })
+            ),
+            "decoded form must match a decoded protected entry",
+        );
+    }
+
+    #[test]
+    fn expunge_allowlist_matches_across_mutf7_forms() {
+        let decoded = "Caf\u{00e9}";
+        let encoded = utf7_imap::encode_utf7_imap(decoded.to_string());
+        let g = FolderGuard::new(&[], &[encoded.clone()]);
+        // Allowlisted in encoded form; both request forms must be allowed.
+        assert!(g.check_expunge(decoded).is_ok());
+        assert!(g.check_expunge(&encoded).is_ok());
+        // A different non-ASCII folder must still be denied.
+        assert!(matches!(
+            g.check_expunge("Sp\u{00e4}m"),
+            Err(AuthzError::ExpungeDenied { .. })
+        ));
+    }
+
+    #[test]
+    fn malformed_mutf7_does_not_panic_and_does_not_bypass() {
+        // A dangling shift sequence ("&" with no terminating "-") is
+        // malformed mUTF-7. normalize() must not panic, and such a name
+        // must not be treated as an unlisted (allowed) folder when it is
+        // in fact the protected one in encoded form.
+        let g = FolderGuard::new(&["Drafts".into()], &[]);
+        // Should not panic; result may be Ok or ProtectedFolder/InvalidFolderName,
+        // but must never panic and must not silently succeed on "Drafts".
+        let _ = g.check_protected("&malformed", "delete");
+        assert!(
+            g.check_protected("Drafts", "delete").is_err(),
+            "plain protected name must remain protected after a malformed probe",
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo nextest run -p rimap-authz folder_guard`
+Expected: PASS. If `protected_non_ascii_folder_rejected_in_both_mutf7_and_decoded_forms` FAILS, a real normalization defect exists — fix `normalize` so config and request forms converge (likely: decode both sides, which it already does — investigate the `utf7_imap` round-trip) before proceeding. If `malformed_mutf7_does_not_panic_and_does_not_bypass` panics, wrap/validate the decode in `normalize` to fall back to the ASCII-lowercased input (matching the existing doc comment).
+
+- [ ] **Step 3: Confirm the tests are meaningful (verify they can fail)**
+
+Temporarily change `normalize` (`folder_guard.rs:18`) to skip decoding:
+```rust
+fn normalize(folder: &str) -> String {
+    folder.to_lowercase()  // TEMPORARY — decode removed
+}
+```
+Run: `cargo nextest run -p rimap-authz folder_guard`
+Expected: the two cross-form tests FAIL (proving they exercise the decode path). Then REVERT `normalize` to its original two-line body and re-run — Expected: PASS.
+
+- [ ] **Step 4: Lint**
+
+Run: `cargo clippy -p rimap-authz --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/rimap-authz/src/folder_guard.rs
+git commit -m "test(authz): cover Modified-UTF-7 normalization in FolderGuard"
+```
+
+---
+
+### Task 2: Fail-closed audit envelope + no-orphan tool_start tests
+
+**Issue:** `run_with_audit_envelope` (`crates/rimap-server/src/mcp/audit_envelope.rs:38`) emits `tool_start` BEFORE constructing the drop-guard and minting the `DispatchTicket`. When the `tool_start` write fails and `fail_open = false`, the call must fail, the body must never run, and ZERO records must reach disk (no orphan `tool_start`). When `fail_open = true`, the failure is suppressed, the body runs, and the call succeeds. Existing tests (`audit_fail_open.rs`, `mcp_audit_failure.rs`) cover the writer counter and the wire-level rejection, but not the on-disk no-orphan property through the envelope.
+
+**Files:**
+- Modify (tests only): `crates/rimap-server/src/mcp/audit_envelope.rs` (append to `#[cfg(test)] mod tests`, after `tool_end_records_export_provenance_from_result`)
+
+`force_next_write_failure()` is reachable: `crates/rimap-server/Cargo.toml:106` dev-deps `rimap-audit` with `features = ["test-injection"]`.
+
+- [ ] **Step 1: Add a fail-open-parameterized writer helper**
+
+In `crates/rimap-server/src/mcp/audit_envelope.rs`, just after the existing `fn test_writer` (ends at line ~302), add:
+
+```rust
+    fn test_writer_fail_open(path: std::path::PathBuf, fail_open: bool) -> AuditWriter {
+        AuditWriter::open(&AuditOptions {
+            path,
+            rotate_bytes: 10 * 1024 * 1024,
+            rotate_keep: 5,
+            retention_seconds: None,
+            fail_open,
+            initial_seq: Seq::FIRST,
+        })
+        .unwrap()
+    }
+```
+
+- [ ] **Step 2: Write the failing/characterization tests**
+
+Append inside `mod tests`:
+
+```rust
+    /// fail_open = false: an injected `tool_start` write failure must abort
+    /// the call with an "audit write failed" error, never run the body, and
+    /// leave ZERO records on disk (no orphan tool_start).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_start_failure_fail_closed_aborts_with_no_orphan() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer_fail_open(path.clone(), false);
+        writer.force_next_write_failure();
+
+        let (tx, _rx) = cancellation_channel();
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx));
+
+        let body_ran = Arc::new(AtomicBool::new(false));
+        let body_ran_clone = Arc::clone(&body_ran);
+        let args = serde_json::Map::new();
+        let result = server
+            .run_with_audit_envelope(
+                ToolName::ListAccounts,
+                None,
+                PostureContext::Infrastructure,
+                &args,
+                |_ticket| async move {
+                    body_ran_clone.store(true, Ordering::SeqCst);
+                    Ok(serde_json::Value::Null)
+                },
+            )
+            .await;
+
+        let err = result.expect_err("fail-closed audit failure must abort the call");
+        assert!(
+            err.message.contains("audit write failed"),
+            "expected audit-write-failed error, got: {}",
+            err.message,
+        );
+        assert!(
+            !body_ran.load(Ordering::SeqCst),
+            "body must not run when tool_start fails fail-closed",
+        );
+
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            contents.lines().count(),
+            0,
+            "a failed tool_start must leave zero records on disk (no orphan):\n{contents}",
+        );
+    }
+
+    /// fail_open = true: the injected `tool_start` write failure is
+    /// suppressed (counted), the body runs, and the call succeeds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tool_start_failure_fail_open_proceeds_and_counts() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use rimap_core::tool::ToolName;
+
+        use crate::mcp::dispatch::PostureContext;
+        use crate::mcp::server::ImapMcpServer;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let writer = test_writer_fail_open(path.clone(), true);
+        writer.force_next_write_failure();
+        // Hold a clone so we can read the suppressed-failure counter after.
+        let writer_probe = writer.clone();
+
+        let (tx, _rx) = cancellation_channel();
+        let server = Arc::new(ImapMcpServer::new_for_tests(writer, tx));
+
+        let body_ran = Arc::new(AtomicBool::new(false));
+        let body_ran_clone = Arc::clone(&body_ran);
+        let args = serde_json::Map::new();
+        let result = server
+            .run_with_audit_envelope(
+                ToolName::ListAccounts,
+                None,
+                PostureContext::Infrastructure,
+                &args,
+                |_ticket| async move {
+                    body_ran_clone.store(true, Ordering::SeqCst);
+                    Ok(serde_json::Value::Null)
+                },
+            )
+            .await;
+
+        assert!(result.is_ok(), "fail-open must let the call succeed");
+        assert!(
+            body_ran.load(Ordering::SeqCst),
+            "body must run when the tool_start failure is suppressed",
+        );
+        assert!(
+            writer_probe.suppressed_failures() >= 1,
+            "fail-open must increment the suppressed-failure counter",
+        );
+    }
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo nextest run -p rimap-server --lib audit_envelope`
+Expected: PASS. If `tool_start_failure_fail_closed_aborts_with_no_orphan` finds records on disk or the body ran, the fail-closed ordering is broken — that is a real defect; fix `run_with_audit_envelope` so `emit_tool_start`'s `Err` returns before the body/guard.
+
+- [ ] **Step 4: Confirm meaningfulness**
+
+Temporarily change `audit_envelope.rs:55` from `.await?;` to `.await.unwrap_or(rimap_audit::Seq::FIRST);` (swallow the error). Run the test — Expected: `tool_start_failure_fail_closed_aborts_with_no_orphan` FAILS (body runs / record written). REVERT to `.await?;` and re-run — Expected: PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `cargo clippy -p rimap-server --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/audit_envelope.rs
+git commit -m "test(server): cover fail-closed audit envelope no-orphan tool_start"
+```
+
+---
+
+### Task 3: Breaker reason mapping + service-vs-user tripping tests
+
+**Issue:** `rimap_error_to_breaker_reason` (`crates/rimap-server/src/mcp/dispatch.rs:83-109`) decides which errors trip the circuit breaker. It is exhaustive over all 19 `ErrorCode`s, but existing tests assert only 3 service codes and 2 user codes. The dispatch-level wiring (`server.rs:128-135`: `Ok → on_success`, service `Err → on_failure`, user `Err → no-op`) is only exercised behind Docker e2e. Add an exhaustive mapping table and a `DispatchGuard<ManualClock>` sequence test.
+
+**Files:**
+- Modify (tests only): `crates/rimap-server/src/mcp/dispatch.rs` (the `#[cfg(test)] mod tests`, replacing the two partial tests at lines 284-315 and 343-354)
+- Modify (tests only): `crates/rimap-authz/src/guard.rs` (append to `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Replace the partial mapping tests with an exhaustive table**
+
+In `crates/rimap-server/src/mcp/dispatch.rs`, replace `breaker_reason_maps_service_failures` (lines 284-315) and `breaker_reason_ignores_user_errors` (lines 343-354) with one table-driven test:
+
+```rust
+    #[test]
+    fn breaker_reason_maps_every_error_code() {
+        use rimap_authz::breaker::FailureReason;
+        use rimap_core::{ErrorCode, RimapError};
+
+        // Exhaustive table over all 19 ErrorCode variants. The mapping fn's
+        // own `match` is compile-exhaustive, so a NEW ErrorCode breaks the
+        // build there; this table pins the SEMANTICS (service trips, user
+        // errors do not).
+        let cases: &[(ErrorCode, Option<FailureReason>)] = &[
+            (ErrorCode::ConnectionLost, Some(FailureReason::ConnectionLost)),
+            (ErrorCode::Auth, Some(FailureReason::Auth)),
+            (ErrorCode::Timeout, Some(FailureReason::Timeout)),
+            (ErrorCode::ImapProtocol, Some(FailureReason::Protocol)),
+            (ErrorCode::SmtpProtocol, Some(FailureReason::Protocol)),
+            (ErrorCode::Tls, Some(FailureReason::Tls)),
+            (ErrorCode::InvalidInput, None),
+            (ErrorCode::PostureDenied, None),
+            (ErrorCode::RateLimited, None),
+            (ErrorCode::CircuitOpen, None),
+            (ErrorCode::NotFound, None),
+            (ErrorCode::AttachmentTooLarge, None),
+            (ErrorCode::ProtectedFolder, None),
+            (ErrorCode::ExpungeDenied, None),
+            (ErrorCode::Config, None),
+            (ErrorCode::Internal, None),
+            (ErrorCode::NoAccount, None),
+            (ErrorCode::UnknownAccount, None),
+            (ErrorCode::Cancelled, None),
+            (ErrorCode::UidValidityChanged, None),
+        ];
+
+        for (code, expected) in cases {
+            let err = RimapError::Imap {
+                code: *code,
+                message: "x".into(),
+                source: None,
+            };
+            assert_eq!(
+                rimap_error_to_breaker_reason(&err),
+                *expected,
+                "mapping mismatch for {code:?}",
+            );
+        }
+        assert_eq!(cases.len(), 20, "table must list all variants (6 service + 14 user)");
+    }
+```
+
+Note: confirm the `ErrorCode` variant list against `crates/rimap-core/src/error.rs` while editing; if a variant name differs, fix the literal. (`cases.len()` is 20 here — 6 `Some` + 14 `None`; adjust the assert to the real count if the enum has changed.)
+
+- [ ] **Step 2: Run the mapping test**
+
+Run: `cargo nextest run -p rimap-server --lib dispatch::tests::breaker_reason_maps_every_error_code`
+Expected: PASS. A mismatch means a service error is misclassified as user (breaker would never trip) or vice versa — a real defect; fix the mapping arm in `dispatch.rs`.
+
+- [ ] **Step 3: Add the guard tripping-sequence test**
+
+In `crates/rimap-authz/src/guard.rs`, append inside `mod tests` (after `matrix_accessor_returns_effective_matrix`):
+
+```rust
+    #[test]
+    fn service_failures_trip_breaker_user_errors_do_not() {
+        let g = guard(Posture::DraftSafe);
+
+        // A tool that DraftSafe permits, so admission is gated only by the breaker.
+        g.pre_dispatch(ToolName::ListFolders).unwrap();
+
+        // One non-auth service failure is below threshold (2): still Closed.
+        g.on_failure(FailureReason::Timeout);
+        g.pre_dispatch(ToolName::ListFolders)
+            .expect("one failure is below the threshold; breaker stays Closed");
+
+        // Second non-auth failure reaches threshold → Open.
+        g.on_failure(FailureReason::Timeout);
+        assert!(
+            matches!(
+                g.pre_dispatch(ToolName::ListFolders),
+                Err(AuthzError::CircuitOpen { .. })
+            ),
+            "two service failures must trip the breaker Open",
+        );
+
+        // After cooldown, a probe + success closes it again.
+        g.breaker().clock.advance(Duration::from_secs(5));
+        g.pre_dispatch(ToolName::ListFolders).unwrap(); // HalfOpen probe
+        g.on_success();
+        g.pre_dispatch(ToolName::ListFolders)
+            .expect("on_success after a half-open probe must close the breaker");
+    }
+
+    #[test]
+    fn single_auth_failure_trips_breaker_immediately() {
+        let g = guard(Posture::DraftSafe);
+        g.pre_dispatch(ToolName::ListFolders).unwrap();
+        g.on_failure(FailureReason::Auth);
+        assert!(
+            matches!(
+                g.pre_dispatch(ToolName::ListFolders),
+                Err(AuthzError::CircuitOpen { .. })
+            ),
+            "a single Auth failure must trip the breaker Open immediately",
+        );
+    }
+```
+
+Note on user errors: user/policy errors (e.g. `InvalidInput`) map to `None` in `rimap_error_to_breaker_reason`, so `on_failure` is NEVER called for them — the breaker cannot observe them. The "user errors do not trip" guarantee is therefore enforced at the mapping layer (Step 1's table), not via the guard. Do not call `g.on_failure` with a user reason; there is no such `FailureReason` variant.
+
+- [ ] **Step 4: Run the guard tests**
+
+Run: `cargo nextest run -p rimap-authz guard`
+Expected: PASS.
+
+- [ ] **Step 5: Lint both crates**
+
+Run: `cargo clippy -p rimap-server -p rimap-authz --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rimap-server/src/mcp/dispatch.rs crates/rimap-authz/src/guard.rs
+git commit -m "test(server): exhaustively cover breaker reason mapping and tripping"
+```
+
+---
+
+### Task 4: Make non-UIDPLUS folder-wide EXPUNGE observable
+
+**Issue (real data loss):** When the server advertises neither MOVE nor UIDPLUS, both `delete_message` (`crates/rimap-imap/src/ops/delete.rs:69-79`) and `copy_delete_fallback` (`crates/rimap-imap/src/ops/move_message.rs:189-198`) issue a bare `session.expunge()`, which removes EVERY `\Deleted` message in the selected folder — not only the targeted UIDs. This is unreachable against Dovecot (always UIDPLUS), uncovered, silent (no warning), and `DeleteResult` carries no fallback signal (unlike `MoveOutcome`).
+
+**Decision (from review):** keep current behavior, but (a) extract the branch into a pure, unit-tested `expunge_strategy` function, (b) emit a `tracing::warn!` on the folder-wide branch, (c) add `used_fallback` to `DeleteResult` to match `MoveOutcome`. No mock server; no functional change to which messages are deleted.
+
+**Files:**
+- Create: `crates/rimap-imap/src/ops/expunge.rs`
+- Modify: `crates/rimap-imap/src/ops/mod.rs` (register the module)
+- Modify: `crates/rimap-imap/src/ops/delete.rs` (use the helper; add `used_fallback`)
+- Modify: `crates/rimap-imap/src/ops/move_message.rs` (use the helper; thread `src_folder` for the warn)
+
+- [ ] **Step 1: Write the failing unit test for the strategy function**
+
+Create `crates/rimap-imap/src/ops/expunge.rs` with the test first (the types it references are added in Step 2):
+
+```rust
+//! EXPUNGE strategy selection shared by delete and move fallbacks.
+//!
+//! After flagging messages `\Deleted`, the server's UIDPLUS capability
+//! decides whether we can scope the expunge to specific UIDs (RFC 4315
+//! `UID EXPUNGE`, safe) or must issue a folder-wide RFC 3501 `EXPUNGE`
+//! that removes ALL `\Deleted` messages in the selected mailbox.
+
+use futures_util::StreamExt;
+
+use crate::connection::ImapSession;
+use crate::error::ImapError;
+
+/// Which EXPUNGE form to issue after flagging messages `\Deleted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpungeStrategy {
+    /// `UID EXPUNGE` (RFC 4315): removes only the named UIDs. Safe.
+    Scoped,
+    /// Plain `EXPUNGE` (RFC 3501): removes ALL `\Deleted` messages in the
+    /// selected folder. Data-loss risk when other messages are flagged
+    /// `\Deleted` by concurrent clients.
+    FolderWide,
+}
+
+/// Choose the EXPUNGE strategy from the server's UIDPLUS capability.
+pub(crate) fn expunge_strategy(has_uidplus: bool) -> ExpungeStrategy {
+    if has_uidplus {
+        ExpungeStrategy::Scoped
+    } else {
+        ExpungeStrategy::FolderWide
+    }
+}
+
+/// Execute the chosen EXPUNGE against the currently selected mailbox,
+/// draining the response stream. Emits a `warn!` on the folder-wide
+/// (data-loss) path so operators can see when the unsafe fallback ran.
+pub(crate) async fn run_expunge(
+    session: &mut ImapSession,
+    uid_set: &str,
+    strategy: ExpungeStrategy,
+    selected_folder: &str,
+) -> Result<(), ImapError> {
+    match strategy {
+        ExpungeStrategy::Scoped => {
+            let stream = session
+                .uid_expunge(uid_set)
+                .await
+                .map_err(super::folders::map_err)?;
+            futures_util::pin_mut!(stream);
+            while let Some(item) = StreamExt::next(&mut stream).await {
+                let _uid = item.map_err(super::folders::map_err)?;
+            }
+        }
+        ExpungeStrategy::FolderWide => {
+            tracing::warn!(
+                folder = %selected_folder,
+                "issuing folder-wide EXPUNGE because the server lacks UIDPLUS; \
+                 every message flagged \\Deleted in this folder is removed, not \
+                 only the targeted UIDs",
+            );
+            let stream = session.expunge().await.map_err(super::folders::map_err)?;
+            futures_util::pin_mut!(stream);
+            while let Some(item) = StreamExt::next(&mut stream).await {
+                let _seq = item.map_err(super::folders::map_err)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ExpungeStrategy, expunge_strategy};
+
+    #[test]
+    fn uidplus_present_selects_scoped() {
+        assert_eq!(expunge_strategy(true), ExpungeStrategy::Scoped);
+    }
+
+    #[test]
+    fn uidplus_absent_selects_folder_wide() {
+        assert_eq!(expunge_strategy(false), ExpungeStrategy::FolderWide);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `crates/rimap-imap/src/ops/mod.rs`, add the module declaration alongside the other `mod`/`pub(crate) mod` lines (match the surrounding visibility style; `delete` and `move_message` are `pub(crate) mod`):
+
+```rust
+pub(crate) mod expunge;
+```
+
+- [ ] **Step 3: Run the strategy unit test**
+
+Run: `cargo nextest run -p rimap-imap expunge`
+Expected: PASS (both `uidplus_present_selects_scoped` and `uidplus_absent_selects_folder_wide`).
+
+- [ ] **Step 4: Use the helper in `delete_message` and add `used_fallback`**
+
+In `crates/rimap-imap/src/ops/delete.rs`, replace the fallback block (lines 52-80, the `} else {` COPY+EXPUNGE branch) so it delegates to `run_expunge`:
+
+```rust
+    } else {
+        // Fallback: COPY + scoped-or-folder-wide EXPUNGE.
+        session
+            .uid_copy(&uid_set, trash_folder)
+            .await
+            .map_err(super::folders::map_err)?;
+        // The \Deleted flag was already set in step 1.
+        let strategy = super::expunge::expunge_strategy(has_uidplus);
+        super::expunge::run_expunge(session, &uid_set, strategy, source_folder).await?;
+    }
+```
+
+Update the `DeleteResult` struct (lines 89-96) to add the signal:
+
+```rust
+/// Result of a `delete_message` operation.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct DeleteResult {
+    /// The UID of the deleted message (in its original folder).
+    pub uid: Uid,
+    /// `true` if the message was moved to Trash; `false` if it was
+    /// already in Trash and only flagged.
+    pub moved_to_trash: bool,
+    /// `true` when the non-atomic COPY+EXPUNGE fallback was used instead
+    /// of server-side `UID MOVE`. When the server also lacks UIDPLUS this
+    /// fallback issues a folder-wide EXPUNGE (data-loss risk); callers
+    /// should surface a security warning. Mirrors `MoveOutcome::used_fallback`.
+    pub used_fallback: bool,
+}
+```
+
+Update BOTH `DeleteResult` construction sites. The early `in_trash` return (lines 39-42):
+
+```rust
+        return Ok(DeleteResult {
+            uid,
+            moved_to_trash: false,
+            used_fallback: false,
+        });
+```
+
+The final return (lines 82-85) — `used_fallback` is true exactly when the COPY+EXPUNGE path ran, i.e. `!has_move`:
+
+```rust
+    Ok(DeleteResult {
+        uid,
+        moved_to_trash: true,
+        used_fallback: !has_move,
+    })
+```
+
+- [ ] **Step 5: Use the helper in `copy_delete_fallback` and thread `src_folder`**
+
+In `crates/rimap-imap/src/ops/move_message.rs`, change `copy_delete_fallback`'s signature (line 144-149) to accept the source folder for the warn, and replace the UIDPLUS branch (lines 178-198) with the helper:
+
+```rust
+async fn copy_delete_fallback(
+    session: &mut ImapSession,
+    src_folder: &str,
+    dest_folder: &str,
+    uids: &[Uid],
+    has_uidplus: bool,
+) -> Result<(Vec<MoveResult>, Option<u32>), ImapError> {
+```
+
+Replace lines 175-200 (the STORE + the `if has_uidplus { … } else { … }` block + the final `Ok(...)`) with:
+
+```rust
+    // Step 3: STORE +FLAGS \Deleted on the originals.
+    store::store(session, uids, &[Flag::Deleted], FlagAction::Add).await?;
+
+    // Step 4: Remove the flagged messages from the source folder.
+    let strategy = crate::ops::expunge::expunge_strategy(has_uidplus);
+    crate::ops::expunge::run_expunge(session, &uid_set, strategy, src_folder).await?;
+
+    Ok((build_results(uids), destination_uid_validity))
+```
+
+Update the single call site (line 111-112) to pass `src_folder`:
+
+```rust
+    if !has_move {
+        let (results, destination_uid_validity) =
+            copy_delete_fallback(session, src_folder, dest_folder, uids, has_uidplus).await?;
+```
+
+- [ ] **Step 6: Build and run the imap crate tests**
+
+Run: `cargo nextest run -p rimap-imap`
+Expected: PASS. The pre-existing `delete.rs` / `move_message.rs` unit tests still pass; the new `expunge::tests` pass. (The Dovecot integration cases require Docker — skip them here; they are run separately.)
+
+- [ ] **Step 7: Verify consumers still compile**
+
+The MCP tool reads `result.moved_to_trash` (`crates/rimap-server/src/tools/mailbox/delete_message.rs:82`); adding a field keeps it compiling. Confirm:
+
+Run: `cargo check -p rimap-server --all-targets`
+Expected: success (no error about missing `used_fallback` — that field is internal to the IMAP result and not required by the tool's own output struct).
+
+- [ ] **Step 8: Lint**
+
+Run: `cargo clippy -p rimap-imap --all-targets --all-features -- -D warnings`
+Expected: no warnings. (If clippy flags `run_expunge` for too many arguments or the `match` for a single-arm style, address per the repo's lint config; 4 params is within the ≤5 limit.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/rimap-imap/src/ops/expunge.rs crates/rimap-imap/src/ops/mod.rs \
+        crates/rimap-imap/src/ops/delete.rs crates/rimap-imap/src/ops/move_message.rs
+git commit -m "feat(imap): surface non-UIDPLUS folder-wide EXPUNGE via strategy enum"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Issue 1 (FolderGuard mUTF-7) → Task 1. ✓
+- Issue 2 (envelope fail-closed, no-orphan) → Task 2. ✓
+- Issue 3 (breaker service-vs-user tripping) → Task 3 (mapping table + guard sequence). ✓
+- Issue 4 (non-UIDPLUS EXPUNGE) → Task 4 (pure strategy fn + warn + `DeleteResult.used_fallback`, per the chosen "pure fn + observe" options). ✓
+
+**Type consistency:** `ExpungeStrategy`/`expunge_strategy`/`run_expunge` defined in Task 4 Step 1 and used with the same names/signatures in Steps 4–5. `DeleteResult.used_fallback` defined in Step 4 and set at all three construction points. `FailureReason` (not `BreakerReason`) used throughout Task 3. `test_writer_fail_open` defined before use in Task 2.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full code. Run commands have explicit expected outcomes.
+
+**Open follow-ups (out of scope, noted not silently dropped):**
+- Threading `DeleteResult.used_fallback` / `MoveOutcome.used_fallback` into the MCP tool *output* so the agent sees the security signal would change a tool output schema and require `just regen-tool-schemas`; deferred.
+- Whether to *refuse* (fail-closed) on neither-MOVE-nor-UIDPLUS instead of observing was explicitly declined in favor of the observe approach.

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,8 @@ extend-ignore-re = [
 # Intentional project vocabulary. Add sparingly with a comment.
 imap = "imap"
 rimap = "rimap"
+# French word stem used in mUTF-7 test fixture ("Café")
+caf = "caf"
 # CVE Numbering Authority — a recognized industry acronym; typos incorrectly suggests "CAN"
 CNA = "CNA"
 # STRIDE table uses bold-letter notation (**I**nformation). Typos sees "nformation" as a fragment.


### PR DESCRIPTION
Implements the `/challenge` review recommendations for this branch: the data-loss condition is precisely identified and surfaced to MCP callers from both delete and move, the breaker table and a security test are made future-proof, and the one residual coverage gap is documented rather than implied as covered.

One commit per finding.

## F2 (high) — distinguish folder-wide EXPUNGE data loss
- Add `fallback_uses_folder_wide_expunge(has_move, has_uidplus)` (`!has_move && !has_uidplus`) with unit tests.
- Add `folder_wide_expunge` to `DeleteResult` and `MoveOutcome`, set at every construction site. `used_fallback` (`!has_move`) stays as the non-atomicity flag.
- Add `WarningCode::ServerFolderWideExpungeDataLoss` (Adversarial). Reword `ServerNonAtomicMoveFallback` to describe non-atomicity only, dropping its data-loss claim.
- Add shared `fallback_security_warnings` helper (unit-tested) and wire it into both the `delete_message` and `move_message` handlers. Delete previously surfaced no warning.
- Regenerate tool-schema fixtures for the new `WarningCode` variant.

## F3 (low) — compile-exhaustive breaker mapping test
Replace the tuple table and `cases.len() == 20` guard with a no-wildcard `match` (`expected_reason`). A new `ErrorCode` now fails the test build until its breaker classification is declared; the explicit `ALL` slice keeps a length assert as a second guard.

## F4 (low) — honest mUTF-7 tests
Rename `malformed_mutf7_does_not_panic_and_does_not_bypass` to `malformed_mutf7_input_does_not_panic` (it only probes no-panic). Add `protected_folder_not_bypassed_by_alternate_mutf7_encoding`, asserting the guard rejects both the mUTF-7 wire form and an uppercased decoded variant.

## F1 (high) — document the residual coverage gap
The folder-wide EXPUNGE runtime path runs only against a server advertising neither MOVE nor UIDPLUS; Dovecot always advertises UIDPLUS, so CI never reaches it. Extend the `expunge.rs` docs, add an `#[ignore]`d placeholder `tests/expunge_folder_wide_gap.rs` naming the intended TLS-mock harness, and add a "Known residual gap" note to the coverage-gap review.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- `cargo nextest run -p rimap-authz -p rimap-server -p rimap-imap`: 842 passed, 1 skipped (the documented-gap placeholder).
- Fixture diff confirmed to be only the added `WarningCode` variant plus the reworded doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)