### PR TITLE
refactor(imap): delete test-only error_code_for wrapper

### DIFF
--- a/crates/rimap-imap/src/connection/mod.rs
+++ b/crates/rimap-imap/src/connection/mod.rs
@@ -280,15 +280,6 @@ impl Connection {
     }
 }
 
-/// Map a connect/login error to its stable short error code for the
-/// audit log. Kept for the test harness that pins the complete
-/// [`ImapError`] -> [`rimap_core::ErrorCode`] mapping; production
-/// callers pass `err.code()` directly through [`ImapError::code`].
-#[cfg(test)]
-fn error_code_for(err: &ImapError) -> &'static str {
-    err.code().as_str()
-}
-
 #[cfg(test)]
 #[expect(clippy::panic, reason = "tests")]
 #[expect(clippy::expect_used, reason = "tests")]
@@ -296,8 +287,6 @@ mod tests {
     use rimap_core::TlsFingerprint;
 
     use crate::error::{AuthFailure, ImapError};
-
-    use super::error_code_for;
 
     fn fp_zeros() -> TlsFingerprint {
         TlsFingerprint::from_hex(&"00".repeat(32)).expect("valid 32-byte hex literal")
@@ -382,7 +371,7 @@ mod tests {
             ),
         ];
         for (err, expected) in &cases {
-            assert_eq!(error_code_for(err), *expected, "for {err:?}");
+            assert_eq!(err.code().as_str(), *expected, "for {err:?}");
         }
     }
 


### PR DESCRIPTION
## What

`error_code_for` was a `#[cfg(test)]` wrapper that only called `err.code().as_str()`. The exhaustiveness guarantee comes from the test (`error_code_for_covers_every_variant`) enumerating every `ImapError` variant, not from the wrapper.

Delete the wrapper, inline `err.code().as_str()` at the single call site, and drop the import. The variant-coverage test still passes.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)