### PR TITLE
refactor(config): add KeyringCredentialResolver to root re-exports

### DIFF
--- a/crates/rimap-config/src/lib.rs
+++ b/crates/rimap-config/src/lib.rs
@@ -13,8 +13,8 @@ pub mod validate;
 pub mod test_support;
 
 pub use crate::credential::{
-    CredentialStore, KEYCHAIN_SERVICE, KeyringStore, PASSWORD_ENV_VAR, account_key,
-    resolve_credential,
+    CredentialStore, KEYCHAIN_SERVICE, KeyringCredentialResolver, KeyringStore, PASSWORD_ENV_VAR,
+    account_key, resolve_credential,
 };
 pub use crate::error::ConfigError;
 #[cfg(feature = "test-support")]


### PR DESCRIPTION
## What

The crate root promotes the credential primitives (`CredentialStore`, `KeyringStore`, `resolve_credential`, `account_key`, ...) but omitted the higher-level `KeyringCredentialResolver` adapter that the server constructs, so consumers reached it via `credential::KeyringCredentialResolver` while its collaborators sat at the crate root.

Add `KeyringCredentialResolver` to the root credential re-export block. The `credential::` path remains valid, so existing call sites are unaffected.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)