### PR TITLE
refactor(content): narrow the unicode surface to crate-root sanitizers

### DIFF
--- a/crates/rimap-content/src/lib.rs
+++ b/crates/rimap-content/src/lib.rs
@@ -9,10 +9,10 @@
 pub mod error;
 pub mod output;
 pub mod parse;
-pub mod unicode;
 
 mod html;
 mod lookalike;
+pub(crate) mod unicode;
 
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
@@ -24,6 +24,14 @@ pub use output::{
 };
 pub use parse::parse_message;
 pub use parse::{RawPart, ThreadingHeaders, extract_threading_headers, walk_attachment_parts};
+// Sanctioned text-sanitization surface. The `unicode` module is crate-private;
+// handlers reach these named entry points at the crate root rather than into
+// the module internals, so the "sanitize every untrusted byte before it
+// reaches the agent" policy is exposed as one curated set.
+pub use unicode::{
+    FilterResult, decode, filter_codepoints, normalize_line_endings, normalize_nfkc, sanitize,
+    truncate_graphemes, truncate_graphemes_in_place,
+};
 
 /// Extract the `Message-ID` header from raw RFC 5322 bytes.
 ///

--- a/crates/rimap-content/tests/properties.rs
+++ b/crates/rimap-content/tests/properties.rs
@@ -5,7 +5,7 @@
 //! minimal counterexamples.
 
 use proptest::prelude::*;
-use rimap_content::unicode;
+use rimap_content::{decode, filter_codepoints, normalize_nfkc, truncate_graphemes};
 
 fn config() -> ProptestConfig {
     ProptestConfig {
@@ -21,8 +21,8 @@ proptest! {
     /// NFKC is idempotent: normalizing twice gives the same result.
     #[test]
     fn nfkc_stable(input in any::<String>()) {
-        let once = unicode::normalize_nfkc(&input);
-        let twice = unicode::normalize_nfkc(&once);
+        let once = normalize_nfkc(&input);
+        let twice = normalize_nfkc(&once);
         prop_assert_eq!(once, twice);
     }
 
@@ -30,7 +30,7 @@ proptest! {
     /// the strip set.
     #[test]
     fn no_stripped_codepoints_in_output(input in any::<String>()) {
-        let result = unicode::filter_codepoints(&input);
+        let result = filter_codepoints(&input);
         for ch in result.text.chars() {
             let c = ch as u32;
             prop_assert!(!is_zero_width(ch), "zero-width {c:#x} in output");
@@ -42,7 +42,7 @@ proptest! {
     /// except tab and newline, and no C1 controls at all.
     #[test]
     fn no_c0_c1_controls_except_tab_newline(input in any::<String>()) {
-        let result = unicode::filter_codepoints(&input);
+        let result = filter_codepoints(&input);
         for ch in result.text.chars() {
             let c = ch as u32;
             if c <= 0x1F {
@@ -55,7 +55,7 @@ proptest! {
     /// decode on any byte slice returns valid UTF-8.
     #[test]
     fn utf8_preserved(bytes in proptest::collection::vec(any::<u8>(), 0..4096)) {
-        let out = unicode::decode(&bytes, Some("utf-8"));
+        let out = decode(&bytes, Some("utf-8"));
         // Rust String is UTF-8 by construction, so this is trivially
         // true — but verify the re-encoded bytes also parse.
         let reencoded = out.as_bytes();
@@ -69,7 +69,7 @@ proptest! {
         input in any::<String>(),
         max_bytes in 0usize..8192,
     ) {
-        let out = unicode::truncate_graphemes(&input, max_bytes);
+        let out = truncate_graphemes(&input, max_bytes);
         prop_assert!(
             out.len() <= max_bytes || max_bytes == 0,
             "out.len()={} max_bytes={}",

--- a/crates/rimap-server/src/tools/admin/list_folders.rs
+++ b/crates/rimap-server/src/tools/admin/list_folders.rs
@@ -35,7 +35,7 @@ fn sanitize_folder_entry(
     folder: &rimap_imap::types::Folder,
     warnings: &mut Vec<SecurityWarning>,
 ) -> (String, Option<String>, Vec<String>) {
-    let (clean_name, name_warnings) = rimap_content::unicode::sanitize(
+    let (clean_name, name_warnings) = rimap_content::sanitize(
         folder.name.as_bytes(),
         None,
         MAX_FOLDER_NAME_BYTES,
@@ -53,8 +53,7 @@ fn sanitize_folder_entry(
     let name_wire = if clean_name == folder.name {
         None
     } else {
-        let capped =
-            rimap_content::unicode::truncate_graphemes(&folder.name, MAX_FOLDER_NAME_BYTES * 4);
+        let capped = rimap_content::truncate_graphemes(&folder.name, MAX_FOLDER_NAME_BYTES * 4);
         Some(escape_wire_name(&capped))
     };
     warnings.extend(name_warnings);
@@ -64,12 +63,8 @@ fn sanitize_folder_entry(
         .iter()
         .map(|attr| {
             let raw = attr.as_wire_str();
-            let (clean, flag_warnings) = rimap_content::unicode::sanitize(
-                raw.as_bytes(),
-                None,
-                MAX_FOLDER_NAME_BYTES,
-                "folder.flag",
-            );
+            let (clean, flag_warnings) =
+                rimap_content::sanitize(raw.as_bytes(), None, MAX_FOLDER_NAME_BYTES, "folder.flag");
             warnings.extend(flag_warnings);
             clean
         })
@@ -120,7 +115,7 @@ pub struct ListFoldersMeta {
 /// MCP response. Returns the sanitized `FolderEntry` list and the
 /// accumulated security warnings.
 ///
-/// Folder names and flags are run through `rimap_content::unicode::sanitize`
+/// Folder names and flags are run through `rimap_content::sanitize`
 /// so server-controlled bidi overrides, zero-width characters, and C0/C1
 /// stripping are surfaced as structured warnings rather than riding
 /// unfiltered under the trusted `meta` envelope (#98).

--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -1,6 +1,6 @@
 //! `fetch_message` tool handler.
 
-use rimap_content::unicode::truncate_graphemes_in_place;
+use rimap_content::truncate_graphemes_in_place;
 use rimap_imap::types::Uid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/rimap-server/src/tools/retrieval/search.rs
+++ b/crates/rimap-server/src/tools/retrieval/search.rs
@@ -358,7 +358,7 @@ fn parse_iso_date(s: &str) -> Result<time::Date, rimap_core::RimapError> {
 /// `unicode::sanitize` entry point — the input is already valid
 /// UTF-8 and envelope snippets do not surface `SecurityWarning`.
 fn sanitize_for_output(s: &str) -> String {
-    use rimap_content::unicode::{
+    use rimap_content::{
         filter_codepoints, normalize_line_endings, normalize_nfkc, truncate_graphemes,
     };
     let normalized = normalize_nfkc(s);

--- a/fuzz/fuzz_targets/content_charset.rs
+++ b/fuzz/fuzz_targets/content_charset.rs
@@ -16,5 +16,5 @@ fuzz_target!(|data: &[u8]| {
     let body = &data[1 + label_len..];
 
     let label = std::str::from_utf8(label_bytes).ok();
-    let _ = rimap_content::unicode::decode(body, label);
+    let _ = rimap_content::decode(body, label);
 });


### PR DESCRIPTION
## What

Server handlers reached past `rimap-content`'s facade into the `unicode` submodule (`rimap_content::unicode::{sanitize, truncate_graphemes, filter_codepoints, normalize_nfkc, normalize_line_endings, truncate_graphemes_in_place}`), so the "sanitize every untrusted byte before it reaches the agent" policy was enforced per-call-site against a publicly browsable low-level module. (`html` and `lookalike` were already private.)

Demote `unicode` to `pub(crate)` and re-export the sanctioned text sanitizers at the crate root, so the curated set is the single public surface. Update the consumers — the `search` / `fetch_message` / `list_folders` handlers, the content property test, and the `content_charset` fuzz target — to the root paths.

No new dispatch abstraction and no `sanitize_for_display` facade: the per-handler sequences differ and none recurs verbatim 3+ times, so `search`'s decode-skipping variant stays local (per the issue's guidance). Behavior unchanged.

Verified: `rimap-content` + `rimap-server` clippy clean (incl. integration tests), 233 content tests pass, and `cargo +nightly fuzz build content_charset` compiles.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)