### PR TITLE
refactor(authz): rename MatrixBuild error variant to ConfigBuild

### DIFF
--- a/crates/rimap-authz/src/error.rs
+++ b/crates/rimap-authz/src/error.rs
@@ -44,11 +44,13 @@ pub enum AuthzError {
         /// variant docs for the special `0` case (half-open probe in flight).
         retry_after_ms: u64,
     },
-    /// Config-time error during matrix build (e.g. unknown override tool).
-    /// Wrapped as a string because we don't want `rimap-authz` to depend on
-    /// the full `ConfigError` variant surface just for display.
-    #[error("authz matrix build failed: {0}")]
-    MatrixBuild(String),
+    /// Config-time error while constructing an authz component — currently
+    /// the governor refusing a degenerate zero-rate limiter (validation
+    /// should have rejected it first). Wrapped as a string because we don't
+    /// want `rimap-authz` to depend on the full `ConfigError` variant surface
+    /// just for display.
+    #[error("authz config build failed: {0}")]
+    ConfigBuild(String),
     /// Folder is in the `protected_folders` list.
     #[error(
         "folder `{folder}` is protected and cannot be {operation}d; \
@@ -85,7 +87,7 @@ impl AuthzError {
             Self::PostureDenied(_) => ErrorCode::PostureDenied,
             Self::RateLimited { .. } => ErrorCode::RateLimited,
             Self::CircuitOpen { .. } => ErrorCode::CircuitOpen,
-            Self::MatrixBuild(_) => ErrorCode::Config,
+            Self::ConfigBuild(_) => ErrorCode::Config,
             Self::ProtectedFolder { .. } => ErrorCode::ProtectedFolder,
             Self::ExpungeDenied { .. } => ErrorCode::ExpungeDenied,
             Self::InvalidFolderName { .. } => ErrorCode::InvalidInput,
@@ -188,7 +190,7 @@ mod tests {
             ErrorCode::CircuitOpen
         );
         assert_eq!(
-            AuthzError::MatrixBuild("x".into()).code(),
+            AuthzError::ConfigBuild("x".into()).code(),
             ErrorCode::Config
         );
         assert_eq!(

--- a/crates/rimap-authz/src/rate_limit.rs
+++ b/crates/rimap-authz/src/rate_limit.rs
@@ -64,7 +64,7 @@ impl Governor {
     /// Build from numeric limits.
     ///
     /// # Errors
-    /// Returns `AuthzError::MatrixBuild` if either rate is zero (validation
+    /// Returns `AuthzError::ConfigBuild` if either rate is zero (validation
     /// should have caught this already, but we refuse to build a degenerate
     /// limiter).
     pub fn new(
@@ -73,12 +73,12 @@ impl Governor {
         sends_per_minute: u32,
     ) -> Result<Self, AuthzError> {
         let cps = NonZeroU32::new(commands_per_second).ok_or_else(|| {
-            AuthzError::MatrixBuild("commands_per_second must be > 0".to_string())
+            AuthzError::ConfigBuild("commands_per_second must be > 0".to_string())
         })?;
         let dpm = NonZeroU32::new(drafts_per_minute)
-            .ok_or_else(|| AuthzError::MatrixBuild("drafts_per_minute must be > 0".to_string()))?;
+            .ok_or_else(|| AuthzError::ConfigBuild("drafts_per_minute must be > 0".to_string()))?;
         let spm = NonZeroU32::new(sends_per_minute)
-            .ok_or_else(|| AuthzError::MatrixBuild("sends_per_minute must be > 0".to_string()))?;
+            .ok_or_else(|| AuthzError::ConfigBuild("sends_per_minute must be > 0".to_string()))?;
         let burst = NonZeroU32::new(commands_per_second.saturating_mul(2).max(1))
             .unwrap_or(NonZeroU32::MIN);
         let global_quota = Quota::per_second(cps).allow_burst(burst);


### PR DESCRIPTION
## What

`AuthzError::MatrixBuild` was only ever constructed in `Governor::new` (`rate_limit.rs`) for a degenerate zero-rate limiter, yet its name and doc described a posture-matrix build failure ("unknown override tool"). `EffectiveMatrix::build` returns `Self`, not `Result` — the unknown-override-tool case is caught earlier in config validation as a `ConfigError`, never this variant. The name was misleading.

Rename the variant to the neutral `ConfigBuild`, update its doc and `Display` string to describe the actual producer, and update the three construction sites. The single `ErrorCode::Config` mapping is unchanged.

No new behavior; the `Display` string changes from "authz matrix build failed" to "authz config build failed" (not asserted by any test).

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)