### PR TITLE
refactor(imap): route fetch_body_with_limit through with_session

### DIFF
--- a/crates/rimap-imap/src/connection/dispatch.rs
+++ b/crates/rimap-imap/src/connection/dispatch.rs
@@ -36,7 +36,14 @@ impl Connection {
             body(session).await
         })
         .await;
-        if let Err(ImapError::ConnectionLost | ImapError::Timeout { .. }) = &result {
+        // SizeLimit aborts a fetch mid-stream, leaving the IMAP response
+        // half-consumed, so the session must be dropped. (`append` is the
+        // only other SizeLimit producer; it checks size before sending, so
+        // invalidating a healthy session there is a harmless reconnect.)
+        if let Err(
+            ImapError::ConnectionLost | ImapError::SizeLimit { .. } | ImapError::Timeout { .. },
+        ) = &result
+        {
             self.invalidate().await;
         }
         result
@@ -225,52 +232,14 @@ impl Connection {
         expected_uidvalidity: Option<u32>,
         limit: u64,
     ) -> Result<Vec<u8>, ImapError> {
-        let dur = self.inner.cfg.command_timeout;
-        let result = crate::time::with_timeout("fetch_body", dur, async {
-            let mut guard = self.session().await?;
-            let session =
-                guard
-                    .as_mut()
-                    .ok_or(ImapError::Protocol(async_imap::error::Error::Bad(
-                        "session invariant violated: guard is None after session()".to_string(),
-                    )))?;
+        self.with_session("fetch_body", async |session| {
             let server_size =
                 crate::ops::fetch::preflight_fetch_size(session, folder, uid, expected_uidvalidity)
                     .await?;
             crate::ops::fetch::preflight_size_check(server_size, limit)?;
             crate::ops::fetch::fetch_body(session, folder, uid, limit, expected_uidvalidity).await
         })
-        .await;
-        // Drop the cached session on ConnectionLost, SizeLimit, OR Timeout.
-        // SizeLimit and Timeout both abort mid-stream, so the IMAP response
-        // state is half-consumed and the session cannot be reused.
-        // UidValidityUnavailable is fail-closed but the session is healthy
-        // (only mailbox identity is unverifiable), so it stays non-invalidating.
-        // The match here lists every ImapError variant explicitly because
-        // workspace lints ban `_ =>` wildcards.
-        let should_invalidate = match &result {
-            Err(
-                ImapError::ConnectionLost | ImapError::SizeLimit { .. } | ImapError::Timeout { .. },
-            ) => true,
-            Err(
-                ImapError::Tls { .. }
-                | ImapError::TlsHandshake(_)
-                | ImapError::Starttls { .. }
-                | ImapError::Connect(_)
-                | ImapError::Auth { .. }
-                | ImapError::Protocol(_)
-                | ImapError::InvalidInput { .. }
-                | ImapError::BatchTooLarge { .. }
-                | ImapError::UidValidityChanged { .. }
-                | ImapError::UidValidityUnavailable { .. }
-                | ImapError::Audit { .. },
-            )
-            | Ok(_) => false,
-        };
-        if should_invalidate {
-            self.invalidate().await;
-        }
-        result
+        .await
     }
 
     /// `UID STORE` — add or remove flags on messages.


### PR DESCRIPTION
## What

`fetch_body_with_limit` re-implemented `with_session`'s scaffolding — the timeout, the `guard.as_mut()` invariant check, the verbatim "session invariant violated" error, and a 19-line exhaustive invalidation match — purely so it could also invalidate the connection on `SizeLimit`. Connection-lifecycle policy lived in two places.

Add `ImapError::SizeLimit` to `with_session`'s invalidation predicate and route `fetch_body_with_limit` through `self.with_session(...)` like its siblings.

## Behavior

- fetch's `SizeLimit` invalidation (the body aborts mid-stream, leaving the IMAP response half-consumed) is **preserved** — the invalidation set is identical before/after for the fetch path.
- The only other `SizeLimit` producer is `append`, whose `check_append_size` runs **before** any session `.await` (a pre-send guard). It now invalidates a healthy session on an oversize append — a harmless extra reconnect, not a correctness change.

146 lib tests pass (including the fetch `SizeLimit`/invalidation and append cases); clippy clean.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)