### PR TITLE
docs(config): fix stale intra-doc links in loader and validate

### DIFF
--- a/crates/rimap-config/src/loader.rs
+++ b/crates/rimap-config/src/loader.rs
@@ -44,7 +44,8 @@ pub fn resolve_config_path(explicit: Option<&Path>) -> Option<PathBuf> {
 }
 
 /// Load and deserialize a config file from the given path. Does **not**
-/// validate semantic constraints — that's [`crate::validate::validate`].
+/// validate semantic constraints — that's [`crate::validate::validate_multi`]
+/// (reached via [`load_and_validate`]).
 ///
 /// # Errors
 /// Returns `ConfigError::Read` if the file cannot be read, or

--- a/crates/rimap-config/src/validate/mod.rs
+++ b/crates/rimap-config/src/validate/mod.rs
@@ -8,15 +8,15 @@
 //!   - Attachment download dir, if non-empty, is writable.
 //!   - All numeric limits are positive and cap/default invariants hold.
 //!
-//! Submodules group helpers by concern:
-//!   - [`compose`]  — multi-account composition pipeline and per-account
+//! Submodules group helpers by concern (all private):
+//!   - `compose`  — multi-account composition pipeline and per-account
 //!     orchestration (the `ValidatedAccountConfig` / `ValidatedMultiConfig`
 //!     types and the public `validate_multi` / `validate_legacy_as_multi`
 //!     entry points)
-//!   - [`identity`] — username and TLS fingerprint
-//!   - [`limits`]   — numeric-limits zero/cap checks
-//!   - [`paths`]    — audit and download-dir filesystem probes
-//!   - [`rules`]    — folder safety, SMTP requirement and encryption,
+//!   - `identity` — username and TLS fingerprint
+//!   - `limits`   — numeric-limits zero/cap checks
+//!   - `paths`    — audit and download-dir filesystem probes
+//!   - `rules`    — folder safety, SMTP requirement and encryption,
 //!     per-tool override resolution
 
 mod compose;


### PR DESCRIPTION
## What

`loader.rs` documented `load_from_path` as deferring semantic validation to `[crate::validate::validate]`, but no `validate` function exists at that path — it was a broken intra-doc link. Point it at `validate_multi` (reached via `load_and_validate`).

The `validate` module header linked its public module doc to the private submodules `compose`/`identity`/`limits`/`paths`/`rules`, emitting `private_intra_doc_links` warnings. Render those names as plain code spans since the modules are private.

Reduces `rimap-config` rustdoc warnings from 7 to 1. The remaining warning is a pre-existing feature-gated link to `validate_multi_allowing_empty` in `error.rs` (valid under `--all-features`), outside this issue's scope.

Documentation only.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)