### PR TITLE
refactor(server): extract merge_protected_folders from build_registry

### DIFF
--- a/crates/rimap-server/src/boot/discovery.rs
+++ b/crates/rimap-server/src/boot/discovery.rs
@@ -25,12 +25,68 @@ pub fn resolve_special_use(folders: &[Folder]) -> SpecialUseMap {
     SpecialUseMap::from_folders(folders)
 }
 
+/// Expand the config-supplied protected-folders list with any
+/// server-declared RFC 6154 special-use names (e.g. Gmail's
+/// `[Gmail]/Sent Mail`), preserving the configured order and appending
+/// only names not already present.
+///
+/// The dedup is case-insensitive so a user-configured literal (`"Sent"`)
+/// is not duplicated when the server also reports `"Sent"` for the same
+/// mailbox. Kept pure — `discovered` is the output of
+/// [`rimap_imap::SpecialUseMap::all_discovered`] — so the security-relevant
+/// merge is unit-testable without a live IMAP connection.
+#[must_use]
+pub fn merge_protected_folders(configured: &[String], discovered: Vec<String>) -> Vec<String> {
+    let mut protected = configured.to_vec();
+    for name in discovered {
+        if !protected.iter().any(|p| p.eq_ignore_ascii_case(&name)) {
+            protected.push(name);
+        }
+    }
+    protected
+}
+
 #[cfg(test)]
 mod tests {
     use rimap_imap::SpecialUse;
     use rimap_imap::types::Folder;
 
-    use super::resolve_special_use;
+    use super::{merge_protected_folders, resolve_special_use};
+
+    fn owned(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn merge_appends_discovered_names_after_configured() {
+        let merged = merge_protected_folders(&owned(&["INBOX"]), owned(&["[Gmail]/Sent Mail"]));
+        assert_eq!(merged, owned(&["INBOX", "[Gmail]/Sent Mail"]));
+    }
+
+    #[test]
+    fn merge_dedups_case_insensitively() {
+        // A configured literal must not be duplicated when the server
+        // reports the same name in a different case.
+        let merged = merge_protected_folders(&owned(&["Sent"]), owned(&["sent", "Trash"]));
+        assert_eq!(merged, owned(&["Sent", "Trash"]));
+    }
+
+    #[test]
+    fn merge_preserves_configured_order_and_keeps_empties() {
+        let merged = merge_protected_folders(&owned(&["a", "b"]), Vec::new());
+        assert_eq!(merged, owned(&["a", "b"]));
+
+        let merged = merge_protected_folders(&[], owned(&["x"]));
+        assert_eq!(merged, owned(&["x"]));
+    }
+
+    #[test]
+    fn merge_dedups_within_discovered_against_running_result() {
+        // Two discovered names that collide case-insensitively with each
+        // other: the second is dropped because the first was appended.
+        let merged = merge_protected_folders(&[], owned(&["Archive", "archive"]));
+        assert_eq!(merged, owned(&["Archive"]));
+    }
 
     fn folder(name: &str, special: Option<SpecialUse>) -> Folder {
         Folder {

--- a/crates/rimap-server/src/main.rs
+++ b/crates/rimap-server/src/main.rs
@@ -459,21 +459,10 @@ async fn build_registry(
             .await
             .with_context(|| format!("listing folders for account {}", id.as_str()))?;
         let special_use = rimap_server::boot::discovery::resolve_special_use(&folders);
-
-        // Expand the config-supplied protected-folders list with any
-        // server-declared RFC 6154 names (e.g. Gmail's `[Gmail]/Sent Mail`).
-        // The merge is case-insensitive so user-configured literals
-        // (`"Sent"`) are not duplicated when the server also reports
-        // `"Sent"` on the same mailbox.
-        let mut protected = acfg.security.protected_folders.clone();
-        for discovered in special_use.all_discovered() {
-            if !protected
-                .iter()
-                .any(|p| p.eq_ignore_ascii_case(&discovered))
-            {
-                protected.push(discovered);
-            }
-        }
+        let protected = rimap_server::boot::discovery::merge_protected_folders(
+            &acfg.security.protected_folders,
+            special_use.all_discovered(),
+        );
 
         let smtp = build_smtp_client(acfg, credentials)?;
 


### PR DESCRIPTION
`build_registry` inlined the security-relevant merge of RFC 6154 special-use folder names into the configured protected-folders list, so the case-insensitive dedup could only be exercised behind a live `list_folders` call.

This extracts it into a pure `discovery::merge_protected_folders(configured, discovered) -> Vec<String>` beside `resolve_special_use`. `build_registry` keeps the live `list_folders` + `resolve_special_use` and feeds `all_discovered()` into the helper.

Behavior is unchanged: configured entries are preserved verbatim and discovered names are appended with a running case-insensitive dedup (a discovered name dedups against earlier-appended names, not just the configured list). Four unit tests pin append order, case-insensitivity, and the running-dedup invariant without a live connection.

Verification:
- 7 `boot::discovery` tests pass (3 pre-existing + 4 new)
- `cargo clippy -p rimap-server --all-targets --all-features` clean

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)