### PR TITLE
refactor(config): delete dead TLS pass-through re-exports

### DIFF
--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -31,4 +31,3 @@ pub use crate::validate::validate_multi_allowing_empty;
 pub use crate::validate::{
     ValidatedAccountConfig, ValidatedMultiConfig, validate_legacy_as_multi, validate_multi,
 };
-pub use rimap_core::tls::{FingerprintParseError, TlsFingerprint};


### PR DESCRIPTION
## What

`rimap-config` re-exported `rimap_core::tls::{FingerprintParseError, TlsFingerprint}` at its crate root, but no config struct uses either type (config stores `tls_fingerprint_sha256` as `Option<String>`) and nothing imports them via the `rimap_config::` path. Delete the dead re-export; callers use `rimap_core::tls` directly.

`pub use rimap_core::ImapEncryption` in `model.rs` is kept — it is the declared type of the public `ImapConfig.encryption` field.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)