### PR TITLE
refactor(imap): factor per-step timeout mapping into local closures

### DIFF
--- a/crates/rimap-imap/src/connection/handshake.rs
+++ b/crates/rimap-imap/src/connection/handshake.rs
@@ -37,47 +37,38 @@ impl Connection {
         let total_deadline = cfg.connect_timeout;
         let started = std::time::Instant::now();
 
+        // Map an elapsed per-step timeout to this function's `(error, None)`
+        // error shape. Factors the repeated timeout arm without wrapping the
+        // (large) step futures in another async layer. Kept local to this fn
+        // because the `(error, None)` shape differs from preflight's (#351).
+        let timeout_err = |op: &'static str| move |_| (ImapError::Timeout { op }, None);
+
         // Step 1: TCP connect. Pre-resolve; failures carry `None`.
         let tcp = timeout(
             total_deadline,
             TcpStream::connect((cfg.host.as_str(), cfg.port)),
         )
         .await
-        .map_err(|_| (ImapError::Timeout { op: "tcp_connect" }, None))?
+        .map_err(timeout_err("tcp_connect"))?
         .map_err(|e| (ImapError::Connect(e), None))?;
 
         // Step 2: TLS establishment. Branches on encryption mode.
         // The `already_greeted` flag tracks whether the plaintext greeting was
         // already consumed during STARTTLS negotiation (true) or must be read
         // from the TLS stream (false).
-        let elapsed = started.elapsed();
-        let remaining = total_deadline.saturating_sub(elapsed);
+        let remaining = total_deadline.saturating_sub(started.elapsed());
         let (tls_stream, already_greeted): (TlsStream<TcpStream>, bool) = match cfg.encryption {
             ImapEncryption::Tls => {
                 let s = timeout(remaining, tls_handshake(tcp, bundle, &cfg.host))
                     .await
-                    .map_err(|_| {
-                        (
-                            ImapError::Timeout {
-                                op: "tls_handshake",
-                            },
-                            None,
-                        )
-                    })?
+                    .map_err(timeout_err("tls_handshake"))?
                     .map_err(|e| (e, None))?;
                 (s, false)
             }
             ImapEncryption::Starttls => {
                 let s = timeout(remaining, starttls_upgrade(tcp, bundle, &cfg.host))
                     .await
-                    .map_err(|_| {
-                        (
-                            ImapError::Timeout {
-                                op: "starttls_upgrade",
-                            },
-                            None,
-                        )
-                    })?
+                    .map_err(timeout_err("starttls_upgrade"))?
                     .map_err(|e| (e, None))?;
                 (s, true)
             }
@@ -87,11 +78,10 @@ impl Connection {
         // may return a credential source on both success and certain failures.
         // STARTTLS already consumed the plaintext greeting during negotiation;
         // `imap_login` must skip the greeting read in that case.
-        let elapsed = started.elapsed();
-        let remaining = total_deadline.saturating_sub(elapsed);
+        let remaining = total_deadline.saturating_sub(started.elapsed());
         timeout(remaining, self.imap_login(tls_stream, already_greeted))
             .await
-            .map_err(|_| (ImapError::Timeout { op: "imap_login" }, None))?
+            .map_err(timeout_err("imap_login"))?
     }
 }
 

--- a/crates/rimap-imap/src/preflight.rs
+++ b/crates/rimap-imap/src/preflight.rs
@@ -67,12 +67,18 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     let total_deadline = cfg.connect_timeout;
     let started = Instant::now();
 
+    // Map an elapsed per-step timeout to ImapError::Timeout { op }. Factors
+    // the repeated timeout arm without wrapping the (large) step futures in
+    // another async layer. Local to this fn because the error shape differs
+    // from the handshake's `(error, None)` (#351).
+    let timeout_err = |op: &'static str| move |_| ImapError::Timeout { op };
+
     let tcp = timeout(
         total_deadline,
         TcpStream::connect((cfg.host.as_str(), cfg.port)),
     )
     .await
-    .map_err(|_| ImapError::Timeout { op: "tcp_connect" })?
+    .map_err(timeout_err("tcp_connect"))?
     .map_err(ImapError::Connect)?;
 
     let remaining = total_deadline.saturating_sub(started.elapsed());
@@ -86,18 +92,14 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
         ImapEncryption::Tls => {
             let s = timeout(remaining, tls_handshake(tcp, &bundle, &cfg.host))
                 .await
-                .map_err(|_| ImapError::Timeout {
-                    op: "tls_handshake",
-                })?
+                .map_err(timeout_err("tls_handshake"))?
                 .map_err(enrich)?;
             (s, false)
         }
         ImapEncryption::Starttls => {
             let s = timeout(remaining, starttls_upgrade(tcp, &bundle, &cfg.host))
                 .await
-                .map_err(|_| ImapError::Timeout {
-                    op: "starttls_upgrade",
-                })?
+                .map_err(timeout_err("starttls_upgrade"))?
                 .map_err(enrich)?;
             (s, true)
         }
@@ -115,9 +117,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
     if !already_greeted {
         timeout(greeting_budget, client.read_response())
             .await
-            .map_err(|_| ImapError::Timeout {
-                op: "imap_greeting",
-            })?
+            .map_err(timeout_err("imap_greeting"))?
             .map_err(ImapError::Connect)?
             .ok_or(ImapError::Connect(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
@@ -131,9 +131,7 @@ pub async fn probe_preflight(cfg: &ConnectionConfig) -> Result<PreflightInfo, Im
         client.run_command_and_check_ok("CAPABILITY", Some(tx)),
     )
     .await
-    .map_err(|_| ImapError::Timeout {
-        op: "imap_capability",
-    })?
+    .map_err(timeout_err("imap_capability"))?
     .map_err(ImapError::Protocol)?;
 
     // Extract capabilities using the same pattern as `capability_advertised`


### PR DESCRIPTION
## What

`connect_with_bundle` (handshake) and `probe_preflight` each repeated the per-step `timeout(remaining, fut).await.map_err(|_| Timeout { op })` arm. Factor the timeout→error mapping into a small local `timeout_err` closure in each function.

The two error shapes differ — the handshake returns `(error, Option<CredentialSource>)`, preflight returns bare `ImapError` — so the closures stay local to each function (no shared cross-function helper), as the issue directs.

## Why a closure and not a helper fn

The closure maps only the elapsed-timeout arm; `timeout(..).await` stays inline. An earlier attempt using a nested generic `async fn step(.., fut)` tripped the workspace `large_futures` lint — wrapping the (large) TLS/login step futures in another async layer inflated the state machine past the threshold. The `map_err`-closure form avoids that entirely.

Behavior unchanged (op names and inner `map_err` preserved); 146 lib tests pass, clippy clean.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)