### PR TITLE
refactor(audit): drop dead ProvenanceBuffer root re-export

### DIFF
--- a/crates/rimap-audit/src/lib.rs
+++ b/crates/rimap-audit/src/lib.rs
@@ -25,7 +25,6 @@ pub use crate::redact::{
     FieldPolicy, RedactionSalt, RedactionSchema, Redactor, ToolRedactionSchema, VerbatimType,
     hash_arguments, redact, schemas,
 };
-pub use crate::writer::provenance::ProvenanceBuffer;
 pub use crate::writer::self_check::{TrailingState, current_inode, read_trailing_state};
 pub use crate::writer::{
     AuditOptions, AuditWriter, ProcessStartInputs, ToolEndInputs, ToolStartInputs,

--- a/crates/rimap-audit/src/writer/provenance.rs
+++ b/crates/rimap-audit/src/writer/provenance.rs
@@ -14,6 +14,15 @@
 //! `String` cannot represent non-UTF-8 bytes. Per-entry length is capped at
 //! `MAX_MESSAGE_ID_LEN` bytes (truncated with a `…[truncated]` suffix);
 //! entry count is capped at `MAX_BUFFER_ENTRIES` (oldest evicted).
+// ProvenanceBuffer is unwired scaffolding: the fetch_message / search
+// feeders that populate it land in a future sprint (see the module doc).
+// It is exercised only by this module's own tests, so the `expect` is
+// scoped to non-test builds — when the feeders are wired, the expectation
+// becomes unfulfilled and prompts its removal.
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "feeders wired in a future sprint; see module doc")
+)]
 
 use std::collections::VecDeque;
 
@@ -36,7 +45,7 @@ const TRUNCATED_SUFFIX: &str = "\u{2026}[truncated]";
 /// Ring buffer of observed Message-IDs with timestamps. Not thread-safe on
 /// its own; the caller holds a `Mutex<ProvenanceBuffer>` if needed.
 #[derive(Debug, Clone)]
-pub struct ProvenanceBuffer {
+pub(crate) struct ProvenanceBuffer {
     window: std::time::Duration,
     entries: VecDeque<Entry>,
 }


### PR DESCRIPTION
## What

`ProvenanceBuffer` was hoisted into the flat crate namespace but had no consumer outside `rimap-audit`. Delete that re-export and demote the type to `pub(crate)`.

`TrailingState` / `current_inode` / `read_trailing_state` (the next re-export line) are **kept** — they are load-bearing for the boot path (`boot/audit_init.rs`) and the `audit_merge` integration test.

## Note on the dead_code expectation

Removing the re-export unmasks that `ProvenanceBuffer` is unwired scaffolding — its `fetch_message` / `search` feeders land in a future sprint (see the module doc), and today it is exercised **only by its own tests**. So demoting alone trips `dead_code` under `-D warnings` (verified: 7 warnings).

The issue's literal recommendation (demote to `pub(crate)`) therefore needed one addition to compile. Rather than delete the planned scaffolding, I scoped a `dead_code` expectation to non-test builds:

```rust
#![cfg_attr(not(test), expect(dead_code, reason = "feeders wired in a future sprint; see module doc"))]
```

This is clean in both compilation configs, and when the feeders are wired (non-test usage appears) the expectation becomes unfulfilled and prompts the suppression's removal. `#[expect]` is the clippy-sanctioned form (`allow_attributes = deny` forbids only `#[allow]`).

Verified: `cargo clippy -p rimap-audit --all-targets --all-features` and lib-only clippy both clean; 154 audit tests pass.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)