### PR TITLE
refactor(imap): collapse is_dead_tcp_kind false-arm enumeration

### DIFF
--- a/crates/rimap-imap/src/ops/folders.rs
+++ b/crates/rimap-imap/src/ops/folders.rs
@@ -215,6 +215,11 @@ fn is_connection_lost(err: &async_imap::error::Error) -> bool {
     false
 }
 
+#[expect(
+    clippy::match_like_matches_macro,
+    reason = "explicit match names the dead-TCP kinds for documentation; \
+              ErrorKind is #[non_exhaustive] so the open arm is required anyway"
+)]
 fn is_dead_tcp_kind(kind: std::io::ErrorKind) -> bool {
     use std::io::ErrorKind;
     match kind {
@@ -223,22 +228,7 @@ fn is_dead_tcp_kind(kind: std::io::ErrorKind) -> bool {
         | ErrorKind::BrokenPipe
         | ErrorKind::UnexpectedEof
         | ErrorKind::NotConnected => true,
-        ErrorKind::NotFound
-        | ErrorKind::PermissionDenied
-        | ErrorKind::ConnectionRefused
-        | ErrorKind::AddrInUse
-        | ErrorKind::AddrNotAvailable
-        | ErrorKind::AlreadyExists
-        | ErrorKind::WouldBlock
-        | ErrorKind::InvalidInput
-        | ErrorKind::InvalidData
-        | ErrorKind::TimedOut
-        | ErrorKind::WriteZero
-        | ErrorKind::Interrupted
-        | ErrorKind::Unsupported
-        | ErrorKind::OutOfMemory
-        | ErrorKind::Other
-        | _ => false,
+        _ => false,
     }
 }
 


### PR DESCRIPTION
## What

`is_dead_tcp_kind` enumerated ~14 non-dead `ErrorKind` variants before a trailing wildcard. The enumeration read as exhaustive but gave no compile-time change detection — a newly added variant silently fell through to `false`. `ErrorKind` is `#[non_exhaustive]`, so the wildcard is required regardless.

Collapse the false arm to a single open `_ => false`. Per project style and the issue, the match stays explicit (not `matches!`); the `match_like_matches_macro` lint is suppressed with a justified `#[expect]`.

Behavior unchanged — the `is_dead_tcp_kind_rejects_non_dead_kinds` test (which enumerates the previously-listed kinds) still passes.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)