### PR TITLE
refactor(audit): encapsulate RedactionSchema fields behind accessors

### DIFF
--- a/crates/rimap-audit/src/redact.rs
+++ b/crates/rimap-audit/src/redact.rs
@@ -94,9 +94,9 @@ const DATE_STRING_MAX_BYTES: usize = 32;
 pub struct RedactionSchema {
     /// Tool identifier. Audit records render this via [`ToolName::as_str`];
     /// tracing spans attach the same string.
-    pub tool: ToolName,
+    tool: ToolName,
     /// Policies keyed by field name.
-    pub policies: BTreeMap<&'static str, FieldPolicy>,
+    policies: BTreeMap<&'static str, FieldPolicy>,
 }
 
 impl RedactionSchema {
@@ -108,6 +108,25 @@ impl RedactionSchema {
             policies.insert(*name, *policy);
         }
         Self { tool, policies }
+    }
+
+    /// Tool this schema applies to.
+    #[must_use]
+    pub fn tool(&self) -> ToolName {
+        self.tool
+    }
+
+    /// Policy for the top-level field `name`, folding in the conservative
+    /// [`FieldPolicy::RedactString`] default for unknown fields. This is the
+    /// only read path callers need; the field map is private so a holder
+    /// cannot downgrade a [`FieldPolicy::Forbidden`] entry after
+    /// construction.
+    #[must_use]
+    pub fn policy_for(&self, name: &str) -> FieldPolicy {
+        self.policies
+            .get(name)
+            .copied()
+            .unwrap_or(FieldPolicy::RedactString)
     }
 }
 
@@ -168,12 +187,7 @@ impl<'a> Redactor<'a> {
         };
         let mut out = Map::new();
         for (name, value) in map {
-            let policy = self
-                .schema
-                .policies
-                .get(name.as_str())
-                .copied()
-                .unwrap_or(FieldPolicy::RedactString);
+            let policy = self.schema.policy_for(name.as_str());
             match policy {
                 FieldPolicy::Verbatim(vt) => match Self::verbatim_check(value, vt) {
                     Some(v) => {
@@ -191,7 +205,7 @@ impl<'a> Redactor<'a> {
                 }
                 FieldPolicy::Forbidden => {
                     tracing::warn!(
-                        tool = self.schema.tool.as_str(),
+                        tool = self.schema.tool().as_str(),
                         field = name.as_str(),
                         "forbidden field present in tool arguments; dropped",
                     );

--- a/fuzz/fuzz_targets/audit_jsonl.rs
+++ b/fuzz/fuzz_targets/audit_jsonl.rs
@@ -46,11 +46,7 @@ fuzz_target!(|data: &[u8]| {
         };
 
         for (name, value_in) in map_in {
-            let policy = schema
-                .policies
-                .get(name.as_str())
-                .copied()
-                .unwrap_or(rimap_audit::FieldPolicy::RedactString);
+            let policy = schema.policy_for(name.as_str());
             if matches!(policy, rimap_audit::FieldPolicy::Verbatim(_)) {
                 continue;
             }


### PR DESCRIPTION
## What

`RedactionSchema` exposed `pub tool` and `pub policies`, letting any holder downgrade a `Forbidden` field after construction and bypass the build-once contract on a security type.

Make both fields private behind read-only accessors:
- `tool() -> ToolName`
- `policy_for(name) -> FieldPolicy`, folding in the conservative `RedactString` default (the exact lookup `Redactor::apply` already performed)

Route `Redactor::apply` and the `audit_jsonl` fuzz target — the only external reader of `.policies` — through `policy_for`. In-crate tests keep direct field access via child-module visibility.

Verified: `cargo clippy -p rimap-audit --all-targets` clean, 154 audit tests pass, and `cargo +nightly fuzz build audit_jsonl` compiles.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)