### PR TITLE
docs(authz): correct matrix.rs module doc

### DIFF
--- a/crates/rimap-authz/src/matrix.rs
+++ b/crates/rimap-authz/src/matrix.rs
@@ -1,5 +1,6 @@
-//! Posture matrix: compile-time `const` truth table for v1 tools × postures,
-//! plus the runtime `EffectiveMatrix` that merges per-tool overrides.
+//! Runtime `EffectiveMatrix`: merges the base posture truth table (the
+//! compile-time `const` table and `base_allows` live in `rimap_core`) with
+//! per-tool overrides, then answers per-tool authorization lookups.
 //!
 //! Derived from design spec §4 "Posture matrix".
 


### PR DESCRIPTION
## What

The `matrix.rs` module doc claimed the file holds the "compile-time `const` truth table for v1 tools × postures". It does not: `base_allows` and `POSTURE_MATRIX` live in `rimap_core` (imported at `matrix.rs:9`, used at `matrix.rs:32`). This file only builds and queries the runtime `EffectiveMatrix`.

Rewrite the module doc to describe what the module actually contains.

Documentation only — no code or behavior change. `cargo doc -p rimap-authz` builds clean.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)