### PR TITLE
refactor(server): move content-parse adapter into tools

### DIFF
--- a/crates/rimap-server/src/mcp/mod.rs
+++ b/crates/rimap-server/src/mcp/mod.rs
@@ -1,7 +1,6 @@
-//! MCP runtime: server handler, response/error types, content parsing.
+//! MCP runtime: server handler, response/error types, dispatch.
 
 pub(crate) mod audit_envelope;
-pub mod content;
 pub(crate) mod dispatch;
 pub mod error;
 pub mod preinit;
@@ -30,8 +29,9 @@ pub mod wire_validator;
 pub mod fuzz_oracle;
 
 /// Render a `tokio::task::JoinError` from `spawn_blocking` as
-/// `RimapError::InternalSourced`. Shared by every `mcp/*` async wrapper so
-/// panics in the blocking threadpool always surface with the same code
+/// `RimapError::InternalSourced`. Shared by every `spawn_blocking` wrapper
+/// (`audit_envelope`, `tools::content_parse`, `tools::retrieval::sandbox`)
+/// so panics in the blocking threadpool always surface with the same code
 /// and message prefix — infrastructure failure, not user input. The
 /// original `JoinError` is preserved via the `#[source]` chain so
 /// tracing subscribers can walk to the underlying panic payload.

--- a/crates/rimap-server/src/tools/content_parse.rs
+++ b/crates/rimap-server/src/tools/content_parse.rs
@@ -88,7 +88,7 @@ pub async fn walk_attachment_parts_async(
 }
 
 /// Classifies `ContentError` via [`classify_content_error`] and panics
-/// via [`spawn_blocking_panic_error`]. Acquires `PARSE_SEMAPHORE`.
+/// via [`crate::mcp::spawn_blocking_panic_error`]. Acquires `PARSE_SEMAPHORE`.
 async fn run_on_blocking_pool<F, T>(work: F) -> Result<T, RimapError>
 where
     F: FnOnce() -> Result<T, ContentError> + Send + 'static,

--- a/crates/rimap-server/src/tools/mod.rs
+++ b/crates/rimap-server/src/tools/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod admin;
 pub mod compose;
+pub(crate) mod content_parse;
 pub(crate) mod fetch_by_uid;
 pub(crate) mod lenient_int;
 pub mod mailbox;

--- a/crates/rimap-server/src/tools/retrieval/download_attachment.rs
+++ b/crates/rimap-server/src/tools/retrieval/download_attachment.rs
@@ -107,7 +107,7 @@ pub async fn handle(
 
     let raw = account.imap.fetch_body(&input.folder, uid, None).await?;
 
-    let parts = crate::mcp::content::walk_attachment_parts_async(raw).await?;
+    let parts = crate::tools::content_parse::walk_attachment_parts_async(raw).await?;
 
     let part = parts
         .into_iter()

--- a/crates/rimap-server/src/tools/retrieval/fetch_message.rs
+++ b/crates/rimap-server/src/tools/retrieval/fetch_message.rs
@@ -115,7 +115,7 @@ pub async fn handle(
     let raw = account.imap.fetch_body(&input.folder, uid, None).await?;
     let raw_size = raw.len();
 
-    let content = crate::mcp::content::parse_message_async(raw).await?;
+    let content = crate::tools::content_parse::parse_message_async(raw).await?;
 
     let mut body_text = content.untrusted.body_text;
     let mut body_html = if include_html {


### PR DESCRIPTION
`mcp/content.rs` held the async wrappers over `rimap_content::parse_message` (`parse_message_async`, `walk_attachment_parts_async`, `classify_content_error`) guarded by `PARSE_SEMAPHORE`. It touches no JSON-RPC, catalog, audit, or wire concern and is consumed only by `crate::tools::retrieval`, so it belonged under `tools`, not the protocol layer.

This relocates it to `crate::tools::content_parse` (pure `git mv`, zero content change), narrows the module to `pub(crate)` since every caller is in-crate, and repoints `fetch_message` and `download_attachment`.

The shared `spawn_blocking_panic_error` helper stays in `mcp` — `audit_envelope` and `tools::retrieval::sandbox` also use it. Its now-stale "every `mcp/*` wrapper" doc and the moved file's bare intra-doc link to it (which would otherwise become an unresolved-link `cargo doc` warning after the move) are updated to the qualified path.

Verification:
- `cargo clippy -p rimap-server --all-targets --all-features` clean
- `cargo doc --no-deps --document-private-items` introduces no new warnings
- 2 relocated `content_parse` unit tests pass

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)