### PR TITLE
fix(server): wire real total_tool_calls in process_end

### DIFF
--- a/crates/rimap-audit/src/writer/core.rs
+++ b/crates/rimap-audit/src/writer/core.rs
@@ -66,6 +66,7 @@ pub struct AuditWriter {
     pub(super) fail_open: bool,
     pub(super) process_id: crate::record::ids::ProcessId,
     pub(super) suppressed_failures: Arc<AtomicU64>,
+    pub(super) tool_calls: Arc<AtomicU64>,
     pub(super) inner: Arc<Mutex<Inner>>,
     #[cfg(any(test, feature = "test-injection"))]
     pub(super) failure_injection: Arc<FailureInjection>,
@@ -141,6 +142,7 @@ impl AuditWriter {
             fail_open: opts.fail_open,
             process_id: crate::record::ids::ProcessId::new_now(),
             suppressed_failures: Arc::new(AtomicU64::new(0)),
+            tool_calls: Arc::new(AtomicU64::new(0)),
             inner: Arc::new(Mutex::new(Inner {
                 buf: BufWriter::new(file),
                 bytes_written,
@@ -187,6 +189,17 @@ impl AuditWriter {
     #[must_use]
     pub fn suppressed_failures(&self) -> u64 {
         self.suppressed_failures.load(Ordering::Relaxed)
+    }
+
+    /// Number of tool calls dispatched in this process — incremented once
+    /// per successful [`AuditWriter::log_tool_start`]. Counts every call
+    /// whose `tool_start` was accepted, including those whose write was
+    /// later suppressed under `fail_open = true`; a `fail_open = false`
+    /// write failure aborts the call and is not counted. Read at shutdown
+    /// to populate `ProcessEnd::total_tool_calls`.
+    #[must_use]
+    pub fn total_tool_calls(&self) -> u64 {
+        self.tool_calls.load(Ordering::Relaxed)
     }
 
     /// Test-only: cause the next `write_record_inner` call to fail with
@@ -761,6 +774,47 @@ mod tests {
         assert_eq!(v["kind"], "process_end");
         assert_eq!(v["reason"], "eof");
         assert_eq!(v["total_tool_calls"], 42);
+    }
+
+    #[test]
+    fn total_tool_calls_counts_each_tool_start() {
+        use crate::writer::ToolStartInputs;
+
+        let dir = TempDir::new().unwrap();
+        let writer = AuditWriter::open(&AuditOptions {
+            path: dir.path().join("audit.jsonl"),
+            rotate_bytes: 0,
+            rotate_keep: 0,
+            retention_seconds: None,
+            fail_open: false,
+            initial_seq: crate::record::ids::Seq::FIRST,
+        })
+        .unwrap();
+
+        assert_eq!(writer.total_tool_calls(), 0);
+
+        let inputs = || ToolStartInputs {
+            tool: rimap_core::tool::ToolName::Search,
+            account: Some("a".to_string()),
+            posture_effective: Some(rimap_core::Posture::DraftSafe),
+            arguments_redacted: serde_json::Value::Object(serde_json::Map::new()),
+            arguments_hash_sha256: "0".repeat(64),
+        };
+        writer.log_tool_start(inputs()).unwrap();
+        writer.log_tool_start(inputs()).unwrap();
+        assert_eq!(writer.total_tool_calls(), 2);
+
+        // A non-tool_start record must not bump the counter.
+        writer
+            .log_process_end(crate::record::ProcessEnd {
+                reason: crate::record::ProcessEndReason::Eof,
+                total_tool_calls: writer.total_tool_calls(),
+            })
+            .unwrap();
+        assert_eq!(writer.total_tool_calls(), 2);
+
+        // Clones share the counter.
+        assert_eq!(writer.clone().total_tool_calls(), 2);
     }
 
     #[test]

--- a/crates/rimap-audit/src/writer/log.rs
+++ b/crates/rimap-audit/src/writer/log.rs
@@ -92,7 +92,14 @@ impl AuditWriter {
         // design. `PostureEffective` serializes as the historical on-disk
         // strings (`"infrastructure"` or the kebab-case posture) so readers
         // can distinguish these records from per-account tool calls.
-        self.emit(crate::record::Payload::ToolStart(inputs.into()))
+        let seq = self.emit(crate::record::Payload::ToolStart(inputs.into()))?;
+        // One increment per dispatched tool call; read at shutdown to fill
+        // `ProcessEnd::total_tool_calls`. `Relaxed` is sufficient — the
+        // count is a monotonic process-lifetime metric, not a happens-before
+        // signal.
+        self.tool_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(seq)
     }
 
     /// Build a `tool_end` record, allocate a seq, and write it.

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -296,11 +296,9 @@ fn emit_process_end(audit: &rimap_audit::AuditWriter, mcp_result: &anyhow::Resul
         Ok(()) => rimap_audit::ProcessEndReason::Eof,
         Err(_) => rimap_audit::ProcessEndReason::Error,
     };
-    // total_tool_calls is not tracked yet — use 0 as placeholder.
-    // A future PR can add an AtomicU64 counter to ImapMcpServer.
     let process_end = rimap_audit::ProcessEnd {
         reason,
-        total_tool_calls: 0,
+        total_tool_calls: audit.total_tool_calls(),
     };
     match audit.log_process_end(process_end) {
         Ok(seq) => tracing::info!(seq = %seq, "process_end audit record written"),


### PR DESCRIPTION
`emit_process_end` hardcoded `total_tool_calls: 0` behind a "future PR can add an AtomicU64" comment, so the documented `n` field on every `process_end` audit record ("number of tool calls dispatched in this process") was always 0 — a phantom metric.

This adds a process-lifetime `tool_calls: Arc<AtomicU64>` to `AuditWriter` (mirroring the existing `suppressed_failures` counter), increments it once on each successful `log_tool_start` — the single per-dispatch chokepoint, shared across all writer clones — and exposes `total_tool_calls()`. `emit_process_end` now reads the real count.

Placing the counter on the writer (which `emit_process_end` already holds, and which is `Arc`-shared across clones) rather than on `ImapMcpServer` means no constructor signatures change.

Count semantics: one increment per successfully-started tool call, including the infrastructure path (`use_account`, `list_accounts`). A call counts when its `tool_start` is accepted (including a write suppressed under `fail_open = true`); a `fail_open = false` write failure aborts the call and is not counted.

Verification:
- new unit test `total_tool_calls_counts_each_tool_start` (starts at 0, increments per `log_tool_start`, non-tool records don't bump it, clones share the counter)
- all 155 `rimap-audit` lib tests pass
- `cargo clippy -p rimap-audit -p rimap-server --all-targets --all-features` clean

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)