### PR TITLE
deps(cargo): bump serde_json 1.0.150 + rpassword 7.5.4, skip windows-sys 0.52 dup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -943,7 +943,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2628,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -2672,7 +2672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2903,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3158,7 +3158,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -138,8 +138,19 @@ skip = [
 # Windows ABI shim. Skipping the older subtrees keeps Windows targets in
 # cargo-deny scope without forcing a coordinated upgrade across unrelated
 # ecosystems. The newest version (0.61) remains the canonical one.
+#
+# `windows-sys 0.52` is hard-pinned by `ring 0.17` (`= "0.52"`, a rustls
+# transitive via rimap-imap), so 0.52 is permanently in the graph and cannot
+# be lifted to 0.61 without forking ring/rustls. The flexible consumers
+# `rustix`/`tempfile`/`errno`/`io-extras`/`fs-set-times`/`winx` declare an
+# open `windows-sys` range that 0.52 satisfies, so cargo's resolver may
+# unify them onto ring's 0.52 node on any lockfile re-resolution (observed
+# when the cargo-minor-patch group regenerated Cargo.lock). Skip the 0.52
+# subtree for the same reason as 0.59. Revisit when `ring` publishes a
+# release using windows-sys >= 0.61.
 skip-tree = [
     { name = "windows-sys", version = "0.59" },
+    { name = "windows-sys", version = "0.52" },
 
     # Sprint 4b: the html5ever ecosystem is mid-split. `scraper 0.26` (our
     # HTML parser) has migrated to html5ever 0.39 / markup5ever 0.39 /


### PR DESCRIPTION
Replaces #383, which fails `cargo deny check bans`.

## What
- Bumps `serde_json` 1.0.149 → 1.0.150 and `rpassword` 7.5.2 → 7.5.4 (same as Dependabot's cargo-minor-patch group, #383).
- Adds `windows-sys` 0.52 to `deny.toml`'s `skip-tree`, alongside the existing 0.59 entry, with the root cause documented inline.

## Why #383 alone fails
Regenerating `Cargo.lock` collapses the flexible `windows-sys` consumers (`rustix`, `tempfile`, `errno`, `io-extras`, `fs-set-times`, `winx`) from 0.61.2 **down** onto the 0.52 node that `ring 0.17` hard-pins (`= "0.52"`, a rustls transitive via `rimap-imap`). That makes `windows-sys` 0.52 and 0.61 both visible to the duplicate check → `bans FAILED: found 2 duplicate entries for crate 'windows-sys'`.

This is upstream-inevitable: `ring` forces 0.52 into the graph and the flexible crates legally accept it, so no `cargo update` (including `--precise`) can unify it without forking ring/rustls. `deny.toml`'s existing windows-sys comment already names `tempfile`/`rustix` as expected older-shim consumers; this extends that documented exception from 0.59 to 0.52.

## Verification (local)
- `cargo deny check` → advisories ok, **bans ok**, licenses ok, sources ok
- `cargo build --workspace --locked` → clean
- `cargo nextest run --workspace --locked` → 1577 passed, 1 skipped (identical to main baseline; the bump is byte-identical to #383, deny.toml is non-compiled config)

Closes #383.