### PR TITLE
refactor(imap): delete inert has_list_status capability plumbing

### DIFF
--- a/crates/rimap-imap/src/connection/dispatch.rs
+++ b/crates/rimap-imap/src/connection/dispatch.rs
@@ -5,8 +5,6 @@
 //! `pub async fn` here is a one-liner that delegates to an op module
 //! under the timeout guard.
 
-use std::sync::atomic::Ordering;
-
 use crate::error::ImapError;
 
 use super::{Connection, ImapSession};
@@ -77,9 +75,8 @@ impl Connection {
         &self,
         pattern: &str,
     ) -> Result<Vec<(crate::types::Folder, Option<crate::types::FolderStatus>)>, ImapError> {
-        let has_list_status = self.inner.has_list_status.load(Ordering::Relaxed);
         self.with_session("list_folders_with_status", async move |session| {
-            crate::ops::folders::list_with_status(session, pattern, has_list_status).await
+            crate::ops::folders::list_with_status(session, pattern).await
         })
         .await
     }

--- a/crates/rimap-imap/src/connection/login.rs
+++ b/crates/rimap-imap/src/connection/login.rs
@@ -143,28 +143,21 @@ impl Connection {
             }
         };
 
-        // Post-login: probe CAPABILITY for MOVE (RFC 6851),
-        // UIDPLUS (RFC 4315), and LIST-STATUS (RFC 5819).
-        let (has_move, has_uidplus, has_list_status) = match session.capabilities().await {
-            Ok(caps) => (
-                caps.has_str("MOVE"),
-                caps.has_str("UIDPLUS"),
-                caps.has_str("LIST-STATUS"),
-            ),
+        // Post-login: probe CAPABILITY for MOVE (RFC 6851) and
+        // UIDPLUS (RFC 4315).
+        let (has_move, has_uidplus) = match session.capabilities().await {
+            Ok(caps) => (caps.has_str("MOVE"), caps.has_str("UIDPLUS")),
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     "post-login CAPABILITY probe failed; \
-                     assuming no MOVE/UIDPLUS/LIST-STATUS support",
+                     assuming no MOVE/UIDPLUS support",
                 );
-                (false, false, false)
+                (false, false)
             }
         };
         self.inner.has_move.store(has_move, Ordering::Relaxed);
         self.inner.has_uidplus.store(has_uidplus, Ordering::Relaxed);
-        self.inner
-            .has_list_status
-            .store(has_list_status, Ordering::Relaxed);
 
         Ok((session, credential_source))
     }

--- a/crates/rimap-imap/src/connection/mod.rs
+++ b/crates/rimap-imap/src/connection/mod.rs
@@ -107,12 +107,6 @@ pub(super) struct ConnectionInner {
     /// Server advertised UIDPLUS capability (RFC 4315) after login.
     /// Reset to `false` on `invalidate()`.
     pub(super) has_uidplus: AtomicBool,
-    /// Server advertised LIST-STATUS capability (RFC 5819) after login.
-    /// Currently informational: async-imap does not yet expose the
-    /// extended LIST command, so `list_folders_with_status` always takes
-    /// the per-folder STATUS fallback path. Once async-imap surfaces
-    /// LIST-STATUS, the fallback can gate on this flag.
-    pub(super) has_list_status: AtomicBool,
 }
 
 impl std::fmt::Debug for Connection {
@@ -169,7 +163,6 @@ impl Connection {
                 session: Mutex::new(None),
                 has_move: AtomicBool::new(false),
                 has_uidplus: AtomicBool::new(false),
-                has_list_status: AtomicBool::new(false),
             }),
         }
     }
@@ -218,23 +211,12 @@ impl Connection {
         self.inner.has_uidplus.load(Ordering::Relaxed)
     }
 
-    /// Whether the server advertises LIST-STATUS (RFC 5819).
-    ///
-    /// Currently informational — `list_folders_with_status` always uses
-    /// the LIST-then-STATUS-per-folder fallback regardless. A future
-    /// async-imap release may expose the extended LIST command.
-    #[must_use]
-    pub fn has_list_status_capability(&self) -> bool {
-        self.inner.has_list_status.load(Ordering::Relaxed)
-    }
-
     /// Drop any current session. Called by ops on connection-lost errors.
     pub(crate) async fn invalidate(&self) {
         let mut guard = self.inner.session.lock().await;
         *guard = None;
         self.inner.has_move.store(false, Ordering::Relaxed);
         self.inner.has_uidplus.store(false, Ordering::Relaxed);
-        self.inner.has_list_status.store(false, Ordering::Relaxed);
     }
 
     /// The full connect/handshake/login/CAPABILITY flow. Emits exactly one

--- a/crates/rimap-imap/src/ops/folders.rs
+++ b/crates/rimap-imap/src/ops/folders.rs
@@ -95,12 +95,8 @@ pub(crate) async fn status(
     })
 }
 
-/// LIST + STATUS combined. Currently always uses the LIST-then-STATUS-
-/// per-folder fallback (because async-imap does not yet expose the
-/// RFC 5819 extended LIST command). The `has_list_status` argument is
-/// reserved for the future wiring — when async-imap exposes
-/// `LIST ... RETURN (STATUS ...)`, this function can dispatch on the
-/// capability flag without any change to callers.
+/// LIST + STATUS combined, using a LIST-then-STATUS-per-folder pass
+/// (async-imap does not yet expose the RFC 5819 extended LIST command).
 ///
 /// Returns (folder, status) pairs. `status` is `None` for non-selectable
 /// folders.
@@ -110,12 +106,7 @@ pub(crate) async fn status(
 pub(crate) async fn list_with_status(
     session: &mut ImapSession,
     pattern: &str,
-    _has_list_status: bool,
 ) -> Result<Vec<(Folder, Option<FolderStatus>)>, ImapError> {
-    // Always take the legacy fallback until async-imap exposes LIST-STATUS.
-    // The `has_list_status` flag is kept on the public surface so the
-    // future extended-LIST wiring is a behavior change, not a signature
-    // change.
     let folders = list(session, pattern).await?;
     let mut out = Vec::with_capacity(folders.len());
     for folder in folders {


### PR DESCRIPTION
## What

The `has_list_status` capability was threaded end-to-end — the `ConnectionInner` field, the post-login CAPABILITY probe + store, the `invalidate()` reset, the public `has_list_status_capability()` accessor, the dispatch load, and the `list_with_status` parameter — yet it gated nothing: `list_with_status` took it as `_has_list_status` and always ran the per-folder STATUS fallback. It was a speculative reservation for a future `async-imap` that exposes the RFC 5819 extended LIST command.

Delete all of it. MOVE (RFC 6851) and UIDPLUS (RFC 4315) probing is kept. The plumbing should be re-introduced in the single commit that actually branches on it.

Behavior is unchanged (the flag never altered control flow); 146 lib tests pass, clippy clean.

Related: #105 (wire LIST-STATUS once async-imap exposes it).
Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)